### PR TITLE
feat: Add vision model support to arkavo-llm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,11 +111,13 @@ name = "arkavo-llm"
 version = "0.8.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arkavo"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "arkavo-cli",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -100,15 +100,15 @@ dependencies = [
 
 [[package]]
 name = "arkavo-encryption"
-version = "0.8.0"
+version = "0.8.1"
 
 [[package]]
 name = "arkavo-git"
-version = "0.8.0"
+version = "0.8.1"
 
 [[package]]
 name = "arkavo-llm"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -126,19 +126,19 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.8.0"
+version = "0.8.1"
 
 [[package]]
 name = "arkavo-repo"
-version = "0.8.0"
+version = "0.8.1"
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.8.0"
+version = "0.8.1"
 
 [[package]]
 name = "arkavo-test"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-vault"
-version = "0.8.0"
+version = "0.8.1"
 
 [[package]]
 name = "async-trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 authors = ["Arkavo Edge Contributors"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AI-powered developer toolkit for secure, intelligent code transformation and tes
 
 ## Key Features
 
-### 🤖 AI Code A@sgent
+### 🤖 AI Code Agent
 - Multi-file refactoring with repository context
 - Automatic commit generation
 - GPU-accelerated terminal UI
@@ -72,6 +72,23 @@ arkavo chat --prompt "Explain this codebase"
 ```
 
 AI-powered conversational interface with streaming responses and repository context. Uses Ollama with `devstral` model by default.
+
+#### Vision Model Support
+For UI testing with screenshots, install a vision-capable model:
+
+```bash
+# Install llava vision model (4.7 GB)
+ollama pull llava:7b
+
+# Use with screenshots
+arkavo chat --prompt "What UI elements are visible?" --image screenshot.png
+
+# Or interactively
+arkavo chat
+> @screenshot path/to/screenshot.png
+```
+
+**Note:** Images are limited to 10MB. Supported formats: PNG, JPEG, WebP.
 
 ### Serve
 ```bash

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AI-powered developer toolkit for secure, intelligent code transformation and tes
 
 ## Key Features
 
-### 🤖 AI Code Agent
+### 🤖 AI Code A@sgent
 - Multi-file refactoring with repository context
 - Automatic commit generation
 - GPU-accelerated terminal UI

--- a/crates/arkavo-cli/src/commands/chat.rs
+++ b/crates/arkavo-cli/src/commands/chat.rs
@@ -1,5 +1,5 @@
 use crate::mcp_client::McpClient;
-use arkavo_llm::{encode_image_file, LlmClient, Message};
+use arkavo_llm::{LlmClient, Message, encode_image_file};
 use serde_json::json;
 use std::env;
 use std::fs;
@@ -37,7 +37,9 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
         println!("Repository context: {}", get_current_directory());
         println!("LLM Provider: {}", client.provider_name());
         println!("Type 'exit' or 'quit' to end the session.");
-        println!("Commands: read <file>, list [path], explain <file>, test, run <test_name>, tools");
+        println!(
+            "Commands: read <file>, list [path], explain <file>, test, run <test_name>, tools"
+        );
         println!("Vision commands: @screenshot <path> - Analyze a screenshot");
         println!();
     }
@@ -104,10 +106,7 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
         if let Some(img_path) = image_path {
             match encode_image_file(&img_path) {
                 Ok(encoded_image) => {
-                    messages.push(Message::user_with_images(
-                        &prompt_text,
-                        vec![encoded_image],
-                    ));
+                    messages.push(Message::user_with_images(&prompt_text, vec![encoded_image]));
                 }
                 Err(e) => {
                     eprintln!("Error loading image: {}", e);
@@ -117,7 +116,7 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
         } else {
             messages.push(Message::user(&prompt_text));
         }
-        
+
         if print_mode {
             runtime.block_on(process_message_print(&client, &messages))?;
         } else {
@@ -163,7 +162,7 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
             // Extract the path after @screenshot
             let after_command = &input[screenshot_pos + "@screenshot ".len()..];
             let img_path = after_command.trim();
-            
+
             if !img_path.is_empty() {
                 match encode_image_file(img_path) {
                     Ok(encoded_image) => {

--- a/crates/arkavo-llm/Cargo.toml
+++ b/crates/arkavo-llm/Cargo.toml
@@ -18,3 +18,7 @@ tracing = "0.1"
 async-trait = "0.1"
 tokio-stream = "0.1"
 bytes = "1.5"
+base64 = "0.22"
+
+[dev-dependencies]
+tempfile = "3.0"

--- a/crates/arkavo-llm/src/chat.rs
+++ b/crates/arkavo-llm/src/chat.rs
@@ -47,9 +47,8 @@ mod tests {
     #[test]
     fn test_chat_request_with_images() {
         let images = vec!["img1".to_string(), "img2".to_string()];
-        let req = ChatRequest::new("Describe these")
-            .with_images(images.clone());
-        
+        let req = ChatRequest::new("Describe these").with_images(images.clone());
+
         assert_eq!(req.content, "Describe these");
         assert_eq!(req.images, images);
     }
@@ -59,7 +58,7 @@ mod tests {
         let req = ChatRequest::new("Test")
             .add_image("img1".to_string())
             .add_image("img2".to_string());
-        
+
         assert_eq!(req.images.len(), 2);
         assert_eq!(req.images[0], "img1");
         assert_eq!(req.images[1], "img2");
@@ -69,17 +68,16 @@ mod tests {
     fn test_chat_request_to_message_without_images() {
         let req = ChatRequest::new("Hello");
         let msg = req.to_message();
-        
+
         assert_eq!(msg.content, "Hello");
         assert_eq!(msg.images, None);
     }
 
     #[test]
     fn test_chat_request_to_message_with_images() {
-        let req = ChatRequest::new("Describe")
-            .with_images(vec!["img1".to_string()]);
+        let req = ChatRequest::new("Describe").with_images(vec!["img1".to_string()]);
         let msg = req.to_message();
-        
+
         assert_eq!(msg.content, "Describe");
         assert_eq!(msg.images, Some(vec!["img1".to_string()]));
     }

--- a/crates/arkavo-llm/src/chat.rs
+++ b/crates/arkavo-llm/src/chat.rs
@@ -1,0 +1,86 @@
+use crate::Message;
+
+#[derive(Debug, Clone)]
+pub struct ChatRequest {
+    pub content: String,
+    pub images: Vec<String>,
+}
+
+impl ChatRequest {
+    pub fn new(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            images: Vec::new(),
+        }
+    }
+
+    pub fn with_images(mut self, images: Vec<String>) -> Self {
+        self.images = images;
+        self
+    }
+
+    pub fn add_image(mut self, image: String) -> Self {
+        self.images.push(image);
+        self
+    }
+
+    pub fn to_message(self) -> Message {
+        if self.images.is_empty() {
+            Message::user(self.content)
+        } else {
+            Message::user_with_images(self.content, self.images)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_chat_request_new() {
+        let req = ChatRequest::new("Hello");
+        assert_eq!(req.content, "Hello");
+        assert!(req.images.is_empty());
+    }
+
+    #[test]
+    fn test_chat_request_with_images() {
+        let images = vec!["img1".to_string(), "img2".to_string()];
+        let req = ChatRequest::new("Describe these")
+            .with_images(images.clone());
+        
+        assert_eq!(req.content, "Describe these");
+        assert_eq!(req.images, images);
+    }
+
+    #[test]
+    fn test_chat_request_add_image() {
+        let req = ChatRequest::new("Test")
+            .add_image("img1".to_string())
+            .add_image("img2".to_string());
+        
+        assert_eq!(req.images.len(), 2);
+        assert_eq!(req.images[0], "img1");
+        assert_eq!(req.images[1], "img2");
+    }
+
+    #[test]
+    fn test_chat_request_to_message_without_images() {
+        let req = ChatRequest::new("Hello");
+        let msg = req.to_message();
+        
+        assert_eq!(msg.content, "Hello");
+        assert_eq!(msg.images, None);
+    }
+
+    #[test]
+    fn test_chat_request_to_message_with_images() {
+        let req = ChatRequest::new("Describe")
+            .with_images(vec!["img1".to_string()]);
+        let msg = req.to_message();
+        
+        assert_eq!(msg.content, "Describe");
+        assert_eq!(msg.images, Some(vec!["img1".to_string()]));
+    }
+}

--- a/crates/arkavo-llm/src/client.rs
+++ b/crates/arkavo-llm/src/client.rs
@@ -1,3 +1,4 @@
+use crate::chat::ChatRequest;
 use crate::ollama::OllamaClient;
 use crate::{Error, Message, Provider, Result, StreamResponse};
 use tokio_stream::Stream;
@@ -43,5 +44,18 @@ impl LlmClient {
 
     pub fn provider_name(&self) -> &str {
         self.provider.name()
+    }
+
+    pub async fn chat(&self, request: ChatRequest) -> Result<String> {
+        let message = request.to_message();
+        self.complete(vec![message]).await
+    }
+
+    pub async fn chat_stream(
+        &self,
+        request: ChatRequest,
+    ) -> Result<Box<dyn Stream<Item = Result<StreamResponse>> + Send + Unpin>> {
+        let message = request.to_message();
+        self.stream(vec![message]).await
     }
 }

--- a/crates/arkavo-llm/src/error.rs
+++ b/crates/arkavo-llm/src/error.rs
@@ -19,6 +19,12 @@ pub enum Error {
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+
+    #[error("Invalid image format: {0}")]
+    InvalidImageFormat(String),
+
+    #[error("Invalid image path: {0}")]
+    InvalidImagePath(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/arkavo-llm/src/image.rs
+++ b/crates/arkavo-llm/src/image.rs
@@ -46,7 +46,7 @@ impl ImageFormat {
 
 pub fn encode_image_file(path: impl AsRef<Path>) -> Result<String> {
     let path = path.as_ref();
-    
+
     if !path.exists() {
         return Err(Error::InvalidImagePath(format!(
             "Image file not found: {}",
@@ -54,12 +54,11 @@ pub fn encode_image_file(path: impl AsRef<Path>) -> Result<String> {
         )));
     }
 
-    let bytes = fs::read(path).map_err(|e| {
-        Error::InvalidImagePath(format!("Failed to read image file: {}", e))
-    })?;
+    let bytes = fs::read(path)
+        .map_err(|e| Error::InvalidImagePath(format!("Failed to read image file: {}", e)))?;
 
     ImageFormat::validate_bytes(&bytes)?;
-    
+
     Ok(BASE64_STANDARD.encode(&bytes))
 }
 
@@ -69,9 +68,10 @@ pub fn encode_image_bytes(bytes: &[u8]) -> Result<String> {
 }
 
 pub fn decode_image(encoded: &str) -> Result<Vec<u8>> {
-    let bytes = BASE64_STANDARD.decode(encoded)
+    let bytes = BASE64_STANDARD
+        .decode(encoded)
         .map_err(|e| Error::InvalidImageFormat(format!("Invalid base64: {}", e)))?;
-    
+
     ImageFormat::validate_bytes(&bytes)?;
     Ok(bytes)
 }
@@ -128,10 +128,10 @@ mod tests {
     #[test]
     fn test_encode_decode_roundtrip() {
         let test_data = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
-        
+
         let encoded = encode_image_bytes(&test_data).unwrap();
         let decoded = decode_image(&encoded).unwrap();
-        
+
         assert_eq!(test_data.to_vec(), decoded);
     }
 
@@ -145,13 +145,13 @@ mod tests {
     #[test]
     fn test_encode_image_file_success() {
         let png_data = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
-        
+
         let mut temp_file = NamedTempFile::new().unwrap();
         temp_file.write_all(&png_data).unwrap();
-        
+
         let encoded = encode_image_file(temp_file.path()).unwrap();
         let decoded = decode_image(&encoded).unwrap();
-        
+
         assert_eq!(png_data.to_vec(), decoded);
     }
 

--- a/crates/arkavo-llm/src/image.rs
+++ b/crates/arkavo-llm/src/image.rs
@@ -1,0 +1,164 @@
+use crate::{Error, Result};
+use base64::prelude::*;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone)]
+pub enum ImageFormat {
+    Png,
+    Jpeg,
+    WebP,
+}
+
+impl ImageFormat {
+    pub fn from_path(path: &Path) -> Result<Self> {
+        let extension = path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .ok_or_else(|| Error::InvalidImageFormat("Missing file extension".to_string()))?;
+
+        match extension.to_lowercase().as_str() {
+            "png" => Ok(ImageFormat::Png),
+            "jpg" | "jpeg" => Ok(ImageFormat::Jpeg),
+            "webp" => Ok(ImageFormat::WebP),
+            _ => Err(Error::InvalidImageFormat(format!(
+                "Unsupported image format: {}",
+                extension
+            ))),
+        }
+    }
+
+    pub fn validate_bytes(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() < 4 {
+            return Err(Error::InvalidImageFormat("File too small".to_string()));
+        }
+
+        match &bytes[..4] {
+            [0x89, 0x50, 0x4E, 0x47] => Ok(ImageFormat::Png),
+            [0xFF, 0xD8, 0xFF, _] => Ok(ImageFormat::Jpeg),
+            _ if bytes.len() >= 12 && &bytes[8..12] == b"WEBP" => Ok(ImageFormat::WebP),
+            _ => Err(Error::InvalidImageFormat(
+                "Unknown or unsupported image format".to_string(),
+            )),
+        }
+    }
+}
+
+pub fn encode_image_file(path: impl AsRef<Path>) -> Result<String> {
+    let path = path.as_ref();
+    
+    if !path.exists() {
+        return Err(Error::InvalidImagePath(format!(
+            "Image file not found: {}",
+            path.display()
+        )));
+    }
+
+    let bytes = fs::read(path).map_err(|e| {
+        Error::InvalidImagePath(format!("Failed to read image file: {}", e))
+    })?;
+
+    ImageFormat::validate_bytes(&bytes)?;
+    
+    Ok(BASE64_STANDARD.encode(&bytes))
+}
+
+pub fn encode_image_bytes(bytes: &[u8]) -> Result<String> {
+    ImageFormat::validate_bytes(bytes)?;
+    Ok(BASE64_STANDARD.encode(bytes))
+}
+
+pub fn decode_image(encoded: &str) -> Result<Vec<u8>> {
+    let bytes = BASE64_STANDARD.decode(encoded)
+        .map_err(|e| Error::InvalidImageFormat(format!("Invalid base64: {}", e)))?;
+    
+    ImageFormat::validate_bytes(&bytes)?;
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_image_format_from_path() {
+        assert!(matches!(
+            ImageFormat::from_path(Path::new("test.png")),
+            Ok(ImageFormat::Png)
+        ));
+        assert!(matches!(
+            ImageFormat::from_path(Path::new("test.jpg")),
+            Ok(ImageFormat::Jpeg)
+        ));
+        assert!(matches!(
+            ImageFormat::from_path(Path::new("test.jpeg")),
+            Ok(ImageFormat::Jpeg)
+        ));
+        assert!(matches!(
+            ImageFormat::from_path(Path::new("test.webp")),
+            Ok(ImageFormat::WebP)
+        ));
+        assert!(ImageFormat::from_path(Path::new("test.txt")).is_err());
+        assert!(ImageFormat::from_path(Path::new("test")).is_err());
+    }
+
+    #[test]
+    fn test_image_format_validation() {
+        let png_header = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        assert!(matches!(
+            ImageFormat::validate_bytes(&png_header),
+            Ok(ImageFormat::Png)
+        ));
+
+        let jpeg_header = [0xFF, 0xD8, 0xFF, 0xE0];
+        assert!(matches!(
+            ImageFormat::validate_bytes(&jpeg_header),
+            Ok(ImageFormat::Jpeg)
+        ));
+
+        let invalid_header = [0x00, 0x00, 0x00, 0x00];
+        assert!(ImageFormat::validate_bytes(&invalid_header).is_err());
+
+        let too_small = [0x89, 0x50];
+        assert!(ImageFormat::validate_bytes(&too_small).is_err());
+    }
+
+    #[test]
+    fn test_encode_decode_roundtrip() {
+        let test_data = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        
+        let encoded = encode_image_bytes(&test_data).unwrap();
+        let decoded = decode_image(&encoded).unwrap();
+        
+        assert_eq!(test_data.to_vec(), decoded);
+    }
+
+    #[test]
+    fn test_encode_image_file_not_found() {
+        let result = encode_image_file("nonexistent.png");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not found"));
+    }
+
+    #[test]
+    fn test_encode_image_file_success() {
+        let png_data = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(&png_data).unwrap();
+        
+        let encoded = encode_image_file(temp_file.path()).unwrap();
+        let decoded = decode_image(&encoded).unwrap();
+        
+        assert_eq!(png_data.to_vec(), decoded);
+    }
+
+    #[test]
+    fn test_decode_invalid_base64() {
+        let result = decode_image("invalid-base64!");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid base64"));
+    }
+}

--- a/crates/arkavo-llm/src/lib.rs
+++ b/crates/arkavo-llm/src/lib.rs
@@ -10,7 +10,7 @@ pub mod stream;
 pub use chat::ChatRequest;
 pub use client::LlmClient;
 pub use error::{Error, Result};
-pub use image::{encode_image_file, encode_image_bytes, decode_image, ImageFormat};
+pub use image::{ImageFormat, decode_image, encode_image_bytes, encode_image_file};
 pub use message::{Message, Role};
 pub use provider::Provider;
 pub use stream::StreamResponse;

--- a/crates/arkavo-llm/src/lib.rs
+++ b/crates/arkavo-llm/src/lib.rs
@@ -1,12 +1,16 @@
+pub mod chat;
 pub mod client;
 pub mod error;
+pub mod image;
 pub mod message;
 pub mod ollama;
 pub mod provider;
 pub mod stream;
 
+pub use chat::ChatRequest;
 pub use client::LlmClient;
 pub use error::{Error, Result};
+pub use image::{encode_image_file, encode_image_bytes, decode_image, ImageFormat};
 pub use message::{Message, Role};
 pub use provider::Provider;
 pub use stream::StreamResponse;

--- a/crates/arkavo-llm/src/message.rs
+++ b/crates/arkavo-llm/src/message.rs
@@ -125,7 +125,7 @@ mod tests {
     fn test_user_with_images() {
         let images = vec!["base64image1".to_string(), "base64image2".to_string()];
         let msg = Message::user_with_images("Describe these images", images.clone());
-        
+
         assert_eq!(msg.role, Role::User);
         assert_eq!(msg.content, "Describe these images");
         assert_eq!(msg.images, Some(images));
@@ -135,7 +135,7 @@ mod tests {
     fn test_message_with_images_serialization() {
         let msg = Message::user_with_images("Test", vec!["image123".to_string()]);
         let json = serde_json::to_string(&msg).unwrap();
-        
+
         assert!(json.contains(r#""role":"user"#));
         assert!(json.contains(r#""content":"Test"#));
         assert!(json.contains(r#""images":["image123"]"#));
@@ -145,7 +145,7 @@ mod tests {
     fn test_message_without_images_serialization() {
         let msg = Message::user("Test without images");
         let json = serde_json::to_string(&msg).unwrap();
-        
+
         assert!(json.contains(r#""role":"user"#));
         assert!(json.contains(r#""content":"Test without images"#));
         assert!(!json.contains(r#""images""#));
@@ -155,9 +155,12 @@ mod tests {
     fn test_message_with_images_deserialization() {
         let json = r#"{"role":"user","content":"Test","images":["img1","img2"]}"#;
         let msg: Message = serde_json::from_str(json).unwrap();
-        
+
         assert_eq!(msg.role, Role::User);
         assert_eq!(msg.content, "Test");
-        assert_eq!(msg.images, Some(vec!["img1".to_string(), "img2".to_string()]));
+        assert_eq!(
+            msg.images,
+            Some(vec!["img1".to_string(), "img2".to_string()])
+        );
     }
 }

--- a/crates/arkavo-llm/src/message.rs
+++ b/crates/arkavo-llm/src/message.rs
@@ -12,6 +12,8 @@ pub enum Role {
 pub struct Message {
     pub role: Role,
     pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub images: Option<Vec<String>>,
 }
 
 impl Message {
@@ -19,6 +21,7 @@ impl Message {
         Self {
             role: Role::System,
             content: content.into(),
+            images: None,
         }
     }
 
@@ -26,6 +29,7 @@ impl Message {
         Self {
             role: Role::User,
             content: content.into(),
+            images: None,
         }
     }
 
@@ -33,6 +37,15 @@ impl Message {
         Self {
             role: Role::Assistant,
             content: content.into(),
+            images: None,
+        }
+    }
+
+    pub fn user_with_images(content: impl Into<String>, images: Vec<String>) -> Self {
+        Self {
+            role: Role::User,
+            content: content.into(),
+            images: Some(images),
         }
     }
 }
@@ -106,5 +119,45 @@ mod tests {
         let msg: Message = serde_json::from_str(json).unwrap();
         assert_eq!(msg.role, Role::User);
         assert_eq!(msg.content, "Hello");
+    }
+
+    #[test]
+    fn test_user_with_images() {
+        let images = vec!["base64image1".to_string(), "base64image2".to_string()];
+        let msg = Message::user_with_images("Describe these images", images.clone());
+        
+        assert_eq!(msg.role, Role::User);
+        assert_eq!(msg.content, "Describe these images");
+        assert_eq!(msg.images, Some(images));
+    }
+
+    #[test]
+    fn test_message_with_images_serialization() {
+        let msg = Message::user_with_images("Test", vec!["image123".to_string()]);
+        let json = serde_json::to_string(&msg).unwrap();
+        
+        assert!(json.contains(r#""role":"user"#));
+        assert!(json.contains(r#""content":"Test"#));
+        assert!(json.contains(r#""images":["image123"]"#));
+    }
+
+    #[test]
+    fn test_message_without_images_serialization() {
+        let msg = Message::user("Test without images");
+        let json = serde_json::to_string(&msg).unwrap();
+        
+        assert!(json.contains(r#""role":"user"#));
+        assert!(json.contains(r#""content":"Test without images"#));
+        assert!(!json.contains(r#""images""#));
+    }
+
+    #[test]
+    fn test_message_with_images_deserialization() {
+        let json = r#"{"role":"user","content":"Test","images":["img1","img2"]}"#;
+        let msg: Message = serde_json::from_str(json).unwrap();
+        
+        assert_eq!(msg.role, Role::User);
+        assert_eq!(msg.content, "Test");
+        assert_eq!(msg.images, Some(vec!["img1".to_string(), "img2".to_string()]));
     }
 }

--- a/crates/arkavo-llm/src/ollama/client.rs
+++ b/crates/arkavo-llm/src/ollama/client.rs
@@ -1,11 +1,22 @@
 use async_trait::async_trait;
 use futures::stream::{self, StreamExt};
 use reqwest::Client;
+use serde::Deserialize;
 use tokio_stream::Stream;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use super::types::{ChatRequest, ChatResponse};
 use crate::{Error, Message, Provider, Result, StreamResponse};
+
+#[derive(Debug, Deserialize)]
+struct ModelInfo {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelsResponse {
+    models: Vec<ModelInfo>,
+}
 
 pub struct OllamaClient {
     client: Client,
@@ -27,13 +38,108 @@ impl OllamaClient {
         let model = std::env::var("OLLAMA_MODEL").ok();
         Ok(Self::new(base_url, model))
     }
+
+    async fn list_models(&self) -> Result<Vec<String>> {
+        debug!("Fetching available models from Ollama");
+        let response = self
+            .client
+            .get(format!("{}/api/tags", self.base_url))
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            warn!("Failed to fetch models from Ollama");
+            return Ok(vec![]);
+        }
+
+        let models_response: ModelsResponse = response.json().await?;
+        Ok(models_response.models.into_iter().map(|m| m.name).collect())
+    }
+
+    async fn select_model(&self, messages: &[Message]) -> Result<String> {
+        let has_images = messages.iter().any(|msg| {
+            msg.images.as_ref().is_some_and(|imgs| !imgs.is_empty())
+        });
+
+        if has_images {
+            self.select_vision_model().await
+        } else {
+            self.select_text_model(messages).await
+        }
+    }
+
+    async fn select_vision_model(&self) -> Result<String> {
+        let available_models = self.list_models().await?;
+        
+        let vision_models = [
+            "qwen2.5vl:latest",
+            "qwen2.5vl",
+            "llava:latest",
+            "llava",
+            "llama3.2-vision:latest",
+            "llama3.2-vision",
+        ];
+
+        for model in &vision_models {
+            if available_models.iter().any(|m| m.contains(model)) {
+                debug!("Selected vision model: {}", model);
+                return Ok(model.to_string());
+            }
+        }
+
+        warn!("No vision model found, using default model");
+        Ok(self.model.clone())
+    }
+
+    async fn select_text_model(&self, messages: &[Message]) -> Result<String> {
+        let available_models = self.list_models().await?;
+        
+        let is_coding = messages.iter().any(|msg| {
+            let content = msg.content.to_lowercase();
+            content.contains("code") || 
+            content.contains("function") || 
+            content.contains("class") ||
+            content.contains("debug") ||
+            content.contains("implement")
+        });
+
+        if is_coding {
+            let coding_models = ["devstral:latest", "devstral"];
+            for model in &coding_models {
+                if available_models.iter().any(|m| m.contains(model)) {
+                    debug!("Selected coding model: {}", model);
+                    return Ok(model.to_string());
+                }
+            }
+        }
+
+        let general_models = [
+            "devstral:latest",
+            "devstral",
+            "llama3.2:latest",
+            "llama3.2",
+            "llama3.1:latest",
+            "llama3.1",
+        ];
+
+        for model in &general_models {
+            if available_models.iter().any(|m| m.contains(model)) {
+                debug!("Selected general model: {}", model);
+                return Ok(model.to_string());
+            }
+        }
+
+        debug!("Using default model: {}", self.model);
+        Ok(self.model.clone())
+    }
 }
 
 #[async_trait]
 impl Provider for OllamaClient {
     async fn complete(&self, messages: Vec<Message>) -> Result<String> {
+        let model = self.select_model(&messages).await?;
         let request = ChatRequest {
-            model: self.model.clone(),
+            model,
             messages,
             stream: false,
         };
@@ -63,8 +169,9 @@ impl Provider for OllamaClient {
         &self,
         messages: Vec<Message>,
     ) -> Result<Box<dyn Stream<Item = Result<StreamResponse>> + Send + Unpin>> {
+        let model = self.select_model(&messages).await?;
         let request = ChatRequest {
-            model: self.model.clone(),
+            model,
             messages,
             stream: true,
         };

--- a/crates/arkavo-llm/src/ollama/client.rs
+++ b/crates/arkavo-llm/src/ollama/client.rs
@@ -77,8 +77,6 @@ impl OllamaClient {
             "llava:7b",
             "llava:latest",
             "llava",
-            "qwen2.5vl:latest",
-            "qwen2.5vl",
             "bakllava:latest",
             "bakllava",
         ];

--- a/crates/arkavo-llm/src/ollama/client.rs
+++ b/crates/arkavo-llm/src/ollama/client.rs
@@ -80,7 +80,9 @@ impl OllamaClient {
             }
         }
 
-        warn!("No vision model found, using default model");
+        warn!(
+            "No vision model found, using default model. Install llava with: ollama pull llava:7b"
+        );
         Ok(self.model.clone())
     }
 

--- a/crates/arkavo-llm/src/ollama/client.rs
+++ b/crates/arkavo-llm/src/ollama/client.rs
@@ -57,9 +57,9 @@ impl OllamaClient {
     }
 
     async fn select_model(&self, messages: &[Message]) -> Result<String> {
-        let has_images = messages.iter().any(|msg| {
-            msg.images.as_ref().is_some_and(|imgs| !imgs.is_empty())
-        });
+        let has_images = messages
+            .iter()
+            .any(|msg| msg.images.as_ref().is_some_and(|imgs| !imgs.is_empty()));
 
         if has_images {
             self.select_vision_model().await
@@ -70,16 +70,8 @@ impl OllamaClient {
 
     async fn select_vision_model(&self) -> Result<String> {
         let available_models = self.list_models().await?;
-        
-        let vision_models = [
-            "llama3.2-vision:latest",
-            "llama3.2-vision",
-            "llava:7b",
-            "llava:latest",
-            "llava",
-            "bakllava:latest",
-            "bakllava",
-        ];
+
+        let vision_models = ["llava:7b", "llava:latest", "llava"];
 
         for model in &vision_models {
             if available_models.iter().any(|m| m.contains(model)) {
@@ -94,14 +86,14 @@ impl OllamaClient {
 
     async fn select_text_model(&self, messages: &[Message]) -> Result<String> {
         let available_models = self.list_models().await?;
-        
+
         let is_coding = messages.iter().any(|msg| {
             let content = msg.content.to_lowercase();
-            content.contains("code") || 
-            content.contains("function") || 
-            content.contains("class") ||
-            content.contains("debug") ||
-            content.contains("implement")
+            content.contains("code")
+                || content.contains("function")
+                || content.contains("class")
+                || content.contains("debug")
+                || content.contains("implement")
         });
 
         if is_coding {
@@ -222,8 +214,10 @@ impl Provider for OllamaClient {
                                         response: Option<String>,
                                         done: bool,
                                     }
-                                    
-                                    if let Ok(stream_resp) = serde_json::from_str::<StreamingResponse>(line) {
+
+                                    if let Ok(stream_resp) =
+                                        serde_json::from_str::<StreamingResponse>(line)
+                                    {
                                         responses.push(Ok(StreamResponse {
                                             content: stream_resp.response.unwrap_or_default(),
                                             done: stream_resp.done,

--- a/crates/arkavo-llm/src/ollama/client.rs
+++ b/crates/arkavo-llm/src/ollama/client.rs
@@ -72,12 +72,15 @@ impl OllamaClient {
         let available_models = self.list_models().await?;
         
         let vision_models = [
-            "qwen2.5vl:latest",
-            "qwen2.5vl",
-            "llava:latest",
-            "llava",
             "llama3.2-vision:latest",
             "llama3.2-vision",
+            "llava:7b",
+            "llava:latest",
+            "llava",
+            "qwen2.5vl:latest",
+            "qwen2.5vl",
+            "bakllava:latest",
+            "bakllava",
         ];
 
         for model in &vision_models {

--- a/crates/arkavo-llm/tests/ollama_integration.rs
+++ b/crates/arkavo-llm/tests/ollama_integration.rs
@@ -87,7 +87,7 @@ async fn test_ollama_error_handling() {
     let messages = vec![Message::user("Hello")];
 
     let result = client.complete(messages).await;
-    
+
     // The error might occur either during model selection or during the actual request
     // Since we're using a completely invalid URL, it should fail somewhere
     if let Err(e) = &result {

--- a/crates/arkavo-llm/tests/ollama_integration.rs
+++ b/crates/arkavo-llm/tests/ollama_integration.rs
@@ -87,10 +87,14 @@ async fn test_ollama_error_handling() {
     let messages = vec![Message::user("Hello")];
 
     let result = client.complete(messages).await;
-    assert!(result.is_err());
-
-    if let Err(e) = result {
+    
+    // The error might occur either during model selection or during the actual request
+    // Since we're using a completely invalid URL, it should fail somewhere
+    if let Err(e) = &result {
         println!("Expected error: {}", e);
+        assert!(e.to_string().contains("error") || e.to_string().contains("failed"));
+    } else {
+        panic!("Expected an error but got success");
     }
 }
 


### PR DESCRIPTION
## Summary
- Implements vision model support for arkavo-llm to enable UI testing with screenshots
- Adds dynamic model selection based on content type (vision/coding/general)
- Enhances chat command for UI testing workflows with screenshot analysis

**This PR supersedes #60** - The previous PR had merge conflicts because arkavo-llm was already added to main in PR #48. This PR adds the vision-specific enhancements on top of the existing arkavo-llm implementation.

## Changes
- Extended `Message` struct with optional `images` field for multimodal content
- Added image encoding/decoding utilities with format validation (PNG, JPEG, WebP)
- Implemented dynamic model selection in Ollama client:
  - Auto-detects vision tasks when images are present
  - Selects appropriate models based on available local models
  - Falls back gracefully when specialized models aren't available
- Enhanced chat command:
  - Added `--image` flag for command-line image analysis
  - Added `@screenshot` command for interactive screenshot analysis
  - Focused system prompt on UI testing workflows
- Added `ChatRequest` builder pattern for unified text/vision API

## Supported Vision Models
- **llava** (including llava:7b) - Tested and confirmed working

## Usage Examples

### Command-line with image:
```bash
cargo run -- chat --prompt "What UI elements are visible?" --image screenshot.png
```

### Interactive mode:
```bash
cargo run -- chat
> @screenshot /path/to/screenshot.png
```

## Test Plan
- [x] Unit tests for image encoding/decoding
- [x] Unit tests for Message with images
- [x] Unit tests for ChatRequest builder
- [x] Integration tests updated for error handling
- [x] Manual testing with Ollama and llava:7b model

## Related Issues
Closes #59 - Vision model support

🤖 Generated with [Claude Code](https://claude.ai/code)