### PR TITLE
feat: implement basic chat command with LLM integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arkavo"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arkavo-cli",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -100,15 +100,15 @@ dependencies = [
 
 [[package]]
 name = "arkavo-encryption"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "arkavo-git"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "arkavo-llm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -124,19 +124,19 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "arkavo-repo"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "arkavo-test"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-vault"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "async-trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 authors = ["Arkavo Edge Contributors"]
 license = "Apache-2.0"

--- a/crates/arkavo-cli/src/commands/chat.rs
+++ b/crates/arkavo-cli/src/commands/chat.rs
@@ -55,7 +55,10 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
             match client.list_tools() {
                 Ok(tools) => {
                     let tool_names: Vec<String> = tools.iter().map(|t| t.name.clone()).collect();
-                    format!("\n\nMCP Integration: Enabled\nAvailable MCP tools: {}\nYou can run tests and interact with iOS simulators through MCP tools.", tool_names.join(", "))
+                    format!(
+                        "\n\nMCP Integration: Enabled\nAvailable MCP tools: {}\nYou can run tests and interact with iOS simulators through MCP tools.",
+                        tool_names.join(", ")
+                    )
                 }
                 Err(e) => {
                     eprintln!("Warning: Failed to list MCP tools: {}", e);
@@ -66,7 +69,8 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
             "\n\nMCP Integration: Enabled\nYou can run tests and interact with iOS simulators through MCP tools.".to_string()
         }
     } else {
-        "\n\nMCP Integration: Disabled\nTo enable MCP tools, set ARKAVO_MCP_ENABLED=true".to_string()
+        "\n\nMCP Integration: Disabled\nTo enable MCP tools, set ARKAVO_MCP_ENABLED=true"
+            .to_string()
     };
 
     let system_prompt = format!(
@@ -114,7 +118,8 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
         }
 
         // Check for file operation commands
-        if let Some(command_response) = handle_command(input, &mcp_client, &client.provider_name()) {
+        if let Some(command_response) = handle_command(input, &mcp_client, &client.provider_name())
+        {
             println!("Assistant: {}", command_response);
             println!();
             continue;
@@ -257,7 +262,11 @@ fn get_repository_context() -> String {
     context
 }
 
-fn handle_command(input: &str, mcp_client: &Option<McpClient>, llm_provider: &str) -> Option<String> {
+fn handle_command(
+    input: &str,
+    mcp_client: &Option<McpClient>,
+    llm_provider: &str,
+) -> Option<String> {
     let parts: Vec<&str> = input.split_whitespace().collect();
     if parts.is_empty() {
         return None;
@@ -269,14 +278,10 @@ fn handle_command(input: &str, mcp_client: &Option<McpClient>, llm_provider: &st
                 return Some("Usage: read <file_path>".to_string());
             }
             let file_path = parts[1..].join(" ");
-            
+
             // Use MCP if available
             if let Some(client) = mcp_client {
-                match client.call_tool(
-                    "read_file",
-                    json!({ "path": file_path }),
-                    llm_provider,
-                ) {
+                match client.call_tool("read_file", json!({ "path": file_path }), llm_provider) {
                     Ok(result) => {
                         if let Some(text) = result.get("result").and_then(|r| r.as_str()) {
                             Some(format!("Content of {} (via MCP):\n\n{}", file_path, text))
@@ -299,14 +304,10 @@ fn handle_command(input: &str, mcp_client: &Option<McpClient>, llm_provider: &st
             } else {
                 ".".to_string()
             };
-            
+
             // Use MCP if available
             if let Some(client) = mcp_client {
-                match client.call_tool(
-                    "list_directory",
-                    json!({ "path": path }),
-                    llm_provider,
-                ) {
+                match client.call_tool("list_directory", json!({ "path": path }), llm_provider) {
                     Ok(result) => {
                         if let Some(text) = result.get("result").and_then(|r| r.as_str()) {
                             Some(format!("Contents of {} (via MCP):\n\n{}", path, text))
@@ -334,13 +335,9 @@ fn handle_command(input: &str, mcp_client: &Option<McpClient>, llm_provider: &st
             if mcp_client.is_none() {
                 return Some("MCP integration is disabled. Set ARKAVO_MCP_ENABLED=true to enable test commands.".to_string());
             }
-            
+
             if let Some(client) = mcp_client {
-                match client.call_tool(
-                    "list_tests",
-                    json!({}),
-                    llm_provider,
-                ) {
+                match client.call_tool("list_tests", json!({}), llm_provider) {
                     Ok(result) => {
                         if let Some(text) = result.get("result").and_then(|r| r.as_str()) {
                             Some(format!("Available tests (via MCP):\n\n{}", text))
@@ -361,14 +358,11 @@ fn handle_command(input: &str, mcp_client: &Option<McpClient>, llm_provider: &st
             if mcp_client.is_none() {
                 return Some("MCP integration is disabled. Set ARKAVO_MCP_ENABLED=true to enable test commands.".to_string());
             }
-            
+
             let test_name = parts[1..].join(" ");
             if let Some(client) = mcp_client {
-                match client.call_tool(
-                    "run_test",
-                    json!({ "test_name": test_name }),
-                    llm_provider,
-                ) {
+                match client.call_tool("run_test", json!({ "test_name": test_name }), llm_provider)
+                {
                     Ok(result) => {
                         if let Some(text) = result.get("result").and_then(|r| r.as_str()) {
                             Some(format!("Test execution result (via MCP):\n\n{}", text))
@@ -395,7 +389,10 @@ fn handle_command(input: &str, mcp_client: &Option<McpClient>, llm_provider: &st
                     Err(e) => Some(format!("Failed to list MCP tools: {}", e)),
                 }
             } else {
-                Some("MCP integration is disabled. Set ARKAVO_MCP_ENABLED=true to enable MCP tools.".to_string())
+                Some(
+                    "MCP integration is disabled. Set ARKAVO_MCP_ENABLED=true to enable MCP tools."
+                        .to_string(),
+                )
             }
         }
         _ => None,

--- a/crates/arkavo-cli/src/commands/chat.rs
+++ b/crates/arkavo-cli/src/commands/chat.rs
@@ -35,7 +35,7 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     } else {
         "\n\nMCP Integration: Disabled\nTo enable MCP tools, set ARKAVO_MCP_ENABLED=true"
     };
-    
+
     let system_prompt = format!(
         "You are Arkavo, an AI assistant helping with software development tasks. \
          You have access to the current repository context and can help with code, \
@@ -44,8 +44,7 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
 \
          Repository context:
 {}{}",
-        repo_context,
-        mcp_info
+        repo_context, mcp_info
     );
     let mut messages = vec![Message::system(&system_prompt)];
 
@@ -168,14 +167,14 @@ fn get_current_directory() -> String {
 fn get_repository_context() -> String {
     let current_dir = env::current_dir().unwrap_or_default();
     let mut context = String::new();
-    
+
     // Get basic repository info
     context.push_str(&format!("Working directory: {}\n", current_dir.display()));
-    
+
     // Check if it's a git repository
     if Path::new(".git").exists() {
         context.push_str("Git repository: Yes\n");
-        
+
         // Get current branch
         if let Ok(output) = std::process::Command::new("git")
             .args(["branch", "--show-current"])
@@ -189,7 +188,7 @@ fn get_repository_context() -> String {
     } else {
         context.push_str("Git repository: No\n");
     }
-    
+
     // List key project files
     context.push_str("\nProject structure:\n");
     if let Ok(entries) = fs::read_dir(&current_dir) {
@@ -198,25 +197,30 @@ fn get_repository_context() -> String {
             .map(|e| e.file_name().to_string_lossy().to_string())
             .collect();
         files.sort();
-        
+
         for file in files.iter().take(20) {
             context.push_str(&format!("  - {}\n", file));
         }
-        
+
         if files.len() > 20 {
             context.push_str(&format!("  ... and {} more files\n", files.len() - 20));
         }
     }
-    
+
     // Check for common project files
-    let project_files = vec!["Cargo.toml", "package.json", "README.md", "requirements.txt"];
+    let project_files = vec![
+        "Cargo.toml",
+        "package.json",
+        "README.md",
+        "requirements.txt",
+    ];
     for file in project_files {
         if Path::new(file).exists() {
             context.push_str(&format!("\nDetected project type: {}\n", file));
             break;
         }
     }
-    
+
     context
 }
 
@@ -225,7 +229,7 @@ fn handle_command(input: &str) -> Option<String> {
     if parts.is_empty() {
         return None;
     }
-    
+
     match parts[0] {
         "read" | "cat" => {
             if parts.len() < 2 {
@@ -291,12 +295,12 @@ fn read_file(file_path: &str) -> Option<String> {
 
 fn list_files(path: &str) -> Option<String> {
     let path = Path::new(path);
-    
+
     match fs::read_dir(path) {
         Ok(entries) => {
             let mut files = Vec::new();
             let mut dirs = Vec::new();
-            
+
             for entry in entries.filter_map(|e| e.ok()) {
                 let file_name = entry.file_name().to_string_lossy().to_string();
                 if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
@@ -305,26 +309,30 @@ fn list_files(path: &str) -> Option<String> {
                     files.push(file_name);
                 }
             }
-            
+
             dirs.sort();
             files.sort();
-            
+
             let mut result = format!("Contents of {}:\n\n", path.display());
-            
+
             for dir in &dirs {
                 result.push_str(&format!("  {}\n", dir));
             }
-            
+
             for file in &files {
                 result.push_str(&format!("  {}\n", file));
             }
-            
+
             if dirs.is_empty() && files.is_empty() {
                 result.push_str("  (empty directory)");
             }
-            
+
             Some(result)
         }
-        Err(e) => Some(format!("Error listing directory '{}': {}", path.display(), e)),
+        Err(e) => Some(format!(
+            "Error listing directory '{}': {}",
+            path.display(),
+            e
+        )),
     }
 }

--- a/crates/arkavo-cli/src/commands/chat.rs
+++ b/crates/arkavo-cli/src/commands/chat.rs
@@ -118,7 +118,7 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
         }
 
         // Check for file operation commands
-        if let Some(command_response) = handle_command(input, &mcp_client, &client.provider_name())
+        if let Some(command_response) = handle_command(input, &mcp_client, client.provider_name())
         {
             println!("Assistant: {}", command_response);
             println!();

--- a/crates/arkavo-cli/src/commands/chat.rs
+++ b/crates/arkavo-cli/src/commands/chat.rs
@@ -1,6 +1,8 @@
 use arkavo_llm::{LlmClient, Message};
 use std::env;
+use std::fs;
 use std::io::{self, Write};
+use std::path::Path;
 use tokio::runtime::Runtime;
 use tokio_stream::StreamExt;
 
@@ -23,14 +25,29 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     println!("Repository context: {}", get_current_directory());
     println!("LLM Provider: {}", client.provider_name());
     println!("Type 'exit' or 'quit' to end the session.");
+    println!("Commands: read <file>, list [path], explain <file>, test, run <test_name>");
     println!();
 
-    // Initialize conversation with system message
-    let mut messages = vec![Message::system(
+    // Initialize conversation with system message including repository context
+    let repo_context = get_repository_context();
+    let mcp_info = if std::env::var("ARKAVO_MCP_ENABLED").unwrap_or_default() == "true" {
+        "\n\nMCP Integration: Enabled\nYou can run tests and interact with iOS simulators through MCP tools."
+    } else {
+        "\n\nMCP Integration: Disabled\nTo enable MCP tools, set ARKAVO_MCP_ENABLED=true"
+    };
+    
+    let system_prompt = format!(
         "You are Arkavo, an AI assistant helping with software development tasks. \
          You have access to the current repository context and can help with code, \
-         testing, and development workflows.",
-    )];
+         testing, and development workflows.
+
+\
+         Repository context:
+{}{}",
+        repo_context,
+        mcp_info
+    );
+    let mut messages = vec![Message::system(&system_prompt)];
 
     // If prompt provided via command line, process it and exit
     if let Some(prompt_text) = prompt {
@@ -64,8 +81,32 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
             continue;
         }
 
+        // Check for file operation commands
+        if let Some(command_response) = handle_command(input) {
+            println!("Assistant: {}", command_response);
+            println!();
+            continue;
+        }
+
+        // Check if input contains explain command - enhance with file context
+        let enhanced_input = if input.starts_with("explain ") {
+            let parts: Vec<&str> = input.split_whitespace().collect();
+            if parts.len() >= 2 {
+                let file_path = parts[1..].join(" ");
+                if let Some(content) = read_file(&file_path) {
+                    format!("{}\n\nFile content:\n{}", input, content)
+                } else {
+                    input.to_string()
+                }
+            } else {
+                input.to_string()
+            }
+        } else {
+            input.to_string()
+        };
+
         // Add user message
-        messages.push(Message::user(input));
+        messages.push(Message::user(&enhanced_input));
 
         // Process with LLM
         match runtime.block_on(process_message(&client, &messages)) {
@@ -121,5 +162,169 @@ fn get_current_directory() -> String {
     match env::current_dir() {
         Ok(path) => path.display().to_string(),
         Err(_) => String::from("Unknown"),
+    }
+}
+
+fn get_repository_context() -> String {
+    let current_dir = env::current_dir().unwrap_or_default();
+    let mut context = String::new();
+    
+    // Get basic repository info
+    context.push_str(&format!("Working directory: {}\n", current_dir.display()));
+    
+    // Check if it's a git repository
+    if Path::new(".git").exists() {
+        context.push_str("Git repository: Yes\n");
+        
+        // Get current branch
+        if let Ok(output) = std::process::Command::new("git")
+            .args(["branch", "--show-current"])
+            .output()
+        {
+            if output.status.success() {
+                let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                context.push_str(&format!("Current branch: {}\n", branch));
+            }
+        }
+    } else {
+        context.push_str("Git repository: No\n");
+    }
+    
+    // List key project files
+    context.push_str("\nProject structure:\n");
+    if let Ok(entries) = fs::read_dir(&current_dir) {
+        let mut files: Vec<String> = entries
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        files.sort();
+        
+        for file in files.iter().take(20) {
+            context.push_str(&format!("  - {}\n", file));
+        }
+        
+        if files.len() > 20 {
+            context.push_str(&format!("  ... and {} more files\n", files.len() - 20));
+        }
+    }
+    
+    // Check for common project files
+    let project_files = vec!["Cargo.toml", "package.json", "README.md", "requirements.txt"];
+    for file in project_files {
+        if Path::new(file).exists() {
+            context.push_str(&format!("\nDetected project type: {}\n", file));
+            break;
+        }
+    }
+    
+    context
+}
+
+fn handle_command(input: &str) -> Option<String> {
+    let parts: Vec<&str> = input.split_whitespace().collect();
+    if parts.is_empty() {
+        return None;
+    }
+    
+    match parts[0] {
+        "read" | "cat" => {
+            if parts.len() < 2 {
+                return Some("Usage: read <file_path>".to_string());
+            }
+            let file_path = parts[1..].join(" ");
+            read_file(&file_path)
+        }
+        "list" | "ls" => {
+            let path = if parts.len() > 1 {
+                parts[1..].join(" ")
+            } else {
+                ".".to_string()
+            };
+            list_files(&path)
+        }
+        "explain" => {
+            if parts.len() < 2 {
+                return Some("Usage: explain <file_path>".to_string());
+            }
+            // This will be handled by the LLM with file context
+            None
+        }
+        "test" => {
+            if std::env::var("ARKAVO_MCP_ENABLED").unwrap_or_default() != "true" {
+                return Some("MCP integration is disabled. Set ARKAVO_MCP_ENABLED=true to enable test commands.".to_string());
+            }
+            // Let the LLM handle test requests through MCP
+            None
+        }
+        "run" => {
+            if parts.len() < 2 {
+                return Some("Usage: run <test_name>".to_string());
+            }
+            if std::env::var("ARKAVO_MCP_ENABLED").unwrap_or_default() != "true" {
+                return Some("MCP integration is disabled. Set ARKAVO_MCP_ENABLED=true to enable test commands.".to_string());
+            }
+            // Let the LLM handle test execution through MCP
+            None
+        }
+        _ => None,
+    }
+}
+
+fn read_file(file_path: &str) -> Option<String> {
+    match fs::read_to_string(file_path) {
+        Ok(content) => {
+            let lines: Vec<&str> = content.lines().collect();
+            let preview = if lines.len() > 50 {
+                format!(
+                    "{}\n\n... (showing first 50 lines of {} total lines)",
+                    lines[..50].join("\n"),
+                    lines.len()
+                )
+            } else {
+                content
+            };
+            Some(format!("Content of {}:\n\n{}", file_path, preview))
+        }
+        Err(e) => Some(format!("Error reading file '{}': {}", file_path, e)),
+    }
+}
+
+fn list_files(path: &str) -> Option<String> {
+    let path = Path::new(path);
+    
+    match fs::read_dir(path) {
+        Ok(entries) => {
+            let mut files = Vec::new();
+            let mut dirs = Vec::new();
+            
+            for entry in entries.filter_map(|e| e.ok()) {
+                let file_name = entry.file_name().to_string_lossy().to_string();
+                if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                    dirs.push(format!("{}/ (dir)", file_name));
+                } else {
+                    files.push(file_name);
+                }
+            }
+            
+            dirs.sort();
+            files.sort();
+            
+            let mut result = format!("Contents of {}:\n\n", path.display());
+            
+            for dir in &dirs {
+                result.push_str(&format!("  {}\n", dir));
+            }
+            
+            for file in &files {
+                result.push_str(&format!("  {}\n", file));
+            }
+            
+            if dirs.is_empty() && files.is_empty() {
+                result.push_str("  (empty directory)");
+            }
+            
+            Some(result)
+        }
+        Err(e) => Some(format!("Error listing directory '{}': {}", path.display(), e)),
     }
 }

--- a/crates/arkavo-cli/src/commands/chat.rs
+++ b/crates/arkavo-cli/src/commands/chat.rs
@@ -118,8 +118,7 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
         }
 
         // Check for file operation commands
-        if let Some(command_response) = handle_command(input, &mcp_client, client.provider_name())
-        {
+        if let Some(command_response) = handle_command(input, &mcp_client, client.provider_name()) {
             println!("Assistant: {}", command_response);
             println!();
             continue;

--- a/crates/arkavo-cli/src/lib.rs
+++ b/crates/arkavo-cli/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod commands;
+pub mod mcp_client;
 
 pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     if args.is_empty() {

--- a/crates/arkavo-cli/src/mcp_client.rs
+++ b/crates/arkavo-cli/src/mcp_client.rs
@@ -1,0 +1,244 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone)]
+pub struct McpClient {
+    process: Arc<Mutex<Child>>,
+    request_id: Arc<Mutex<u64>>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcRequest {
+    jsonrpc: String,
+    id: u64,
+    method: String,
+    params: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcResponse {
+    jsonrpc: String,
+    id: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcError {
+    code: i32,
+    message: String,
+    data: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolCallMetadata {
+    pub timestamp: u64,
+    pub llm_origin: String,
+    pub tool_name: String,
+    pub arguments: Value,
+    pub request_id: u64,
+}
+
+impl McpClient {
+    pub fn new(mcp_url: Option<String>) -> Result<Self, Box<dyn std::error::Error>> {
+        // If URL provided, parse it to extract command and args
+        let (cmd, args) = if let Some(url) = mcp_url {
+            // For now, support simple command URLs like "arkavo mcp"
+            let parts: Vec<String> = url.split_whitespace().map(|s| s.to_string()).collect();
+            if parts.is_empty() {
+                return Err("Invalid MCP URL".into());
+            }
+            (parts[0].clone(), parts[1..].to_vec())
+        } else {
+            // Default to local arkavo mcp
+            ("arkavo".to_string(), vec!["mcp".to_string()])
+        };
+
+        // Start MCP server process
+        let mut child = Command::new(&cmd)
+            .args(&args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("Failed to start MCP server '{}': {}", cmd, e))?;
+
+        // Initialize the MCP server
+        let stdin = child.stdin.as_mut().ok_or("Failed to get stdin")?;
+        let stdout = child.stdout.take().ok_or("Failed to get stdout")?;
+
+        let init_request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: 1,
+            method: "initialize".to_string(),
+            params: Some(json!({
+                "clientInfo": {
+                    "name": "arkavo-chat",
+                    "version": env!("CARGO_PKG_VERSION")
+                }
+            })),
+        };
+
+        // Send initialize request
+        writeln!(stdin, "{}", serde_json::to_string(&init_request)?)?;
+        stdin.flush()?;
+
+        // Read initialize response
+        let reader = BufReader::new(stdout);
+        let mut lines = reader.lines();
+        if let Some(Ok(line)) = lines.next() {
+            let response: JsonRpcResponse = serde_json::from_str(&line)?;
+            if let Some(error) = response.error {
+                return Err(format!("MCP initialization failed: {}", error.message).into());
+            }
+            eprintln!("MCP server initialized: {:?}", response.result);
+        }
+        drop(lines); // Drop lines iterator to release reader
+
+        // Note: stdout is consumed by BufReader, process communication will happen per request
+
+        Ok(Self {
+            process: Arc::new(Mutex::new(child)),
+            request_id: Arc::new(Mutex::new(2)), // Start from 2 since we used 1 for init
+        })
+    }
+
+    pub fn list_tools(&self) -> Result<Vec<Tool>, Box<dyn std::error::Error>> {
+        let response = self.send_request("tools/list", None)?;
+        
+        if let Some(result) = response.result {
+            if let Some(tools_value) = result.get("tools") {
+                let tools: Vec<Tool> = serde_json::from_value(tools_value.clone())?;
+                Ok(tools)
+            } else {
+                Ok(vec![])
+            }
+        } else {
+            Ok(vec![])
+        }
+    }
+
+    pub fn call_tool(
+        &self,
+        tool_name: &str,
+        arguments: Value,
+        llm_origin: &str,
+    ) -> Result<Value, Box<dyn std::error::Error>> {
+        // Create metadata for logging
+        let metadata = ToolCallMetadata {
+            timestamp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            llm_origin: llm_origin.to_string(),
+            tool_name: tool_name.to_string(),
+            arguments: arguments.clone(),
+            request_id: *self.request_id.lock().unwrap(),
+        };
+
+        // Log the tool call
+        eprintln!(
+            "[MCP Tool Call] {} | LLM: {} | Tool: {} | Args: {}",
+            metadata.timestamp,
+            metadata.llm_origin,
+            metadata.tool_name,
+            serde_json::to_string(&metadata.arguments)?
+        );
+
+        let params = json!({
+            "name": tool_name,
+            "arguments": arguments
+        });
+
+        let response = self.send_request("tools/call", Some(params))?;
+
+        if let Some(error) = response.error {
+            return Err(format!("Tool execution error: {}", error.message).into());
+        }
+
+        // Extract the text content from the MCP response format
+        if let Some(result) = response.result {
+            if let Some(content_array) = result.get("content").and_then(|c| c.as_array()) {
+                if let Some(first_content) = content_array.first() {
+                    if let Some(text) = first_content.get("text").and_then(|t| t.as_str()) {
+                        return Ok(json!({ "result": text }));
+                    }
+                }
+            }
+            Ok(result)
+        } else {
+            Ok(json!({}))
+        }
+    }
+
+    fn send_request(
+        &self,
+        method: &str,
+        params: Option<Value>,
+    ) -> Result<JsonRpcResponse, Box<dyn std::error::Error>> {
+        let mut process = self.process.lock().unwrap();
+        
+        // Get next request ID
+        let request_id = {
+            let mut id = self.request_id.lock().unwrap();
+            let current = *id;
+            *id += 1;
+            current
+        };
+
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: request_id,
+            method: method.to_string(),
+            params,
+        };
+
+        // Send request
+        if let Some(stdin) = process.stdin.as_mut() {
+            writeln!(stdin, "{}", serde_json::to_string(&request)?)?;
+            stdin.flush()?;
+        } else {
+            return Err("Failed to get stdin".into());
+        }
+
+        // Read response line by line
+        let mut line = String::new();
+        use std::io::BufRead;
+        
+        if let Some(stdout) = process.stdout.as_mut() {
+            let mut reader = BufReader::new(stdout);
+            reader.read_line(&mut line)?;
+        } else {
+            return Err("Failed to get stdout".into());
+        }
+        
+        if !line.is_empty() {
+            let response: JsonRpcResponse = serde_json::from_str(&line)?;
+            Ok(response)
+        } else {
+            Err("No response from MCP server".into())
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Tool {
+    pub name: String,
+    pub description: String,
+    #[serde(rename = "inputSchema")]
+    pub input_schema: Value,
+}
+
+impl Drop for McpClient {
+    fn drop(&mut self) {
+        if let Ok(mut process) = self.process.lock() {
+            let _ = process.kill();
+        }
+    }
+}

--- a/crates/arkavo-cli/src/mcp_client.rs
+++ b/crates/arkavo-cli/src/mcp_client.rs
@@ -21,7 +21,9 @@ struct JsonRpcRequest {
 
 #[derive(Debug, Deserialize)]
 struct JsonRpcResponse {
+    #[allow(dead_code)]
     jsonrpc: String,
+    #[allow(dead_code)]
     id: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     result: Option<Value>,
@@ -31,8 +33,10 @@ struct JsonRpcResponse {
 
 #[derive(Debug, Deserialize)]
 struct JsonRpcError {
+    #[allow(dead_code)]
     code: i32,
     message: String,
+    #[allow(dead_code)]
     data: Option<Value>,
 }
 

--- a/crates/arkavo-cli/src/mcp_client.rs
+++ b/crates/arkavo-cli/src/mcp_client.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
@@ -111,7 +111,7 @@ impl McpClient {
 
     pub fn list_tools(&self) -> Result<Vec<Tool>, Box<dyn std::error::Error>> {
         let response = self.send_request("tools/list", None)?;
-        
+
         if let Some(result) = response.result {
             if let Some(tools_value) = result.get("tools") {
                 let tools: Vec<Tool> = serde_json::from_value(tools_value.clone())?;
@@ -183,7 +183,7 @@ impl McpClient {
         params: Option<Value>,
     ) -> Result<JsonRpcResponse, Box<dyn std::error::Error>> {
         let mut process = self.process.lock().unwrap();
-        
+
         // Get next request ID
         let request_id = {
             let mut id = self.request_id.lock().unwrap();
@@ -210,14 +210,14 @@ impl McpClient {
         // Read response line by line
         let mut line = String::new();
         use std::io::BufRead;
-        
+
         if let Some(stdout) = process.stdout.as_mut() {
             let mut reader = BufReader::new(stdout);
             reader.read_line(&mut line)?;
         } else {
             return Err("Failed to get stdout".into());
         }
-        
+
         if !line.is_empty() {
             let response: JsonRpcResponse = serde_json::from_str(&line)?;
             Ok(response)


### PR DESCRIPTION
## Summary
- Implements basic chat command with LLM integration as specified in #40
- Adds repository context awareness and file operation capabilities
- Integrates with arkavo-test via MCP when enabled

## Implementation Details

### Repository Context
- Collects and displays current working directory, git status, and branch information
- Lists project structure in system prompt for better LLM understanding
- Detects project type based on common configuration files

### File Operations
- `read <file>` or `cat <file>`: Read file contents with preview limit
- `list [path]` or `ls [path]`: List directory contents
- `explain <file>`: Automatically injects file content into LLM context

### MCP Integration
- Checks `ARKAVO_MCP_ENABLED` environment variable
- Provides stubs for `test` and `run <test_name>` commands
- Informs user about MCP status in system prompt

### Other Features
- Streaming responses for better UX
- Clear command to reset conversation
- Interactive and single-prompt modes
- Helpful command list on startup

## Testing
- Built and tested with `cargo build` and `cargo clippy`
- Manual testing of file operations (list, read)
- All existing tests pass

## Version
- Bumped to 0.7.0 (minor version increase)

Closes #40

🤖 Generated with [Claude Code](https://claude.ai/code)