### PR TITLE
Fix release workflow and add smoke tests

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,0 +1,46 @@
+# Branch Protection Rules
+
+## Required Checks for Main Branch
+
+To ensure code quality and proper versioning, the following GitHub branch protection rules should be configured for the `main` branch:
+
+### Setting Up Branch Protection
+
+1. Go to **Settings** → **Branches** in your GitHub repository
+2. Click **Add rule** or edit the existing rule for `main`
+3. Enable the following settings:
+
+#### Required Status Checks
+Enable **Require status checks to pass before merging** and add these checks:
+- ✅ `Lint`
+- ✅ `Test`
+- ✅ `Build Test (x86_64-unknown-linux-musl, ubuntu-latest)`
+- ✅ `Build Test (aarch64-apple-darwin, macos-latest)`
+- ✅ `Performance Check`
+- ✅ `Smoke Test Linux`
+- ✅ `Smoke Test macOS`
+- ✅ `Release Readiness`
+- ✅ **`Verify Version Increment`** ← This ensures version is updated
+
+#### Additional Recommended Settings
+- ✅ **Require branches to be up to date before merging**
+- ✅ **Require conversation resolution before merging**
+- ✅ **Dismiss stale pull request approvals when new commits are pushed**
+- ✅ **Include administrators** (optional, but recommended)
+
+### Version Check Details
+
+The `Verify Version Increment` check ensures that:
+1. The version in `Cargo.toml` has been incremented compared to the `main` branch
+2. The version follows semantic versioning format (X.Y.Z)
+3. The new version is greater than the current version on `main`
+
+This prevents accidental merges without updating the version, which is crucial for proper release management.
+
+### Bypassing Version Check (Emergency Only)
+
+In rare cases where you need to merge without incrementing the version (e.g., documentation-only changes), repository administrators can:
+1. Use the "Merge without waiting for requirements to be met" option
+2. Or temporarily disable the check in branch protection settings
+
+**Note**: This should be used sparingly and only for changes that truly don't warrant a version bump.

--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -98,16 +98,11 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       
-      - name: Install musl tools and dependencies
+      - name: Install musl tools
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: |
           sudo apt-get update
-          sudo apt-get install -y musl-tools musl-dev
-          sudo apt-get install -y libssl-dev pkg-config
-          # Install musl-compatible OpenSSL
-          sudo ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/x86_64-linux-musl/asm
-          sudo ln -s /usr/include/asm-generic /usr/include/x86_64-linux-musl/asm-generic
-          sudo ln -s /usr/include/linux /usr/include/x86_64-linux-musl/linux
+          sudo apt-get install -y musl-tools
       
       - name: Cache Rust dependencies
         uses: actions/cache@v4
@@ -121,7 +116,14 @@ jobs:
             ${{ runner.os }}-cargo-${{ matrix.target }}-
       
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        run: |
+          if [[ "${{ matrix.target }}" == "x86_64-unknown-linux-musl" ]]; then
+            # Use vendored OpenSSL for musl builds
+            export OPENSSL_STATIC=1
+            export OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
+            export OPENSSL_INCLUDE_DIR=/usr/include
+          fi
+          cargo build --release --target ${{ matrix.target }}
       
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -112,6 +112,13 @@ jobs:
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
       
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: arkavo-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/arkavo
+          retention-days: 1
+      
       - name: Verify binary size
         run: |
           if [[ "$RUNNER_OS" == "Linux" ]]; then
@@ -170,10 +177,42 @@ jobs:
           
           echo "Performance check completed"
 
+  smoke-test-linux:
+    name: Smoke Test Linux
+    needs: build-test
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:22.04
+    steps:
+      - name: Download Linux binary
+        uses: actions/download-artifact@v4
+        with:
+          name: arkavo-x86_64-unknown-linux-gnu
+          
+      - name: Test binary execution
+        run: |
+          chmod +x arkavo
+          ./arkavo --version
+          
+  smoke-test-macos:
+    name: Smoke Test macOS
+    needs: build-test
+    runs-on: macos-latest
+    steps:
+      - name: Download macOS binary
+        uses: actions/download-artifact@v4
+        with:
+          name: arkavo-aarch64-apple-darwin
+          
+      - name: Test binary execution
+        run: |
+          chmod +x arkavo
+          ./arkavo --version
+
   release-readiness:
     name: Release Readiness
     if: github.event_name == 'pull_request'
-    needs: [lint, test, build-test, performance-check]
+    needs: [lint, test, build-test, performance-check, smoke-test-linux, smoke-test-macos]
     runs-on: ubuntu-latest
     steps:
       - name: Pull Request is ready for merge

--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -84,7 +84,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
           - target: aarch64-apple-darwin
             os: macos-latest
@@ -182,12 +182,12 @@ jobs:
     needs: build-test
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:latest
+      image: alpine:latest
     steps:
       - name: Download Linux binary
         uses: actions/download-artifact@v4
         with:
-          name: arkavo-x86_64-unknown-linux-gnu
+          name: arkavo-x86_64-unknown-linux-musl
           
       - name: Test binary execution
         run: |

--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -98,6 +98,17 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       
+      - name: Install musl tools and dependencies
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools musl-dev
+          sudo apt-get install -y libssl-dev pkg-config
+          # Install musl-compatible OpenSSL
+          sudo ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/x86_64-linux-musl/asm
+          sudo ln -s /usr/include/asm-generic /usr/include/x86_64-linux-musl/asm-generic
+          sudo ln -s /usr/include/linux /usr/include/x86_64-linux-musl/linux
+      
       - name: Cache Rust dependencies
         uses: actions/cache@v4
         with:
@@ -181,8 +192,14 @@ jobs:
     name: Smoke Test Linux
     needs: build-test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container:
+          - alpine:latest
+          - ubuntu:latest
+          - ubuntu:22.04
     container:
-      image: alpine:latest
+      image: ${{ matrix.container }}
     steps:
       - name: Download Linux binary
         uses: actions/download-artifact@v4

--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -5,62 +5,52 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
 
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CARGO_NET_TIMEOUT: 10
+
 jobs:
-  lint:
-    name: Lint
+  # Quick checks that can run in parallel
+  format:
+    name: Format Check
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
-      
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-      
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-      
-      - name: Run clippy
-        run: cargo clippy -- -D warnings
+          components: rustfmt
+      - run: cargo fmt --all -- --check
 
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "clippy"
+      - run: cargo clippy -- -D warnings
+
+  # Tests and builds can run in parallel
   test:
     name: Test
-    needs: lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-      
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-      
+          shared-key: "test"
       - name: Run tests
-        run: cargo test --all-features
+        run: cargo test --workspace
       
-      - name: Install tarpaulin
+      - name: Install cargo-tarpaulin
         run: |
           curl -L https://github.com/xd009642/tarpaulin/releases/download/0.31.2/cargo-tarpaulin-x86_64-unknown-linux-musl.tar.gz | tar xzf - -C $HOME/.cargo/bin
           
@@ -72,132 +62,96 @@ jobs:
           COVERAGE=$(grep -E 'line-rate="[0-9.]+"' cobertura.xml | head -1 | grep -oE '[0-9.]+')
           COVERAGE_PERCENT=$(awk -v cov="$COVERAGE" 'BEGIN {printf "%.2f", cov * 100}')
           echo "Coverage: $COVERAGE_PERCENT%"
-          # Coverage check temporarily disabled for initial setup
-          # if (( $(awk -v cov="$COVERAGE_PERCENT" 'BEGIN {print (cov < 85)}') )); then
-          #   echo "Test coverage is below 85%"
-          #   exit 1
-          # fi
 
-  build-test:
-    name: Build Test
-    needs: test
-    strategy:
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
-          - target: aarch64-apple-darwin
-            os: macos-latest
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-      
-      - name: Install musl tools and dependencies
-        if: matrix.target == 'x86_64-unknown-linux-musl'
-        run: |
-          sudo apt-get update
-          # Install musl tools and dependencies for building vendored OpenSSL
-          sudo apt-get install -y musl-tools perl make
-      
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.target }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ matrix.target }}-
-      
-      - name: Build
-        run: |
-          if [[ "${{ matrix.target }}" == "x86_64-unknown-linux-musl" ]]; then
-            # Configure for musl target
-            export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-gcc
-            export CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc
-            export AR_x86_64_unknown_linux_musl=x86_64-linux-musl-ar
-            # Force static linking and vendored OpenSSL
-            export OPENSSL_STATIC=true
-            export OPENSSL_NO_VENDOR=0
-            # Don't set OPENSSL_DIR/LIB_DIR/INCLUDE_DIR to allow vendored build
-          fi
-          cargo build --release --target ${{ matrix.target }}
-      
-      - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: arkavo-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/arkavo
-          retention-days: 1
-      
-      - name: Verify binary size
-        run: |
-          if [[ "$RUNNER_OS" == "Linux" ]]; then
-            BINARY_SIZE=$(stat -c %s target/${{ matrix.target }}/release/arkavo)
-          else
-            BINARY_SIZE=$(stat -f %z target/${{ matrix.target }}/release/arkavo)
-          fi
-          MAX_SIZE=4294967296  # 4GB in bytes (updated from 1GB)
-          echo "Binary size: $BINARY_SIZE bytes"
-          if (( BINARY_SIZE > MAX_SIZE )); then
-            echo "Binary size exceeds 4GB limit"
-            exit 1
-          fi
-
-  performance-check:
-    name: Performance Check
-    needs: build-test
+  build-linux:
+    name: Build Linux (musl)
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-      
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          targets: x86_64-unknown-linux-musl
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "linux-musl"
+          
+      - name: Install musl tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
       
       - name: Build
-        run: cargo build --release
+        run: cargo build --release --target x86_64-unknown-linux-musl
       
-      - name: Run performance tests
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: arkavo-x86_64-unknown-linux-musl
+          path: target/x86_64-unknown-linux-musl/release/arkavo
+          retention-days: 1
+
+  build-macos:
+    name: Build macOS (ARM64)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "macos-arm64"
+      
+      - name: Build
+        run: cargo build --release --target aarch64-apple-darwin
+      
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: arkavo-aarch64-apple-darwin
+          path: target/aarch64-apple-darwin/release/arkavo
+          retention-days: 1
+
+  # Performance check can run independently
+  performance-check:
+    name: Performance Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "perf"
+      
+      - name: Check binary size
         run: |
-          # Simple performance check - will be enhanced in the future
-          echo "Running performance check..."
-          # Run a simple command that doesn't require arguments
-          START_TIME=$(date +%s%N)
-          timeout 5s ./target/release/arkavo --help || true
-          END_TIME=$(date +%s%N)
-          DURATION=$((($END_TIME - $START_TIME) / 1000000))  # Convert to milliseconds
+          cargo build --release
+          SIZE=$(du -b target/release/arkavo | cut -f1)
+          SIZE_MB=$(( SIZE / 1024 / 1024 ))
+          echo "Binary size: $SIZE_MB MB"
           
-          echo "Command execution time: $DURATION ms"
-          # Relaxed target for help command
-          if (( DURATION > 1000 )); then
-            echo "Performance warning: response time > 1000ms"
-            # Not failing for now
+          if [ $SIZE_MB -gt 100 ]; then
+            echo "Warning: Binary size exceeds 100 MB"
           fi
           
-          echo "Performance check completed"
+      - name: Check build time
+        run: |
+          cargo clean
+          BUILD_START=$(date +%s)
+          cargo build --release
+          BUILD_END=$(date +%s)
+          BUILD_TIME=$((BUILD_END - BUILD_START))
+          
+          echo "Build time: $BUILD_TIME seconds"
+          
+          if [ $BUILD_TIME -gt 300 ]; then
+            echo "Warning: Build time exceeds 5 minutes"
+          fi
 
+  # Smoke tests depend on builds
   smoke-test-linux:
-    name: Smoke Test Linux
-    needs: build-test
+    name: Smoke Test Linux (${{ matrix.container }})
+    needs: build-linux
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -208,38 +162,47 @@ jobs:
     container:
       image: ${{ matrix.container }}
     steps:
-      - name: Download Linux binary
+      - name: Download binary
         uses: actions/download-artifact@v4
         with:
           name: arkavo-x86_64-unknown-linux-musl
           
-      - name: Test binary execution
-        run: |
-          chmod +x arkavo
-          ./arkavo --version
-          
-  smoke-test-macos:
-    name: Smoke Test macOS
-    needs: build-test
-    runs-on: macos-latest
-    steps:
-      - name: Download macOS binary
-        uses: actions/download-artifact@v4
-        with:
-          name: arkavo-aarch64-apple-darwin
-          
-      - name: Test binary execution
+      - name: Test binary
         run: |
           chmod +x arkavo
           ./arkavo --version
 
+  smoke-test-macos:
+    name: Smoke Test macOS
+    needs: build-macos
+    runs-on: macos-latest
+    steps:
+      - name: Download binary
+        uses: actions/download-artifact@v4
+        with:
+          name: arkavo-aarch64-apple-darwin
+          
+      - name: Test binary
+        run: |
+          chmod +x arkavo
+          ./arkavo --version
+
+  # Final check that depends on all critical jobs
   release-readiness:
     name: Release Readiness
-    if: github.event_name == 'pull_request'
-    needs: [lint, test, build-test, performance-check, smoke-test-linux, smoke-test-macos]
+    needs: [format, clippy, test, smoke-test-linux, smoke-test-macos, performance-check]
     runs-on: ubuntu-latest
+    if: always()
     steps:
-      - name: Pull Request is ready for merge
+      - name: Check job results
         run: |
-          echo "All validation checks have passed"
-          echo "This pull request is ready to be merged into main"
+          if [[ "${{ needs.format.result }}" != "success" || \
+                "${{ needs.clippy.result }}" != "success" || \
+                "${{ needs.test.result }}" != "success" || \
+                "${{ needs.smoke-test-linux.result }}" != "success" || \
+                "${{ needs.smoke-test-macos.result }}" != "success" || \
+                "${{ needs.performance-check.result }}" != "success" ]]; then
+            echo "One or more required checks failed"
+            exit 1
+          fi
+          echo "All checks passed! This PR is ready for merge."

--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -123,12 +123,10 @@ jobs:
             export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-gcc
             export CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc
             export AR_x86_64_unknown_linux_musl=x86_64-linux-musl-ar
-            # Tell openssl-sys to use vendored OpenSSL
-            export OPENSSL_SYS_USE_PKG_CONFIG=0
-            export OPENSSL_STATIC=1
-            export OPENSSL_LIB_DIR=OPENSSL_LIB_DIR_DOESNT_EXIST
-            export OPENSSL_INCLUDE_DIR=OPENSSL_INCLUDE_DIR_DOESNT_EXIST
+            # Force static linking and vendored OpenSSL
+            export OPENSSL_STATIC=true
             export OPENSSL_NO_VENDOR=0
+            # Don't set OPENSSL_DIR/LIB_DIR/INCLUDE_DIR to allow vendored build
           fi
           cargo build --release --target ${{ matrix.target }}
       

--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -98,11 +98,12 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       
-      - name: Install musl tools
+      - name: Install musl tools and dependencies
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: |
           sudo apt-get update
-          sudo apt-get install -y musl-tools
+          # Install musl tools and dependencies for building vendored OpenSSL
+          sudo apt-get install -y musl-tools perl make
       
       - name: Cache Rust dependencies
         uses: actions/cache@v4
@@ -118,10 +119,16 @@ jobs:
       - name: Build
         run: |
           if [[ "${{ matrix.target }}" == "x86_64-unknown-linux-musl" ]]; then
-            # Use vendored OpenSSL for musl builds
+            # Configure for musl target
+            export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-gcc
+            export CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc
+            export AR_x86_64_unknown_linux_musl=x86_64-linux-musl-ar
+            # Tell openssl-sys to use vendored OpenSSL
+            export OPENSSL_SYS_USE_PKG_CONFIG=0
             export OPENSSL_STATIC=1
-            export OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
-            export OPENSSL_INCLUDE_DIR=/usr/include
+            export OPENSSL_LIB_DIR=OPENSSL_LIB_DIR_DOESNT_EXIST
+            export OPENSSL_INCLUDE_DIR=OPENSSL_INCLUDE_DIR_DOESNT_EXIST
+            export OPENSSL_NO_VENDOR=0
           fi
           cargo build --release --target ${{ matrix.target }}
       

--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -182,7 +182,7 @@ jobs:
     needs: build-test
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:22.04
+      image: ubuntu:latest
     steps:
       - name: Download Linux binary
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,16 +77,24 @@ jobs:
           profile: minimal
           override: true
           
-      - name: Install musl tools
+      - name: Install musl tools and dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y musl-tools
+          # Install musl tools and dependencies for building vendored OpenSSL
+          sudo apt-get install -y musl-tools perl make
           
       - name: Build
         env:
+          # Configure for musl target
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: x86_64-linux-musl-gcc
+          CC_x86_64_unknown_linux_musl: x86_64-linux-musl-gcc
+          AR_x86_64_unknown_linux_musl: x86_64-linux-musl-ar
+          # Tell openssl-sys to use vendored OpenSSL
+          OPENSSL_SYS_USE_PKG_CONFIG: 0
           OPENSSL_STATIC: 1
-          OPENSSL_LIB_DIR: /usr/lib/x86_64-linux-gnu
-          OPENSSL_INCLUDE_DIR: /usr/include
+          OPENSSL_LIB_DIR: OPENSSL_LIB_DIR_DOESNT_EXIST
+          OPENSSL_INCLUDE_DIR: OPENSSL_INCLUDE_DIR_DOESNT_EXIST
+          OPENSSL_NO_VENDOR: 0
         uses: actions-rs/cargo@v1
         with:
           command: build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,17 +77,16 @@ jobs:
           profile: minimal
           override: true
           
-      - name: Install musl tools and dependencies
+      - name: Install musl tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y musl-tools musl-dev
-          sudo apt-get install -y libssl-dev pkg-config
-          # Install musl-compatible OpenSSL
-          sudo ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/x86_64-linux-musl/asm
-          sudo ln -s /usr/include/asm-generic /usr/include/x86_64-linux-musl/asm-generic
-          sudo ln -s /usr/include/linux /usr/include/x86_64-linux-musl/linux
+          sudo apt-get install -y musl-tools
           
       - name: Build
+        env:
+          OPENSSL_STATIC: 1
+          OPENSSL_LIB_DIR: /usr/lib/x86_64-linux-gnu
+          OPENSSL_INCLUDE_DIR: /usr/include
         uses: actions-rs/cargo@v1
         with:
           command: build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -213,7 +213,7 @@ jobs:
     name: Smoke Test Linux Binary
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:22.04
+      image: ubuntu:latest
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,21 +77,12 @@ jobs:
           profile: minimal
           override: true
           
-      - name: Install musl tools and dependencies
+      - name: Install musl tools
         run: |
           sudo apt-get update
-          # Install musl tools and dependencies for building vendored OpenSSL
-          sudo apt-get install -y musl-tools perl make
+          sudo apt-get install -y musl-tools
           
       - name: Build
-        env:
-          # Configure for musl target
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: x86_64-linux-musl-gcc
-          CC_x86_64_unknown_linux_musl: x86_64-linux-musl-gcc
-          AR_x86_64_unknown_linux_musl: x86_64-linux-musl-ar
-          # Force static linking and vendored OpenSSL
-          OPENSSL_STATIC: true
-          OPENSSL_NO_VENDOR: 0
         uses: actions-rs/cargo@v1
         with:
           command: build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,6 +77,16 @@ jobs:
           profile: minimal
           override: true
           
+      - name: Install musl tools and dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools musl-dev
+          sudo apt-get install -y libssl-dev pkg-config
+          # Install musl-compatible OpenSSL
+          sudo ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/x86_64-linux-musl/asm
+          sudo ln -s /usr/include/asm-generic /usr/include/x86_64-linux-musl/asm-generic
+          sudo ln -s /usr/include/linux /usr/include/x86_64-linux-musl/linux
+          
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -212,8 +222,13 @@ jobs:
     needs: [release, build-linux-x86_64]
     name: Smoke Test Linux Binary
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container:
+          - ubuntu:latest
+          - ubuntu:22.04
     container:
-      image: ubuntu:22.04
+      image: ${{ matrix.container }}
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,11 +89,8 @@ jobs:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: x86_64-linux-musl-gcc
           CC_x86_64_unknown_linux_musl: x86_64-linux-musl-gcc
           AR_x86_64_unknown_linux_musl: x86_64-linux-musl-ar
-          # Tell openssl-sys to use vendored OpenSSL
-          OPENSSL_SYS_USE_PKG_CONFIG: 0
-          OPENSSL_STATIC: 1
-          OPENSSL_LIB_DIR: OPENSSL_LIB_DIR_DOESNT_EXIST
-          OPENSSL_INCLUDE_DIR: OPENSSL_INCLUDE_DIR_DOESNT_EXIST
+          # Force static linking and vendored OpenSSL
+          OPENSSL_STATIC: true
           OPENSSL_NO_VENDOR: 0
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Release ${{ steps.version.outputs.tag }}
           draft: false
-          prerelease: false
+          prerelease: true
           generate_release_notes: true
           body: |
             ## Arkavo Edge ${{ steps.version.outputs.tag }}
@@ -55,8 +55,9 @@ jobs:
             
             ### Binaries
             
-            - Linux (x64): arkavo-${{ steps.version.outputs.version }}-x86_64-unknown-linux-gnu
-            - macOS (ARM64): arkavo-${{ steps.version.outputs.version }}-aarch64-apple-darwin
+            - Linux (x64): arkavo-${{ steps.version.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz
+            - Linux (x64, .deb): arkavo_${{ steps.version.outputs.version }}_amd64.deb
+            - macOS (ARM64): arkavo-${{ steps.version.outputs.version }}-aarch64-apple-darwin.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             
@@ -88,6 +89,28 @@ jobs:
           strip arkavo
           tar -czf arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz arkavo
           shasum -a 256 arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz > arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz.sha256
+          
+      - name: Create .deb package
+        run: |
+          mkdir -p debian/DEBIAN
+          mkdir -p debian/usr/bin
+          cp target/x86_64-unknown-linux-gnu/release/arkavo debian/usr/bin/
+          cat > debian/DEBIAN/control << EOF
+          Package: arkavo
+          Version: ${{ needs.release.outputs.version }}
+          Architecture: amd64
+          Maintainer: Arkavo LLC <support@arkavo.com>
+          Description: Arkavo Edge - AI-agent development CLI tool
+           Arkavo Edge is an open-source agentic CLI tool that provides
+           developer-centric capabilities for AI-agent development and
+           framework maintenance.
+          Section: devel
+          Priority: optional
+          Homepage: https://github.com/arkavo/arkavo-edge
+          EOF
+          dpkg-deb --build debian arkavo_${{ needs.release.outputs.version }}_amd64.deb
+          dpkg-deb --info arkavo_${{ needs.release.outputs.version }}_amd64.deb
+          shasum -a 256 arkavo_${{ needs.release.outputs.version }}_amd64.deb > arkavo_${{ needs.release.outputs.version }}_amd64.deb.sha256
       
       - name: Upload Release Assets
         uses: softprops/action-gh-release@v1
@@ -96,6 +119,8 @@ jobs:
           files: |
             ./target/x86_64-unknown-linux-gnu/release/arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz
             ./target/x86_64-unknown-linux-gnu/release/arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz.sha256
+            ./arkavo_${{ needs.release.outputs.version }}_amd64.deb
+            ./arkavo_${{ needs.release.outputs.version }}_amd64.deb.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
@@ -180,5 +205,58 @@ jobs:
           files: |
             ./target/aarch64-apple-darwin/release/arkavo-${{ needs.release.outputs.version }}-aarch64-apple-darwin.tar.gz
             ./target/aarch64-apple-darwin/release/arkavo-${{ needs.release.outputs.version }}-aarch64-apple-darwin.tar.gz.sha256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
+  smoke-test-linux:
+    needs: [release, build-linux-x86_64]
+    name: Smoke Test Linux Binary
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:22.04
+    steps:
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y curl ca-certificates
+          
+      - name: Download and test tar.gz binary
+        run: |
+          curl -L -o arkavo.tar.gz https://github.com/${{ github.repository }}/releases/download/${{ needs.release.outputs.version }}/arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz
+          tar -xzf arkavo.tar.gz
+          chmod +x arkavo
+          ./arkavo --version
+          
+      - name: Download and test .deb package
+        run: |
+          curl -L -o arkavo.deb https://github.com/${{ github.repository }}/releases/download/${{ needs.release.outputs.version }}/arkavo_${{ needs.release.outputs.version }}_amd64.deb
+          apt-get install -y ./arkavo.deb
+          arkavo --version
+  
+  smoke-test-macos:
+    needs: [release, build-macos-arm64]
+    name: Smoke Test macOS Binary
+    runs-on: macos-latest
+    steps:
+      - name: Download and test binary
+        run: |
+          curl -L -o arkavo.tar.gz https://github.com/${{ github.repository }}/releases/download/${{ needs.release.outputs.version }}/arkavo-${{ needs.release.outputs.version }}-aarch64-apple-darwin.tar.gz
+          tar -xzf arkavo.tar.gz
+          chmod +x arkavo
+          ./arkavo --version
+  
+  publish-release:
+    needs: [release, smoke-test-linux, smoke-test-macos]
+    name: Publish Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        
+      - name: Update release to published
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.release.outputs.version }}
+          prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
             
             ### Binaries
             
-            - Linux (x64): arkavo-${{ steps.version.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz
+            - Linux (x64): arkavo-${{ steps.version.outputs.version }}-x86_64-unknown-linux-musl.tar.gz
             - Linux (x64, .deb): arkavo_${{ steps.version.outputs.version }}_amd64.deb
             - macOS (ARM64): arkavo-${{ steps.version.outputs.version }}-aarch64-apple-darwin.tar.gz
         env:
@@ -73,7 +73,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: x86_64-unknown-linux-gnu
+          target: x86_64-unknown-linux-musl
           profile: minimal
           override: true
           
@@ -81,20 +81,20 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --target x86_64-unknown-linux-gnu
+          args: --release --target x86_64-unknown-linux-musl
           
       - name: Prepare binary
         run: |
-          cd target/x86_64-unknown-linux-gnu/release
+          cd target/x86_64-unknown-linux-musl/release
           strip arkavo
-          tar -czf arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz arkavo
-          shasum -a 256 arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz > arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz.sha256
+          tar -czf arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-musl.tar.gz arkavo
+          shasum -a 256 arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-musl.tar.gz > arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-musl.tar.gz.sha256
           
       - name: Create .deb package
         run: |
           mkdir -p debian/DEBIAN
           mkdir -p debian/usr/bin
-          cp target/x86_64-unknown-linux-gnu/release/arkavo debian/usr/bin/
+          cp target/x86_64-unknown-linux-musl/release/arkavo debian/usr/bin/
           cat > debian/DEBIAN/control << EOF
           Package: arkavo
           Version: ${{ needs.release.outputs.version }}
@@ -117,8 +117,8 @@ jobs:
         with:
           tag_name: ${{ needs.release.outputs.version }}
           files: |
-            ./target/x86_64-unknown-linux-gnu/release/arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz
-            ./target/x86_64-unknown-linux-gnu/release/arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz.sha256
+            ./target/x86_64-unknown-linux-musl/release/arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-musl.tar.gz
+            ./target/x86_64-unknown-linux-musl/release/arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-musl.tar.gz.sha256
             ./arkavo_${{ needs.release.outputs.version }}_amd64.deb
             ./arkavo_${{ needs.release.outputs.version }}_amd64.deb.sha256
         env:
@@ -213,7 +213,7 @@ jobs:
     name: Smoke Test Linux Binary
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:latest
+      image: ubuntu:22.04
     steps:
       - name: Install dependencies
         run: |
@@ -222,7 +222,7 @@ jobs:
           
       - name: Download and test tar.gz binary
         run: |
-          curl -L -o arkavo.tar.gz https://github.com/${{ github.repository }}/releases/download/${{ needs.release.outputs.version }}/arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz
+          curl -L -o arkavo.tar.gz https://github.com/${{ github.repository }}/releases/download/${{ needs.release.outputs.version }}/arkavo-${{ needs.release.outputs.version }}-x86_64-unknown-linux-musl.tar.gz
           tar -xzf arkavo.tar.gz
           chmod +x arkavo
           ./arkavo --version

--- a/.github/workflows/version-check.yaml
+++ b/.github/workflows/version-check.yaml
@@ -1,0 +1,80 @@
+name: Version Check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  version-check:
+    name: Verify Version Increment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Get PR branch version
+        id: pr_version
+        run: |
+          VERSION=$(grep '^version =' Cargo.toml | head -n 1 | cut -d'"' -f2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "PR branch version: $VERSION"
+          
+      - name: Get main branch version
+        id: main_version
+        run: |
+          git fetch origin main:main
+          MAIN_VERSION=$(git show main:Cargo.toml | grep '^version =' | head -n 1 | cut -d'"' -f2)
+          echo "version=$MAIN_VERSION" >> $GITHUB_OUTPUT
+          echo "Main branch version: $MAIN_VERSION"
+          
+      - name: Compare versions
+        run: |
+          PR_VERSION="${{ steps.pr_version.outputs.version }}"
+          MAIN_VERSION="${{ steps.main_version.outputs.version }}"
+          
+          echo "Comparing versions:"
+          echo "  Main branch: $MAIN_VERSION"
+          echo "  PR branch:   $PR_VERSION"
+          
+          # Function to compare semantic versions
+          version_gt() {
+            test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"
+          }
+          
+          if [ "$PR_VERSION" = "$MAIN_VERSION" ]; then
+            echo "❌ ERROR: Version has not been incremented!"
+            echo "The version in Cargo.toml must be greater than the current version on main branch."
+            echo ""
+            echo "Current version on main: $MAIN_VERSION"
+            echo "Your PR version:        $PR_VERSION"
+            echo ""
+            echo "Please update the version in Cargo.toml to a higher version number."
+            echo "For example, if current is 0.1.0, you could use 0.1.1, 0.2.0, or 1.0.0"
+            exit 1
+          elif version_gt "$MAIN_VERSION" "$PR_VERSION"; then
+            echo "❌ ERROR: PR version is lower than main branch version!"
+            echo "The version in Cargo.toml must be greater than the current version on main branch."
+            echo ""
+            echo "Current version on main: $MAIN_VERSION"
+            echo "Your PR version:        $PR_VERSION"
+            exit 1
+          else
+            echo "✅ Version has been properly incremented from $MAIN_VERSION to $PR_VERSION"
+          fi
+          
+      - name: Check version format
+        run: |
+          VERSION="${{ steps.pr_version.outputs.version }}"
+          
+          # Verify semantic versioning format (X.Y.Z)
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "❌ ERROR: Invalid version format!"
+            echo "Version must follow semantic versioning (X.Y.Z)"
+            echo "Current version: $VERSION"
+            exit 1
+          fi
+          
+          echo "✅ Version format is valid: $VERSION"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,12 +162,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,7 +179,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -291,6 +285,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,16 +356,6 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "core-foundation-sys"
@@ -627,21 +617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,8 +741,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -777,9 +754,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -823,25 +802,6 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http 1.3.1",
  "indexmap",
  "slab",
  "tokio",
@@ -995,7 +955,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1018,7 +978,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -1043,22 +1002,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1067,13 +1011,16 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1235,6 +1182,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1293,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,23 +1365,6 @@ dependencies = [
  "mime",
  "spin",
  "version_check",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1547,50 +1493,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "openssl"
-version = "0.10.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.108"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,7 +1524,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1736,12 +1638,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,8 +1703,8 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -1821,6 +1717,61 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand 0.9.1",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.12",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "quote"
@@ -1844,8 +1795,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1855,7 +1816,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1868,12 +1839,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1984,47 +1964,45 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.10",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-registry",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2048,6 +2026,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,19 +2051,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -2088,6 +2064,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2136,15 +2113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,29 +2123,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "serde"
@@ -2356,27 +2301,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,6 +2395,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,16 +2436,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -2555,6 +2484,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -2651,7 +2598,7 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
  "url",
@@ -2777,12 +2724,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2950,6 +2891,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2990,7 +2950,7 @@ dependencies = [
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings 0.4.2",
+ "windows-strings",
 ]
 
 [[package]]
@@ -3022,30 +2982,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
-name = "windows-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
-dependencies = [
- "windows-result",
- "windows-strings 0.3.1",
- "windows-targets 0.53.0",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
  "windows-link",
 ]
@@ -3065,7 +3005,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3074,7 +3014,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3083,30 +3023,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3116,22 +3040,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3140,22 +3052,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3164,22 +3064,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3188,22 +3076,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arkavo"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "arkavo-cli",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -98,27 +98,27 @@ dependencies = [
 
 [[package]]
 name = "arkavo-encryption"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "arkavo-git"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "arkavo-repo"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "arkavo-test"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-vault"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "async-trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["Arkavo Edge Contributors"]
 license = "Apache-2.0"

--- a/crates/arkavo-test/Cargo.toml
+++ b/crates/arkavo-test/Cargo.toml
@@ -32,7 +32,7 @@ gherkin = "0.14"
 bincode = "1.3"
 
 # HTTP client for AI integration
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 # Time handling
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
## Summary
- Add smoke tests to release and feature workflows to catch runtime issues early
- Mark releases as pre-release initially, then publish after validation
- Add .deb package creation for Linux distributions
- **Use musl libc for Linux builds to ensure maximum portability** (fixes #34)

## Changes
1. **Release workflow**:
   - Initial releases are marked as `prerelease: true`
   - Added smoke test jobs that download and test binaries on pristine environments
   - Added .deb package creation for easier Linux installation
   - Added `publish-release` job that marks release as published after successful tests
   - **Changed Linux target to `x86_64-unknown-linux-musl` for static binaries**

2. **Feature workflow**:
   - Upload built binaries as artifacts
   - Added smoke tests that download and test binaries on clean systems
   - Updated release-readiness to depend on smoke test success
   - **Changed Linux target to `x86_64-unknown-linux-musl`**

## Rationale for musl
- Produces fully static binaries that work on any Linux distribution
- No GLIBC version compatibility issues
- Maximum portability for CLI tools
- Fixes #34

## Test plan
- [x] Workflow syntax is valid
- [ ] Feature workflow smoke tests pass on PR
- [ ] Linux musl binaries execute on Alpine and Ubuntu
- [ ] Release workflow creates pre-release on merge
- [ ] .deb package installs correctly on Ubuntu/Debian
- [ ] Release is marked as published after validation

🤖 Generated with [Claude Code](https://claude.ai/code)