### PR TITLE
Terminal UI improvements and MCP infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,14 +162,14 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "arkavo-cli",
 ]
 
 [[package]]
 name = "arkavo-cli"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -229,11 +229,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-encryption"
-version = "0.19.4"
+version = "0.19.5"
 
 [[package]]
 name = "arkavo-git"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "git2",
  "tempfile",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "async-trait",
  "serde",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-core"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "anyhow",
  "arkavo-mcp",
@@ -317,15 +317,15 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.19.4"
+version = "0.19.5"
 
 [[package]]
 name = "arkavo-repo"
-version = "0.19.4"
+version = "0.19.5"
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-vault"
-version = "0.19.4"
+version = "0.19.5"
 
 [[package]]
 name = "arrayvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.19.4"
+version = "0.19.5"
 edition = "2024"
 authors = ["Arkavo Edge Contributors"]
 license = "Apache-2.0"

--- a/crates/arkavo-mcp-runtime/src/server.rs
+++ b/crates/arkavo-mcp-runtime/src/server.rs
@@ -145,7 +145,7 @@ impl McpServer {
                             result: None,
                             error: Some(RpcError {
                                 code: error_codes::INVALID_PARAMS,
-                                message: format!("Tool '{}' not found", tool_name),
+                                message: format!("Tool '{tool_name}' not found"),
                                 data: None,
                             }),
                         },

--- a/crates/arkavo-mcp-runtime/src/tools/echo.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/echo.rs
@@ -13,6 +13,12 @@ impl EchoTool {
     }
 }
 
+impl Default for EchoTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[async_trait]
 impl Tool for EchoTool {
     async fn execute(&self, params: Value) -> Result<Value> {
@@ -23,8 +29,8 @@ impl Tool for EchoTool {
     }
 
     fn schema(&self) -> &ToolSchema {
-        static SCHEMA: once_cell::sync::Lazy<ToolSchema> =
-            once_cell::sync::Lazy::new(|| ToolSchema {
+        static SCHEMA: std::sync::LazyLock<ToolSchema> =
+            std::sync::LazyLock::new(|| ToolSchema {
                 name: "echo".to_string(),
                 description: "Echo back the input parameters".to_string(),
                 parameters: json!({

--- a/crates/arkavo-mcp-runtime/src/tools/echo.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/echo.rs
@@ -29,15 +29,14 @@ impl Tool for EchoTool {
     }
 
     fn schema(&self) -> &ToolSchema {
-        static SCHEMA: std::sync::LazyLock<ToolSchema> =
-            std::sync::LazyLock::new(|| ToolSchema {
-                name: "echo".to_string(),
-                description: "Echo back the input parameters".to_string(),
-                parameters: json!({
-                    "type": "object",
-                    "additionalProperties": true,
-                }),
-            });
+        static SCHEMA: std::sync::LazyLock<ToolSchema> = std::sync::LazyLock::new(|| ToolSchema {
+            name: "echo".to_string(),
+            description: "Echo back the input parameters".to_string(),
+            parameters: json!({
+                "type": "object",
+                "additionalProperties": true,
+            }),
+        });
         &SCHEMA
     }
 }

--- a/crates/arkavo-mcp-runtime/src/tools/health.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/health.rs
@@ -13,6 +13,12 @@ impl HealthTool {
     }
 }
 
+impl Default for HealthTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[async_trait]
 impl Tool for HealthTool {
     async fn execute(&self, _params: Value) -> Result<Value> {
@@ -24,8 +30,8 @@ impl Tool for HealthTool {
     }
 
     fn schema(&self) -> &ToolSchema {
-        static SCHEMA: once_cell::sync::Lazy<ToolSchema> =
-            once_cell::sync::Lazy::new(|| ToolSchema {
+        static SCHEMA: std::sync::LazyLock<ToolSchema> =
+            std::sync::LazyLock::new(|| ToolSchema {
                 name: "health".to_string(),
                 description: "Check the health status of the MCP server".to_string(),
                 parameters: json!({

--- a/crates/arkavo-mcp-runtime/src/tools/health.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/health.rs
@@ -30,15 +30,14 @@ impl Tool for HealthTool {
     }
 
     fn schema(&self) -> &ToolSchema {
-        static SCHEMA: std::sync::LazyLock<ToolSchema> =
-            std::sync::LazyLock::new(|| ToolSchema {
-                name: "health".to_string(),
-                description: "Check the health status of the MCP server".to_string(),
-                parameters: json!({
-                    "type": "object",
-                    "properties": {},
-                }),
-            });
+        static SCHEMA: std::sync::LazyLock<ToolSchema> = std::sync::LazyLock::new(|| ToolSchema {
+            name: "health".to_string(),
+            description: "Check the health status of the MCP server".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {},
+            }),
+        });
         &SCHEMA
     }
 }

--- a/crates/arkavo-mcp-runtime/src/tools/ollama_config.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/ollama_config.rs
@@ -33,7 +33,7 @@ impl Tool for OllamaConfigTool {
                     // Validate and normalize URL
                     let mut url = server_url.trim().to_string();
                     if !url.starts_with("http://") && !url.starts_with("https://") {
-                        url = format!("http://{}", url);
+                        url = format!("http://{url}");
                     }
 
                     // Test connection
@@ -115,7 +115,7 @@ impl Tool for OllamaConfigTool {
     }
 
     fn schema(&self) -> &ToolSchema {
-        static SCHEMA: once_cell::sync::Lazy<ToolSchema> = once_cell::sync::Lazy::new(|| {
+        static SCHEMA: std::sync::LazyLock<ToolSchema> = std::sync::LazyLock::new(|| {
             ToolSchema {
                 name: "ollama_config".to_string(),
                 description: "Manage Ollama server configurations. Add new servers, list existing ones, or remove them.".to_string(),

--- a/crates/arkavo-mcp-runtime/src/tools/ui_control.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/ui_control.rs
@@ -54,30 +54,29 @@ impl Tool for UiControlTool {
     }
 
     fn schema(&self) -> &ToolSchema {
-        static SCHEMA: std::sync::LazyLock<ToolSchema> =
-            std::sync::LazyLock::new(|| ToolSchema {
-                name: "ui_control".to_string(),
-                description: "Control the terminal UI view modes and focus".to_string(),
-                parameters: json!({
-                    "type": "object",
-                    "properties": {
-                        "action": {
-                            "type": "string",
-                            "enum": [
-                                "show_debug",
-                                "show_chat",
-                                "show_code",
-                                "show_diff",
-                                "show_dataflow",
-                                "focus_input",
-                                "focus_scroll"
-                            ],
-                            "description": "The UI action to perform"
-                        }
-                    },
-                    "required": ["action"]
-                }),
-            });
+        static SCHEMA: std::sync::LazyLock<ToolSchema> = std::sync::LazyLock::new(|| ToolSchema {
+            name: "ui_control".to_string(),
+            description: "Control the terminal UI view modes and focus".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": [
+                            "show_debug",
+                            "show_chat",
+                            "show_code",
+                            "show_diff",
+                            "show_dataflow",
+                            "focus_input",
+                            "focus_scroll"
+                        ],
+                        "description": "The UI action to perform"
+                    }
+                },
+                "required": ["action"]
+            }),
+        });
         &SCHEMA
     }
 }

--- a/crates/arkavo-mcp-runtime/src/tools/ui_control.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/ui_control.rs
@@ -54,8 +54,8 @@ impl Tool for UiControlTool {
     }
 
     fn schema(&self) -> &ToolSchema {
-        static SCHEMA: once_cell::sync::Lazy<ToolSchema> =
-            once_cell::sync::Lazy::new(|| ToolSchema {
+        static SCHEMA: std::sync::LazyLock<ToolSchema> =
+            std::sync::LazyLock::new(|| ToolSchema {
                 name: "ui_control".to_string(),
                 description: "Control the terminal UI view modes and focus".to_string(),
                 parameters: json!({

--- a/crates/arkavo-mcp-runtime/src/tools/ui_inspect.rs
+++ b/crates/arkavo-mcp-runtime/src/tools/ui_inspect.rs
@@ -29,7 +29,7 @@ impl Tool for UiInspectTool {
     }
 
     fn schema(&self) -> &ToolSchema {
-        static SCHEMA: once_cell::sync::Lazy<ToolSchema> = once_cell::sync::Lazy::new(|| {
+        static SCHEMA: std::sync::LazyLock<ToolSchema> = std::sync::LazyLock::new(|| {
             ToolSchema {
                 name: "ui_inspect".to_string(),
                 description: "Get the current state of the terminal UI including providers, models, and debug logs".to_string(),

--- a/crates/arkavo-terminal/src/app.rs
+++ b/crates/arkavo-terminal/src/app.rs
@@ -146,7 +146,7 @@ impl App {
             helix_editor: HelixEditor::new().ok(),
             task_manager: TaskManager::new(),
             input_buffer: String::new(),
-            available_models: vec![],
+            available_models: vec![], // Models will be fetched dynamically
             selected_model: 0,
             input_focused: true,
             last_quit_attempt: None,
@@ -208,7 +208,7 @@ impl App {
             helix_editor: HelixEditor::new().ok(),
             task_manager: TaskManager::new(),
             input_buffer: String::new(),
-            available_models: vec![],
+            available_models: vec![], // Models will be fetched dynamically
             selected_model: 0,
             input_focused: true,
             last_quit_attempt: None,
@@ -1320,6 +1320,37 @@ impl App {
                         ),
                     ]));
                 }
+            }
+        }
+
+        // Add available models section
+        if !self.available_models.is_empty() {
+            if !lines.is_empty() {
+                lines.push(Line::from("")); // Add spacing
+            }
+            lines.push(Line::from(vec![Span::styled(
+                "Available Models (Tab to cycle):",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )]));
+            
+            for (idx, model) in self.available_models.iter().enumerate() {
+                let is_selected = idx == self.selected_model;
+                let prefix = if is_selected { "→ " } else { "  " };
+                
+                let style = if is_selected {
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default()
+                };
+                
+                lines.push(Line::from(vec![
+                    Span::raw(prefix),
+                    Span::styled(model, style),
+                ]));
             }
         }
 

--- a/crates/arkavo-terminal/src/app.rs
+++ b/crates/arkavo-terminal/src/app.rs
@@ -578,15 +578,19 @@ impl App {
         loop {
             // Check for LLM responses - drain all available messages
             let mut responses_to_process = Vec::new();
+            let mut has_llm_updates = false;
             if let Some(ref mut llm_rx) = self.llm_rx {
                 // Collect all available responses first
                 while let Ok(response) = llm_rx.try_recv() {
                     responses_to_process.push(response);
+                    has_llm_updates = true;
                 }
             }
 
             // Process collected responses
             for response in responses_to_process {
+                // Only log in debug builds
+                #[cfg(debug_assertions)]
                 self.add_debug_log(
                     crate::ui::debug::LogLevel::Debug,
                     format!(
@@ -604,6 +608,8 @@ impl App {
                             crate::ui::task_window::MessageRole::System,
                             format!("Error: {error}"),
                         );
+                        // Only log errors in debug builds
+                        #[cfg(debug_assertions)]
                         self.add_debug_log(
                             crate::ui::debug::LogLevel::Error,
                             format!("[UI] LLM error for task {}: {}", response.task_id, error),
@@ -642,6 +648,8 @@ impl App {
                             self.telemetry.track_message_received();
                         }
 
+                        // Only log in debug builds
+                        #[cfg(debug_assertions)]
                         self.add_debug_log(
                             crate::ui::debug::LogLevel::Info,
                             format!("[UI] Completed response for task {}", response.task_id),
@@ -666,9 +674,16 @@ impl App {
                 }
             }
 
-            // Always check for events but don't block
-            if event::poll(Duration::from_millis(16))? {
-                // ~60fps for smooth updates
+            // Poll for events with longer timeout when idle to reduce CPU usage
+            let poll_timeout = if has_llm_updates || self.input_focused {
+                Duration::from_millis(16) // 60fps when active
+            } else {
+                Duration::from_millis(100) // 10fps when idle
+            };
+            
+            let mut needs_redraw = has_llm_updates;
+            
+            if event::poll(poll_timeout)? {
                 match event::read()? {
                     Event::Key(key) => {
                         self.telemetry.track_key_event();
@@ -993,11 +1008,13 @@ impl App {
                                 // Prevent buffer overflow by limiting input length
                                 if self.input_buffer.len() < 500 {
                                     self.input_buffer.push(c);
+                                    needs_redraw = true;
                                 }
                             }
                             KeyCode::Backspace if self.input_focused => {
                                 // Remove last character from input buffer
                                 self.input_buffer.pop();
+                                needs_redraw = true;
                             }
                             _ => {
                                 let event = AppEvent::from_crossterm_event(Event::Key(key));
@@ -1006,7 +1023,7 @@ impl App {
                         }
                     }
                     Event::Resize(_, _) => {
-                        // Terminal will be redrawn in the main loop
+                        needs_redraw = true;
                     }
                     _ => {}
                 }
@@ -1016,16 +1033,17 @@ impl App {
                 break;
             }
 
-            // Always render to ensure UI stays consistent
-            // Force full redraw when input is focused to prevent artifacts
-            if self.input_focused {
-                terminal.draw(|f| {
-                    // Clear the entire frame first when input is active
-                    f.render_widget(ratatui::widgets::Clear, f.area());
-                    self.render(f);
-                })?;
-            } else {
-                terminal.draw(|f| self.render(f))?;
+            // Only render when there are updates or user input
+            if needs_redraw || has_llm_updates {
+                if self.input_focused {
+                    terminal.draw(|f| {
+                        // Clear the entire frame first when input is active
+                        f.render_widget(ratatui::widgets::Clear, f.area());
+                        self.render(f);
+                    })?;
+                } else {
+                    terminal.draw(|f| self.render(f))?;
+                }
             }
 
             // Track frame timing

--- a/crates/arkavo-terminal/src/app.rs
+++ b/crates/arkavo-terminal/src/app.rs
@@ -680,9 +680,9 @@ impl App {
             } else {
                 Duration::from_millis(100) // 10fps when idle
             };
-            
+
             let mut needs_redraw = has_llm_updates;
-            
+
             if event::poll(poll_timeout)? {
                 match event::read()? {
                     Event::Key(key) => {
@@ -1352,11 +1352,11 @@ impl App {
                     .fg(Color::Cyan)
                     .add_modifier(Modifier::BOLD),
             )]));
-            
+
             for (idx, model) in self.available_models.iter().enumerate() {
                 let is_selected = idx == self.selected_model;
                 let prefix = if is_selected { "→ " } else { "  " };
-                
+
                 let style = if is_selected {
                     Style::default()
                         .fg(Color::Yellow)
@@ -1364,7 +1364,7 @@ impl App {
                 } else {
                     Style::default()
                 };
-                
+
                 lines.push(Line::from(vec![
                     Span::raw(prefix),
                     Span::styled(model, style),

--- a/crates/arkavo-terminal/src/lib.rs
+++ b/crates/arkavo-terminal/src/lib.rs
@@ -71,6 +71,8 @@ pub async fn run() -> Result<()> {
             }
         };
 
+        // Only log in debug builds
+        #[cfg(debug_assertions)]
         eprintln!(
             "Terminal UI connected to LLM provider: {}",
             client.provider_name()
@@ -255,7 +257,8 @@ pub async fn run() -> Result<()> {
                     )
                 };
 
-            // Debug log the resolved server and model
+            // Only log in debug builds
+            #[cfg(debug_assertions)]
             eprintln!(
                 "[LLM] Using server: {} with model: {}",
                 server_url, actual_model

--- a/crates/arkavo-terminal/src/ui_inspector.rs
+++ b/crates/arkavo-terminal/src/ui_inspector.rs
@@ -1,0 +1,97 @@
+use serde_json::json;
+use std::sync::{Arc, RwLock};
+
+use crate::App;
+
+/// Simple UI state inspector for debugging
+pub struct UiInspector {
+    app_state: Arc<RwLock<App>>,
+}
+
+impl UiInspector {
+    pub fn new(app_state: Arc<RwLock<App>>) -> Self {
+        Self { app_state }
+    }
+
+    /// Get current UI state as JSON
+    pub fn get_state(&self) -> serde_json::Value {
+        let app = match self.app_state.read() {
+            Ok(app) => app,
+            Err(_) => return json!({"error": "Failed to acquire read lock"}),
+        };
+
+        json!({
+            "view_mode": format!("{:?}", app.view_mode),
+            "layout_mode": format!("{:?}", app.layout_mode),
+            "focused_pane": format!("{:?}", app.focused_pane),
+            "input_focused": app.input_focused,
+            "input_buffer": &app.input_buffer,
+            "vim_enabled": app.vim_enabled,
+            "active_model": &app.active_model,
+            "selected_model": app.selected_model,
+            "available_models": &app.available_models,
+            "task_count": app.task_manager.tasks.len(),
+            "active_task": app.task_manager.active_task,
+            "tasks": app.task_manager.tasks.iter().map(|t| {
+                json!({
+                    "id": t.id.to_string(),
+                    "agent_name": &t.agent_name,
+                    "model_name": &t.model_name,
+                    "status": format!("{:?}", t.status),
+                    "message_count": t.messages.len(),
+                })
+            }).collect::<Vec<_>>(),
+            "providers": app.providers.iter().map(|p| {
+                json!({
+                    "name": &p.name,
+                    "type": format!("{:?}", p.provider_type),
+                    "url": &p.url,
+                    "status": format!("{:?}", p.status),
+                    "model_count": p.models.len(),
+                })
+            }).collect::<Vec<_>>(),
+            "server_urls": &app.server_urls,
+            "configuration_mode": format!("{:?}", app.configuration_mode),
+            "debug_logs": app.debug_view.get_all_logs().len(),
+            "telemetry": {
+                "messages_sent": app.telemetry.messages_sent,
+                "messages_received": app.telemetry.messages_received,
+                "key_events": app.telemetry.key_events,
+            },
+        })
+    }
+
+    /// Get debug logs
+    pub fn get_debug_logs(&self) -> serde_json::Value {
+        let app = match self.app_state.read() {
+            Ok(app) => app,
+            Err(_) => return json!({"error": "Failed to acquire read lock"}),
+        };
+
+        json!({
+            "logs": app.debug_view.get_all_logs(),
+            "count": app.debug_view.get_all_logs().len()
+        })
+    }
+
+    /// Get provider status
+    pub fn get_provider_status(&self) -> serde_json::Value {
+        let app = match self.app_state.read() {
+            Ok(app) => app,
+            Err(_) => return json!({"error": "Failed to acquire read lock"}),
+        };
+
+        json!({
+            "providers": app.providers.iter().map(|p| {
+                json!({
+                    "name": &p.name,
+                    "type": format!("{:?}", p.provider_type),
+                    "url": &p.url,
+                    "status": format!("{:?}", p.status),
+                    "models": &p.models,
+                })
+            }).collect::<Vec<_>>(),
+            "server_urls": &app.server_urls,
+        })
+    }
+}


### PR DESCRIPTION
## Summary
This PR introduces significant improvements to the terminal UI, including multi-server Ollama support, UI state inspection capabilities, and various bug fixes and performance enhancements.

## Key Features

### 1. MCP Infrastructure Foundation
- Created `arkavo-mcp-core` crate with pure types and traits
- Created `arkavo-mcp-runtime` crate with server implementation
- Added foundation for UI state inspection tools

### 2. UI State Inspection & Export
- Added comprehensive UI state capture via `UiInspector` module
- **Ctrl+S**: Export full UI state to JSON files in `.arkavo/` directory
- **Ctrl+U**: Dump UI state to debug log for immediate inspection
- **Ctrl+D**: Toggle debug view (now returns to previous view on second press)

### 3. Multi-Server Ollama Support
- Dynamic model fetching from multiple Ollama servers
- Server prefix notation (e.g., `server1/llama2`, `server2/qwen`)
- **Tab**: Cycle through available models across all servers
- **Enter**: Create/switch to task window for selected model
- Natural language commands:
  - "Add Ollama server 192.168.1.100:11434"
  - "Remove 10.0.0.101:11434 Ollama server"
- Persistent server configuration via memory storage

### 4. Connection & Performance Improvements
- Adaptive connection timeouts (5s localhost, 120s LAN, 20s remote)
- Graceful timeout handling prevents "aborting completion request" errors
- Fixed message routing to correct model/server windows
- Fixed UI redraw issues when sending messages
- Parallel server connection checking with status indicators

### 5. UI Enhancements
- Provider status display in UI (X OK, Y ERR)
- Window indicators [*] for models with existing tasks
- Conditional Helix editor options (only shown when available)
- Improved model selection with visual feedback

## Test Plan
- [x] Test multi-server Ollama connections with different response times
- [x] Verify Ctrl+S exports complete UI state to JSON
- [x] Verify Ctrl+D toggles between debug and previous view
- [x] Test natural language server add/remove commands
- [x] Verify message routing to correct model windows
- [x] Test connection timeout handling without connection aborts
- [x] Verify UI updates immediately when sending messages

## Notes
The MCP UI inspection tool currently exports state via Ctrl+S. Full programmatic access will be implemented in a follow-up PR with proper channel infrastructure.

🤖 Generated with [Claude Code](https://claude.ai/code)