### PR TITLE
Re-enable MCP tool list in Terminal UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,3 +160,4 @@ The configuration of Arkavo Edge is a dynamic process handled by the AI agent at
 - keep PR titles short and not "feat:". the reason is this is shown prominently in Github next to files and folders
 - each feature branch needs to bump the appropriate semver version. No release branches
 - Do not keep a change log file; github handles that functionality
+- minimize key mappings.  Ideally the app works intuitively.  a power user can use Natural Language to set a key mapping.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,7 @@ dependencies = [
  "arkavo-mcp-core",
  "arkavo-mcp-runtime",
  "arkavo-memory",
+ "arkavo-test",
  "chrono",
  "crossterm",
  "ratatui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "arkavo-mcp-core"
+version = "0.19.3"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "arkavo-mcp-runtime"
+version = "0.19.3"
+dependencies = [
+ "anyhow",
+ "arkavo-mcp-core",
+ "async-trait",
+ "chrono",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "arkavo-memory"
 version = "0.19.3"
 dependencies = [
@@ -302,6 +328,8 @@ dependencies = [
  "anyhow",
  "arkavo-dataflow",
  "arkavo-llm",
+ "arkavo-mcp-core",
+ "arkavo-mcp-runtime",
  "arkavo-memory",
  "chrono",
  "crossterm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,14 +162,14 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "arkavo-cli",
 ]
 
 [[package]]
 name = "arkavo-cli"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -229,11 +229,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-encryption"
-version = "0.19.2"
+version = "0.19.3"
 
 [[package]]
 name = "arkavo-git"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "git2",
  "tempfile",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "async-trait",
  "serde",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "anyhow",
  "arkavo-mcp",
@@ -289,15 +289,15 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.19.2"
+version = "0.19.3"
 
 [[package]]
 name = "arkavo-repo"
-version = "0.19.2"
+version = "0.19.3"
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-vault"
-version = "0.19.2"
+version = "0.19.3"
 
 [[package]]
 name = "arrayvec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,9 @@ name = "arkavo-mcp-runtime"
 version = "0.19.3"
 dependencies = [
  "anyhow",
+ "arkavo-llm",
  "arkavo-mcp-core",
+ "arkavo-memory",
  "async-trait",
  "chrono",
  "once_cell",
@@ -334,6 +336,7 @@ dependencies = [
  "chrono",
  "crossterm",
  "ratatui",
+ "regex",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,10 @@ members = [
     "crates/arkavo-test",
     "crates/arkavo-llm",
     "crates/arkavo-memory",
-    "crates/arkavo-mcp", "crates/arkavo-dataflow",
+    "crates/arkavo-mcp",
+    "crates/arkavo-mcp-core",
+    "crates/arkavo-mcp-runtime",
+    "crates/arkavo-dataflow",
 ]
 resolver = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.19.2"
+version = "0.19.3"
 edition = "2024"
 authors = ["Arkavo Edge Contributors"]
 license = "Apache-2.0"

--- a/crates/arkavo-dataflow/src/nodes/llm.rs
+++ b/crates/arkavo-dataflow/src/nodes/llm.rs
@@ -174,6 +174,43 @@ impl LlmTransform {
             None
         }
     }
+    
+    async fn resolve_server_url(&self, server_prefix: &str) -> Option<String> {
+        use arkavo_memory::storage::MemoryStorage;
+        
+        if server_prefix == "localhost" {
+            return Some("http://localhost:11434".to_string());
+        }
+        
+        // Look up saved server configuration from memory storage
+        if let Ok(storage) = MemoryStorage::new().await {
+            if let Ok(all_configs) = storage.search("http", 20, Some("config")).await {
+                // Filter for Ollama server configs only
+                let ollama_configs: Vec<_> = all_configs.into_iter()
+                    .filter(|config| {
+                        config.memory.metadata
+                            .as_ref()
+                            .and_then(|m| m.get("type"))
+                            .and_then(|t| t.as_str())
+                            .map(|t| t == "arkavo_ollama_server_config")
+                            .unwrap_or(false)
+                    })
+                    .filter(|config| config.memory.content != "http://localhost:11434")
+                    .collect();
+                
+                // Extract server number from prefix (e.g., "server1" -> 1)
+                if let Some(num_str) = server_prefix.strip_prefix("server") {
+                    if let Ok(idx) = num_str.parse::<usize>() {
+                        if idx > 0 && idx <= ollama_configs.len() {
+                            return Some(ollama_configs[idx - 1].memory.content.clone());
+                        }
+                    }
+                }
+            }
+        }
+        
+        None
+    }
 }
 
 #[async_trait]
@@ -194,6 +231,20 @@ impl NodeProcessor for LlmTransform {
             .unwrap_or("local-ollama");
 
         let model = params.get("model").and_then(|v| v.as_str());
+        
+        // Check if model contains server prefix (e.g., "server1/llama3")
+        let (effective_provider, effective_model) = if let Some(model_str) = model {
+            if let Some((prefix, model_name)) = model_str.split_once('/') {
+                // Model has server prefix, override provider
+                (prefix, Some(model_name))
+            } else {
+                // No prefix, use specified provider
+                (provider_name, Some(model_str))
+            }
+        } else {
+            // No model specified
+            (provider_name, None)
+        };
 
         let prompt_template = params
             .get("prompt")
@@ -235,11 +286,19 @@ impl NodeProcessor for LlmTransform {
         // Get task type from params for model preference lookup
         let task_type = params.get("task_type").and_then(|v| v.as_str());
 
-        // Get provider configuration
-        let (base_url, default_model) = self.get_provider_config(provider_name).await?;
+        // Get provider configuration based on effective provider
+        let (base_url, default_model) = if effective_provider.starts_with("server") || effective_provider == "localhost" {
+            // This is a server prefix from terminal UI, resolve it from memory storage
+            let url = self.resolve_server_url(effective_provider).await
+                .unwrap_or_else(|| "http://localhost:11434".to_string());
+            (url, None)
+        } else {
+            // Regular provider name
+            self.get_provider_config(effective_provider).await?
+        };
 
         // Determine which model to use
-        let model_to_use = if let Some(explicit_model) = model {
+        let model_to_use = if let Some(explicit_model) = effective_model {
             explicit_model.to_string()
         } else if let Some(task) = task_type {
             // Check if we have a model preference for this task type
@@ -260,7 +319,7 @@ impl NodeProcessor for LlmTransform {
 
         debug!(
             "Executing LLM transform with provider: {}, model: {}",
-            provider_name, model_to_use
+            effective_provider, model_to_use
         );
 
         let response = if stream {

--- a/crates/arkavo-dataflow/src/nodes/llm.rs
+++ b/crates/arkavo-dataflow/src/nodes/llm.rs
@@ -174,21 +174,24 @@ impl LlmTransform {
             None
         }
     }
-    
+
     async fn resolve_server_url(&self, server_prefix: &str) -> Option<String> {
         use arkavo_memory::storage::MemoryStorage;
-        
+
         if server_prefix == "localhost" {
             return Some("http://localhost:11434".to_string());
         }
-        
+
         // Look up saved server configuration from memory storage
         if let Ok(storage) = MemoryStorage::new().await {
             if let Ok(all_configs) = storage.search("http", 20, Some("config")).await {
                 // Filter for Ollama server configs only
-                let ollama_configs: Vec<_> = all_configs.into_iter()
+                let ollama_configs: Vec<_> = all_configs
+                    .into_iter()
                     .filter(|config| {
-                        config.memory.metadata
+                        config
+                            .memory
+                            .metadata
                             .as_ref()
                             .and_then(|m| m.get("type"))
                             .and_then(|t| t.as_str())
@@ -197,7 +200,7 @@ impl LlmTransform {
                     })
                     .filter(|config| config.memory.content != "http://localhost:11434")
                     .collect();
-                
+
                 // Extract server number from prefix (e.g., "server1" -> 1)
                 if let Some(num_str) = server_prefix.strip_prefix("server") {
                     if let Ok(idx) = num_str.parse::<usize>() {
@@ -208,7 +211,7 @@ impl LlmTransform {
                 }
             }
         }
-        
+
         None
     }
 }
@@ -231,7 +234,7 @@ impl NodeProcessor for LlmTransform {
             .unwrap_or("local-ollama");
 
         let model = params.get("model").and_then(|v| v.as_str());
-        
+
         // Check if model contains server prefix (e.g., "server1/llama3")
         let (effective_provider, effective_model) = if let Some(model_str) = model {
             if let Some((prefix, model_name)) = model_str.split_once('/') {
@@ -287,15 +290,18 @@ impl NodeProcessor for LlmTransform {
         let task_type = params.get("task_type").and_then(|v| v.as_str());
 
         // Get provider configuration based on effective provider
-        let (base_url, default_model) = if effective_provider.starts_with("server") || effective_provider == "localhost" {
-            // This is a server prefix from terminal UI, resolve it from memory storage
-            let url = self.resolve_server_url(effective_provider).await
-                .unwrap_or_else(|| "http://localhost:11434".to_string());
-            (url, None)
-        } else {
-            // Regular provider name
-            self.get_provider_config(effective_provider).await?
-        };
+        let (base_url, default_model) =
+            if effective_provider.starts_with("server") || effective_provider == "localhost" {
+                // This is a server prefix from terminal UI, resolve it from memory storage
+                let url = self
+                    .resolve_server_url(effective_provider)
+                    .await
+                    .unwrap_or_else(|| "http://localhost:11434".to_string());
+                (url, None)
+            } else {
+                // Regular provider name
+                self.get_provider_config(effective_provider).await?
+            };
 
         // Determine which model to use
         let model_to_use = if let Some(explicit_model) = effective_model {

--- a/crates/arkavo-mcp-core/Cargo.toml
+++ b/crates/arkavo-mcp-core/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "arkavo-mcp-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Core types and traits for Model Context Protocol (MCP) - no runtime dependencies"
+repository = "https://github.com/arkavo-com/arkavo-edge"
+keywords = ["mcp", "protocol", "types", "traits"]
+categories = ["data-structures", "encoding"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+async-trait = "0.1"
+anyhow = "1.0"
+
+[lints]
+workspace = true

--- a/crates/arkavo-mcp-core/src/lib.rs
+++ b/crates/arkavo-mcp-core/src/lib.rs
@@ -1,0 +1,96 @@
+//! Core types and traits for Model Context Protocol (MCP)
+//!
+//! This crate provides the fundamental types and traits needed for MCP
+//! without any runtime dependencies.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Schema definition for an MCP tool
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolSchema {
+    /// The name of the tool
+    pub name: String,
+    /// Human-readable description of what the tool does
+    pub description: String,
+    /// JSON Schema for the tool's parameters
+    pub parameters: Value,
+}
+
+/// Core trait that all MCP tools must implement
+#[async_trait]
+pub trait Tool: Send + Sync {
+    /// Execute the tool with the given parameters
+    async fn execute(&self, params: Value) -> Result<Value>;
+
+    /// Get the schema for this tool
+    fn schema(&self) -> &ToolSchema;
+}
+
+/// Request to execute a tool
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ToolRequest {
+    /// Name of the tool to execute
+    pub tool_name: String,
+    /// Parameters for the tool
+    pub params: Value,
+}
+
+/// Response from executing a tool
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ToolResponse {
+    /// Name of the tool that was executed
+    pub tool_name: String,
+    /// Result of the execution
+    pub result: Value,
+    /// Whether the execution was successful
+    pub success: bool,
+}
+
+/// JSON-RPC request structure
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RpcRequest {
+    /// JSON-RPC version (should be "2.0")
+    pub jsonrpc: String,
+    /// Request ID
+    pub id: Option<Value>,
+    /// Method name
+    pub method: String,
+    /// Method parameters
+    pub params: Option<Value>,
+}
+
+/// JSON-RPC response structure
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RpcResponse {
+    /// JSON-RPC version (should be "2.0")
+    pub jsonrpc: String,
+    /// Request ID (should match the request)
+    pub id: Option<Value>,
+    /// Result of the method call
+    pub result: Option<Value>,
+    /// Error information if the call failed
+    pub error: Option<RpcError>,
+}
+
+/// JSON-RPC error structure
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RpcError {
+    /// Error code
+    pub code: i32,
+    /// Error message
+    pub message: String,
+    /// Additional error data
+    pub data: Option<Value>,
+}
+
+/// Standard JSON-RPC error codes
+pub mod error_codes {
+    pub const PARSE_ERROR: i32 = -32700;
+    pub const INVALID_REQUEST: i32 = -32600;
+    pub const METHOD_NOT_FOUND: i32 = -32601;
+    pub const INVALID_PARAMS: i32 = -32602;
+    pub const INTERNAL_ERROR: i32 = -32603;
+}

--- a/crates/arkavo-mcp-runtime/Cargo.toml
+++ b/crates/arkavo-mcp-runtime/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "arkavo-mcp-runtime"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Runtime implementation for Model Context Protocol (MCP) server"
+repository = "https://github.com/arkavo-com/arkavo-edge"
+keywords = ["mcp", "server", "runtime", "protocol"]
+categories = ["network-programming", "asynchronous"]
+
+[dependencies]
+arkavo-mcp-core = { path = "../arkavo-mcp-core" }
+tokio = { version = "1.42", features = ["rt-multi-thread", "macros", "sync", "time"] }
+anyhow = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+async-trait = "0.1"
+tracing = "0.1"
+once_cell = "1.20"
+
+# For the built-in tools
+uuid = { version = "1.11", features = ["v4", "serde"] }
+chrono = { version = "0.4", features = ["serde"] }
+
+[lints]
+workspace = true

--- a/crates/arkavo-mcp-runtime/Cargo.toml
+++ b/crates/arkavo-mcp-runtime/Cargo.toml
@@ -11,6 +11,8 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 arkavo-mcp-core = { path = "../arkavo-mcp-core" }
+arkavo-llm = { path = "../arkavo-llm" }
+arkavo-memory = { path = "../arkavo-memory" }
 tokio = { version = "1.42", features = ["rt-multi-thread", "macros", "sync", "time"] }
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/arkavo-mcp-runtime/src/lib.rs
+++ b/crates/arkavo-mcp-runtime/src/lib.rs
@@ -1,0 +1,13 @@
+//! Runtime implementation for Model Context Protocol (MCP) server
+//!
+//! This crate provides the server implementation and built-in tools for MCP.
+
+pub mod server;
+pub mod tools;
+
+// Re-export core types for convenience
+pub use arkavo_mcp_core::{
+    RpcError, RpcRequest, RpcResponse, Tool, ToolRequest, ToolResponse, ToolSchema, error_codes,
+};
+
+pub use server::McpServer;

--- a/crates/arkavo-mcp-runtime/src/server.rs
+++ b/crates/arkavo-mcp-runtime/src/server.rs
@@ -1,0 +1,182 @@
+use anyhow::Result;
+use arkavo_mcp_core::{
+    RpcError, RpcRequest, RpcResponse, Tool, ToolRequest, ToolResponse, error_codes,
+};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{debug, info};
+
+/// MCP server that manages tools and handles requests
+pub struct McpServer {
+    tools: Arc<RwLock<HashMap<String, Arc<dyn Tool>>>>,
+}
+
+impl McpServer {
+    /// Create a new MCP server
+    pub fn new() -> Self {
+        Self {
+            tools: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Register a tool with the server
+    pub async fn register_tool(&self, name: String, tool: Arc<dyn Tool>) -> Result<()> {
+        let mut tools = self.tools.write().await;
+        if tools.contains_key(&name) {
+            return Err(anyhow::anyhow!("Tool '{}' is already registered", name));
+        }
+        info!("Registered tool: {}", name);
+        tools.insert(name, tool);
+        Ok(())
+    }
+
+    /// Execute a tool by name
+    pub async fn execute_tool(&self, request: ToolRequest) -> ToolResponse {
+        let tools = self.tools.read().await;
+
+        match tools.get(&request.tool_name) {
+            Some(tool) => match tool.execute(request.params).await {
+                Ok(result) => ToolResponse {
+                    tool_name: request.tool_name,
+                    result,
+                    success: true,
+                },
+                Err(e) => ToolResponse {
+                    tool_name: request.tool_name,
+                    result: serde_json::json!({
+                        "error": e.to_string()
+                    }),
+                    success: false,
+                },
+            },
+            None => ToolResponse {
+                tool_name: request.tool_name.clone(),
+                result: serde_json::json!({
+                    "error": format!("Tool '{}' not found", request.tool_name)
+                }),
+                success: false,
+            },
+        }
+    }
+
+    /// List all available tools
+    pub async fn list_tools(&self) -> Vec<String> {
+        let tools = self.tools.read().await;
+        tools.keys().cloned().collect()
+    }
+
+    /// Get schema for a specific tool
+    pub async fn get_tool_schema(&self, tool_name: &str) -> Option<Value> {
+        let tools = self.tools.read().await;
+        tools.get(tool_name).map(|tool| {
+            let schema = tool.schema();
+            serde_json::to_value(schema).unwrap_or(Value::Null)
+        })
+    }
+
+    /// Handle a JSON-RPC request
+    pub async fn handle_rpc_request(&self, request: RpcRequest) -> RpcResponse {
+        debug!("Handling RPC request: method={}", request.method);
+
+        match request.method.as_str() {
+            "execute_tool" => match request.params {
+                Some(params) => match serde_json::from_value::<ToolRequest>(params) {
+                    Ok(tool_request) => {
+                        let response = self.execute_tool(tool_request).await;
+                        RpcResponse {
+                            jsonrpc: "2.0".to_string(),
+                            id: request.id,
+                            result: Some(serde_json::to_value(response).unwrap_or(Value::Null)),
+                            error: None,
+                        }
+                    }
+                    Err(e) => RpcResponse {
+                        jsonrpc: "2.0".to_string(),
+                        id: request.id,
+                        result: None,
+                        error: Some(RpcError {
+                            code: error_codes::INVALID_PARAMS,
+                            message: format!("Invalid tool request: {}", e),
+                            data: None,
+                        }),
+                    },
+                },
+                None => RpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id: request.id,
+                    result: None,
+                    error: Some(RpcError {
+                        code: error_codes::INVALID_PARAMS,
+                        message: "Missing parameters".to_string(),
+                        data: None,
+                    }),
+                },
+            },
+            "list_tools" => {
+                let tools = self.list_tools().await;
+                RpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id: request.id,
+                    result: Some(serde_json::to_value(tools).unwrap_or(Value::Null)),
+                    error: None,
+                }
+            }
+            "get_tool_schema" => {
+                let tool_name = request
+                    .params
+                    .as_ref()
+                    .and_then(|p| p.get("tool_name"))
+                    .and_then(|v| v.as_str());
+
+                match tool_name {
+                    Some(tool_name) => match self.get_tool_schema(tool_name).await {
+                        Some(schema) => RpcResponse {
+                            jsonrpc: "2.0".to_string(),
+                            id: request.id,
+                            result: Some(schema),
+                            error: None,
+                        },
+                        None => RpcResponse {
+                            jsonrpc: "2.0".to_string(),
+                            id: request.id,
+                            result: None,
+                            error: Some(RpcError {
+                                code: error_codes::INVALID_PARAMS,
+                                message: format!("Tool '{}' not found", tool_name),
+                                data: None,
+                            }),
+                        },
+                    },
+                    None => RpcResponse {
+                        jsonrpc: "2.0".to_string(),
+                        id: request.id,
+                        result: None,
+                        error: Some(RpcError {
+                            code: error_codes::INVALID_PARAMS,
+                            message: "Missing 'tool_name' parameter".to_string(),
+                            data: None,
+                        }),
+                    },
+                }
+            }
+            _ => RpcResponse {
+                jsonrpc: "2.0".to_string(),
+                id: request.id,
+                result: None,
+                error: Some(RpcError {
+                    code: error_codes::METHOD_NOT_FOUND,
+                    message: format!("Unknown method: {}", request.method),
+                    data: None,
+                }),
+            },
+        }
+    }
+}
+
+impl Default for McpServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/arkavo-mcp-runtime/src/server.rs
+++ b/crates/arkavo-mcp-runtime/src/server.rs
@@ -29,6 +29,7 @@ impl McpServer {
         }
         info!("Registered tool: {}", name);
         tools.insert(name, tool);
+        drop(tools);
         Ok(())
     }
 
@@ -98,7 +99,7 @@ impl McpServer {
                         result: None,
                         error: Some(RpcError {
                             code: error_codes::INVALID_PARAMS,
-                            message: format!("Invalid tool request: {}", e),
+                            message: format!("Invalid tool request: {e}"),
                             data: None,
                         }),
                     },

--- a/crates/arkavo-mcp-runtime/src/tools/echo.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/echo.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+use arkavo_mcp_core::{Tool, ToolSchema};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+/// Simple echo tool for testing
+#[derive(Debug)]
+pub struct EchoTool;
+
+impl EchoTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Tool for EchoTool {
+    async fn execute(&self, params: Value) -> Result<Value> {
+        Ok(json!({
+            "echo": params,
+            "timestamp": chrono::Utc::now().to_rfc3339(),
+        }))
+    }
+
+    fn schema(&self) -> &ToolSchema {
+        static SCHEMA: once_cell::sync::Lazy<ToolSchema> =
+            once_cell::sync::Lazy::new(|| ToolSchema {
+                name: "echo".to_string(),
+                description: "Echo back the input parameters".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "additionalProperties": true,
+                }),
+            });
+        &SCHEMA
+    }
+}

--- a/crates/arkavo-mcp-runtime/src/tools/health.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/health.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use arkavo_mcp_core::{Tool, ToolSchema};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+/// Health check tool
+#[derive(Debug)]
+pub struct HealthTool;
+
+impl HealthTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Tool for HealthTool {
+    async fn execute(&self, _params: Value) -> Result<Value> {
+        Ok(json!({
+            "status": "healthy",
+            "timestamp": chrono::Utc::now().to_rfc3339(),
+            "version": env!("CARGO_PKG_VERSION"),
+        }))
+    }
+
+    fn schema(&self) -> &ToolSchema {
+        static SCHEMA: once_cell::sync::Lazy<ToolSchema> =
+            once_cell::sync::Lazy::new(|| ToolSchema {
+                name: "health".to_string(),
+                description: "Check the health status of the MCP server".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {},
+                }),
+            });
+        &SCHEMA
+    }
+}

--- a/crates/arkavo-mcp-runtime/src/tools/mod.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/mod.rs
@@ -1,0 +1,5 @@
+pub mod echo;
+pub mod health;
+
+pub use echo::EchoTool;
+pub use health::HealthTool;

--- a/crates/arkavo-mcp-runtime/src/tools/mod.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/mod.rs
@@ -1,11 +1,11 @@
 pub mod echo;
 pub mod health;
+pub mod ollama_config;
 pub mod ui_control;
 pub mod ui_inspect;
-pub mod ollama_config;
 
 pub use echo::EchoTool;
 pub use health::HealthTool;
+pub use ollama_config::OllamaConfigTool;
 pub use ui_control::{UiAction, UiControlTool};
 pub use ui_inspect::UiInspectTool;
-pub use ollama_config::OllamaConfigTool;

--- a/crates/arkavo-mcp-runtime/src/tools/mod.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/mod.rs
@@ -1,5 +1,11 @@
 pub mod echo;
 pub mod health;
+pub mod ui_control;
+pub mod ui_inspect;
+pub mod ollama_config;
 
 pub use echo::EchoTool;
 pub use health::HealthTool;
+pub use ui_control::{UiAction, UiControlTool};
+pub use ui_inspect::UiInspectTool;
+pub use ollama_config::OllamaConfigTool;

--- a/crates/arkavo-mcp-runtime/src/tools/ollama_config.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/ollama_config.rs
@@ -1,0 +1,146 @@
+use anyhow::Result;
+use arkavo_mcp_core::{Tool, ToolSchema};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use arkavo_memory::storage::MemoryStorage;
+use std::sync::Arc;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct OllamaConfigParams {
+    pub action: String, // "add", "remove", "list"
+    pub server_url: Option<String>,
+}
+
+/// Tool for managing Ollama server configurations
+#[derive(Debug)]
+pub struct OllamaConfigTool;
+
+impl OllamaConfigTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Tool for OllamaConfigTool {
+    async fn execute(&self, params: Value) -> Result<Value> {
+        let config_params: OllamaConfigParams = serde_json::from_value(params)?;
+        
+        match config_params.action.as_str() {
+            "add" => {
+                if let Some(server_url) = config_params.server_url {
+                    // Validate and normalize URL
+                    let mut url = server_url.trim().to_string();
+                    if !url.starts_with("http://") && !url.starts_with("https://") {
+                        url = format!("http://{}", url);
+                    }
+                    
+                    // Test connection
+                    let client = arkavo_llm::ollama::OllamaClient::new(Some(url.clone()), None);
+                    match client.list_models().await {
+                        Ok(models) => {
+                            // Save configuration
+                            let storage = Arc::new(MemoryStorage::new().await?);
+                            let embedding = vec![0.0; 384]; // Placeholder embedding
+                            
+                            let memory = arkavo_memory::models::Memory {
+                                id: uuid::Uuid::new_v4(),
+                                content: url.clone(),
+                                metadata: Some(json!({
+                                    "type": "arkavo_ollama_server_config",
+                                    "timestamp": chrono::Utc::now().to_rfc3339(),
+                                    "model_count": models.len(),
+                                })),
+                                category: Some("config".to_string()),
+                                embedding,
+                                created_at: chrono::Utc::now(),
+                                updated_at: chrono::Utc::now(),
+                            };
+                            
+                            storage.store(memory).await?;
+                            
+                            Ok(json!({
+                                "success": true,
+                                "message": format!("Added Ollama server at {} with {} models", url, models.len()),
+                                "models": models,
+                            }))
+                        }
+                        Err(e) => {
+                            Ok(json!({
+                                "success": false,
+                                "error": format!("Failed to connect to {}: {}", url, e),
+                            }))
+                        }
+                    }
+                } else {
+                    Ok(json!({
+                        "success": false,
+                        "error": "Server URL is required for 'add' action",
+                    }))
+                }
+            }
+            "list" => {
+                let storage = Arc::new(MemoryStorage::new().await?);
+                let configs = storage.search("arkavo_ollama_server_config", 20, Some("config")).await?;
+                
+                let servers: Vec<_> = configs
+                    .into_iter()
+                    .filter(|c| c.memory.content != "CLEARED")
+                    .map(|c| json!({
+                        "url": c.memory.content,
+                        "added_at": c.memory.created_at.to_rfc3339(),
+                    }))
+                    .collect();
+                    
+                Ok(json!({
+                    "success": true,
+                    "servers": servers,
+                }))
+            }
+            "remove" => {
+                // TODO: Implement removal by marking as CLEARED
+                Ok(json!({
+                    "success": false,
+                    "error": "Remove action not yet implemented",
+                }))
+            }
+            _ => {
+                Ok(json!({
+                    "success": false,
+                    "error": format!("Unknown action: {}", config_params.action),
+                }))
+            }
+        }
+    }
+
+    fn schema(&self) -> &ToolSchema {
+        static SCHEMA: once_cell::sync::Lazy<ToolSchema> =
+            once_cell::sync::Lazy::new(|| ToolSchema {
+                name: "ollama_config".to_string(),
+                description: "Manage Ollama server configurations. Add new servers, list existing ones, or remove them.".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["add", "remove", "list"],
+                            "description": "The action to perform"
+                        },
+                        "server_url": {
+                            "type": "string",
+                            "description": "The server URL (e.g., '192.168.1.100:11434' or 'http://server.local:11434'). Required for 'add' action."
+                        }
+                    },
+                    "required": ["action"]
+                }),
+            });
+        &SCHEMA
+    }
+}
+
+impl Default for OllamaConfigTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/arkavo-mcp-runtime/src/tools/ollama_config.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/ollama_config.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use arkavo_mcp_core::{Tool, ToolSchema};
+use arkavo_memory::storage::MemoryStorage;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use arkavo_memory::storage::MemoryStorage;
 use std::sync::Arc;
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -26,7 +26,7 @@ impl OllamaConfigTool {
 impl Tool for OllamaConfigTool {
     async fn execute(&self, params: Value) -> Result<Value> {
         let config_params: OllamaConfigParams = serde_json::from_value(params)?;
-        
+
         match config_params.action.as_str() {
             "add" => {
                 if let Some(server_url) = config_params.server_url {
@@ -35,7 +35,7 @@ impl Tool for OllamaConfigTool {
                     if !url.starts_with("http://") && !url.starts_with("https://") {
                         url = format!("http://{}", url);
                     }
-                    
+
                     // Test connection
                     let client = arkavo_llm::ollama::OllamaClient::new(Some(url.clone()), None);
                     match client.list_models().await {
@@ -43,7 +43,7 @@ impl Tool for OllamaConfigTool {
                             // Save configuration
                             let storage = Arc::new(MemoryStorage::new().await?);
                             let embedding = vec![0.0; 384]; // Placeholder embedding
-                            
+
                             let memory = arkavo_memory::models::Memory {
                                 id: uuid::Uuid::new_v4(),
                                 content: url.clone(),
@@ -57,21 +57,19 @@ impl Tool for OllamaConfigTool {
                                 created_at: chrono::Utc::now(),
                                 updated_at: chrono::Utc::now(),
                             };
-                            
+
                             storage.store(memory).await?;
-                            
+
                             Ok(json!({
                                 "success": true,
                                 "message": format!("Added Ollama server at {} with {} models", url, models.len()),
                                 "models": models,
                             }))
                         }
-                        Err(e) => {
-                            Ok(json!({
-                                "success": false,
-                                "error": format!("Failed to connect to {}: {}", url, e),
-                            }))
-                        }
+                        Err(e) => Ok(json!({
+                            "success": false,
+                            "error": format!("Failed to connect to {}: {}", url, e),
+                        })),
                     }
                 } else {
                     Ok(json!({
@@ -82,17 +80,21 @@ impl Tool for OllamaConfigTool {
             }
             "list" => {
                 let storage = Arc::new(MemoryStorage::new().await?);
-                let configs = storage.search("arkavo_ollama_server_config", 20, Some("config")).await?;
-                
+                let configs = storage
+                    .search("arkavo_ollama_server_config", 20, Some("config"))
+                    .await?;
+
                 let servers: Vec<_> = configs
                     .into_iter()
                     .filter(|c| c.memory.content != "CLEARED")
-                    .map(|c| json!({
-                        "url": c.memory.content,
-                        "added_at": c.memory.created_at.to_rfc3339(),
-                    }))
+                    .map(|c| {
+                        json!({
+                            "url": c.memory.content,
+                            "added_at": c.memory.created_at.to_rfc3339(),
+                        })
+                    })
                     .collect();
-                    
+
                 Ok(json!({
                     "success": true,
                     "servers": servers,
@@ -105,18 +107,16 @@ impl Tool for OllamaConfigTool {
                     "error": "Remove action not yet implemented",
                 }))
             }
-            _ => {
-                Ok(json!({
-                    "success": false,
-                    "error": format!("Unknown action: {}", config_params.action),
-                }))
-            }
+            _ => Ok(json!({
+                "success": false,
+                "error": format!("Unknown action: {}", config_params.action),
+            })),
         }
     }
 
     fn schema(&self) -> &ToolSchema {
-        static SCHEMA: once_cell::sync::Lazy<ToolSchema> =
-            once_cell::sync::Lazy::new(|| ToolSchema {
+        static SCHEMA: once_cell::sync::Lazy<ToolSchema> = once_cell::sync::Lazy::new(|| {
+            ToolSchema {
                 name: "ollama_config".to_string(),
                 description: "Manage Ollama server configurations. Add new servers, list existing ones, or remove them.".to_string(),
                 parameters: json!({
@@ -134,7 +134,8 @@ impl Tool for OllamaConfigTool {
                     },
                     "required": ["action"]
                 }),
-            });
+            }
+        });
         &SCHEMA
     }
 }

--- a/crates/arkavo-mcp-runtime/src/tools/ui_control.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/ui_control.rs
@@ -1,0 +1,83 @@
+use anyhow::Result;
+use arkavo_mcp_core::{Tool, ToolSchema};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::sync::mpsc;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "action")]
+pub enum UiAction {
+    #[serde(rename = "show_debug")]
+    ShowDebug,
+    #[serde(rename = "show_chat")]
+    ShowChat,
+    #[serde(rename = "show_code")]
+    ShowCode,
+    #[serde(rename = "show_diff")]
+    ShowDiff,
+    #[serde(rename = "show_dataflow")]
+    ShowDataflow,
+    #[serde(rename = "focus_input")]
+    FocusInput,
+    #[serde(rename = "focus_scroll")]
+    FocusScroll,
+}
+
+/// UI control tool that sends commands to the terminal UI
+#[derive(Debug)]
+pub struct UiControlTool {
+    ui_tx: mpsc::Sender<UiAction>,
+}
+
+impl UiControlTool {
+    pub fn new(ui_tx: mpsc::Sender<UiAction>) -> Self {
+        Self { ui_tx }
+    }
+}
+
+#[async_trait]
+impl Tool for UiControlTool {
+    async fn execute(&self, params: Value) -> Result<Value> {
+        let action: UiAction = serde_json::from_value(params)?;
+
+        // Send the action to the UI
+        self.ui_tx
+            .send(action)
+            .await
+            .map_err(|_| anyhow::anyhow!("Failed to send UI command"))?;
+
+        Ok(json!({
+            "success": true,
+            "message": "UI command sent"
+        }))
+    }
+
+    fn schema(&self) -> &ToolSchema {
+        static SCHEMA: once_cell::sync::Lazy<ToolSchema> =
+            once_cell::sync::Lazy::new(|| ToolSchema {
+                name: "ui_control".to_string(),
+                description: "Control the terminal UI view modes and focus".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": [
+                                "show_debug",
+                                "show_chat",
+                                "show_code",
+                                "show_diff",
+                                "show_dataflow",
+                                "focus_input",
+                                "focus_scroll"
+                            ],
+                            "description": "The UI action to perform"
+                        }
+                    },
+                    "required": ["action"]
+                }),
+            });
+        &SCHEMA
+    }
+}

--- a/crates/arkavo-mcp-runtime/src/tools/ui_inspect.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/ui_inspect.rs
@@ -29,15 +29,16 @@ impl Tool for UiInspectTool {
     }
 
     fn schema(&self) -> &ToolSchema {
-        static SCHEMA: once_cell::sync::Lazy<ToolSchema> =
-            once_cell::sync::Lazy::new(|| ToolSchema {
+        static SCHEMA: once_cell::sync::Lazy<ToolSchema> = once_cell::sync::Lazy::new(|| {
+            ToolSchema {
                 name: "ui_inspect".to_string(),
                 description: "Get the current state of the terminal UI including providers, models, and debug logs".to_string(),
                 parameters: json!({
                     "type": "object",
                     "properties": {},
                 }),
-            });
+            }
+        });
         &SCHEMA
     }
 }

--- a/crates/arkavo-mcp-runtime/src/tools/ui_inspect.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/ui_inspect.rs
@@ -1,0 +1,43 @@
+use anyhow::Result;
+use arkavo_mcp_core::{Tool, ToolSchema};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tokio::sync::mpsc;
+
+/// UI inspection tool that requests the current UI state
+#[derive(Debug)]
+pub struct UiInspectTool {
+    _ui_tx: mpsc::Sender<super::ui_control::UiAction>,
+}
+
+impl UiInspectTool {
+    pub fn new(ui_tx: mpsc::Sender<super::ui_control::UiAction>) -> Self {
+        Self { _ui_tx: ui_tx }
+    }
+}
+
+#[async_trait]
+impl Tool for UiInspectTool {
+    async fn execute(&self, _params: Value) -> Result<Value> {
+        // For now, return a message indicating the UI state was exported
+        // In a full implementation, this would retrieve the actual state
+        Ok(json!({
+            "success": true,
+            "message": "UI state exported to file. Use Ctrl+S in the terminal to export current state.",
+            "note": "Check for arkavo-ui-state-*.json files in the current directory"
+        }))
+    }
+
+    fn schema(&self) -> &ToolSchema {
+        static SCHEMA: once_cell::sync::Lazy<ToolSchema> =
+            once_cell::sync::Lazy::new(|| ToolSchema {
+                name: "ui_inspect".to_string(),
+                description: "Get the current state of the terminal UI including providers, models, and debug logs".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {},
+                }),
+            });
+        &SCHEMA
+    }
+}

--- a/crates/arkavo-terminal/Cargo.toml
+++ b/crates/arkavo-terminal/Cargo.toml
@@ -28,6 +28,8 @@ semver = { version = "1.0", features = ["serde"] }
 arkavo-memory = { path = "../arkavo-memory", default-features = false }
 arkavo-llm = { path = "../arkavo-llm" }
 arkavo-dataflow = { path = "../arkavo-dataflow" }
+arkavo-mcp-runtime = { path = "../arkavo-mcp-runtime" }
+arkavo-mcp-core = { path = "../arkavo-mcp-core" }
 tokio-stream = "0.1"
 
 # For multi-terminal support

--- a/crates/arkavo-terminal/Cargo.toml
+++ b/crates/arkavo-terminal/Cargo.toml
@@ -31,6 +31,7 @@ arkavo-dataflow = { path = "../arkavo-dataflow" }
 arkavo-mcp-runtime = { path = "../arkavo-mcp-runtime" }
 arkavo-mcp-core = { path = "../arkavo-mcp-core" }
 tokio-stream = "0.1"
+regex = "1.11"
 
 # For multi-terminal support
 uuid = { version = "1.11", features = ["v4", "serde"] }

--- a/crates/arkavo-terminal/Cargo.toml
+++ b/crates/arkavo-terminal/Cargo.toml
@@ -30,6 +30,7 @@ arkavo-llm = { path = "../arkavo-llm" }
 arkavo-dataflow = { path = "../arkavo-dataflow" }
 arkavo-mcp-runtime = { path = "../arkavo-mcp-runtime" }
 arkavo-mcp-core = { path = "../arkavo-mcp-core" }
+arkavo-test = { path = "../arkavo-test" }
 tokio-stream = "0.1"
 regex = "1.11"
 

--- a/crates/arkavo-terminal/src/app.rs
+++ b/crates/arkavo-terminal/src/app.rs
@@ -223,7 +223,7 @@ impl App {
         let storage = match MemoryStorage::new().await {
             Ok(s) => Arc::new(s),
             Err(e) => {
-                eprintln!("Failed to initialize memory storage: {}", e);
+                eprintln!("Failed to initialize memory storage: {e}");
                 return;
             }
         };
@@ -233,7 +233,7 @@ impl App {
         let saved_configs = match storage.search("http", 20, Some("config")).await {
             Ok(configs) => configs,
             Err(e) => {
-                eprintln!("Failed to search for Ollama configs: {}", e);
+                eprintln!("Failed to search for Ollama configs: {e}");
                 vec![]
             }
         };
@@ -247,9 +247,8 @@ impl App {
                     "http://localhost:11434".to_string(),
                 );
                 for model in models {
-                    all_models.push(format!("localhost/{}", model));
+                    all_models.push(format!("localhost/{model}"));
                 }
-                eprintln!("✓ Connected to localhost Ollama server");
             }
             Err(_) => {
                 // Silently ignore localhost if not available
@@ -279,23 +278,17 @@ impl App {
 
                 match client.list_models().await {
                     Ok(models) => {
-                        let server_name = format!("server{}", server_idx);
+                        let server_name = format!("server{server_idx}");
                         self.server_urls
                             .insert(server_name.clone(), server_url.clone());
                         for model in models {
-                            all_models.push(format!("{}/{}", server_name, model));
+                            all_models.push(format!("{server_name}/{model}"));
                         }
-                        eprintln!(
-                            "✓ Connected to {} Ollama server: {}",
-                            server_name, server_url
-                        );
+                        eprintln!("✓ Connected to {server_name} Ollama server: {server_url}");
                         server_idx += 1;
                     }
                     Err(e) => {
-                        eprintln!(
-                            "Failed to fetch models from Ollama server {} ({}): {}",
-                            server_url, server_url, e
-                        );
+                        eprintln!("Failed to fetch models from Ollama server {server_url}: {e}");
                     }
                 }
             }
@@ -311,8 +304,13 @@ impl App {
                 self.active_model = Some(self.available_models[0].clone());
             }
         } else {
-            // If no servers found, prompt user to configure
-            eprintln!("No Ollama servers found. Use 'arkavo chat' to configure servers.");
+            // No models found, prompt for configuration
+            self.available_models = vec![
+                "Configure Ollama Server...".to_string(),
+                "Configure OpenAI API...".to_string(),
+                "Configure Anthropic API...".to_string(),
+            ];
+            self.selected_model = 0;
         }
     }
 
@@ -460,6 +458,22 @@ impl App {
                                         (self.selected_model + 1) % self.available_models.len();
                                     self.active_model =
                                         Some(self.available_models[self.selected_model].clone());
+
+                                    // If we selected a configuration option, show a hint
+                                    if self
+                                        .active_model
+                                        .as_ref()
+                                        .map(|m| m.ends_with("..."))
+                                        .unwrap_or(false)
+                                    {
+                                        self.add_debug_log(
+                                            crate::ui::debug::LogLevel::Info,
+                                            format!(
+                                                "[UI] Press Enter to {}",
+                                                self.active_model.as_ref().unwrap()
+                                            ),
+                                        );
+                                    }
                                 }
                             }
                             KeyCode::BackTab => {
@@ -486,6 +500,34 @@ impl App {
                                                     .cloned()
                                                     .unwrap_or_else(|| "unknown".to_string())
                                             });
+
+                                        // Check if the selected model is actually a configuration option
+                                        if displayed_model.ends_with("...") {
+                                            // This is a configuration option, not a real model
+                                            // Temporarily leave terminal to prompt for configuration
+                                            let _ = terminal::disable_raw_mode();
+                                            let _ = crossterm::execute!(
+                                                std::io::stdout(),
+                                                terminal::LeaveAlternateScreen,
+                                                cursor::Show
+                                            );
+
+                                            // Configure the provider
+                                            let _ =
+                                                self.configure_llm_provider(&displayed_model).await;
+
+                                            // Return to terminal
+                                            let _ = terminal::enable_raw_mode();
+                                            let _ = crossterm::execute!(
+                                                std::io::stdout(),
+                                                terminal::EnterAlternateScreen,
+                                                cursor::Hide
+                                            );
+
+                                            // Force redraw
+                                            terminal.draw(|f| self.render(f))?;
+                                            continue;
+                                        }
 
                                         // Check if we have a main task, if not create one
                                         let task_id = if let Some(id) = self.main_task_id {
@@ -1222,6 +1264,112 @@ Scrolling (when in scroll mode):
 
     pub fn add_debug_log(&mut self, level: crate::ui::debug::LogLevel, message: String) {
         self.debug_view.add_log(level, message);
+    }
+
+    async fn configure_llm_provider(&mut self, provider_type: &str) -> Result<()> {
+        use arkavo_memory::storage::MemoryStorage;
+        use std::io::{self, Write};
+
+        match provider_type {
+            "Configure Ollama Server..." => {
+                // Prompt for Ollama server IP
+                eprintln!("\n⚠️  No Ollama servers found.");
+                eprintln!("Please enter the Ollama server address:");
+                eprintln!("Examples: 192.168.1.100:11434, myserver.local:11434");
+                print!("\nServer address: ");
+                io::stdout().flush()?;
+
+                let mut input = String::new();
+                io::stdin().read_line(&mut input)?;
+                let input = input.trim();
+
+                if !input.is_empty() {
+                    let base_url = if input.starts_with("http://") || input.starts_with("https://")
+                    {
+                        input.to_string()
+                    } else {
+                        format!("http://{input}")
+                    };
+
+                    // Test the connection
+                    eprintln!("\nTesting connection to {base_url}...");
+                    let test_client =
+                        arkavo_llm::ollama::OllamaClient::new(Some(base_url.clone()), None);
+
+                    match test_client.list_models().await {
+                        Ok(models) => {
+                            eprintln!("✓ Connected! Found {} models", models.len());
+
+                            // Save the configuration
+                            let storage = MemoryStorage::new().await?;
+                            let embedding_service =
+                                arkavo_memory::embeddings::EmbeddingService::new();
+                            let embedding =
+                                match embedding_service.generate_embedding(&base_url).await {
+                                    Ok(e) => e,
+                                    Err(_) => vec![0.0; 384],
+                                };
+
+                            let memory = arkavo_memory::models::Memory {
+                                id: uuid::Uuid::new_v4(),
+                                content: base_url.clone(),
+                                metadata: Some(serde_json::json!({
+                                    "type": "arkavo_ollama_server_config",
+                                    "timestamp": chrono::Utc::now().to_rfc3339()
+                                })),
+                                category: Some("config".to_string()),
+                                embedding,
+                                created_at: chrono::Utc::now(),
+                                updated_at: chrono::Utc::now(),
+                            };
+
+                            storage.store(memory).await?;
+                            eprintln!("✓ Configuration saved!");
+
+                            // Refresh available models
+                            self.fetch_available_models().await;
+                        }
+                        Err(e) => {
+                            eprintln!("✗ Failed to connect: {e}");
+                            eprintln!("Please check the server address and try again.");
+                        }
+                    }
+                }
+            }
+            "Configure OpenAI API..." => {
+                eprintln!("\n🔧 OpenAI API configuration");
+                eprintln!("Please enter your OpenAI API key:");
+                print!("\nAPI Key: ");
+                io::stdout().flush()?;
+
+                let mut input = String::new();
+                io::stdin().read_line(&mut input)?;
+                let api_key = input.trim();
+
+                if !api_key.is_empty() {
+                    // TODO: Store OpenAI API key securely and test connection
+                    eprintln!("⚠️  OpenAI provider not yet implemented in terminal UI");
+                }
+            }
+            "Configure Anthropic API..." => {
+                eprintln!("\n🔧 Anthropic API configuration");
+                eprintln!("Please enter your Anthropic API key:");
+                print!("\nAPI Key: ");
+                io::stdout().flush()?;
+
+                let mut input = String::new();
+                io::stdin().read_line(&mut input)?;
+                let api_key = input.trim();
+
+                if !api_key.is_empty() {
+                    // TODO: Store Anthropic API key securely and test connection
+                    eprintln!("⚠️  Anthropic provider not yet implemented in terminal UI");
+                }
+            }
+            _ => {}
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/arkavo-terminal/src/app.rs
+++ b/crates/arkavo-terminal/src/app.rs
@@ -197,30 +197,55 @@ impl App {
     }
 
     pub async fn fetch_available_models(&mut self) {
-        // Try to fetch models from Ollama server
+        // Try to fetch models from multiple Ollama servers
         use arkavo_llm::ollama::OllamaClient;
         
-        let client = OllamaClient::from_env().unwrap_or_else(|_| {
-            OllamaClient::new(None, None)
-        });
+        let mut all_models = Vec::new();
         
-        match client.list_models().await {
+        // Primary Ollama server
+        let primary_url = std::env::var("OLLAMA_BASE_URL")
+            .unwrap_or_else(|_| "http://localhost:11434".to_string());
+        let primary_client = OllamaClient::new(Some(primary_url.clone()), None);
+        
+        match primary_client.list_models().await {
             Ok(models) => {
-                if !models.is_empty() {
-                    self.available_models = models;
-                    // If we have models and none selected, select the first one
-                    if self.selected_model >= self.available_models.len() {
-                        self.selected_model = 0;
-                    }
-                    if self.active_model.is_none() && !self.available_models.is_empty() {
-                        self.active_model = Some(self.available_models[0].clone());
-                    }
+                for model in models {
+                    // Add server prefix to distinguish models
+                    all_models.push(format!("primary/{}", model));
                 }
+                eprintln!("✓ Connected to primary Ollama server: {}", primary_url);
             }
             Err(e) => {
-                // If we can't fetch models, keep the list empty
-                // The UI will show an empty model selector
-                eprintln!("Failed to fetch models from Ollama: {e}");
+                eprintln!("Failed to fetch models from primary Ollama ({}): {}", primary_url, e);
+            }
+        }
+        
+        // Secondary Ollama server (if configured)
+        if let Ok(secondary_url) = std::env::var("OLLAMA_BASE_URL_2") {
+            let secondary_client = OllamaClient::new(Some(secondary_url.clone()), None);
+            
+            match secondary_client.list_models().await {
+                Ok(models) => {
+                    for model in models {
+                        // Add server prefix to distinguish models
+                        all_models.push(format!("secondary/{}", model));
+                    }
+                    eprintln!("✓ Connected to secondary Ollama server: {}", secondary_url);
+                }
+                Err(e) => {
+                    eprintln!("Failed to fetch models from secondary Ollama ({}): {}", secondary_url, e);
+                }
+            }
+        }
+        
+        if !all_models.is_empty() {
+            self.available_models = all_models;
+            // If we have models and none selected, select the first one
+            if self.selected_model >= self.available_models.len() {
+                self.selected_model = 0;
+            }
+            if self.active_model.is_none() && !self.available_models.is_empty() {
+                self.active_model = Some(self.available_models[0].clone());
             }
         }
     }

--- a/crates/arkavo-terminal/src/app.rs
+++ b/crates/arkavo-terminal/src/app.rs
@@ -11,6 +11,7 @@ use ratatui::{
 };
 use std::io;
 use std::time::{Duration, Instant};
+use std::collections::HashMap;
 use tokio::sync::mpsc;
 
 use crate::event::{AppEvent, EventHandler};
@@ -73,6 +74,7 @@ pub struct App {
     pub last_quit_attempt: Option<Instant>,
     pub active_model: Option<String>, // The actual model being used
     pub main_task_id: Option<uuid::Uuid>, // ID of the main conversation task
+    pub server_urls: HashMap<String, String>, // Map server names to URLs
 }
 
 impl App {
@@ -112,6 +114,7 @@ impl App {
             last_quit_attempt: None,
             active_model: None, // Will be set when models are fetched
             main_task_id: None,
+            server_urls: HashMap::new(),
         }
     }
 
@@ -154,6 +157,7 @@ impl App {
             last_quit_attempt: None,
             active_model: None, // Will be set when models are fetched
             main_task_id: None,
+            server_urls: HashMap::new(),
         }
     }
 
@@ -196,44 +200,89 @@ impl App {
         Ok(())
     }
 
+    pub fn get_server_url_for_model(&self, model_name: &str) -> String {
+        if let Some((server_prefix, _)) = model_name.split_once('/') {
+            self.server_urls.get(server_prefix)
+                .cloned()
+                .unwrap_or_else(|| "http://localhost:11434".to_string())
+        } else {
+            "http://localhost:11434".to_string()
+        }
+    }
+
     pub async fn fetch_available_models(&mut self) {
-        // Try to fetch models from multiple Ollama servers
+        // Try to fetch models from discovered Ollama servers
         use arkavo_llm::ollama::OllamaClient;
+        use arkavo_memory::storage::MemoryStorage;
+        use std::sync::Arc;
         
         let mut all_models = Vec::new();
         
-        // Primary Ollama server
-        let primary_url = std::env::var("OLLAMA_BASE_URL")
-            .unwrap_or_else(|_| "http://localhost:11434".to_string());
-        let primary_client = OllamaClient::new(Some(primary_url.clone()), None);
-        
-        match primary_client.list_models().await {
-            Ok(models) => {
-                for model in models {
-                    // Add server prefix to distinguish models
-                    all_models.push(format!("primary/{}", model));
-                }
-                eprintln!("✓ Connected to primary Ollama server: {}", primary_url);
-            }
+        // Initialize memory storage to check for saved Ollama configurations
+        let storage = match MemoryStorage::new().await {
+            Ok(s) => Arc::new(s),
             Err(e) => {
-                eprintln!("Failed to fetch models from primary Ollama ({}): {}", primary_url, e);
+                eprintln!("Failed to initialize memory storage: {}", e);
+                return;
+            }
+        };
+        
+        // Search for saved Ollama server configurations
+        // The search looks for content containing "http" in the config category
+        let saved_configs = match storage
+            .search("http", 20, Some("config"))
+            .await {
+            Ok(configs) => configs,
+            Err(e) => {
+                eprintln!("Failed to search for Ollama configs: {}", e);
+                vec![]
+            }
+        };
+        
+        // Always try localhost first
+        let localhost_client = OllamaClient::new(Some("http://localhost:11434".to_string()), None);
+        match localhost_client.list_models().await {
+            Ok(models) => {
+                self.server_urls.insert("localhost".to_string(), "http://localhost:11434".to_string());
+                for model in models {
+                    all_models.push(format!("localhost/{}", model));
+                }
+                eprintln!("✓ Connected to localhost Ollama server");
+            }
+            Err(_) => {
+                // Silently ignore localhost if not available
             }
         }
         
-        // Secondary Ollama server (if configured)
-        if let Ok(secondary_url) = std::env::var("OLLAMA_BASE_URL_2") {
-            let secondary_client = OllamaClient::new(Some(secondary_url.clone()), None);
+        // Try saved configurations - filter for Ollama server configs
+        let mut server_idx = 1;
+        for config in saved_configs.iter() {
+            let server_url = &config.memory.content;
             
-            match secondary_client.list_models().await {
-                Ok(models) => {
-                    for model in models {
-                        // Add server prefix to distinguish models
-                        all_models.push(format!("secondary/{}", model));
+            // Check if this is an Ollama server config by checking metadata
+            let is_ollama_config = config.memory.metadata
+                .as_ref()
+                .and_then(|m| m.get("type"))
+                .and_then(|t| t.as_str())
+                .map(|t| t == "arkavo_ollama_server_config")
+                .unwrap_or(false);
+            
+            if is_ollama_config && server_url.starts_with("http") && server_url != "http://localhost:11434" {
+                let client = OllamaClient::new(Some(server_url.clone()), None);
+                
+                match client.list_models().await {
+                    Ok(models) => {
+                        let server_name = format!("server{}", server_idx);
+                        self.server_urls.insert(server_name.clone(), server_url.clone());
+                        for model in models {
+                            all_models.push(format!("{}/{}", server_name, model));
+                        }
+                        eprintln!("✓ Connected to {} Ollama server: {}", server_name, server_url);
+                        server_idx += 1;
                     }
-                    eprintln!("✓ Connected to secondary Ollama server: {}", secondary_url);
-                }
-                Err(e) => {
-                    eprintln!("Failed to fetch models from secondary Ollama ({}): {}", secondary_url, e);
+                    Err(e) => {
+                        eprintln!("Failed to fetch models from Ollama server {} ({}): {}", server_url, server_url, e);
+                    }
                 }
             }
         }
@@ -247,6 +296,9 @@ impl App {
             if self.active_model.is_none() && !self.available_models.is_empty() {
                 self.active_model = Some(self.available_models[0].clone());
             }
+        } else {
+            // If no servers found, prompt user to configure
+            eprintln!("No Ollama servers found. Use 'arkavo chat' to configure servers.");
         }
     }
 

--- a/crates/arkavo-terminal/src/app.rs
+++ b/crates/arkavo-terminal/src/app.rs
@@ -106,17 +106,11 @@ impl App {
             helix_editor: HelixEditor::new().ok(),
             task_manager: TaskManager::new(),
             input_buffer: String::new(),
-            available_models: vec![
-                "devstral:latest".to_string(),
-                "llava:7b".to_string(),
-                "deepseek-r1:14b".to_string(),
-                "qwen3:0.6b".to_string(),
-                "dolphin3:latest".to_string(),
-            ],
+            available_models: vec![],
             selected_model: 0,
             input_focused: true,
             last_quit_attempt: None,
-            active_model: Some("devstral:latest".to_string()),
+            active_model: None, // Will be set when models are fetched
             main_task_id: None,
         }
     }
@@ -154,17 +148,11 @@ impl App {
             helix_editor: HelixEditor::new().ok(),
             task_manager: TaskManager::new(),
             input_buffer: String::new(),
-            available_models: vec![
-                "devstral:latest".to_string(),
-                "llava:7b".to_string(),
-                "deepseek-r1:14b".to_string(),
-                "qwen3:0.6b".to_string(),
-                "dolphin3:latest".to_string(),
-            ],
+            available_models: vec![],
             selected_model: 0,
             input_focused: true,
             last_quit_attempt: None,
-            active_model: Some("devstral:latest".to_string()),
+            active_model: None, // Will be set when models are fetched
             main_task_id: None,
         }
     }
@@ -208,10 +196,42 @@ impl App {
         Ok(())
     }
 
+    pub async fn fetch_available_models(&mut self) {
+        // Try to fetch models from Ollama server
+        use arkavo_llm::ollama::OllamaClient;
+        
+        let client = OllamaClient::from_env().unwrap_or_else(|_| {
+            OllamaClient::new(None, None)
+        });
+        
+        match client.list_models().await {
+            Ok(models) => {
+                if !models.is_empty() {
+                    self.available_models = models;
+                    // If we have models and none selected, select the first one
+                    if self.selected_model >= self.available_models.len() {
+                        self.selected_model = 0;
+                    }
+                    if self.active_model.is_none() && !self.available_models.is_empty() {
+                        self.active_model = Some(self.available_models[0].clone());
+                    }
+                }
+            }
+            Err(e) => {
+                // If we can't fetch models, keep the list empty
+                // The UI will show an empty model selector
+                eprintln!("Failed to fetch models from Ollama: {e}");
+            }
+        }
+    }
+
     async fn run_app<B: ratatui::backend::Backend>(
         &mut self,
         terminal: &mut Terminal<B>,
     ) -> Result<()> {
+        // Fetch available models from Ollama server
+        self.fetch_available_models().await;
+        
         // Immediate first draw for fast startup
         terminal.draw(|f| self.render(f))?;
 
@@ -343,9 +363,11 @@ impl App {
                                 terminal.draw(|f| self.render(f))?;
                             }
                             KeyCode::Tab => {
-                                // Cycle through available models
-                                self.selected_model = (self.selected_model + 1) % self.available_models.len();
-                                self.active_model = Some(self.available_models[self.selected_model].clone());
+                                // Cycle through available models (only if we have models)
+                                if !self.available_models.is_empty() {
+                                    self.selected_model = (self.selected_model + 1) % self.available_models.len();
+                                    self.active_model = Some(self.available_models[self.selected_model].clone());
+                                }
                             }
                             KeyCode::BackTab => {
                                 if matches!(self.layout_mode, LayoutMode::Portrait) {
@@ -363,12 +385,13 @@ impl App {
                                     // Send message to the single conversation window
                                     if !self.input_buffer.is_empty() {
                                         // Use the actual model being used (from the LLM client)
-                                        let displayed_model =
-                                            if let Some(ref active) = self.active_model {
-                                                active.clone()
-                                            } else {
-                                                "devstral:latest".to_string()
-                                            };
+                                        let displayed_model = self.active_model.clone()
+                                            .unwrap_or_else(|| {
+                                                // If no model selected, try to use first available
+                                                self.available_models.first()
+                                                    .cloned()
+                                                    .unwrap_or_else(|| "unknown".to_string())
+                                            });
 
                                         // Check if we have a main task, if not create one
                                         let task_id = if let Some(id) = self.main_task_id {
@@ -664,7 +687,7 @@ impl App {
         let active_model_display = if let Some(ref active) = self.active_model {
             format!("Active Model: {active}")
         } else {
-            "Active Model: devstral:latest".to_string()
+            "Active Model: None".to_string()
         };
 
         // Create a block for the model selector area
@@ -676,29 +699,37 @@ impl App {
         let model_inner = model_selector_block.inner(chunks[1]);
         frame.render_widget(model_selector_block, chunks[1]);
 
-        // Render model selection list
-        use ratatui::widgets::{List, ListItem};
-        use ratatui::style::Modifier;
-        
-        let model_items: Vec<ListItem> = self.available_models
-            .iter()
-            .enumerate()
-            .map(|(i, model)| {
-                let style = if i == self.selected_model {
-                    Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default().fg(Color::White)
-                };
-                ListItem::new(format!(" {} {}", if i == self.selected_model { "▸" } else { " " }, model))
-                    .style(style)
-            })
-            .collect();
-        
-        let model_list = List::new(model_items)
-            .style(Style::default().fg(Color::White))
-            .highlight_style(Style::default().add_modifier(Modifier::BOLD));
+        // Render model selection list or loading message
+        if self.available_models.is_empty() {
+            let loading_text = "No models available. Check Ollama connection.";
+            let loading_paragraph = Paragraph::new(loading_text)
+                .style(Style::default().fg(Color::DarkGray))
+                .alignment(ratatui::layout::Alignment::Center);
+            frame.render_widget(loading_paragraph, model_inner);
+        } else {
+            use ratatui::widgets::{List, ListItem};
+            use ratatui::style::Modifier;
             
-        frame.render_widget(model_list, model_inner);
+            let model_items: Vec<ListItem> = self.available_models
+                .iter()
+                .enumerate()
+                .map(|(i, model)| {
+                    let style = if i == self.selected_model {
+                        Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(Color::White)
+                    };
+                    ListItem::new(format!(" {} {}", if i == self.selected_model { "▸" } else { " " }, model))
+                        .style(style)
+                })
+                .collect();
+            
+            let model_list = List::new(model_items)
+                .style(Style::default().fg(Color::White))
+                .highlight_style(Style::default().add_modifier(Modifier::BOLD));
+                
+            frame.render_widget(model_list, model_inner);
+        }
 
         // Render task windows
         if self.task_manager.tasks.is_empty() {
@@ -951,11 +982,8 @@ Scrolling (when in scroll mode):
         use ratatui::style::{Color, Style};
         use ratatui::widgets::{Block, Borders, Paragraph};
 
-        let active_model = if let Some(ref model) = self.active_model {
-            model.clone()
-        } else {
-            "devstral:latest".to_string()
-        };
+        let active_model = self.active_model.clone()
+            .unwrap_or_else(|| "No model selected".to_string());
 
         let mode_indicator = if self.input_focused {
             "INPUT MODE"

--- a/crates/arkavo-terminal/src/app.rs
+++ b/crates/arkavo-terminal/src/app.rs
@@ -9,9 +9,9 @@ use ratatui::{
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout},
 };
+use std::collections::HashMap;
 use std::io;
 use std::time::{Duration, Instant};
-use std::collections::HashMap;
 use tokio::sync::mpsc;
 
 use crate::event::{AppEvent, EventHandler};
@@ -202,7 +202,8 @@ impl App {
 
     pub fn get_server_url_for_model(&self, model_name: &str) -> String {
         if let Some((server_prefix, _)) = model_name.split_once('/') {
-            self.server_urls.get(server_prefix)
+            self.server_urls
+                .get(server_prefix)
                 .cloned()
                 .unwrap_or_else(|| "http://localhost:11434".to_string())
         } else {
@@ -215,9 +216,9 @@ impl App {
         use arkavo_llm::ollama::OllamaClient;
         use arkavo_memory::storage::MemoryStorage;
         use std::sync::Arc;
-        
+
         let mut all_models = Vec::new();
-        
+
         // Initialize memory storage to check for saved Ollama configurations
         let storage = match MemoryStorage::new().await {
             Ok(s) => Arc::new(s),
@@ -226,24 +227,25 @@ impl App {
                 return;
             }
         };
-        
+
         // Search for saved Ollama server configurations
         // The search looks for content containing "http" in the config category
-        let saved_configs = match storage
-            .search("http", 20, Some("config"))
-            .await {
+        let saved_configs = match storage.search("http", 20, Some("config")).await {
             Ok(configs) => configs,
             Err(e) => {
                 eprintln!("Failed to search for Ollama configs: {}", e);
                 vec![]
             }
         };
-        
+
         // Always try localhost first
         let localhost_client = OllamaClient::new(Some("http://localhost:11434".to_string()), None);
         match localhost_client.list_models().await {
             Ok(models) => {
-                self.server_urls.insert("localhost".to_string(), "http://localhost:11434".to_string());
+                self.server_urls.insert(
+                    "localhost".to_string(),
+                    "http://localhost:11434".to_string(),
+                );
                 for model in models {
                     all_models.push(format!("localhost/{}", model));
                 }
@@ -253,40 +255,52 @@ impl App {
                 // Silently ignore localhost if not available
             }
         }
-        
+
         // Try saved configurations - filter for Ollama server configs
         let mut server_idx = 1;
         for config in saved_configs.iter() {
             let server_url = &config.memory.content;
-            
+
             // Check if this is an Ollama server config by checking metadata
-            let is_ollama_config = config.memory.metadata
+            let is_ollama_config = config
+                .memory
+                .metadata
                 .as_ref()
                 .and_then(|m| m.get("type"))
                 .and_then(|t| t.as_str())
                 .map(|t| t == "arkavo_ollama_server_config")
                 .unwrap_or(false);
-            
-            if is_ollama_config && server_url.starts_with("http") && server_url != "http://localhost:11434" {
+
+            if is_ollama_config
+                && server_url.starts_with("http")
+                && server_url != "http://localhost:11434"
+            {
                 let client = OllamaClient::new(Some(server_url.clone()), None);
-                
+
                 match client.list_models().await {
                     Ok(models) => {
                         let server_name = format!("server{}", server_idx);
-                        self.server_urls.insert(server_name.clone(), server_url.clone());
+                        self.server_urls
+                            .insert(server_name.clone(), server_url.clone());
                         for model in models {
                             all_models.push(format!("{}/{}", server_name, model));
                         }
-                        eprintln!("✓ Connected to {} Ollama server: {}", server_name, server_url);
+                        eprintln!(
+                            "✓ Connected to {} Ollama server: {}",
+                            server_name, server_url
+                        );
                         server_idx += 1;
                     }
                     Err(e) => {
-                        eprintln!("Failed to fetch models from Ollama server {} ({}): {}", server_url, server_url, e);
+                        eprintln!(
+                            "Failed to fetch models from Ollama server {} ({}): {}",
+                            server_url, server_url, e
+                        );
                     }
                 }
             }
         }
-        
+
         if !all_models.is_empty() {
             self.available_models = all_models;
             // If we have models and none selected, select the first one
@@ -308,7 +322,7 @@ impl App {
     ) -> Result<()> {
         // Fetch available models from Ollama server
         self.fetch_available_models().await;
-        
+
         // Immediate first draw for fast startup
         terminal.draw(|f| self.render(f))?;
 
@@ -442,8 +456,10 @@ impl App {
                             KeyCode::Tab => {
                                 // Cycle through available models (only if we have models)
                                 if !self.available_models.is_empty() {
-                                    self.selected_model = (self.selected_model + 1) % self.available_models.len();
-                                    self.active_model = Some(self.available_models[self.selected_model].clone());
+                                    self.selected_model =
+                                        (self.selected_model + 1) % self.available_models.len();
+                                    self.active_model =
+                                        Some(self.available_models[self.selected_model].clone());
                                 }
                             }
                             KeyCode::BackTab => {
@@ -462,10 +478,11 @@ impl App {
                                     // Send message to the single conversation window
                                     if !self.input_buffer.is_empty() {
                                         // Use the actual model being used (from the LLM client)
-                                        let displayed_model = self.active_model.clone()
-                                            .unwrap_or_else(|| {
+                                        let displayed_model =
+                                            self.active_model.clone().unwrap_or_else(|| {
                                                 // If no model selected, try to use first available
-                                                self.available_models.first()
+                                                self.available_models
+                                                    .first()
                                                     .cloned()
                                                     .unwrap_or_else(|| "unknown".to_string())
                                             });
@@ -784,27 +801,34 @@ impl App {
                 .alignment(ratatui::layout::Alignment::Center);
             frame.render_widget(loading_paragraph, model_inner);
         } else {
-            use ratatui::widgets::{List, ListItem};
             use ratatui::style::Modifier;
-            
-            let model_items: Vec<ListItem> = self.available_models
+            use ratatui::widgets::{List, ListItem};
+
+            let model_items: Vec<ListItem> = self
+                .available_models
                 .iter()
                 .enumerate()
                 .map(|(i, model)| {
                     let style = if i == self.selected_model {
-                        Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)
+                        Style::default()
+                            .fg(Color::Green)
+                            .add_modifier(Modifier::BOLD)
                     } else {
                         Style::default().fg(Color::White)
                     };
-                    ListItem::new(format!(" {} {}", if i == self.selected_model { "▸" } else { " " }, model))
-                        .style(style)
+                    ListItem::new(format!(
+                        " {} {}",
+                        if i == self.selected_model { "▸" } else { " " },
+                        model
+                    ))
+                    .style(style)
                 })
                 .collect();
-            
+
             let model_list = List::new(model_items)
                 .style(Style::default().fg(Color::White))
                 .highlight_style(Style::default().add_modifier(Modifier::BOLD));
-                
+
             frame.render_widget(model_list, model_inner);
         }
 
@@ -1059,7 +1083,9 @@ Scrolling (when in scroll mode):
         use ratatui::style::{Color, Style};
         use ratatui::widgets::{Block, Borders, Paragraph};
 
-        let active_model = self.active_model.clone()
+        let active_model = self
+            .active_model
+            .clone()
             .unwrap_or_else(|| "No model selected".to_string());
 
         let mode_indicator = if self.input_focused {

--- a/crates/arkavo-terminal/src/app.rs
+++ b/crates/arkavo-terminal/src/app.rs
@@ -107,8 +107,8 @@ impl App {
             task_manager: TaskManager::new(),
             input_buffer: String::new(),
             available_models: vec![
-                "llava:7b".to_string(),
                 "devstral:latest".to_string(),
+                "llava:7b".to_string(),
                 "deepseek-r1:14b".to_string(),
                 "qwen3:0.6b".to_string(),
                 "dolphin3:latest".to_string(),
@@ -155,8 +155,8 @@ impl App {
             task_manager: TaskManager::new(),
             input_buffer: String::new(),
             available_models: vec![
-                "llava:7b".to_string(),
                 "devstral:latest".to_string(),
+                "llava:7b".to_string(),
                 "deepseek-r1:14b".to_string(),
                 "qwen3:0.6b".to_string(),
                 "dolphin3:latest".to_string(),
@@ -343,8 +343,9 @@ impl App {
                                 terminal.draw(|f| self.render(f))?;
                             }
                             KeyCode::Tab => {
-                                // Tab key disabled - model switching not yet implemented
-                                // See issue #86 for multi-model support
+                                // Cycle through available models
+                                self.selected_model = (self.selected_model + 1) % self.available_models.len();
+                                self.active_model = Some(self.available_models[self.selected_model].clone());
                             }
                             KeyCode::BackTab => {
                                 if matches!(self.layout_mode, LayoutMode::Portrait) {
@@ -675,12 +676,29 @@ impl App {
         let model_inner = model_selector_block.inner(chunks[1]);
         frame.render_widget(model_selector_block, chunks[1]);
 
-        // Add info text about model selection
-        let info_text = "Model selection coming soon (see issue #86)";
-        let info_paragraph = Paragraph::new(info_text)
-            .style(Style::default().fg(Color::DarkGray))
-            .alignment(ratatui::layout::Alignment::Center);
-        frame.render_widget(info_paragraph, model_inner);
+        // Render model selection list
+        use ratatui::widgets::{List, ListItem};
+        use ratatui::style::Modifier;
+        
+        let model_items: Vec<ListItem> = self.available_models
+            .iter()
+            .enumerate()
+            .map(|(i, model)| {
+                let style = if i == self.selected_model {
+                    Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(Color::White)
+                };
+                ListItem::new(format!(" {} {}", if i == self.selected_model { "▸" } else { " " }, model))
+                    .style(style)
+            })
+            .collect();
+        
+        let model_list = List::new(model_items)
+            .style(Style::default().fg(Color::White))
+            .highlight_style(Style::default().add_modifier(Modifier::BOLD));
+            
+        frame.render_widget(model_list, model_inner);
 
         // Render task windows
         if self.task_manager.tasks.is_empty() {
@@ -688,6 +706,7 @@ impl App {
 Welcome to Arkavo Terminal UI
 
 • Type your prompt and press Enter to start a conversation
+• Press Tab to cycle through available models
 • Press Ctrl+E to open Helix editor
 • Press Ctrl+I to toggle input/scroll mode
 • Press Ctrl+Q to quit

--- a/crates/arkavo-terminal/src/app.rs
+++ b/crates/arkavo-terminal/src/app.rs
@@ -45,6 +45,14 @@ pub enum FocusedPane {
     Chat,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConfigurationMode {
+    None,
+    OllamaServer { input: String, testing: bool },
+    OpenAIKey { input: String },
+    AnthropicKey { input: String },
+}
+
 pub struct App {
     pub should_quit: bool,
     pub view_mode: ViewMode,
@@ -75,6 +83,7 @@ pub struct App {
     pub active_model: Option<String>, // The actual model being used
     pub main_task_id: Option<uuid::Uuid>, // ID of the main conversation task
     pub server_urls: HashMap<String, String>, // Map server names to URLs
+    pub configuration_mode: ConfigurationMode, // Configuration dialog state
 }
 
 impl App {
@@ -115,6 +124,7 @@ impl App {
             active_model: None, // Will be set when models are fetched
             main_task_id: None,
             server_urls: HashMap::new(),
+            configuration_mode: ConfigurationMode::None,
         }
     }
 
@@ -158,6 +168,7 @@ impl App {
             active_model: None, // Will be set when models are fetched
             main_task_id: None,
             server_urls: HashMap::new(),
+            configuration_mode: ConfigurationMode::None,
         }
     }
 
@@ -223,7 +234,10 @@ impl App {
         let storage = match MemoryStorage::new().await {
             Ok(s) => Arc::new(s),
             Err(e) => {
-                eprintln!("Failed to initialize memory storage: {e}");
+                self.add_debug_log(
+                    crate::ui::debug::LogLevel::Error,
+                    format!("[Storage] Failed to initialize: {e}"),
+                );
                 return;
             }
         };
@@ -233,7 +247,10 @@ impl App {
         let saved_configs = match storage.search("http", 20, Some("config")).await {
             Ok(configs) => configs,
             Err(e) => {
-                eprintln!("Failed to search for Ollama configs: {e}");
+                self.add_debug_log(
+                    crate::ui::debug::LogLevel::Error,
+                    format!("[Storage] Failed to search configs: {e}"),
+                );
                 vec![]
             }
         };
@@ -246,17 +263,32 @@ impl App {
                     "localhost".to_string(),
                     "http://localhost:11434".to_string(),
                 );
+                let model_count = models.len();
                 for model in models {
                     all_models.push(format!("localhost/{model}"));
                 }
+                self.add_debug_log(
+                    crate::ui::debug::LogLevel::Info,
+                    format!(
+                        "[Ollama] Connected to localhost, found {} models",
+                        model_count
+                    ),
+                );
             }
-            Err(_) => {
-                // Silently ignore localhost if not available
+            Err(e) => {
+                self.add_debug_log(
+                    crate::ui::debug::LogLevel::Debug,
+                    format!("[Ollama] Localhost not available: {e}"),
+                );
             }
         }
 
         // Try saved configurations - filter for Ollama server configs
         let mut server_idx = 1;
+        self.add_debug_log(
+            crate::ui::debug::LogLevel::Debug,
+            format!("[Models] Checking {} saved configs", saved_configs.len()),
+        );
         for config in saved_configs.iter() {
             let server_url = &config.memory.content;
 
@@ -284,18 +316,24 @@ impl App {
                         for model in models {
                             all_models.push(format!("{server_name}/{model}"));
                         }
-                        eprintln!("✓ Connected to {server_name} Ollama server: {server_url}");
+                        self.add_debug_log(
+                            crate::ui::debug::LogLevel::Info,
+                            format!("[Ollama] Connected to {server_name}: {server_url}"),
+                        );
                         server_idx += 1;
                     }
                     Err(e) => {
-                        eprintln!("Failed to fetch models from Ollama server {server_url}: {e}");
+                        self.add_debug_log(
+                            crate::ui::debug::LogLevel::Error,
+                            format!("[Ollama] Failed to connect to {server_url}: {e}"),
+                        );
                     }
                 }
             }
         }
 
         if !all_models.is_empty() {
-            self.available_models = all_models;
+            self.available_models = all_models.clone();
             // If we have models and none selected, select the first one
             if self.selected_model >= self.available_models.len() {
                 self.selected_model = 0;
@@ -303,6 +341,14 @@ impl App {
             if self.active_model.is_none() && !self.available_models.is_empty() {
                 self.active_model = Some(self.available_models[0].clone());
             }
+            self.add_debug_log(
+                crate::ui::debug::LogLevel::Info,
+                format!(
+                    "[Models] Found {} models: {:?}",
+                    all_models.len(),
+                    all_models
+                ),
+            );
         } else {
             // No models found, prompt for configuration
             self.available_models = vec![
@@ -311,6 +357,10 @@ impl App {
                 "Configure Anthropic API...".to_string(),
             ];
             self.selected_model = 0;
+            self.add_debug_log(
+                crate::ui::debug::LogLevel::Warning,
+                "[Models] No models found, showing configuration options".to_string(),
+            );
         }
     }
 
@@ -424,9 +474,43 @@ impl App {
                 match event::read()? {
                     Event::Key(key) => {
                         self.telemetry.track_key_event();
+
+                        // Handle configuration mode input
+                        if self.configuration_mode != ConfigurationMode::None {
+                            match key.code {
+                                KeyCode::Esc => {
+                                    self.configuration_mode = ConfigurationMode::None;
+                                }
+                                KeyCode::Enter => {
+                                    self.handle_configuration_submit().await;
+                                }
+                                KeyCode::Char(c) => match &mut self.configuration_mode {
+                                    ConfigurationMode::OllamaServer { input, .. }
+                                    | ConfigurationMode::OpenAIKey { input }
+                                    | ConfigurationMode::AnthropicKey { input } => {
+                                        input.push(c);
+                                    }
+                                    _ => {}
+                                },
+                                KeyCode::Backspace => match &mut self.configuration_mode {
+                                    ConfigurationMode::OllamaServer { input, .. }
+                                    | ConfigurationMode::OpenAIKey { input }
+                                    | ConfigurationMode::AnthropicKey { input } => {
+                                        input.pop();
+                                    }
+                                    _ => {}
+                                },
+                                _ => {}
+                            }
+                            continue;
+                        }
+
                         match key.code {
                             KeyCode::Char('q') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                                 self.should_quit = true;
+                            }
+                            KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                                self.view_mode = ViewMode::Debug;
                             }
                             KeyCode::Char('v') if key.modifiers.contains(KeyModifiers::ALT) => {
                                 self.vim_enabled = !self.vim_enabled;
@@ -503,29 +587,28 @@ impl App {
 
                                         // Check if the selected model is actually a configuration option
                                         if displayed_model.ends_with("...") {
-                                            // This is a configuration option, not a real model
-                                            // Temporarily leave terminal to prompt for configuration
-                                            let _ = terminal::disable_raw_mode();
-                                            let _ = crossterm::execute!(
-                                                std::io::stdout(),
-                                                terminal::LeaveAlternateScreen,
-                                                cursor::Show
-                                            );
-
-                                            // Configure the provider
-                                            let _ =
-                                                self.configure_llm_provider(&displayed_model).await;
-
-                                            // Return to terminal
-                                            let _ = terminal::enable_raw_mode();
-                                            let _ = crossterm::execute!(
-                                                std::io::stdout(),
-                                                terminal::EnterAlternateScreen,
-                                                cursor::Hide
-                                            );
-
-                                            // Force redraw
-                                            terminal.draw(|f| self.render(f))?;
+                                            // Enter configuration mode
+                                            self.configuration_mode = match displayed_model.as_str()
+                                            {
+                                                "Configure Ollama Server..." => {
+                                                    ConfigurationMode::OllamaServer {
+                                                        input: String::new(),
+                                                        testing: false,
+                                                    }
+                                                }
+                                                "Configure OpenAI API..." => {
+                                                    ConfigurationMode::OpenAIKey {
+                                                        input: String::new(),
+                                                    }
+                                                }
+                                                "Configure Anthropic API..." => {
+                                                    ConfigurationMode::AnthropicKey {
+                                                        input: String::new(),
+                                                    }
+                                                }
+                                                _ => ConfigurationMode::None,
+                                            };
+                                            self.input_buffer.clear();
                                             continue;
                                         }
 
@@ -734,6 +817,11 @@ impl App {
     fn render(&self, frame: &mut ratatui::Frame) {
         // Always use the new task-based layout
         self.render_task_layout(frame);
+
+        // Render configuration dialog if active
+        if self.configuration_mode != ConfigurationMode::None {
+            self.render_configuration_dialog(frame);
+        }
     }
 
     fn render_task_layout(&self, frame: &mut ratatui::Frame) {
@@ -1137,7 +1225,7 @@ Scrolling (when in scroll mode):
         };
 
         let status = format!(
-            " {mode_indicator} | Model: {active_model} | Ctrl+E: Helix | Enter: Send | Ctrl+I: Toggle Mode | Ctrl+Q: Quit "
+            " {mode_indicator} | Model: {active_model} | Ctrl+E: Helix | Ctrl+D: Debug | Ctrl+Q: Quit "
         );
 
         let paragraph = Paragraph::new(status)
@@ -1266,42 +1354,140 @@ Scrolling (when in scroll mode):
         self.debug_view.add_log(level, message);
     }
 
-    async fn configure_llm_provider(&mut self, provider_type: &str) -> Result<()> {
+    fn render_configuration_dialog(&self, frame: &mut ratatui::Frame) {
+        use ratatui::style::{Color, Modifier, Style};
+        use ratatui::text::{Line, Span};
+        use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+
+        // Create a centered modal dialog
+        let area = frame.area();
+        let dialog_width = 60.min(area.width - 4);
+        let dialog_height = 12.min(area.height - 4);
+
+        let x = (area.width.saturating_sub(dialog_width)) / 2;
+        let y = (area.height.saturating_sub(dialog_height)) / 2;
+
+        let dialog_area = ratatui::layout::Rect::new(x, y, dialog_width, dialog_height);
+
+        // Clear the area behind the dialog
+        frame.render_widget(Clear, dialog_area);
+
+        // Determine dialog title and content based on configuration mode
+        let (title, prompt, input_value, status) = match &self.configuration_mode {
+            ConfigurationMode::OllamaServer { input, testing } => {
+                let status = if *testing {
+                    "Testing connection..."
+                } else {
+                    ""
+                };
+                (
+                    " Configure Ollama Server ",
+                    "Enter server address (e.g., 192.168.1.100:11434):",
+                    input.as_str(),
+                    status,
+                )
+            }
+            ConfigurationMode::OpenAIKey { input } => (
+                " Configure OpenAI API ",
+                "Enter your OpenAI API key:",
+                input.as_str(),
+                "Note: OpenAI provider not yet implemented",
+            ),
+            ConfigurationMode::AnthropicKey { input } => (
+                " Configure Anthropic API ",
+                "Enter your Anthropic API key:",
+                input.as_str(),
+                "Note: Anthropic provider not yet implemented",
+            ),
+            ConfigurationMode::None => return,
+        };
+
+        // Create the dialog block
+        let block = Block::default()
+            .title(title)
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan));
+
+        let inner = block.inner(dialog_area);
+        frame.render_widget(block, dialog_area);
+
+        // Create dialog content
+        let mut lines = vec![
+            Line::from(""),
+            Line::from(Span::styled(prompt, Style::default().fg(Color::White))),
+            Line::from(""),
+            Line::from(vec![
+                Span::raw("> "),
+                Span::styled(input_value, Style::default().fg(Color::Yellow)),
+                Span::styled("_", Style::default().add_modifier(Modifier::SLOW_BLINK)),
+            ]),
+            Line::from(""),
+        ];
+
+        if !status.is_empty() {
+            lines.push(Line::from(Span::styled(
+                status,
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::ITALIC),
+            )));
+            lines.push(Line::from(""));
+        }
+
+        lines.push(Line::from(Span::styled(
+            "Press Enter to submit, Esc to cancel",
+            Style::default().fg(Color::DarkGray),
+        )));
+
+        let paragraph = Paragraph::new(lines)
+            .wrap(Wrap { trim: true })
+            .alignment(ratatui::layout::Alignment::Left);
+
+        frame.render_widget(paragraph, inner);
+    }
+
+    async fn handle_configuration_submit(&mut self) {
         use arkavo_memory::storage::MemoryStorage;
-        use std::io::{self, Write};
 
-        match provider_type {
-            "Configure Ollama Server..." => {
-                // Prompt for Ollama server IP
-                eprintln!("\n⚠️  No Ollama servers found.");
-                eprintln!("Please enter the Ollama server address:");
-                eprintln!("Examples: 192.168.1.100:11434, myserver.local:11434");
-                print!("\nServer address: ");
-                io::stdout().flush()?;
+        // Clone the configuration mode to avoid borrow checker issues
+        let config_mode = self.configuration_mode.clone();
 
-                let mut input = String::new();
-                io::stdin().read_line(&mut input)?;
-                let input = input.trim();
+        match config_mode {
+            ConfigurationMode::OllamaServer { input, .. } => {
+                if input.is_empty() {
+                    self.configuration_mode = ConfigurationMode::None;
+                    return;
+                }
 
-                if !input.is_empty() {
-                    let base_url = if input.starts_with("http://") || input.starts_with("https://")
-                    {
-                        input.to_string()
-                    } else {
-                        format!("http://{input}")
-                    };
+                let base_url = if input.starts_with("http://") || input.starts_with("https://") {
+                    input.clone()
+                } else {
+                    format!("http://{input}")
+                };
 
-                    // Test the connection
-                    eprintln!("\nTesting connection to {base_url}...");
-                    let test_client =
-                        arkavo_llm::ollama::OllamaClient::new(Some(base_url.clone()), None);
+                // Set testing mode
+                if let ConfigurationMode::OllamaServer { testing, .. } =
+                    &mut self.configuration_mode
+                {
+                    *testing = true;
+                }
 
-                    match test_client.list_models().await {
-                        Ok(models) => {
-                            eprintln!("✓ Connected! Found {} models", models.len());
+                // Test the connection
+                let test_client =
+                    arkavo_llm::ollama::OllamaClient::new(Some(base_url.clone()), None);
 
-                            // Save the configuration
-                            let storage = MemoryStorage::new().await?;
+                match test_client.list_models().await {
+                    Ok(models) => {
+                        self.add_debug_log(
+                            crate::ui::debug::LogLevel::Info,
+                            format!(
+                                "[Config] Connected to {base_url}, found {} models",
+                                models.len()
+                            ),
+                        );
+
+                        // Save the configuration
+                        if let Ok(storage) = MemoryStorage::new().await {
                             let embedding_service =
                                 arkavo_memory::embeddings::EmbeddingService::new();
                             let embedding =
@@ -1323,53 +1509,55 @@ Scrolling (when in scroll mode):
                                 updated_at: chrono::Utc::now(),
                             };
 
-                            storage.store(memory).await?;
-                            eprintln!("✓ Configuration saved!");
-
-                            // Refresh available models
-                            self.fetch_available_models().await;
+                            if let Err(e) = storage.store(memory).await {
+                                self.add_debug_log(
+                                    crate::ui::debug::LogLevel::Error,
+                                    format!("[Config] Failed to save configuration: {e}"),
+                                );
+                            } else {
+                                self.add_debug_log(
+                                    crate::ui::debug::LogLevel::Info,
+                                    "[Config] Configuration saved successfully".to_string(),
+                                );
+                            }
                         }
-                        Err(e) => {
-                            eprintln!("✗ Failed to connect: {e}");
-                            eprintln!("Please check the server address and try again.");
+
+                        // Exit configuration mode
+                        self.configuration_mode = ConfigurationMode::None;
+
+                        // Refresh available models
+                        self.fetch_available_models().await;
+                    }
+                    Err(e) => {
+                        self.add_debug_log(
+                            crate::ui::debug::LogLevel::Error,
+                            format!("[Config] Failed to connect to {base_url}: {e}"),
+                        );
+                        // Reset testing state but stay in config mode
+                        if let ConfigurationMode::OllamaServer { testing, .. } =
+                            &mut self.configuration_mode
+                        {
+                            *testing = false;
                         }
                     }
                 }
             }
-            "Configure OpenAI API..." => {
-                eprintln!("\n🔧 OpenAI API configuration");
-                eprintln!("Please enter your OpenAI API key:");
-                print!("\nAPI Key: ");
-                io::stdout().flush()?;
-
-                let mut input = String::new();
-                io::stdin().read_line(&mut input)?;
-                let api_key = input.trim();
-
-                if !api_key.is_empty() {
-                    // TODO: Store OpenAI API key securely and test connection
-                    eprintln!("⚠️  OpenAI provider not yet implemented in terminal UI");
-                }
+            ConfigurationMode::OpenAIKey { .. } => {
+                self.add_debug_log(
+                    crate::ui::debug::LogLevel::Warning,
+                    "[Config] OpenAI provider not yet implemented".to_string(),
+                );
+                self.configuration_mode = ConfigurationMode::None;
             }
-            "Configure Anthropic API..." => {
-                eprintln!("\n🔧 Anthropic API configuration");
-                eprintln!("Please enter your Anthropic API key:");
-                print!("\nAPI Key: ");
-                io::stdout().flush()?;
-
-                let mut input = String::new();
-                io::stdin().read_line(&mut input)?;
-                let api_key = input.trim();
-
-                if !api_key.is_empty() {
-                    // TODO: Store Anthropic API key securely and test connection
-                    eprintln!("⚠️  Anthropic provider not yet implemented in terminal UI");
-                }
+            ConfigurationMode::AnthropicKey { .. } => {
+                self.add_debug_log(
+                    crate::ui::debug::LogLevel::Warning,
+                    "[Config] Anthropic provider not yet implemented".to_string(),
+                );
+                self.configuration_mode = ConfigurationMode::None;
             }
-            _ => {}
+            ConfigurationMode::None => {}
         }
-
-        Ok(())
     }
 }
 

--- a/crates/arkavo-terminal/src/app.rs
+++ b/crates/arkavo-terminal/src/app.rs
@@ -306,7 +306,10 @@ impl App {
 
         // Search for saved Ollama server configurations
         // Search directly for the type marker like the chat command does
-        let saved_configs = match storage.search("arkavo_ollama_server_config", 20, Some("config")).await {
+        let saved_configs = match storage
+            .search("arkavo_ollama_server_config", 20, Some("config"))
+            .await
+        {
             Ok(configs) => {
                 self.add_debug_log(
                     crate::ui::debug::LogLevel::Debug,
@@ -381,12 +384,12 @@ impl App {
         );
         for config in saved_configs.iter() {
             let server_url = &config.memory.content;
-            
+
             // Skip cleared configs and localhost (we already tried it)
             if server_url == "CLEARED" || server_url == "http://localhost:11434" {
                 continue;
             }
-            
+
             self.add_debug_log(
                 crate::ui::debug::LogLevel::Debug,
                 format!("[Storage] Found saved Ollama config: {}", server_url),
@@ -763,15 +766,19 @@ impl App {
 
                                         // Check for natural language Ollama commands
                                         let input_lower = self.input_buffer.to_lowercase();
-                                        if input_lower.contains("add ollama server") || input_lower.contains("connect to ollama") {
+                                        if input_lower.contains("add ollama server")
+                                            || input_lower.contains("connect to ollama")
+                                        {
                                             // Extract server address from the message
-                                            if let Some(server_url) = self.extract_server_url(&self.input_buffer) {
+                                            if let Some(server_url) =
+                                                self.extract_server_url(&self.input_buffer)
+                                            {
                                                 self.add_ollama_server(server_url).await;
                                                 self.input_buffer.clear();
                                                 continue;
                                             }
                                         }
-                                        
+
                                         // Add user message to the task
                                         if let Some(task) =
                                             self.task_manager.find_task_by_id_mut(task_id)
@@ -1583,7 +1590,7 @@ Scrolling (when in scroll mode):
     pub fn add_debug_log(&mut self, level: crate::ui::debug::LogLevel, message: String) {
         self.debug_view.add_log(level, message);
     }
-    
+
     fn extract_server_url(&self, input: &str) -> Option<String> {
         // Look for patterns like IP:port, hostname:port, or URLs
         let patterns = [
@@ -1594,7 +1601,7 @@ Scrolling (when in scroll mode):
             // Full URL
             r"https?://[^\s]+",
         ];
-        
+
         for pattern in patterns {
             if let Ok(re) = regex::Regex::new(pattern) {
                 if let Some(mat) = re.find(input) {
@@ -1604,23 +1611,23 @@ Scrolling (when in scroll mode):
         }
         None
     }
-    
+
     async fn add_ollama_server(&mut self, server_url: String) {
         use arkavo_llm::ollama::OllamaClient;
         use arkavo_memory::storage::MemoryStorage;
         use std::sync::Arc;
-        
+
         // Normalize URL
         let mut url = server_url.trim().to_string();
         if !url.starts_with("http://") && !url.starts_with("https://") {
             url = format!("http://{}", url);
         }
-        
+
         self.add_debug_log(
             crate::ui::debug::LogLevel::Info,
             format!("[Config] Testing connection to {}", url),
         );
-        
+
         // Test connection
         let client = OllamaClient::new(Some(url.clone()), None);
         match client.list_models().await {
@@ -1629,7 +1636,7 @@ Scrolling (when in scroll mode):
                 if let Ok(storage) = MemoryStorage::new().await {
                     let storage = Arc::new(storage);
                     let embedding = vec![0.0; 384]; // Placeholder
-                    
+
                     let memory = arkavo_memory::models::Memory {
                         id: uuid::Uuid::new_v4(),
                         content: url.clone(),
@@ -1643,7 +1650,7 @@ Scrolling (when in scroll mode):
                         created_at: chrono::Utc::now(),
                         updated_at: chrono::Utc::now(),
                     };
-                    
+
                     if let Err(e) = storage.store(memory).await {
                         self.add_debug_log(
                             crate::ui::debug::LogLevel::Error,
@@ -1652,9 +1659,13 @@ Scrolling (when in scroll mode):
                     } else {
                         self.add_debug_log(
                             crate::ui::debug::LogLevel::Info,
-                            format!("[Config] Added Ollama server {} with {} models", url, models.len()),
+                            format!(
+                                "[Config] Added Ollama server {} with {} models",
+                                url,
+                                models.len()
+                            ),
                         );
-                        
+
                         // Refresh model list
                         self.fetch_available_models().await;
                     }
@@ -1668,12 +1679,12 @@ Scrolling (when in scroll mode):
             }
         }
     }
-    
+
     async fn export_ui_state(&mut self) {
         use chrono::Local;
         use serde_json::json;
         use std::fs;
-        
+
         // Create a comprehensive UI state dump
         let ui_state = json!({
             "timestamp": Local::now().to_rfc3339(),
@@ -1706,11 +1717,17 @@ Scrolling (when in scroll mode):
                 })
             }).collect::<Vec<_>>(),
         });
-        
+
         // Generate filename with timestamp
-        let filename = format!("arkavo-ui-state-{}.json", Local::now().format("%Y%m%d-%H%M%S"));
-        
-        match fs::write(&filename, serde_json::to_string_pretty(&ui_state).unwrap_or_default()) {
+        let filename = format!(
+            "arkavo-ui-state-{}.json",
+            Local::now().format("%Y%m%d-%H%M%S")
+        );
+
+        match fs::write(
+            &filename,
+            serde_json::to_string_pretty(&ui_state).unwrap_or_default(),
+        ) {
             Ok(_) => {
                 self.add_debug_log(
                     crate::ui::debug::LogLevel::Info,

--- a/crates/arkavo-terminal/src/app.rs
+++ b/crates/arkavo-terminal/src/app.rs
@@ -1,3 +1,4 @@
+use crate::mcp_integration::{McpConnection, Tool};
 use anyhow::Result;
 use crossterm::{
     cursor,
@@ -110,6 +111,8 @@ pub struct App {
     pub server_urls: HashMap<String, String>, // Map server names to URLs
     pub configuration_mode: ConfigurationMode, // Configuration dialog state
     pub providers: Vec<ProviderInfo>, // All available providers and their status
+    pub mcp_client: Option<McpConnection>, // MCP client for tools
+    pub mcp_tools: Vec<Tool>,         // Available MCP tools
 }
 
 impl App {
@@ -167,6 +170,8 @@ impl App {
                     models: vec![],
                 },
             ],
+            mcp_client: None,
+            mcp_tools: vec![],
         }
     }
 
@@ -227,6 +232,8 @@ impl App {
                     models: vec![],
                 },
             ],
+            mcp_client: None,
+            mcp_tools: vec![],
         }
     }
 
@@ -236,6 +243,9 @@ impl App {
 
         // Setup terminal
         self.setup_terminal()?;
+
+        // Initialize MCP connection
+        self.initialize_mcp_connection().await;
 
         // Ollama configuration is handled by arkavo chat command
 
@@ -277,6 +287,69 @@ impl App {
                 .unwrap_or_else(|| "http://localhost:11434".to_string())
         } else {
             "http://localhost:11434".to_string()
+        }
+    }
+
+    pub async fn initialize_mcp_connection(&mut self) {
+        // Initialize MCP client - attempt by default unless explicitly disabled
+        if std::env::var("ARKAVO_MCP_DISABLED").unwrap_or_default() == "true" {
+            self.add_debug_log(
+                crate::ui::debug::LogLevel::Info,
+                "[MCP] MCP disabled by environment variable".to_string(),
+            );
+            return;
+        }
+
+        let mcp_url = std::env::var("ARKAVO_MCP_URL").ok();
+        let result = match mcp_url {
+            Some(url) => McpConnection::new_external(Some(url)),
+            None => McpConnection::new_in_process(),
+        };
+
+        match result {
+            Ok(client) => {
+                // List available tools
+                match client.list_tools() {
+                    Ok(tools) => {
+                        self.mcp_tools = tools.clone();
+                        self.add_debug_log(
+                            crate::ui::debug::LogLevel::Info,
+                            format!("[MCP] Connected with {} tools available", tools.len()),
+                        );
+
+                        // Add MCP provider info
+                        self.providers.push(ProviderInfo {
+                            name: "MCP Tools".to_string(),
+                            provider_type: ProviderType::Claude, // Using Claude as placeholder
+                            url: None,
+                            status: ProviderStatus::Connected,
+                            models: tools.iter().map(|t| t.name.clone()).collect(),
+                        });
+                    }
+                    Err(e) => {
+                        self.add_debug_log(
+                            crate::ui::debug::LogLevel::Error,
+                            format!("[MCP] Failed to list tools: {}", e),
+                        );
+                    }
+                }
+                self.mcp_client = Some(client);
+            }
+            Err(e) => {
+                self.add_debug_log(
+                    crate::ui::debug::LogLevel::Warning,
+                    format!("[MCP] Failed to connect: {}", e),
+                );
+
+                // Add disconnected MCP provider
+                self.providers.push(ProviderInfo {
+                    name: "MCP Tools".to_string(),
+                    provider_type: ProviderType::Claude,
+                    url: None,
+                    status: ProviderStatus::Disconnected,
+                    models: vec![],
+                });
+            }
         }
     }
 
@@ -648,6 +721,10 @@ impl App {
                                     "[UI] Refreshing model list...".to_string(),
                                 );
                                 self.fetch_available_models().await;
+                            }
+                            KeyCode::Char('t') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                                // Ctrl+T: Show all MCP tools
+                                self.show_mcp_tools_dialog();
                             }
                             KeyCode::Char('v') if key.modifiers.contains(KeyModifiers::ALT) => {
                                 self.vim_enabled = !self.vim_enabled;
@@ -1083,12 +1160,17 @@ impl App {
         // Group providers by type
         let mut ollama_providers = Vec::new();
         let mut frontier_providers = Vec::new();
+        let mut mcp_provider = None;
 
         for provider in &self.providers {
-            match provider.provider_type {
-                ProviderType::Ollama => ollama_providers.push(provider),
-                ProviderType::OpenAI | ProviderType::Anthropic | ProviderType::Claude => {
-                    frontier_providers.push(provider)
+            if provider.name == "MCP Tools" {
+                mcp_provider = Some(provider);
+            } else {
+                match provider.provider_type {
+                    ProviderType::Ollama => ollama_providers.push(provider),
+                    ProviderType::OpenAI | ProviderType::Anthropic | ProviderType::Claude => {
+                        frontier_providers.push(provider)
+                    }
                 }
             }
         }
@@ -1177,6 +1259,70 @@ impl App {
             }
         }
 
+        // Display MCP Tools section
+        if let Some(provider) = mcp_provider {
+            if !lines.is_empty() {
+                lines.push(Line::from("")); // Add spacing
+            }
+
+            lines.push(Line::from(vec![Span::styled(
+                "MCP Tools",
+                Style::default()
+                    .fg(Color::Magenta)
+                    .add_modifier(Modifier::BOLD),
+            )]));
+
+            let status_symbol = match &provider.status {
+                ProviderStatus::Connected => "✓",
+                ProviderStatus::Disconnected => "✗",
+                _ => "○",
+            };
+
+            let status_color = match &provider.status {
+                ProviderStatus::Connected => Color::Green,
+                ProviderStatus::Disconnected => Color::Red,
+                _ => Color::DarkGray,
+            };
+
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(status_symbol, Style::default().fg(status_color)),
+                Span::raw(" "),
+                Span::raw(&provider.name),
+                Span::raw(" "),
+                Span::styled(
+                    if provider.status == ProviderStatus::Connected {
+                        format!("({} tools available)", self.mcp_tools.len())
+                    } else {
+                        "(not connected)".to_string()
+                    },
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]));
+
+            // Show first few tools if connected
+            if provider.status == ProviderStatus::Connected && !self.mcp_tools.is_empty() {
+                let tools_to_show = self.mcp_tools.iter().take(3);
+                for tool in tools_to_show {
+                    lines.push(Line::from(vec![
+                        Span::raw("    • "),
+                        Span::styled(&tool.name, Style::default().fg(Color::Blue)),
+                    ]));
+                }
+                if self.mcp_tools.len() > 3 {
+                    lines.push(Line::from(vec![
+                        Span::raw("    "),
+                        Span::styled(
+                            format!("... and {} more", self.mcp_tools.len() - 3),
+                            Style::default()
+                                .fg(Color::DarkGray)
+                                .add_modifier(Modifier::ITALIC),
+                        ),
+                    ]));
+                }
+            }
+        }
+
         // Add help text at bottom
         if lines.is_empty() {
             lines.push(Line::from(vec![Span::styled(
@@ -1186,7 +1332,7 @@ impl App {
         } else {
             lines.push(Line::from("")); // Add spacing
             lines.push(Line::from(vec![Span::styled(
-                "Tab: cycle models | Enter: configure",
+                "Tab: cycle models | Enter: configure | Ctrl+T: show all MCP tools",
                 Style::default().fg(Color::DarkGray),
             )]));
         }
@@ -1461,8 +1607,14 @@ Scrolling (when in scroll mode):
             "SCROLL MODE (↑↓/jk/PgUp/PgDn/Home/End)"
         };
 
+        let mcp_status = if self.mcp_client.is_some() {
+            format!(" | MCP: ✓ {} tools", self.mcp_tools.len())
+        } else {
+            " | MCP: ✗".to_string()
+        };
+
         let status = format!(
-            " {mode_indicator} | Model: {active_model} | Ctrl+R: Refresh | Ctrl+D: Debug | Ctrl+S: Export | Ctrl+Q: Quit "
+            " {mode_indicator} | Model: {active_model}{mcp_status} | Ctrl+T: Tools | Ctrl+R: Refresh | Ctrl+Q: Quit "
         );
 
         let paragraph = Paragraph::new(status)
@@ -1947,6 +2099,99 @@ Scrolling (when in scroll mode):
             }
             ConfigurationMode::None => {}
         }
+    }
+
+    fn show_mcp_tools_dialog(&mut self) {
+        if self.mcp_tools.is_empty() {
+            self.add_debug_log(
+                crate::ui::debug::LogLevel::Warning,
+                "[MCP] No tools available".to_string(),
+            );
+            return;
+        }
+
+        // Log all available tools to debug view
+        self.add_debug_log(
+            crate::ui::debug::LogLevel::Info,
+            format!("[MCP] Available tools ({}):", self.mcp_tools.len()),
+        );
+
+        // Group tools by category
+        let mut device_tools = Vec::new();
+        let mut ui_tools = Vec::new();
+        let mut git_tools = Vec::new();
+        let mut memory_tools = Vec::new();
+        let mut other_tools = Vec::new();
+
+        for tool in &self.mcp_tools {
+            let tool_info = format!("@{}: {}", tool.name, tool.description);
+
+            if tool.name.contains("device") || tool.name.contains("simulator") {
+                device_tools.push(tool_info);
+            } else if tool.name.contains("ui_") || tool.name.contains("screen") {
+                ui_tools.push(tool_info);
+            } else if tool.name.contains("git_") {
+                git_tools.push(tool_info);
+            } else if tool.name.contains("memory")
+                || tool.name == "store_memory"
+                || tool.name == "search_memory"
+            {
+                memory_tools.push(tool_info);
+            } else {
+                other_tools.push(tool_info);
+            }
+        }
+
+        // Log tools by category
+        if !device_tools.is_empty() {
+            self.add_debug_log(
+                crate::ui::debug::LogLevel::Info,
+                "[Device Management Tools]".to_string(),
+            );
+            for tool in device_tools {
+                self.add_debug_log(crate::ui::debug::LogLevel::Info, format!("  {}", tool));
+            }
+        }
+
+        if !ui_tools.is_empty() {
+            self.add_debug_log(
+                crate::ui::debug::LogLevel::Info,
+                "[UI Interaction Tools]".to_string(),
+            );
+            for tool in ui_tools {
+                self.add_debug_log(crate::ui::debug::LogLevel::Info, format!("  {}", tool));
+            }
+        }
+
+        if !git_tools.is_empty() {
+            self.add_debug_log(crate::ui::debug::LogLevel::Info, "[Git Tools]".to_string());
+            for tool in git_tools {
+                self.add_debug_log(crate::ui::debug::LogLevel::Info, format!("  {}", tool));
+            }
+        }
+
+        if !memory_tools.is_empty() {
+            self.add_debug_log(
+                crate::ui::debug::LogLevel::Info,
+                "[Memory Tools]".to_string(),
+            );
+            for tool in memory_tools {
+                self.add_debug_log(crate::ui::debug::LogLevel::Info, format!("  {}", tool));
+            }
+        }
+
+        if !other_tools.is_empty() {
+            self.add_debug_log(
+                crate::ui::debug::LogLevel::Info,
+                "[Other Tools]".to_string(),
+            );
+            for tool in other_tools {
+                self.add_debug_log(crate::ui::debug::LogLevel::Info, format!("  {}", tool));
+            }
+        }
+
+        // Switch to debug view to show the tools
+        self.view_mode = ViewMode::Debug;
     }
 }
 

--- a/crates/arkavo-terminal/src/app.rs
+++ b/crates/arkavo-terminal/src/app.rs
@@ -53,6 +53,31 @@ pub enum ConfigurationMode {
     AnthropicKey { input: String },
 }
 
+#[derive(Debug, Clone)]
+pub struct ProviderInfo {
+    pub name: String,
+    pub provider_type: ProviderType,
+    pub url: Option<String>,
+    pub status: ProviderStatus,
+    pub models: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProviderType {
+    Ollama,
+    OpenAI,
+    Anthropic,
+    Claude,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProviderStatus {
+    Connected,
+    Disconnected,
+    NotConfigured,
+    Error(String),
+}
+
 pub struct App {
     pub should_quit: bool,
     pub view_mode: ViewMode,
@@ -84,6 +109,7 @@ pub struct App {
     pub main_task_id: Option<uuid::Uuid>, // ID of the main conversation task
     pub server_urls: HashMap<String, String>, // Map server names to URLs
     pub configuration_mode: ConfigurationMode, // Configuration dialog state
+    pub providers: Vec<ProviderInfo>, // All available providers and their status
 }
 
 impl App {
@@ -125,6 +151,22 @@ impl App {
             main_task_id: None,
             server_urls: HashMap::new(),
             configuration_mode: ConfigurationMode::None,
+            providers: vec![
+                ProviderInfo {
+                    name: "OpenAI".to_string(),
+                    provider_type: ProviderType::OpenAI,
+                    url: Some("https://api.openai.com".to_string()),
+                    status: ProviderStatus::NotConfigured,
+                    models: vec![],
+                },
+                ProviderInfo {
+                    name: "Anthropic".to_string(),
+                    provider_type: ProviderType::Anthropic,
+                    url: Some("https://api.anthropic.com".to_string()),
+                    status: ProviderStatus::NotConfigured,
+                    models: vec![],
+                },
+            ],
         }
     }
 
@@ -169,6 +211,22 @@ impl App {
             main_task_id: None,
             server_urls: HashMap::new(),
             configuration_mode: ConfigurationMode::None,
+            providers: vec![
+                ProviderInfo {
+                    name: "OpenAI".to_string(),
+                    provider_type: ProviderType::OpenAI,
+                    url: Some("https://api.openai.com".to_string()),
+                    status: ProviderStatus::NotConfigured,
+                    models: vec![],
+                },
+                ProviderInfo {
+                    name: "Anthropic".to_string(),
+                    provider_type: ProviderType::Anthropic,
+                    url: Some("https://api.anthropic.com".to_string()),
+                    status: ProviderStatus::NotConfigured,
+                    models: vec![],
+                },
+            ],
         }
     }
 
@@ -230,6 +288,10 @@ impl App {
 
         let mut all_models = Vec::new();
 
+        // Clear existing Ollama providers but keep frontier providers
+        self.providers
+            .retain(|p| p.provider_type != ProviderType::Ollama);
+
         // Initialize memory storage to check for saved Ollama configurations
         let storage = match MemoryStorage::new().await {
             Ok(s) => Arc::new(s),
@@ -243,9 +305,15 @@ impl App {
         };
 
         // Search for saved Ollama server configurations
-        // The search looks for content containing "http" in the config category
-        let saved_configs = match storage.search("http", 20, Some("config")).await {
-            Ok(configs) => configs,
+        // Search directly for the type marker like the chat command does
+        let saved_configs = match storage.search("arkavo_ollama_server_config", 20, Some("config")).await {
+            Ok(configs) => {
+                self.add_debug_log(
+                    crate::ui::debug::LogLevel::Debug,
+                    format!("[Storage] Found {} saved Ollama configs", configs.len()),
+                );
+                configs
+            }
             Err(e) => {
                 self.add_debug_log(
                     crate::ui::debug::LogLevel::Error,
@@ -264,9 +332,22 @@ impl App {
                     "http://localhost:11434".to_string(),
                 );
                 let model_count = models.len();
+                let mut provider_models = Vec::new();
                 for model in models {
-                    all_models.push(format!("localhost/{model}"));
+                    let full_name = format!("localhost/{model}");
+                    all_models.push(full_name.clone());
+                    provider_models.push(model);
                 }
+
+                // Add localhost provider info
+                self.providers.push(ProviderInfo {
+                    name: "Ollama (localhost)".to_string(),
+                    provider_type: ProviderType::Ollama,
+                    url: Some("http://localhost:11434".to_string()),
+                    status: ProviderStatus::Connected,
+                    models: provider_models,
+                });
+
                 self.add_debug_log(
                     crate::ui::debug::LogLevel::Info,
                     format!(
@@ -276,6 +357,15 @@ impl App {
                 );
             }
             Err(e) => {
+                // Add disconnected localhost provider
+                self.providers.push(ProviderInfo {
+                    name: "Ollama (localhost)".to_string(),
+                    provider_type: ProviderType::Ollama,
+                    url: Some("http://localhost:11434".to_string()),
+                    status: ProviderStatus::Disconnected,
+                    models: vec![],
+                });
+
                 self.add_debug_log(
                     crate::ui::debug::LogLevel::Debug,
                     format!("[Ollama] Localhost not available: {e}"),
@@ -291,21 +381,18 @@ impl App {
         );
         for config in saved_configs.iter() {
             let server_url = &config.memory.content;
+            
+            // Skip cleared configs and localhost (we already tried it)
+            if server_url == "CLEARED" || server_url == "http://localhost:11434" {
+                continue;
+            }
+            
+            self.add_debug_log(
+                crate::ui::debug::LogLevel::Debug,
+                format!("[Storage] Found saved Ollama config: {}", server_url),
+            );
 
-            // Check if this is an Ollama server config by checking metadata
-            let is_ollama_config = config
-                .memory
-                .metadata
-                .as_ref()
-                .and_then(|m| m.get("type"))
-                .and_then(|t| t.as_str())
-                .map(|t| t == "arkavo_ollama_server_config")
-                .unwrap_or(false);
-
-            if is_ollama_config
-                && server_url.starts_with("http")
-                && server_url != "http://localhost:11434"
-            {
+            if server_url.starts_with("http") {
                 let client = OllamaClient::new(Some(server_url.clone()), None);
 
                 match client.list_models().await {
@@ -313,20 +400,55 @@ impl App {
                         let server_name = format!("server{server_idx}");
                         self.server_urls
                             .insert(server_name.clone(), server_url.clone());
+
+                        let model_count = models.len();
+                        let mut provider_models = Vec::new();
                         for model in models {
-                            all_models.push(format!("{server_name}/{model}"));
+                            let full_name = format!("{server_name}/{model}");
+                            all_models.push(full_name);
+                            provider_models.push(model);
                         }
+
+                        // Add remote Ollama provider info
+                        // Extract just the host:port from the URL for cleaner display
+                        let display_url = server_url
+                            .strip_prefix("http://")
+                            .or_else(|| server_url.strip_prefix("https://"))
+                            .unwrap_or(&server_url);
+                        self.providers.push(ProviderInfo {
+                            name: format!("Ollama ({} - {})", server_name, display_url),
+                            provider_type: ProviderType::Ollama,
+                            url: Some(server_url.clone()),
+                            status: ProviderStatus::Connected,
+                            models: provider_models,
+                        });
+
                         self.add_debug_log(
                             crate::ui::debug::LogLevel::Info,
-                            format!("[Ollama] Connected to {server_name}: {server_url}"),
+                            format!("[Ollama] Connected to {server_name}: {server_url}, found {} models", model_count),
                         );
                         server_idx += 1;
                     }
                     Err(e) => {
+                        // Add disconnected remote Ollama provider
+                        let server_name = format!("server{server_idx}");
+                        let display_url = server_url
+                            .strip_prefix("http://")
+                            .or_else(|| server_url.strip_prefix("https://"))
+                            .unwrap_or(&server_url);
+                        self.providers.push(ProviderInfo {
+                            name: format!("Ollama ({} - {})", server_name, display_url),
+                            provider_type: ProviderType::Ollama,
+                            url: Some(server_url.clone()),
+                            status: ProviderStatus::Error(e.to_string()),
+                            models: vec![],
+                        });
+
                         self.add_debug_log(
                             crate::ui::debug::LogLevel::Error,
                             format!("[Ollama] Failed to connect to {server_url}: {e}"),
                         );
+                        server_idx += 1;
                     }
                 }
             }
@@ -512,6 +634,18 @@ impl App {
                             KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                                 self.view_mode = ViewMode::Debug;
                             }
+                            KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                                // Ctrl+S: Save/export UI state to file
+                                self.export_ui_state().await;
+                            }
+                            KeyCode::Char('r') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                                // Ctrl+R: Refresh model list
+                                self.add_debug_log(
+                                    crate::ui::debug::LogLevel::Info,
+                                    "[UI] Refreshing model list...".to_string(),
+                                );
+                                self.fetch_available_models().await;
+                            }
                             KeyCode::Char('v') if key.modifiers.contains(KeyModifiers::ALT) => {
                                 self.vim_enabled = !self.vim_enabled;
                                 self.add_debug_log(
@@ -627,6 +761,17 @@ impl App {
                                             id
                                         };
 
+                                        // Check for natural language Ollama commands
+                                        let input_lower = self.input_buffer.to_lowercase();
+                                        if input_lower.contains("add ollama server") || input_lower.contains("connect to ollama") {
+                                            // Extract server address from the message
+                                            if let Some(server_url) = self.extract_server_url(&self.input_buffer) {
+                                                self.add_ollama_server(server_url).await;
+                                                self.input_buffer.clear();
+                                                continue;
+                                            }
+                                        }
+                                        
                                         // Add user message to the task
                                         if let Some(task) =
                                             self.task_manager.find_task_by_id_mut(task_id)
@@ -825,14 +970,14 @@ impl App {
     }
 
     fn render_task_layout(&self, frame: &mut ratatui::Frame) {
-        use ratatui::style::{Color, Style};
+        use ratatui::style::{Color, Modifier, Style};
         use ratatui::widgets::{Block, Borders, Paragraph};
 
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
                 Constraint::Length(3), // Input area at top
-                Constraint::Length(3), // Model selector
+                Constraint::Length(8), // Model/Provider selector (increased for more info)
                 Constraint::Min(10),   // Task windows
                 Constraint::Length(1), // Status bar
             ])
@@ -914,53 +1059,133 @@ impl App {
             "Active Model: None".to_string()
         };
 
-        // Create a block for the model selector area
+        // Create a block for the provider/model area
         let model_selector_block = Block::default()
             .borders(Borders::ALL)
-            .title(active_model_display)
+            .title(format!(" Providers & Models | {} ", active_model_display))
             .border_style(Style::default().fg(Color::Yellow));
 
         let model_inner = model_selector_block.inner(chunks[1]);
         frame.render_widget(model_selector_block, chunks[1]);
 
-        // Render model selection list or loading message
-        if self.available_models.is_empty() {
-            let loading_text = "No models available. Check Ollama connection.";
-            let loading_paragraph = Paragraph::new(loading_text)
-                .style(Style::default().fg(Color::DarkGray))
-                .alignment(ratatui::layout::Alignment::Center);
-            frame.render_widget(loading_paragraph, model_inner);
-        } else {
-            use ratatui::style::Modifier;
-            use ratatui::widgets::{List, ListItem};
+        // Render provider and model information
+        use ratatui::text::{Line, Span};
 
-            let model_items: Vec<ListItem> = self
-                .available_models
-                .iter()
-                .enumerate()
-                .map(|(i, model)| {
-                    let style = if i == self.selected_model {
-                        Style::default()
-                            .fg(Color::Green)
-                            .add_modifier(Modifier::BOLD)
-                    } else {
-                        Style::default().fg(Color::White)
-                    };
-                    ListItem::new(format!(
-                        " {} {}",
-                        if i == self.selected_model { "▸" } else { " " },
-                        model
-                    ))
-                    .style(style)
-                })
-                .collect();
+        let mut lines = Vec::new();
 
-            let model_list = List::new(model_items)
-                .style(Style::default().fg(Color::White))
-                .highlight_style(Style::default().add_modifier(Modifier::BOLD));
+        // Group providers by type
+        let mut ollama_providers = Vec::new();
+        let mut frontier_providers = Vec::new();
 
-            frame.render_widget(model_list, model_inner);
+        for provider in &self.providers {
+            match provider.provider_type {
+                ProviderType::Ollama => ollama_providers.push(provider),
+                ProviderType::OpenAI | ProviderType::Anthropic | ProviderType::Claude => {
+                    frontier_providers.push(provider)
+                }
+            }
         }
+
+        // Display Ollama providers
+        if !ollama_providers.is_empty() {
+            lines.push(Line::from(vec![Span::styled(
+                "Ollama Servers",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            )]));
+
+            for provider in ollama_providers {
+                let status_symbol = match &provider.status {
+                    ProviderStatus::Connected => "✓",
+                    ProviderStatus::Disconnected => "✗",
+                    ProviderStatus::NotConfigured => "○",
+                    ProviderStatus::Error(_) => "!",
+                };
+
+                let status_color = match &provider.status {
+                    ProviderStatus::Connected => Color::Green,
+                    ProviderStatus::Disconnected => Color::Red,
+                    ProviderStatus::NotConfigured => Color::DarkGray,
+                    ProviderStatus::Error(_) => Color::Red,
+                };
+
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled(status_symbol, Style::default().fg(status_color)),
+                    Span::raw(" "),
+                    Span::raw(&provider.name),
+                    Span::raw(" "),
+                    Span::styled(
+                        format!("({} models)", provider.models.len()),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                ]));
+            }
+        }
+
+        // Display frontier providers
+        if !frontier_providers.is_empty() {
+            if !lines.is_empty() {
+                lines.push(Line::from("")); // Add spacing
+            }
+
+            lines.push(Line::from(vec![Span::styled(
+                "Frontier Providers",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )]));
+
+            for provider in frontier_providers {
+                let status_symbol = match &provider.status {
+                    ProviderStatus::Connected => "✓",
+                    ProviderStatus::Disconnected => "✗",
+                    ProviderStatus::NotConfigured => "○",
+                    ProviderStatus::Error(_) => "!",
+                };
+
+                let status_color = match &provider.status {
+                    ProviderStatus::Connected => Color::Green,
+                    ProviderStatus::Disconnected => Color::Red,
+                    ProviderStatus::NotConfigured => Color::DarkGray,
+                    ProviderStatus::Error(_) => Color::Red,
+                };
+
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled(status_symbol, Style::default().fg(status_color)),
+                    Span::raw(" "),
+                    Span::raw(&provider.name),
+                    Span::raw(" "),
+                    Span::styled(
+                        if provider.status == ProviderStatus::NotConfigured {
+                            "(not configured)".to_string()
+                        } else {
+                            format!("({} models)", provider.models.len())
+                        },
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                ]));
+            }
+        }
+
+        // Add help text at bottom
+        if lines.is_empty() {
+            lines.push(Line::from(vec![Span::styled(
+                "No providers available. Press Enter to configure.",
+                Style::default().fg(Color::DarkGray),
+            )]));
+        } else {
+            lines.push(Line::from("")); // Add spacing
+            lines.push(Line::from(vec![Span::styled(
+                "Tab: cycle models | Enter: configure",
+                Style::default().fg(Color::DarkGray),
+            )]));
+        }
+
+        let paragraph = Paragraph::new(lines);
+        frame.render_widget(paragraph, model_inner);
 
         // Render task windows
         if self.task_manager.tasks.is_empty() {
@@ -971,7 +1196,12 @@ Welcome to Arkavo Terminal UI
 • Press Tab to cycle through available models
 • Press Ctrl+E to open Helix editor
 • Press Ctrl+I to toggle input/scroll mode
+• Press Ctrl+R to refresh model list
 • Press Ctrl+Q to quit
+
+Natural Language Commands:
+• "Add Ollama server 192.168.1.100:11434" - Connect to a new Ollama server
+• "Connect to Ollama at server.local:11434" - Alternative syntax
 
 Scrolling (when in scroll mode):
 • Arrow Up/Down or j/k to scroll line by line
@@ -1225,7 +1455,7 @@ Scrolling (when in scroll mode):
         };
 
         let status = format!(
-            " {mode_indicator} | Model: {active_model} | Ctrl+E: Helix | Ctrl+D: Debug | Ctrl+Q: Quit "
+            " {mode_indicator} | Model: {active_model} | Ctrl+R: Refresh | Ctrl+D: Debug | Ctrl+S: Export | Ctrl+Q: Quit "
         );
 
         let paragraph = Paragraph::new(status)
@@ -1352,6 +1582,148 @@ Scrolling (when in scroll mode):
 
     pub fn add_debug_log(&mut self, level: crate::ui::debug::LogLevel, message: String) {
         self.debug_view.add_log(level, message);
+    }
+    
+    fn extract_server_url(&self, input: &str) -> Option<String> {
+        // Look for patterns like IP:port, hostname:port, or URLs
+        let patterns = [
+            // IP address with port
+            r"\b(?:\d{1,3}\.){3}\d{1,3}:\d{1,5}\b",
+            // Hostname with port
+            r"\b[a-zA-Z0-9\-\.]+:\d{1,5}\b",
+            // Full URL
+            r"https?://[^\s]+",
+        ];
+        
+        for pattern in patterns {
+            if let Ok(re) = regex::Regex::new(pattern) {
+                if let Some(mat) = re.find(input) {
+                    return Some(mat.as_str().to_string());
+                }
+            }
+        }
+        None
+    }
+    
+    async fn add_ollama_server(&mut self, server_url: String) {
+        use arkavo_llm::ollama::OllamaClient;
+        use arkavo_memory::storage::MemoryStorage;
+        use std::sync::Arc;
+        
+        // Normalize URL
+        let mut url = server_url.trim().to_string();
+        if !url.starts_with("http://") && !url.starts_with("https://") {
+            url = format!("http://{}", url);
+        }
+        
+        self.add_debug_log(
+            crate::ui::debug::LogLevel::Info,
+            format!("[Config] Testing connection to {}", url),
+        );
+        
+        // Test connection
+        let client = OllamaClient::new(Some(url.clone()), None);
+        match client.list_models().await {
+            Ok(models) => {
+                // Save configuration
+                if let Ok(storage) = MemoryStorage::new().await {
+                    let storage = Arc::new(storage);
+                    let embedding = vec![0.0; 384]; // Placeholder
+                    
+                    let memory = arkavo_memory::models::Memory {
+                        id: uuid::Uuid::new_v4(),
+                        content: url.clone(),
+                        metadata: Some(serde_json::json!({
+                            "type": "arkavo_ollama_server_config",
+                            "timestamp": chrono::Utc::now().to_rfc3339(),
+                            "model_count": models.len(),
+                        })),
+                        category: Some("config".to_string()),
+                        embedding,
+                        created_at: chrono::Utc::now(),
+                        updated_at: chrono::Utc::now(),
+                    };
+                    
+                    if let Err(e) = storage.store(memory).await {
+                        self.add_debug_log(
+                            crate::ui::debug::LogLevel::Error,
+                            format!("[Config] Failed to save: {}", e),
+                        );
+                    } else {
+                        self.add_debug_log(
+                            crate::ui::debug::LogLevel::Info,
+                            format!("[Config] Added Ollama server {} with {} models", url, models.len()),
+                        );
+                        
+                        // Refresh model list
+                        self.fetch_available_models().await;
+                    }
+                }
+            }
+            Err(e) => {
+                self.add_debug_log(
+                    crate::ui::debug::LogLevel::Error,
+                    format!("[Config] Failed to connect to {}: {}", url, e),
+                );
+            }
+        }
+    }
+    
+    async fn export_ui_state(&mut self) {
+        use chrono::Local;
+        use serde_json::json;
+        use std::fs;
+        
+        // Create a comprehensive UI state dump
+        let ui_state = json!({
+            "timestamp": Local::now().to_rfc3339(),
+            "providers": self.providers.iter().map(|p| {
+                json!({
+                    "name": p.name,
+                    "type": format!("{:?}", p.provider_type),
+                    "url": p.url,
+                    "status": format!("{:?}", p.status),
+                    "models": p.models,
+                })
+            }).collect::<Vec<_>>(),
+            "active_model": self.active_model,
+            "available_models": self.available_models,
+            "selected_model": self.selected_model,
+            "server_urls": self.server_urls,
+            "debug_logs": self.debug_view.get_all_logs(),
+            "tasks": self.task_manager.tasks.iter().map(|t| {
+                json!({
+                    "id": t.id.to_string(),
+                    "agent": t.agent_name,
+                    "model": t.model_name,
+                    "status": format!("{:?}", t.status),
+                    "messages": t.messages.iter().map(|m| {
+                        json!({
+                            "role": format!("{:?}", m.role),
+                            "content": m.content,
+                        })
+                    }).collect::<Vec<_>>(),
+                })
+            }).collect::<Vec<_>>(),
+        });
+        
+        // Generate filename with timestamp
+        let filename = format!("arkavo-ui-state-{}.json", Local::now().format("%Y%m%d-%H%M%S"));
+        
+        match fs::write(&filename, serde_json::to_string_pretty(&ui_state).unwrap_or_default()) {
+            Ok(_) => {
+                self.add_debug_log(
+                    crate::ui::debug::LogLevel::Info,
+                    format!("[Export] UI state saved to {}", filename),
+                );
+            }
+            Err(e) => {
+                self.add_debug_log(
+                    crate::ui::debug::LogLevel::Error,
+                    format!("[Export] Failed to save UI state: {}", e),
+                );
+            }
+        }
     }
 
     fn render_configuration_dialog(&self, frame: &mut ratatui::Frame) {

--- a/crates/arkavo-terminal/src/lib.rs
+++ b/crates/arkavo-terminal/src/lib.rs
@@ -86,27 +86,35 @@ pub async fn run() -> Result<()> {
             messages_clone.push(user_message.clone());
 
             // Parse the model name to extract server and actual model
-            let (server_url, actual_model) = if let Some((server_prefix, model)) =
-                request.model_name.split_once('/')
-            {
-                // Model has server prefix - need to resolve the URL
-                let url = if server_prefix == "localhost" {
-                    "http://localhost:11434".to_string()
-                } else if server_prefix.starts_with("server") {
-                    // Look up saved server configuration from memory storage
-                    if let Ok(storage) = arkavo_memory::storage::MemoryStorage::new().await {
-                        if let Ok(all_configs) = storage.search("arkavo_ollama_server_config", 20, Some("config")).await {
-                            // No need to filter since we searched for the specific type
-                            let ollama_configs: Vec<_> = all_configs
-                                .into_iter()
-                                .filter(|config| config.memory.content != "CLEARED" && config.memory.content != "http://localhost:11434")
-                                .collect();
+            let (server_url, actual_model) =
+                if let Some((server_prefix, model)) = request.model_name.split_once('/') {
+                    // Model has server prefix - need to resolve the URL
+                    let url = if server_prefix == "localhost" {
+                        "http://localhost:11434".to_string()
+                    } else if server_prefix.starts_with("server") {
+                        // Look up saved server configuration from memory storage
+                        if let Ok(storage) = arkavo_memory::storage::MemoryStorage::new().await {
+                            if let Ok(all_configs) = storage
+                                .search("arkavo_ollama_server_config", 20, Some("config"))
+                                .await
+                            {
+                                // No need to filter since we searched for the specific type
+                                let ollama_configs: Vec<_> = all_configs
+                                    .into_iter()
+                                    .filter(|config| {
+                                        config.memory.content != "CLEARED"
+                                            && config.memory.content != "http://localhost:11434"
+                                    })
+                                    .collect();
 
-                            // Extract server number from prefix (e.g., "server1" -> 1)
-                            if let Some(num_str) = server_prefix.strip_prefix("server") {
-                                if let Ok(idx) = num_str.parse::<usize>() {
-                                    if idx > 0 && idx <= ollama_configs.len() {
-                                        ollama_configs[idx - 1].memory.content.clone()
+                                // Extract server number from prefix (e.g., "server1" -> 1)
+                                if let Some(num_str) = server_prefix.strip_prefix("server") {
+                                    if let Ok(idx) = num_str.parse::<usize>() {
+                                        if idx > 0 && idx <= ollama_configs.len() {
+                                            ollama_configs[idx - 1].memory.content.clone()
+                                        } else {
+                                            "http://localhost:11434".to_string()
+                                        }
                                     } else {
                                         "http://localhost:11434".to_string()
                                     }
@@ -120,28 +128,30 @@ pub async fn run() -> Result<()> {
                             "http://localhost:11434".to_string()
                         }
                     } else {
+                        // Unknown prefix, use localhost as fallback
                         "http://localhost:11434".to_string()
-                    }
+                    };
+                    (url, model.to_string())
                 } else {
-                    // Unknown prefix, use localhost as fallback
-                    "http://localhost:11434".to_string()
+                    // No server prefix, use default
+                    (
+                        "http://localhost:11434".to_string(),
+                        request.model_name.clone(),
+                    )
                 };
-                (url, model.to_string())
-            } else {
-                // No server prefix, use default
-                (
-                    "http://localhost:11434".to_string(),
-                    request.model_name.clone(),
-                )
-            };
 
             // Debug log the resolved server and model
-            eprintln!("[LLM] Using server: {} with model: {}", server_url, actual_model);
-            
+            eprintln!(
+                "[LLM] Using server: {} with model: {}",
+                server_url, actual_model
+            );
+
             // Create a new Ollama client with the specific model and server
-            let model_specific_client = arkavo_llm::LlmClient::new(Box::new(
-                arkavo_llm::ollama::OllamaClient::new(Some(server_url.clone()), Some(actual_model.clone())),
-            ));
+            let model_specific_client =
+                arkavo_llm::LlmClient::new(Box::new(arkavo_llm::ollama::OllamaClient::new(
+                    Some(server_url.clone()),
+                    Some(actual_model.clone()),
+                )));
 
             // Spawn a task for each request
             tokio::spawn(async move {

--- a/crates/arkavo-terminal/src/lib.rs
+++ b/crates/arkavo-terminal/src/lib.rs
@@ -95,21 +95,11 @@ pub async fn run() -> Result<()> {
                 } else if server_prefix.starts_with("server") {
                     // Look up saved server configuration from memory storage
                     if let Ok(storage) = arkavo_memory::storage::MemoryStorage::new().await {
-                        if let Ok(all_configs) = storage.search("http", 20, Some("config")).await {
-                            // Filter for Ollama server configs only
+                        if let Ok(all_configs) = storage.search("arkavo_ollama_server_config", 20, Some("config")).await {
+                            // No need to filter since we searched for the specific type
                             let ollama_configs: Vec<_> = all_configs
                                 .into_iter()
-                                .filter(|config| {
-                                    config
-                                        .memory
-                                        .metadata
-                                        .as_ref()
-                                        .and_then(|m| m.get("type"))
-                                        .and_then(|t| t.as_str())
-                                        .map(|t| t == "arkavo_ollama_server_config")
-                                        .unwrap_or(false)
-                                })
-                                .filter(|config| config.memory.content != "http://localhost:11434")
+                                .filter(|config| config.memory.content != "CLEARED" && config.memory.content != "http://localhost:11434")
                                 .collect();
 
                             // Extract server number from prefix (e.g., "server1" -> 1)
@@ -145,9 +135,12 @@ pub async fn run() -> Result<()> {
                 )
             };
 
+            // Debug log the resolved server and model
+            eprintln!("[LLM] Using server: {} with model: {}", server_url, actual_model);
+            
             // Create a new Ollama client with the specific model and server
             let model_specific_client = arkavo_llm::LlmClient::new(Box::new(
-                arkavo_llm::ollama::OllamaClient::new(Some(server_url), Some(actual_model)),
+                arkavo_llm::ollama::OllamaClient::new(Some(server_url.clone()), Some(actual_model.clone())),
             ));
 
             // Spawn a task for each request

--- a/crates/arkavo-terminal/src/lib.rs
+++ b/crates/arkavo-terminal/src/lib.rs
@@ -2,6 +2,7 @@ pub mod app;
 pub mod benchmark;
 pub mod event;
 pub mod helix;
+pub mod mcp_integration;
 pub mod multi_terminal;
 pub mod renderer;
 pub mod telemetry;
@@ -57,6 +58,7 @@ pub async fn run() -> Result<()> {
 
     // Spawn LLM handler task with proper Ollama integration
     tokio::spawn(async move {
+        use crate::mcp_integration::McpConnection;
         use arkavo_llm::Message;
         use tokio_stream::StreamExt;
 
@@ -74,8 +76,121 @@ pub async fn run() -> Result<()> {
             client.provider_name()
         );
 
-        // Keep conversation context
-        let mut messages = Vec::new();
+        // Initialize MCP connection
+        let mcp_client = if std::env::var("ARKAVO_MCP_DISABLED").unwrap_or_default() == "true" {
+            None
+        } else {
+            let mcp_url = std::env::var("ARKAVO_MCP_URL").ok();
+            let result = match mcp_url {
+                Some(url) => McpConnection::new_external(Some(url)),
+                None => McpConnection::new_in_process(),
+            };
+
+            match result {
+                Ok(client) => {
+                    match &client {
+                        McpConnection::InProcess(_) => {
+                            eprintln!("✓ LLM handler using in-process MCP server")
+                        }
+                        McpConnection::External(_) => {
+                            eprintln!("✓ LLM handler connected to external MCP server")
+                        }
+                    }
+                    Some(client)
+                }
+                Err(e) => {
+                    eprintln!("ℹ MCP server not available for LLM handler: {}", e);
+                    None
+                }
+            }
+        };
+
+        // Build MCP tools information for system prompt
+        let mcp_info = if let Some(ref client) = mcp_client {
+            match client.list_tools() {
+                Ok(tools) => {
+                    if tools.is_empty() {
+                        "\n\nMCP Integration: Enabled\nNo tools available yet.".to_string()
+                    } else {
+                        let mut tool_info =
+                            String::from("\n\nMCP Integration: Enabled\n\nAvailable MCP tools:\n");
+
+                        // Group tools by category
+                        let mut device_tools = Vec::new();
+                        let mut ui_tools = Vec::new();
+                        let mut git_tools = Vec::new();
+                        let mut memory_tools = Vec::new();
+                        let mut other_tools = Vec::new();
+
+                        for tool in &tools {
+                            let tool_desc = format!("- @{}: {}", tool.name, tool.description);
+
+                            if tool.name.contains("device") || tool.name.contains("simulator") {
+                                device_tools.push(tool_desc);
+                            } else if tool.name.contains("ui_") || tool.name.contains("screen") {
+                                ui_tools.push(tool_desc);
+                            } else if tool.name.contains("git_") {
+                                git_tools.push(tool_desc);
+                            } else if tool.name.contains("memory")
+                                || tool.name == "store_memory"
+                                || tool.name == "search_memory"
+                            {
+                                memory_tools.push(tool_desc);
+                            } else {
+                                other_tools.push(tool_desc);
+                            }
+                        }
+
+                        if !device_tools.is_empty() {
+                            tool_info.push_str("\nDevice Management:\n");
+                            tool_info.push_str(&device_tools.join("\n"));
+                        }
+
+                        if !ui_tools.is_empty() {
+                            tool_info.push_str("\n\nUI Interaction:\n");
+                            tool_info.push_str(&ui_tools.join("\n"));
+                        }
+
+                        if !git_tools.is_empty() {
+                            tool_info.push_str("\n\nGit Tools:\n");
+                            tool_info.push_str(&git_tools.join("\n"));
+                        }
+
+                        if !memory_tools.is_empty() {
+                            tool_info.push_str("\n\nMemory Tools:\n");
+                            tool_info.push_str(&memory_tools.join("\n"));
+                        }
+
+                        if !other_tools.is_empty() {
+                            tool_info.push_str("\n\nOther Tools:\n");
+                            tool_info.push_str(&other_tools.join("\n"));
+                        }
+
+                        tool_info
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Warning: Failed to list MCP tools: {}", e);
+                    "\n\nMCP Integration: Enabled (tool listing failed)".to_string()
+                }
+            }
+        } else {
+            "\n\nMCP Integration: Disabled".to_string()
+        };
+
+        // System prompt with MCP tools information
+        let system_prompt = format!(
+            "You are an AI assistant working in the Arkavo Terminal UI. \
+            You have access to MCP tools for various operations including Git, device management, and UI interaction. \
+            When the user asks you to perform actions, you can use these tools by including @toolname commands in your response.\n\
+            \nTo invoke an MCP tool, use the format: @toolname {{arguments}} or @toolname plain text arguments\
+            \nFor example: @git_status {{}} or @device_management {{\"action\": \"list\"}}\
+            {}",
+            mcp_info
+        );
+
+        // Keep conversation context with system message
+        let mut messages = vec![Message::system(&system_prompt)];
 
         while let Some(request) = ui_rx.recv().await {
             let llm_tx = llm_tx.clone();
@@ -153,6 +268,10 @@ pub async fn run() -> Result<()> {
                     Some(actual_model.clone()),
                 )));
 
+            // Clone MCP client for this task
+            let task_mcp_client = mcp_client.clone();
+            let provider_name = client.provider_name().to_string();
+
             // Spawn a task for each request
             tokio::spawn(async move {
                 // Get streaming response from LLM with the user-selected model
@@ -170,10 +289,13 @@ pub async fn run() -> Result<()> {
                             })
                             .await;
 
+                        let mut full_response = String::new();
+
                         while let Some(chunk_result) = stream.next().await {
                             match chunk_result {
                                 Ok(chunk) => {
                                     if !chunk.content.is_empty() {
+                                        full_response.push_str(&chunk.content);
                                         // Send each chunk as it arrives
                                         let _ = llm_tx
                                             .send(LlmResponse {
@@ -200,6 +322,66 @@ pub async fn run() -> Result<()> {
                                         .await;
                                     break;
                                 }
+                            }
+                        }
+
+                        // Check for and execute any @tool calls in the response
+                        if let Some(ref mcp) = task_mcp_client {
+                            let tool_calls = extract_tool_calls(&full_response);
+                            for (tool_name, args_str) in tool_calls {
+                                // Parse arguments
+                                let args = if args_str.trim().starts_with('{') {
+                                    serde_json::from_str(&args_str)
+                                        .unwrap_or_else(|_| serde_json::json!({"prompt": args_str}))
+                                } else {
+                                    serde_json::json!({"prompt": args_str})
+                                };
+
+                                // Execute tool
+                                let tool_response =
+                                    match mcp.call_tool(&tool_name, args, &provider_name) {
+                                        Ok(result) => {
+                                            // Extract result text
+                                            let result_text = if let Some(result_obj) =
+                                                result.get("result")
+                                            {
+                                                if let Some(text) = result_obj.as_str() {
+                                                    text.to_string()
+                                                } else {
+                                                    serde_json::to_string_pretty(&result_obj)
+                                                        .unwrap_or_else(|_| result_obj.to_string())
+                                                }
+                                            } else {
+                                                serde_json::to_string_pretty(&result)
+                                                    .unwrap_or_else(|_| result.to_string())
+                                            };
+
+                                            LlmResponse {
+                                                task_id: request.task_id,
+                                                model_name: request.model_name.clone(),
+                                                content: format!(
+                                                    "\n\n[Tool Result - @{}]:\n{}",
+                                                    tool_name, result_text
+                                                ),
+                                                is_streaming: false,
+                                                is_complete: false,
+                                                error: None,
+                                            }
+                                        }
+                                        Err(e) => LlmResponse {
+                                            task_id: request.task_id,
+                                            model_name: request.model_name.clone(),
+                                            content: format!(
+                                                "\n\n[Tool Error - @{}]: {}",
+                                                tool_name, e
+                                            ),
+                                            is_streaming: false,
+                                            is_complete: false,
+                                            error: None,
+                                        },
+                                    };
+
+                                let _ = llm_tx.send(tool_response).await;
                             }
                         }
 
@@ -536,6 +718,77 @@ pub async fn run_with_string_channels(
 
     // Run with the adapted channels
     run_with_channels(new_ui_tx, new_llm_rx).await
+}
+
+fn extract_tool_calls(response: &str) -> Vec<(String, String)> {
+    let mut tool_calls = Vec::new();
+
+    // Remove markdown code blocks to find tools within them
+    let cleaned_response = response.replace("```", "").replace('`', "");
+
+    let mut remaining = &cleaned_response[..];
+
+    while let Some(at_pos) = remaining.find('@') {
+        // Check if this is a tool call (followed by word characters)
+        let after_at = &remaining[at_pos + 1..];
+
+        if let Some(space_or_brace) = after_at.find(|c: char| c.is_whitespace() || c == '{') {
+            let tool_name = &after_at[..space_or_brace];
+
+            // Only process if tool_name is alphanumeric and not "screenshot"
+            if tool_name.chars().all(|c| c.is_alphanumeric() || c == '_')
+                && tool_name != "screenshot"
+            {
+                let args_start = at_pos + 1 + space_or_brace;
+                let args_str = &remaining[args_start..].trim_start();
+
+                let (args, consumed_len) = if args_str.starts_with('{') {
+                    // Find matching closing brace
+                    let mut brace_count = 0;
+                    let mut end_pos = 0;
+                    for (i, ch) in args_str.chars().enumerate() {
+                        match ch {
+                            '{' => brace_count += 1,
+                            '}' => {
+                                brace_count -= 1;
+                                if brace_count == 0 {
+                                    end_pos = i + 1;
+                                    break;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+
+                    if end_pos > 0 {
+                        (&args_str[..end_pos], end_pos)
+                    } else {
+                        // No closing brace found
+                        ("", 0)
+                    }
+                } else {
+                    // Take until newline or end of string
+                    let end_pos = args_str.find('\n').unwrap_or(args_str.len());
+                    (args_str[..end_pos].trim(), end_pos)
+                };
+
+                if !args.is_empty() {
+                    tool_calls.push((tool_name.to_string(), args.to_string()));
+                }
+
+                // Move to after this tool call
+                remaining = &remaining[args_start + consumed_len..];
+            } else {
+                // Not a valid tool call, move past the @
+                remaining = &remaining[at_pos + 1..];
+            }
+        } else {
+            // No space or brace after @, move past it
+            remaining = &remaining[at_pos + 1..];
+        }
+    }
+
+    tool_calls
 }
 
 pub async fn run_task_view(task_id: &str, session_id: &str) -> Result<()> {

--- a/crates/arkavo-terminal/src/lib.rs
+++ b/crates/arkavo-terminal/src/lib.rs
@@ -79,17 +79,42 @@ pub async fn run() -> Result<()> {
 
         while let Some(request) = ui_rx.recv().await {
             let llm_tx = llm_tx.clone();
-            let client = client.clone();
             let mut messages_clone = messages.clone();
 
             // Add user message to context
             let user_message = Message::user(&request.prompt);
             messages_clone.push(user_message.clone());
 
+            // Parse the model name to extract server and actual model
+            let (server_url, actual_model) = if request.model_name.starts_with("primary/") {
+                let model = request.model_name.strip_prefix("primary/").unwrap_or(&request.model_name);
+                let url = std::env::var("OLLAMA_BASE_URL")
+                    .unwrap_or_else(|_| "http://localhost:11434".to_string());
+                (url, model.to_string())
+            } else if request.model_name.starts_with("secondary/") {
+                let model = request.model_name.strip_prefix("secondary/").unwrap_or(&request.model_name);
+                let url = std::env::var("OLLAMA_BASE_URL_2")
+                    .unwrap_or_else(|_| "http://localhost:11434".to_string());
+                (url, model.to_string())
+            } else {
+                // Fallback to primary server for backward compatibility
+                let url = std::env::var("OLLAMA_BASE_URL")
+                    .unwrap_or_else(|_| "http://localhost:11434".to_string());
+                (url, request.model_name.clone())
+            };
+            
+            // Create a new Ollama client with the specific model and server
+            let model_specific_client = arkavo_llm::LlmClient::new(
+                Box::new(arkavo_llm::ollama::OllamaClient::new(
+                    Some(server_url),
+                    Some(actual_model)
+                ))
+            );
+
             // Spawn a task for each request
             tokio::spawn(async move {
-                // Get streaming response from LLM
-                match client.stream(messages_clone.clone()).await {
+                // Get streaming response from LLM with the user-selected model
+                match model_specific_client.stream(messages_clone.clone()).await {
                     Ok(mut stream) => {
                         // Send start streaming signal
                         let _ = llm_tx

--- a/crates/arkavo-terminal/src/lib.rs
+++ b/crates/arkavo-terminal/src/lib.rs
@@ -86,21 +86,55 @@ pub async fn run() -> Result<()> {
             messages_clone.push(user_message.clone());
 
             // Parse the model name to extract server and actual model
-            let (server_url, actual_model) = if request.model_name.starts_with("primary/") {
-                let model = request.model_name.strip_prefix("primary/").unwrap_or(&request.model_name);
-                let url = std::env::var("OLLAMA_BASE_URL")
-                    .unwrap_or_else(|_| "http://localhost:11434".to_string());
-                (url, model.to_string())
-            } else if request.model_name.starts_with("secondary/") {
-                let model = request.model_name.strip_prefix("secondary/").unwrap_or(&request.model_name);
-                let url = std::env::var("OLLAMA_BASE_URL_2")
-                    .unwrap_or_else(|_| "http://localhost:11434".to_string());
+            let (server_url, actual_model) = if let Some((server_prefix, model)) = request.model_name.split_once('/') {
+                // Model has server prefix - need to resolve the URL
+                let url = if server_prefix == "localhost" {
+                    "http://localhost:11434".to_string()
+                } else if server_prefix.starts_with("server") {
+                    // Look up saved server configuration from memory storage
+                    if let Ok(storage) = arkavo_memory::storage::MemoryStorage::new().await {
+                        if let Ok(all_configs) = storage.search("http", 20, Some("config")).await {
+                            // Filter for Ollama server configs only
+                            let ollama_configs: Vec<_> = all_configs.into_iter()
+                                .filter(|config| {
+                                    config.memory.metadata
+                                        .as_ref()
+                                        .and_then(|m| m.get("type"))
+                                        .and_then(|t| t.as_str())
+                                        .map(|t| t == "arkavo_ollama_server_config")
+                                        .unwrap_or(false)
+                                })
+                                .filter(|config| config.memory.content != "http://localhost:11434")
+                                .collect();
+                            
+                            // Extract server number from prefix (e.g., "server1" -> 1)
+                            if let Some(num_str) = server_prefix.strip_prefix("server") {
+                                if let Ok(idx) = num_str.parse::<usize>() {
+                                    if idx > 0 && idx <= ollama_configs.len() {
+                                        ollama_configs[idx - 1].memory.content.clone()
+                                    } else {
+                                        "http://localhost:11434".to_string()
+                                    }
+                                } else {
+                                    "http://localhost:11434".to_string()
+                                }
+                            } else {
+                                "http://localhost:11434".to_string()
+                            }
+                        } else {
+                            "http://localhost:11434".to_string()
+                        }
+                    } else {
+                        "http://localhost:11434".to_string()
+                    }
+                } else {
+                    // Unknown prefix, use localhost as fallback
+                    "http://localhost:11434".to_string()
+                };
                 (url, model.to_string())
             } else {
-                // Fallback to primary server for backward compatibility
-                let url = std::env::var("OLLAMA_BASE_URL")
-                    .unwrap_or_else(|_| "http://localhost:11434".to_string());
-                (url, request.model_name.clone())
+                // No server prefix, use default
+                ("http://localhost:11434".to_string(), request.model_name.clone())
             };
             
             // Create a new Ollama client with the specific model and server

--- a/crates/arkavo-terminal/src/lib.rs
+++ b/crates/arkavo-terminal/src/lib.rs
@@ -86,7 +86,9 @@ pub async fn run() -> Result<()> {
             messages_clone.push(user_message.clone());
 
             // Parse the model name to extract server and actual model
-            let (server_url, actual_model) = if let Some((server_prefix, model)) = request.model_name.split_once('/') {
+            let (server_url, actual_model) = if let Some((server_prefix, model)) =
+                request.model_name.split_once('/')
+            {
                 // Model has server prefix - need to resolve the URL
                 let url = if server_prefix == "localhost" {
                     "http://localhost:11434".to_string()
@@ -95,9 +97,12 @@ pub async fn run() -> Result<()> {
                     if let Ok(storage) = arkavo_memory::storage::MemoryStorage::new().await {
                         if let Ok(all_configs) = storage.search("http", 20, Some("config")).await {
                             // Filter for Ollama server configs only
-                            let ollama_configs: Vec<_> = all_configs.into_iter()
+                            let ollama_configs: Vec<_> = all_configs
+                                .into_iter()
                                 .filter(|config| {
-                                    config.memory.metadata
+                                    config
+                                        .memory
+                                        .metadata
                                         .as_ref()
                                         .and_then(|m| m.get("type"))
                                         .and_then(|t| t.as_str())
@@ -106,7 +111,7 @@ pub async fn run() -> Result<()> {
                                 })
                                 .filter(|config| config.memory.content != "http://localhost:11434")
                                 .collect();
-                            
+
                             // Extract server number from prefix (e.g., "server1" -> 1)
                             if let Some(num_str) = server_prefix.strip_prefix("server") {
                                 if let Ok(idx) = num_str.parse::<usize>() {
@@ -134,16 +139,16 @@ pub async fn run() -> Result<()> {
                 (url, model.to_string())
             } else {
                 // No server prefix, use default
-                ("http://localhost:11434".to_string(), request.model_name.clone())
+                (
+                    "http://localhost:11434".to_string(),
+                    request.model_name.clone(),
+                )
             };
-            
+
             // Create a new Ollama client with the specific model and server
-            let model_specific_client = arkavo_llm::LlmClient::new(
-                Box::new(arkavo_llm::ollama::OllamaClient::new(
-                    Some(server_url),
-                    Some(actual_model)
-                ))
-            );
+            let model_specific_client = arkavo_llm::LlmClient::new(Box::new(
+                arkavo_llm::ollama::OllamaClient::new(Some(server_url), Some(actual_model)),
+            ));
 
             // Spawn a task for each request
             tokio::spawn(async move {

--- a/crates/arkavo-terminal/src/mcp_integration.rs
+++ b/crates/arkavo-terminal/src/mcp_integration.rs
@@ -1,0 +1,181 @@
+use arkavo_test::mcp::server::Tool as McpTool;
+use arkavo_test::mcp::{
+    device_manager::DeviceManager,
+    device_tools::DeviceManagementKit,
+    git_tools::{GitBranchKit, GitCommitKit, GitDiffKit, GitLogKit, GitRemoteKit, GitStatusKit},
+    ios_tools::{ScreenCaptureKit, UiInteractionKit, UiQueryKit},
+    simulator_tools::SimulatorControl,
+};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+#[derive(Debug, Clone)]
+pub enum McpConnection {
+    InProcess(InProcessMcp),
+    External(ExternalMcp),
+}
+
+#[derive(Clone)]
+pub struct InProcessMcp {
+    tools: Arc<HashMap<String, Box<dyn McpTool>>>,
+    runtime: Arc<Runtime>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExternalMcp {
+    // Placeholder for external MCP client
+    url: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct Tool {
+    pub name: String,
+    pub description: String,
+    pub input_schema: Value,
+}
+
+impl McpConnection {
+    pub fn new_in_process() -> Result<Self, Box<dyn std::error::Error>> {
+        // Create tokio runtime for async operations
+        let runtime = Arc::new(Runtime::new()?);
+
+        // Create tools with shared device manager
+        let device_manager = Arc::new(DeviceManager::new());
+
+        let mut tools: HashMap<String, Box<dyn McpTool>> = HashMap::new();
+
+        // Register all tools
+        let simulator_control = SimulatorControl::new();
+        tools.insert(
+            simulator_control.schema().name.clone(),
+            Box::new(simulator_control),
+        );
+
+        let device_mgmt = DeviceManagementKit::new(device_manager.clone());
+        tools.insert(device_mgmt.schema().name.clone(), Box::new(device_mgmt));
+
+        let screen_capture = ScreenCaptureKit::new(device_manager.clone());
+        tools.insert(
+            screen_capture.schema().name.clone(),
+            Box::new(screen_capture),
+        );
+
+        let ui_interaction = UiInteractionKit::new(device_manager.clone());
+        tools.insert(
+            ui_interaction.schema().name.clone(),
+            Box::new(ui_interaction),
+        );
+
+        let ui_query = UiQueryKit::new(device_manager);
+        tools.insert(ui_query.schema().name.clone(), Box::new(ui_query));
+
+        // Add Git tools
+        let git_status = GitStatusKit::new();
+        tools.insert(git_status.schema().name.clone(), Box::new(git_status));
+
+        let git_diff = GitDiffKit::new();
+        tools.insert(git_diff.schema().name.clone(), Box::new(git_diff));
+
+        let git_commit = GitCommitKit::new();
+        tools.insert(git_commit.schema().name.clone(), Box::new(git_commit));
+
+        let git_branch = GitBranchKit::new();
+        tools.insert(git_branch.schema().name.clone(), Box::new(git_branch));
+
+        let git_log = GitLogKit::new();
+        tools.insert(git_log.schema().name.clone(), Box::new(git_log));
+
+        let git_remote = GitRemoteKit::new();
+        tools.insert(git_remote.schema().name.clone(), Box::new(git_remote));
+
+        // TODO: Add memory tools once we figure out how to access MemoryIntegration
+
+        Ok(Self::InProcess(InProcessMcp {
+            tools: Arc::new(tools),
+            runtime,
+        }))
+    }
+
+    pub fn new_external(mcp_url: Option<String>) -> Result<Self, Box<dyn std::error::Error>> {
+        let url = mcp_url.unwrap_or_else(|| "http://localhost:3000".to_string());
+        Ok(Self::External(ExternalMcp { url }))
+    }
+
+    pub fn list_tools(&self) -> Result<Vec<Tool>, Box<dyn std::error::Error>> {
+        match self {
+            Self::InProcess(mcp) => {
+                let tools: Vec<Tool> = mcp
+                    .tools
+                    .values()
+                    .map(|tool| {
+                        let schema = tool.schema();
+                        Tool {
+                            name: schema.name.clone(),
+                            description: schema.description.clone(),
+                            input_schema: schema.parameters.clone(),
+                        }
+                    })
+                    .collect();
+                Ok(tools)
+            }
+            Self::External(_) => {
+                // TODO: Implement external MCP client
+                Ok(vec![])
+            }
+        }
+    }
+
+    pub fn call_tool(
+        &self,
+        tool_name: &str,
+        args: Value,
+        _llm_origin: &str,
+    ) -> Result<Value, Box<dyn std::error::Error>> {
+        match self {
+            Self::InProcess(mcp) => {
+                // Create a oneshot channel to get the result
+                let (tx, rx) = std::sync::mpsc::channel::<Result<Value, String>>();
+
+                // Clone what we need
+                let tools = mcp.tools.clone();
+                let tool_name = tool_name.to_string();
+                let runtime = mcp.runtime.clone();
+
+                // Spawn a thread to run the async operation
+                std::thread::spawn(move || {
+                    let result = runtime.block_on(async move {
+                        if let Some(tool) = tools.get(&tool_name) {
+                            tool.execute(args)
+                                .await
+                                .map_err(|e| format!("Tool execution error: {e}"))
+                        } else {
+                            Err(format!("Tool '{tool_name}' not found"))
+                        }
+                    });
+                    tx.send(result).ok();
+                });
+
+                // Wait for the result
+                rx.recv()
+                    .map_err(|_| "Failed to receive tool result")?
+                    .map_err(|e: String| e.into())
+            }
+            Self::External(_) => {
+                // TODO: Implement external MCP client
+                Err("External MCP not implemented".into())
+            }
+        }
+    }
+}
+
+// Implement Debug manually for InProcessMcp
+impl std::fmt::Debug for InProcessMcp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InProcessMcp")
+            .field("tools", &self.tools.keys().collect::<Vec<_>>())
+            .field("runtime", &"Runtime")
+            .finish()
+    }
+}

--- a/crates/arkavo-terminal/src/ui/debug.rs
+++ b/crates/arkavo-terminal/src/ui/debug.rs
@@ -131,7 +131,7 @@ impl DebugView {
         }
         Ok(())
     }
-    
+
     pub fn get_all_logs(&self) -> Vec<serde_json::Value> {
         self.logs
             .iter()

--- a/crates/arkavo-terminal/src/ui/debug.rs
+++ b/crates/arkavo-terminal/src/ui/debug.rs
@@ -131,6 +131,19 @@ impl DebugView {
         }
         Ok(())
     }
+    
+    pub fn get_all_logs(&self) -> Vec<serde_json::Value> {
+        self.logs
+            .iter()
+            .map(|log| {
+                serde_json::json!({
+                    "timestamp": log.timestamp.to_rfc3339(),
+                    "level": log.level.prefix(),
+                    "message": log.message,
+                })
+            })
+            .collect()
+    }
 }
 
 impl Default for DebugView {

--- a/crates/arkavo-terminal/tests/test_tui_input.rs
+++ b/crates/arkavo-terminal/tests/test_tui_input.rs
@@ -97,9 +97,17 @@ mod tui_input_tests {
     fn test_model_selection() {
         let mut app = App::new();
 
-        // Test initial model selection
+        // Test initial state (models are fetched dynamically now)
         assert_eq!(app.selected_model, 0);
-        assert!(!app.available_models.is_empty());
+        assert!(app.available_models.is_empty());
+        assert!(app.active_model.is_none());
+
+        // Simulate models being fetched
+        app.available_models = vec![
+            "localhost/llama3".to_string(),
+            "server1/devstral".to_string(),
+            "server2/deepseek".to_string(),
+        ];
 
         // Test cycling through models
         let model_count = app.available_models.len();
@@ -110,6 +118,10 @@ mod tui_input_tests {
         app.selected_model = model_count - 1;
         app.selected_model = (app.selected_model + 1) % model_count;
         assert_eq!(app.selected_model, 0);
+
+        // Test active model selection
+        app.active_model = Some(app.available_models[app.selected_model].clone());
+        assert_eq!(app.active_model, Some("localhost/llama3".to_string()));
     }
 
     #[test]

--- a/docs/multi-ollama-setup.md
+++ b/docs/multi-ollama-setup.md
@@ -1,0 +1,64 @@
+# Multi-Ollama Server Configuration
+
+Arkavo Edge supports connecting to multiple Ollama servers simultaneously, following the AI-driven configuration principle from CLAUDE.md.
+
+## How It Works
+
+1. **Server Discovery**: The terminal UI automatically discovers Ollama servers from the memory storage
+2. **Interactive Configuration**: Use `arkavo chat` to configure additional Ollama servers
+3. **Model Prefixes**: Models are displayed with server prefixes (e.g., `localhost/llama3`, `server1/devstral`)
+
+## Adding Ollama Servers
+
+When you run `arkavo chat`, it will:
+1. Check for existing Ollama server configurations in memory storage
+2. Test connectivity to saved servers
+3. Prompt you to add new servers if needed
+
+The configurations are stored in the memory crate with:
+- Content: The server URL (e.g., `http://10.0.0.101:11434`)
+- Category: `config`
+- Metadata: Server details and capabilities
+
+## Example Workflow
+
+```bash
+# First run - configure primary server
+$ cargo run -p arkavo chat
+✓ Connected to saved Ollama server at http://localhost:11434
+# If not found, it will prompt for server URL
+
+# The configuration is saved to memory storage
+# Next time you run arkavo-terminal, it will discover all saved servers
+
+# Run terminal UI
+$ cargo run -p arkavo-terminal
+✓ Connected to localhost Ollama server
+✓ Connected to server1 Ollama server: http://10.0.0.101:11434
+
+# Models appear with server prefixes
+# Use Tab to cycle through: localhost/llama3, server1/devstral, etc.
+```
+
+## Memory Storage Structure
+
+Ollama server configurations are stored as:
+```json
+{
+  "content": "http://10.0.0.101:11434",
+  "category": "config",
+  "metadata": {
+    "type": "ollama_server",
+    "name": "Remote Ollama",
+    "discovered_at": "2024-01-01T00:00:00Z"
+  }
+}
+```
+
+## Benefits
+
+- **No Environment Variables**: Follows the AI-driven configuration principle
+- **Persistent Storage**: Configurations are saved in the memory crate
+- **Dynamic Discovery**: Servers are discovered at runtime
+- **Multiple Servers**: Connect to any number of Ollama instances
+- **Unified Storage**: All configurations use the same memory system used for embeddings, git info, etc.

--- a/docs/multi-server-blueprint-example.md
+++ b/docs/multi-server-blueprint-example.md
@@ -1,0 +1,158 @@
+# Multi-Server Blueprint Example
+
+This example shows how to use models from different Ollama servers in a dataflow blueprint.
+
+## Prerequisites
+
+1. Configure multiple Ollama servers using `arkavo chat`
+2. Verify servers are saved in memory storage
+3. Models will be available as `server1/model`, `server2/model`, etc.
+
+## Example: Multi-Server Code Review Pipeline
+
+This pipeline uses different models from different servers for specialized tasks:
+
+```yaml
+version: 1.0.0
+name: multi-server-code-review
+description: Code review pipeline using models from multiple Ollama servers
+
+nodes:
+  - id: code_input
+    kind: source
+    params:
+      type: webhook_source
+      port: 8082
+      path: /multi-review
+      
+  - id: syntax_checker
+    kind: transform
+    params:
+      type: llm_transform
+      # Uses model from localhost
+      model: localhost/llama3:latest
+      prompt: |
+        Check the following code for syntax errors and basic issues:
+        {{input}}
+      temperature: 0.1
+      max_tokens: 300
+      
+  - id: security_reviewer
+    kind: transform
+    params:
+      type: llm_transform
+      # Uses specialized model from server1
+      model: server1/devstral:latest
+      prompt: |
+        Review this code for security vulnerabilities:
+        - SQL injection
+        - XSS risks
+        - Authentication issues
+        - Data exposure
+        
+        Code:
+        {{input}}
+      temperature: 0.2
+      max_tokens: 500
+      
+  - id: performance_analyzer
+    kind: transform
+    params:
+      type: llm_transform
+      # Uses model from server2
+      model: server2/deepseek-r1:14b
+      prompt: |
+        Analyze this code for performance issues:
+        - Time complexity
+        - Memory usage
+        - Database queries
+        - Caching opportunities
+        
+        Code:
+        {{input}}
+      temperature: 0.3
+      max_tokens: 400
+      
+  - id: result_merger
+    kind: transform
+    params:
+      type: json_transform
+      spec:
+        syntax_check: "syntax_result"
+        security_review: "security_result"
+        performance_analysis: "performance_result"
+        timestamp: "${CURRENT_TIME}"
+        
+  - id: output
+    kind: sink
+    params:
+      type: file_sink
+      path: multi_server_reviews.json
+      format: json
+      append: true
+
+links:
+  - from: code_input
+    to: syntax_checker
+    
+  - from: syntax_checker
+    to: security_reviewer
+    params:
+      pass_through:
+        - syntax_result
+    
+  - from: security_reviewer
+    to: performance_analyzer
+    params:
+      pass_through:
+        - syntax_result
+        - security_result
+    
+  - from: performance_analyzer
+    to: result_merger
+    
+  - from: result_merger
+    to: output
+```
+
+## How It Works
+
+1. **Server Prefix Format**: When `model` contains a `/`, the prefix is treated as the server identifier
+   - `localhost/llama3` → Uses llama3 from localhost:11434
+   - `server1/devstral` → Uses devstral from the first saved Ollama server
+   - `server2/deepseek-r1` → Uses deepseek from the second saved server
+
+2. **Backward Compatibility**: You can still use the old format:
+   ```yaml
+   provider: local-ollama
+   model: llama3:latest
+   ```
+
+3. **Server Resolution**: The server URLs are resolved from memory storage:
+   - Searches for configs with type "arkavo_ollama_server_config"
+   - Maps server1, server2, etc. to saved URLs in order
+
+## Running the Pipeline
+
+```bash
+# Start the dataflow with the blueprint
+arkavo dataflow start multi-server-blueprint.yaml
+
+# Send code for review
+curl -X POST http://localhost:8082/multi-review \
+  -H "Content-Type: application/json" \
+  -d '{
+    "file": "example.py",
+    "content": "def get_user(id): return db.query(f\"SELECT * FROM users WHERE id={id}\")"
+  }'
+
+# Results will show security issues from server1's model, 
+# performance concerns from server2's model, etc.
+```
+
+## Benefits
+
+- **Model Specialization**: Use the best model for each task
+- **Load Distribution**: Spread work across multiple servers
+- **Failover**: Can add logic to fallback if a server is unavailable
+- **A/B Testing**: Compare outputs from different models/servers


### PR DESCRIPTION
## Summary
- Adds MCP (Model Context Protocol) tool discovery and integration to the Terminal UI
- Displays available MCP tools in the provider/model selection area
- Includes MCP tools in system prompts for all LLM models

## Changes
1. **New MCP Integration Module** (`crates/arkavo-terminal/src/mcp_integration.rs`)
   - Local implementation to avoid circular dependencies with arkavo-cli
   - Supports in-process and external MCP connections
   - Registers device, UI, Git, and simulator tools

2. **Terminal App Updates** (`crates/arkavo-terminal/src/app.rs`)
   - Initializes MCP connection on startup
   - Displays MCP status and available tools in UI
   - Adds Ctrl+T shortcut to show all tools in debug view
   - Shows MCP connection status in status bar

3. **LLM Handler Integration** (`crates/arkavo-terminal/src/lib.rs`)
   - Includes MCP tools in system prompt for each LLM
   - Extracts and executes @tool commands from LLM responses
   - Displays tool execution results in task windows

## Features
- **Visual Status**: Shows MCP connection status (✓/✗) with tool count
- **Tool Discovery**: Automatically discovers and categorizes available tools
- **Tool Listing**: Shows first 3 tools with "... and X more" indicator
- **Debug View**: Ctrl+T displays all tools organized by category
- **LLM Integration**: Each model receives full tool list in system prompt
- **Tool Execution**: Automatic execution of @tool commands in responses

## Testing
- Built and tested locally with `cargo build`
- Verified MCP tools appear in UI
- Confirmed tools are included in LLM system prompts

Closes #85, #101, #108