### PR TITLE
Fix codesign hanging in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -193,13 +193,19 @@ jobs:
           override: true
 
       - name: Decode and import signing certificate
+        timeout-minutes: 5
         run: |
+          echo "Creating and configuring keychain..."
           echo "${{ secrets.MACOS_CERTIFICATE }}" | base64 --decode > /tmp/certificate.p12
           security create-keychain -p "" build.keychain
           security default-keychain -s build.keychain
           security unlock-keychain -p "" build.keychain
-          security import /tmp/certificate.p12 -k build.keychain -P "${{ secrets.MACOS_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
+          security set-keychain-settings -t 3600 -u build.keychain
+          echo "Importing certificate..."
+          security import /tmp/certificate.p12 -k build.keychain -P "${{ secrets.MACOS_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" build.keychain
+          echo "Verifying certificate import..."
+          security find-identity -v -p codesigning build.keychain
 
       - name: Build
         uses: actions-rs/cargo@v1
@@ -212,8 +218,11 @@ jobs:
           strip target/aarch64-apple-darwin/release/arkavo
 
       - name: Codesign binary
+        timeout-minutes: 5
         run: |
-          codesign --force --keychain build.keychain --options=runtime --timestamp --sign "Developer ID Application: Arkavo LLC (M8GS7ZT95Y)" target/aarch64-apple-darwin/release/arkavo
+          echo "Starting codesign process..."
+          codesign --verbose --force --keychain build.keychain --options=runtime --timestamp --sign "Developer ID Application: Arkavo LLC (M8GS7ZT95Y)" target/aarch64-apple-darwin/release/arkavo
+          echo "Codesign completed successfully"
 
       - name: Create ZIP for notarization
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["crates/arkavo-protocol/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.21.2"
+version = "0.21.3"
 edition = "2024"
 authors = ["Arkavo Edge Contributors"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Add timeouts and verbose debugging to prevent codesign from hanging indefinitely
- Improve keychain configuration with proper timeout settings and permissions
- Add certificate verification step to catch import issues early

## Test plan
- [ ] CI workflow completes without hanging on codesign step
- [ ] Certificate import shows valid identity in logs
- [ ] Codesign process completes within 5 minute timeout
- [ ] Release builds successfully sign and notarize

🤖 Generated with [Claude Code](https://claude.ai/code)