### PR TITLE
fix codesign

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -178,7 +178,7 @@ jobs:
 
       - name: Codesign binary
         run: |
-          codesign --force --options=runtime --timestamp --sign "Developer ID Application: Arkavo LLC (M8GS7ZT95Y)" target/aarch64-apple-darwin/release/arkavo
+          codesign --force --keychain build.keychain --options=runtime --timestamp --sign "Developer ID Application: Arkavo LLC (M8GS7ZT95Y)" target/aarch64-apple-darwin/release/arkavo
 
       - name: Create ZIP for notarization
         run: |


### PR DESCRIPTION
explicitly pointing `codesign` to the correct keychain. This ensures it looks in the right place for the certificate without any ambiguity.