### PR TITLE
LLM feature flags remote and local

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -151,8 +151,8 @@ jobs:
           # Run arkavo-memory tests without embeddings (non-embedding tests only)
           cargo test -p arkavo-memory --lib
           cargo test -p arkavo-memory --test mcp_integration_test
-          # Run arkavo-llm tests without local feature (API tests only)
-          cargo test -p arkavo-llm --lib
+          # Run arkavo-llm tests with remote feature only (API tests only)
+          cargo test -p arkavo-llm --lib --no-default-features --features llm-remote
           # Note: arkavo-test is excluded on Linux as it contains iOS/macOS specific tests
           # Note: arkavo-llm integration tests excluded as they require local feature
 
@@ -196,6 +196,20 @@ jobs:
           # Test arkavo-test with embeddings enabled
           cargo test -p arkavo-test --features embeddings --lib
 
+  test-llm-local:
+    name: Test with Local LLM (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "test-llm-local"
+      - name: Run local LLM tests
+        run: |
+          # Test arkavo-llm with local feature
+          cargo test -p arkavo-llm --features llm-local
+
   build-linux:
     name: Build Linux (${{ matrix.target }})
     runs-on: ubuntu-latest
@@ -207,7 +221,7 @@ jobs:
             features: default
             artifact_name: arkavo-x86_64-linux
           - target: x86_64-unknown-linux-musl
-            features: memory
+            features: memory,llm-remote
             artifact_name: arkavo-x86_64-linux-musl
     steps:
       - uses: actions/checkout@v4
@@ -255,7 +269,7 @@ jobs:
           if [ "${{ matrix.target }}" = "x86_64-unknown-linux-gnu" ]; then
             echo "Full featured build with local LLM, mDNS, and memory support" > release-package/features.txt
           else
-            echo "Slim static build with memory support only (no local LLM or mDNS)" > release-package/features.txt
+            echo "Slim static build with memory and remote LLM support (no local LLM or mDNS)" > release-package/features.txt
           fi
 
       - name: Upload binary

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,14 +66,14 @@ jobs:
             ### Binaries
 
             #### Linux
-            - **Full featured** (glibc, local LLM + mDNS): arkavo-${{ steps.version.outputs.version }}-x86_64-linux.tar.gz
-            - **Static/slim** (musl, memory only): arkavo-${{ steps.version.outputs.version }}-x86_64-linux-musl.tar.gz
+            - **Full featured** (glibc, local LLM + remote LLM + mDNS): arkavo-${{ steps.version.outputs.version }}-x86_64-linux.tar.gz
+            - **Static/slim** (musl, memory + remote LLM): arkavo-${{ steps.version.outputs.version }}-x86_64-linux-musl.tar.gz
             - **Debian package** (full featured): arkavo_${{ steps.version.outputs.version }}_amd64.deb
             
             #### macOS
             - **ARM64** (full featured): arkavo-${{ steps.version.outputs.version }}-aarch64-apple-darwin.tar.gz
             
-            Choose the musl build for containers/Alpine Linux. Choose the glibc build for desktop Linux with local LLM support.
+            Choose the musl build for containers/Alpine Linux with remote LLM support. Choose the glibc build for desktop Linux with both local and remote LLM support.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -90,7 +90,7 @@ jobs:
             artifact_suffix: x86_64-linux
             needs_musl: false
           - target: x86_64-unknown-linux-musl
-            features: memory
+            features: memory,llm-remote
             artifact_suffix: x86_64-linux-musl
             needs_musl: true
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,14 +165,14 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "arkavo-cli",
 ]
 
 [[package]]
 name = "arkavo-cli"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -237,11 +237,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-encryption"
-version = "0.21.2"
+version = "0.21.3"
 
 [[package]]
 name = "arkavo-git"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "git2",
  "tempfile",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "async-trait",
  "serde",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-core"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "anyhow",
  "arkavo-mcp",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -365,11 +365,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.21.2"
+version = "0.21.3"
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-vault"
-version = "0.21.2"
+version = "0.21.3"
 
 [[package]]
 name = "arrayvec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,14 +165,14 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "arkavo-cli",
 ]
 
 [[package]]
 name = "arkavo-cli"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -237,11 +237,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-encryption"
-version = "0.21.3"
+version = "0.21.4"
 
 [[package]]
 name = "arkavo-git"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "git2",
  "tempfile",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "async-trait",
  "serde",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-core"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "anyhow",
  "arkavo-mcp",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -365,11 +365,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.21.3"
+version = "0.21.4"
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-vault"
-version = "0.21.3"
+version = "0.21.4"
 
 [[package]]
 name = "arrayvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["crates/arkavo-protocol/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.21.3"
+version = "0.21.4"
 edition = "2024"
 authors = ["Arkavo Edge Contributors"]
 license = "Apache-2.0"

--- a/crates/arkavo-cli/Cargo.toml
+++ b/crates/arkavo-cli/Cargo.toml
@@ -16,7 +16,7 @@ default = ["memory", "mdns", "local"]
 memory = ["arkavo-test/memory"]
 embeddings = ["memory", "arkavo-memory/embeddings", "arkavo-test/embeddings"]
 mdns = ["zeroconf"]
-local = ["dep:arkavo-llm", "arkavo-llm/local", "arkavo-dataflow/local", "arkavo-dataflow/llm", "arkavo-terminal/llm"]
+local = ["dep:arkavo-llm", "arkavo-llm/local", "arkavo-dataflow/local", "arkavo-terminal/llm-local"]
 
 [dependencies]
 arkavo-terminal = { path = "../arkavo-terminal", default-features = false }
@@ -25,7 +25,7 @@ arkavo-test = { path = "../arkavo-test" }
 arkavo-llm = { path = "../arkavo-llm", optional = true }
 arkavo-memory = { path = "../arkavo-memory", default-features = false }
 arkavo-mcp = { path = "../arkavo-mcp" }
-arkavo-dataflow = { path = "../arkavo-dataflow", default-features = false, features = ["nl", "sandbox", "llm"] }
+arkavo-dataflow = { path = "../arkavo-dataflow", default-features = false, features = ["nl", "sandbox", "llm-remote"] }
 arkavo-protocol = { path = "../arkavo-protocol", features = ["mdns"] }
 gethostname = "0.5"
 zeroconf = { version = "0.14", optional = true }

--- a/crates/arkavo-cli/Cargo.toml
+++ b/crates/arkavo-cli/Cargo.toml
@@ -17,6 +17,7 @@ memory = ["arkavo-test/memory"]
 embeddings = ["memory", "arkavo-memory/embeddings", "arkavo-test/embeddings"]
 mdns = ["zeroconf"]
 local = ["dep:arkavo-llm", "arkavo-llm/local", "arkavo-dataflow/local", "arkavo-terminal/llm-local"]
+llm-remote = ["dep:arkavo-llm", "arkavo-llm/llm-remote", "arkavo-dataflow/llm-remote", "arkavo-terminal/llm-remote"]
 
 [dependencies]
 arkavo-terminal = { path = "../arkavo-terminal", default-features = false }

--- a/crates/arkavo-cli/src/conversation_manager.rs
+++ b/crates/arkavo-cli/src/conversation_manager.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "local")]
-use arkavo_llm::{LlmClient, Message};
+use arkavo_llm::LlmClient;
 use arkavo_memory::storage::MemoryStorage;
 use chrono::{DateTime, Utc};
 use indicatif::{ProgressBar, ProgressStyle};

--- a/crates/arkavo-dataflow/Cargo.toml
+++ b/crates/arkavo-dataflow/Cargo.toml
@@ -8,11 +8,12 @@ repository.workspace = true
 description.workspace = true
 
 [features]
-default = ["nl", "sandbox", "llm"]
+default = ["nl", "sandbox", "llm-remote"]
 nl = []
 sandbox = []
-llm = ["dep:arkavo-llm"]
-local = ["llm", "arkavo-llm?/local"]
+llm-remote = ["dep:arkavo-llm", "arkavo-llm?/llm-remote"]
+llm-local = ["dep:arkavo-llm", "arkavo-llm?/llm-local"]
+local = ["llm-local"]
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/arkavo-dataflow/src/nodes/mod.rs
+++ b/crates/arkavo-dataflow/src/nodes/mod.rs
@@ -1,22 +1,22 @@
-#[cfg(feature = "llm")]
+#[cfg(any(feature = "llm-remote", feature = "llm-local"))]
 pub mod anthropic_provider;
 pub mod auth_manager;
 pub mod http_client;
-#[cfg(feature = "llm")]
+#[cfg(any(feature = "llm-remote", feature = "llm-local"))]
 pub mod llm;
-#[cfg(feature = "llm")]
+#[cfg(any(feature = "llm-remote", feature = "llm-local"))]
 pub mod llm_config;
-#[cfg(feature = "llm")]
+#[cfg(any(feature = "llm-remote", feature = "llm-local"))]
 pub mod llm_discovery;
-#[cfg(feature = "llm")]
+#[cfg(any(feature = "llm-remote", feature = "llm-local"))]
 pub mod model_registry;
-#[cfg(feature = "llm")]
+#[cfg(any(feature = "llm-remote", feature = "llm-local"))]
 pub mod openai_provider;
-#[cfg(feature = "llm")]
+#[cfg(any(feature = "llm-remote", feature = "llm-local"))]
 pub mod provider_error;
-#[cfg(feature = "llm")]
+#[cfg(any(feature = "llm-remote", feature = "llm-local"))]
 pub mod provider_factory;
-#[cfg(feature = "llm")]
+#[cfg(any(feature = "llm-remote", feature = "llm-local"))]
 pub mod provider_health;
 pub mod sink;
 pub mod source;
@@ -61,7 +61,7 @@ impl NodeRegistry {
         // Transforms
         self.register("json_transform", Box::new(transform::JsonTransform));
         self.register("filter_transform", Box::new(transform::FilterTransform));
-        #[cfg(feature = "llm")]
+        #[cfg(any(feature = "llm-remote", feature = "llm-local"))]
         self.register("llm_transform", Box::new(llm::LlmTransform::new()));
 
         // Sinks

--- a/crates/arkavo-dataflow/src/nodes/provider_factory.rs
+++ b/crates/arkavo-dataflow/src/nodes/provider_factory.rs
@@ -2,6 +2,7 @@ use super::anthropic_provider::{AnthropicConfig, AnthropicProvider};
 use super::auth_manager::AuthManager;
 use super::openai_provider::{OpenAIConfig, OpenAIProvider};
 use anyhow::Result;
+#[cfg(feature = "llm-remote")]
 use arkavo_llm::ollama::OllamaClient;
 use arkavo_llm::provider::Provider;
 use async_trait::async_trait;
@@ -13,24 +14,47 @@ use std::sync::Arc;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum ProviderType {
+    #[cfg(feature = "llm-remote")]
     Ollama,
+    #[cfg(feature = "llm-remote")]
     OpenAI,
+    #[cfg(feature = "llm-remote")]
     Anthropic,
+    #[cfg(feature = "llm-remote")]
     Gemini,
+    #[cfg(feature = "llm-local")]
     Local,
     Custom(String),
 }
 
 impl ProviderType {
     pub fn from_name(name: &str) -> Self {
-        match name.to_lowercase().as_str() {
-            n if n.contains("ollama") => ProviderType::Ollama,
-            n if n.contains("openai") => ProviderType::OpenAI,
-            n if n.contains("anthropic") => ProviderType::Anthropic,
-            n if n.contains("gemini") => ProviderType::Gemini,
-            n if n.contains("local") => ProviderType::Local,
-            _ => ProviderType::Custom(name.to_string()),
+        let name_lower = name.to_lowercase();
+
+        #[cfg(feature = "llm-remote")]
+        {
+            if name_lower.contains("ollama") {
+                return ProviderType::Ollama;
+            }
+            if name_lower.contains("openai") {
+                return ProviderType::OpenAI;
+            }
+            if name_lower.contains("anthropic") {
+                return ProviderType::Anthropic;
+            }
+            if name_lower.contains("gemini") {
+                return ProviderType::Gemini;
+            }
         }
+
+        #[cfg(feature = "llm-local")]
+        {
+            if name_lower.contains("local") {
+                return ProviderType::Local;
+            }
+        }
+
+        ProviderType::Custom(name.to_string())
     }
 }
 
@@ -68,8 +92,10 @@ pub trait ProviderFactory: Send + Sync {
 }
 
 /// Factory for creating Ollama provider instances
+#[cfg(feature = "llm-remote")]
 pub struct OllamaProviderFactory;
 
+#[cfg(feature = "llm-remote")]
 #[async_trait]
 impl ProviderFactory for OllamaProviderFactory {
     async fn create_provider(&self, config: &ProviderConfig) -> Result<Box<dyn Provider>> {
@@ -116,9 +142,13 @@ impl ProviderFactoryRegistry {
         };
 
         // Register default factories
-        registry.register(Arc::new(OllamaProviderFactory));
-        registry.register(Arc::new(OpenAIProviderFactory));
-        registry.register(Arc::new(AnthropicProviderFactory));
+        #[cfg(feature = "llm-remote")]
+        {
+            registry.register(Arc::new(OllamaProviderFactory));
+            registry.register(Arc::new(OpenAIProviderFactory));
+            registry.register(Arc::new(AnthropicProviderFactory));
+        }
+        #[cfg(feature = "llm-local")]
         registry.register(Arc::new(LocalProviderFactory));
 
         registry
@@ -159,8 +189,10 @@ impl Default for ProviderFactoryRegistry {
 }
 
 /// Factory for creating OpenAI provider instances
+#[cfg(feature = "llm-remote")]
 pub struct OpenAIProviderFactory;
 
+#[cfg(feature = "llm-remote")]
 #[async_trait]
 impl ProviderFactory for OpenAIProviderFactory {
     async fn create_provider(&self, config: &ProviderConfig) -> Result<Box<dyn Provider>> {
@@ -249,8 +281,10 @@ impl ProviderFactory for OpenAIProviderFactory {
 }
 
 /// Factory for creating Anthropic provider instances
+#[cfg(feature = "llm-remote")]
 pub struct AnthropicProviderFactory;
 
+#[cfg(feature = "llm-remote")]
 #[async_trait]
 impl ProviderFactory for AnthropicProviderFactory {
     async fn create_provider(&self, config: &ProviderConfig) -> Result<Box<dyn Provider>> {
@@ -332,8 +366,10 @@ impl ProviderFactory for AnthropicProviderFactory {
 }
 
 /// Factory for creating Local provider instances
+#[cfg(feature = "llm-local")]
 pub struct LocalProviderFactory;
 
+#[cfg(feature = "llm-local")]
 #[async_trait]
 impl ProviderFactory for LocalProviderFactory {
     async fn create_provider(&self, config: &ProviderConfig) -> Result<Box<dyn Provider>> {
@@ -357,13 +393,10 @@ impl ProviderFactory for LocalProviderFactory {
         let provider = arkavo_llm::local::LocalProvider::new(model_name, model_path)?;
 
         // Initialize the provider (load model)
-        #[cfg(feature = "local")]
-        {
-            provider
-                .initialize()
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to initialize local provider: {}", e))?;
-        }
+        provider
+            .initialize()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to initialize local provider: {}", e))?;
 
         Ok(Box::new(provider))
     }
@@ -394,23 +427,31 @@ mod tests {
 
     #[test]
     fn test_provider_type_from_name() {
-        assert_eq!(
-            ProviderType::from_name("local-ollama"),
-            ProviderType::Ollama
-        );
-        assert_eq!(
-            ProviderType::from_name("ollama-remote"),
-            ProviderType::Ollama
-        );
-        assert_eq!(ProviderType::from_name("openai"), ProviderType::OpenAI);
-        assert_eq!(ProviderType::from_name("local"), ProviderType::Local);
-        assert_eq!(ProviderType::from_name("local-gemma"), ProviderType::Local);
+        #[cfg(feature = "llm-remote")]
+        #[cfg(feature = "llm-remote")]
+        {
+            assert_eq!(
+                ProviderType::from_name("local-ollama"),
+                ProviderType::Ollama
+            );
+            assert_eq!(
+                ProviderType::from_name("ollama-remote"),
+                ProviderType::Ollama
+            );
+            assert_eq!(ProviderType::from_name("openai"), ProviderType::OpenAI);
+        }
+        #[cfg(feature = "llm-local")]
+        {
+            assert_eq!(ProviderType::from_name("local"), ProviderType::Local);
+            assert_eq!(ProviderType::from_name("local-gemma"), ProviderType::Local);
+        }
         assert_eq!(
             ProviderType::from_name("custom-llm"),
             ProviderType::Custom("custom-llm".to_string())
         );
     }
 
+    #[cfg(feature = "llm-remote")]
     #[tokio::test]
     async fn test_ollama_factory_validation() {
         let factory = OllamaProviderFactory;

--- a/crates/arkavo-llm/Cargo.toml
+++ b/crates/arkavo-llm/Cargo.toml
@@ -12,8 +12,10 @@ categories = ["command-line-utilities", "development-tools"]
 
 
 [features]
-default = ["local"]
-local = ["dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:hf-hub", "dep:tokenizers", "dep:bytemuck", "dep:cfg-if", "dep:sha2", "dep:indicatif", "dep:dirs", "dep:toml"]
+default = []
+llm-remote = []
+llm-local = ["dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:hf-hub", "dep:tokenizers", "dep:bytemuck", "dep:cfg-if", "dep:sha2", "dep:indicatif", "dep:dirs", "dep:toml"]
+local = ["llm-local"]  # Alias for compatibility
 metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal"]
 
 [dependencies]

--- a/crates/arkavo-llm/src/client.rs
+++ b/crates/arkavo-llm/src/client.rs
@@ -1,9 +1,10 @@
 use crate::chat::ChatRequest;
+#[cfg(feature = "llm-remote")]
 use crate::ollama::OllamaClient;
 use crate::{Error, Message, Provider, Result, StreamResponse};
 use tokio_stream::Stream;
 
-#[cfg(feature = "local")]
+#[cfg(feature = "llm-local")]
 use crate::local::LocalProvider;
 
 pub struct LlmClient {
@@ -21,28 +22,37 @@ impl LlmClient {
             .unwrap_or_else(|_| "ollama".to_string())
             .to_lowercase();
 
-        let provider: Box<dyn Provider> = match provider_name.as_str() {
-            "ollama" => Box::new(OllamaClient::from_env()?),
-            _ => {
-                return Err(Error::Config(format!("Unknown provider: {provider_name}")));
+        match provider_name.as_str() {
+            #[cfg(feature = "llm-remote")]
+            "ollama" => {
+                let provider = Box::new(OllamaClient::from_env()?);
+                Ok(Self::new(provider))
             }
-        };
+            _ => {
+                #[cfg(feature = "llm-remote")]
+                return Err(Error::Config(format!("Unknown provider: {provider_name}")));
 
-        Ok(Self::new(provider))
+                #[cfg(not(feature = "llm-remote"))]
+                return Err(Error::Config(
+                    "No LLM providers available. Build with 'llm-remote' or 'llm-local' feature enabled.".to_string()
+                ));
+            }
+        }
     }
 
     pub async fn from_local_model(model_name: &str, model_path: String) -> Result<Self> {
-        #[cfg(feature = "local")]
+        #[cfg(feature = "llm-local")]
         {
             let provider = LocalProvider::new(model_name.to_string(), Some(model_path))?;
             // Initialize the provider to load the model
             provider.initialize().await?;
             Ok(Self::new(Box::new(provider)))
         }
-        #[cfg(not(feature = "local"))]
+        #[cfg(not(feature = "llm-local"))]
         {
+            let _ = (model_name, model_path); // Suppress unused variable warnings
             Err(Error::Config(
-                "Local models require the 'local' feature to be enabled".to_string(),
+                "Local models require the 'llm-local' feature to be enabled".to_string(),
             ))
         }
     }

--- a/crates/arkavo-llm/src/lib.rs
+++ b/crates/arkavo-llm/src/lib.rs
@@ -2,8 +2,10 @@ pub mod chat;
 pub mod client;
 pub mod error;
 pub mod image;
+#[cfg(feature = "llm-local")]
 pub mod local;
 pub mod message;
+#[cfg(feature = "llm-remote")]
 pub mod ollama;
 pub mod provider;
 pub mod stream;

--- a/crates/arkavo-llm/src/local/mod.rs
+++ b/crates/arkavo-llm/src/local/mod.rs
@@ -2,29 +2,29 @@ pub mod provider;
 
 pub use provider::LocalProvider;
 
-#[cfg(feature = "local")]
+#[cfg(feature = "llm-local")]
 pub mod config;
 
-#[cfg(feature = "local")]
+#[cfg(feature = "llm-local")]
 pub mod download_manager;
 
-#[cfg(feature = "local")]
+#[cfg(feature = "llm-local")]
 pub mod model_loader;
 
-#[cfg(feature = "local")]
+#[cfg(feature = "llm-local")]
 pub mod tokenizer;
 
-#[cfg(feature = "local")]
+#[cfg(feature = "llm-local")]
 pub mod tokenizer_utils;
 
-#[cfg(feature = "local")]
+#[cfg(feature = "llm-local")]
 pub mod worker;
 
-#[cfg(feature = "local")]
+#[cfg(feature = "llm-local")]
 pub mod streaming;
 
-#[cfg(feature = "local")]
+#[cfg(feature = "llm-local")]
 pub use config::LocalConfig;
 
-#[cfg(feature = "local")]
+#[cfg(feature = "llm-local")]
 pub use download_manager::{ModelDownloader, ModelManifest, ModelSpec};

--- a/crates/arkavo-llm/src/local/provider.rs
+++ b/crates/arkavo-llm/src/local/provider.rs
@@ -2,22 +2,22 @@ use crate::{Error, Message, Provider, Result, StreamResponse};
 use async_trait::async_trait;
 use tokio_stream::Stream;
 
-#[cfg(feature = "local")]
+#[cfg(feature = "llm-local")]
 use super::model_loader::{Model, ModelLoader};
 
-#[cfg(feature = "local")]
+#[cfg(feature = "llm-local")]
 use candle_core::Tensor;
 
-#[cfg(feature = "local")]
+#[cfg(feature = "llm-local")]
 use std::sync::Arc;
 
-#[cfg(feature = "local")]
+#[cfg(feature = "llm-local")]
 use tokio::sync::Mutex;
 
-#[cfg(feature = "local")]
+#[cfg(feature = "llm-local")]
 use super::worker::WorkerHandle;
 
-#[cfg(feature = "local")]
+#[cfg(feature = "llm-local")]
 struct Inner {
     model_loader: ModelLoader,
     #[allow(dead_code)]
@@ -28,21 +28,21 @@ struct Inner {
 }
 
 pub struct LocalProvider {
-    #[cfg(feature = "local")]
+    #[cfg(feature = "llm-local")]
     inner: Arc<Mutex<Inner>>,
     model_name: String,
 }
 
 impl LocalProvider {
     pub fn new(model_name: String, model_path: Option<String>) -> Result<Self> {
-        #[cfg(not(feature = "local"))]
+        #[cfg(not(feature = "llm-local"))]
         {
             return Err(Error::Config(
-                "Local provider requires 'local' feature to be enabled".to_string(),
+                "Local provider requires 'llm-local' feature to be enabled".to_string(),
             ));
         }
 
-        #[cfg(feature = "local")]
+        #[cfg(feature = "llm-local")]
         {
             let model_loader = ModelLoader::new(&model_name, model_path.as_deref())?;
 
@@ -59,7 +59,7 @@ impl LocalProvider {
         }
     }
 
-    #[cfg(feature = "local")]
+    #[cfg(feature = "llm-local")]
     #[allow(clippy::missing_panics_doc)]
     #[allow(clippy::significant_drop_tightening)]
     pub async fn initialize(&self) -> Result<()> {
@@ -86,14 +86,14 @@ impl LocalProvider {
 impl Provider for LocalProvider {
     #[allow(clippy::significant_drop_tightening)]
     async fn complete(&self, messages: Vec<Message>) -> Result<String> {
-        #[cfg(not(feature = "local"))]
+        #[cfg(not(feature = "llm-local"))]
         {
             return Err(Error::Config(
-                "Local provider requires 'local' feature to be enabled".to_string(),
+                "Local provider requires 'llm-local' feature to be enabled".to_string(),
             ));
         }
 
-        #[cfg(feature = "local")]
+        #[cfg(feature = "llm-local")]
         {
             let prompt = messages
                 .iter()
@@ -297,14 +297,14 @@ impl Provider for LocalProvider {
         &self,
         _messages: Vec<Message>,
     ) -> Result<Box<dyn Stream<Item = Result<StreamResponse>> + Send + Unpin>> {
-        #[cfg(not(feature = "local"))]
+        #[cfg(not(feature = "llm-local"))]
         {
             return Err(Error::Config(
-                "Local provider requires 'local' feature to be enabled".to_string(),
+                "Local provider requires 'llm-local' feature to be enabled".to_string(),
             ));
         }
 
-        #[cfg(feature = "local")]
+        #[cfg(feature = "llm-local")]
         {
             let prompt = _messages
                 .iter()

--- a/crates/arkavo-llm/tests/integration_test.rs
+++ b/crates/arkavo-llm/tests/integration_test.rs
@@ -19,11 +19,23 @@ mod tests {
 
     #[test]
     fn test_client_creation() {
-        // Test that client can be created without panicking
-        let result = LlmClient::from_env();
-        assert!(result.is_ok());
+        // When llm-remote feature is enabled, client should be created successfully
+        // even without environment variables (zero config)
+        #[cfg(feature = "llm-remote")]
+        {
+            let result = LlmClient::from_env();
+            assert!(result.is_ok(), "Client creation should succeed with zero config");
 
-        let client = result.unwrap();
-        assert_eq!(client.provider_name(), "ollama");
+            let client = result.unwrap();
+            assert_eq!(client.provider_name(), "ollama");
+        }
+
+        // When only llm-local feature is enabled, from_env() will fail
+        // because it defaults to ollama which requires llm-remote
+        #[cfg(all(not(feature = "llm-remote"), feature = "llm-local"))]
+        {
+            let result = LlmClient::from_env();
+            assert!(result.is_err(), "Client creation should fail without llm-remote feature");
+        }
     }
 }

--- a/crates/arkavo-llm/tests/integration_test.rs
+++ b/crates/arkavo-llm/tests/integration_test.rs
@@ -24,7 +24,10 @@ mod tests {
         #[cfg(feature = "llm-remote")]
         {
             let result = LlmClient::from_env();
-            assert!(result.is_ok(), "Client creation should succeed with zero config");
+            assert!(
+                result.is_ok(),
+                "Client creation should succeed with zero config"
+            );
 
             let client = result.unwrap();
             assert_eq!(client.provider_name(), "ollama");
@@ -35,7 +38,10 @@ mod tests {
         #[cfg(all(not(feature = "llm-remote"), feature = "llm-local"))]
         {
             let result = LlmClient::from_env();
-            assert!(result.is_err(), "Client creation should fail without llm-remote feature");
+            assert!(
+                result.is_err(),
+                "Client creation should fail without llm-remote feature"
+            );
         }
     }
 }

--- a/crates/arkavo-llm/tests/ollama_integration.rs
+++ b/crates/arkavo-llm/tests/ollama_integration.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "llm-remote")]
+
 use arkavo_llm::{LlmClient, Message};
 use serial_test::serial;
 use std::env;

--- a/crates/arkavo-terminal/Cargo.toml
+++ b/crates/arkavo-terminal/Cargo.toml
@@ -11,8 +11,9 @@ categories = ["command-line-interface", "command-line-utilities"]
 readme = "CLAUDE.md"
 
 [features]
-default = ["llm"]
-llm = ["dep:arkavo-llm", "arkavo-dataflow/llm"]
+default = ["llm-remote"]
+llm-remote = ["dep:arkavo-llm", "arkavo-dataflow/llm-remote"]
+llm-local = ["dep:arkavo-llm", "arkavo-dataflow/llm-local"]
 
 [dependencies]
 ratatui = { version = "0.29", features = ["crossterm"] }
@@ -29,7 +30,7 @@ serde_json = "1.0"
 semver = { version = "1.0", features = ["serde"] }
 arkavo-memory = { path = "../arkavo-memory", default-features = false }
 arkavo-llm = { path = "../arkavo-llm", default-features = false, optional = true }
-arkavo-dataflow = { path = "../arkavo-dataflow", default-features = false, features = ["nl", "sandbox", "llm"] }
+arkavo-dataflow = { path = "../arkavo-dataflow", default-features = false, features = ["nl", "sandbox", "llm-remote"] }
 arkavo-mcp-runtime = { path = "../arkavo-mcp-runtime" }
 arkavo-mcp-core = { path = "../arkavo-mcp-core" }
 arkavo-test = { path = "../arkavo-test" }

--- a/crates/arkavo-terminal/src/app.rs
+++ b/crates/arkavo-terminal/src/app.rs
@@ -348,7 +348,7 @@ impl App {
         }
     }
 
-    #[cfg(feature = "llm")]
+    #[cfg(any(feature = "llm-remote", feature = "llm-local"))]
     pub async fn fetch_available_models(&mut self) {
         // Try to fetch models from discovered Ollama servers
         use arkavo_llm::ollama::OllamaClient;
@@ -560,7 +560,7 @@ impl App {
         }
     }
 
-    #[cfg(not(feature = "llm"))]
+    #[cfg(not(any(feature = "llm-remote", feature = "llm-local")))]
     pub async fn fetch_available_models(&mut self) {
         // When LLM feature is disabled, show only configuration message
         self.available_models = vec!["LLM features disabled in this build".to_string()];
@@ -1032,9 +1032,15 @@ impl App {
                                             if let Some(server_url) =
                                                 self.extract_server_url(&self.input_buffer)
                                             {
-                                                #[cfg(feature = "llm")]
+                                                #[cfg(any(
+                                                    feature = "llm-remote",
+                                                    feature = "llm-local"
+                                                ))]
                                                 self.add_ollama_server(server_url).await;
-                                                #[cfg(not(feature = "llm"))]
+                                                #[cfg(not(any(
+                                                    feature = "llm-remote",
+                                                    feature = "llm-local"
+                                                )))]
                                                 {
                                                     let _ = server_url;
                                                     self.add_debug_log(
@@ -1956,7 +1962,7 @@ Scrolling (when in scroll mode):
         None
     }
 
-    #[cfg(feature = "llm")]
+    #[cfg(any(feature = "llm-remote", feature = "llm-local"))]
     async fn add_ollama_server(&mut self, server_url: String) {
         use arkavo_llm::ollama::OllamaClient;
         use arkavo_memory::storage::MemoryStorage;
@@ -2205,7 +2211,7 @@ Scrolling (when in scroll mode):
                 }
 
                 // Test the connection
-                #[cfg(feature = "llm")]
+                #[cfg(any(feature = "llm-remote", feature = "llm-local"))]
                 {
                     use arkavo_memory::storage::MemoryStorage;
 
@@ -2279,7 +2285,7 @@ Scrolling (when in scroll mode):
                     }
                 }
 
-                #[cfg(not(feature = "llm"))]
+                #[cfg(not(any(feature = "llm-remote", feature = "llm-local")))]
                 {
                     let _ = base_url; // Suppress unused warning
                     self.add_debug_log(

--- a/crates/arkavo-terminal/src/lib.rs
+++ b/crates/arkavo-terminal/src/lib.rs
@@ -12,7 +12,7 @@ pub mod vim;
 mod tests;
 
 use anyhow::Result;
-#[cfg(feature = "llm")]
+#[cfg(any(feature = "llm-remote", feature = "llm-local"))]
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
@@ -61,18 +61,18 @@ pub struct TerminalContext {
 
 pub async fn run() -> Result<()> {
     // Create channels for LLM communication
-    #[cfg(feature = "llm")]
+    #[cfg(any(feature = "llm-remote", feature = "llm-local"))]
     let (ui_tx, ui_rx) = mpsc::channel::<LlmRequest>(100);
-    #[cfg(not(feature = "llm"))]
+    #[cfg(not(any(feature = "llm-remote", feature = "llm-local")))]
     let (ui_tx, _ui_rx) = mpsc::channel::<LlmRequest>(100);
 
-    #[cfg(feature = "llm")]
+    #[cfg(any(feature = "llm-remote", feature = "llm-local"))]
     let (llm_tx, llm_rx) = mpsc::channel::<LlmResponse>(100);
-    #[cfg(not(feature = "llm"))]
+    #[cfg(not(any(feature = "llm-remote", feature = "llm-local")))]
     let (_llm_tx, llm_rx) = mpsc::channel::<LlmResponse>(100);
 
     // Spawn LLM handler task with proper Ollama integration
-    #[cfg(feature = "llm")]
+    #[cfg(any(feature = "llm-remote", feature = "llm-local"))]
     {
         let mut ui_rx = ui_rx;
         let llm_tx = llm_tx.clone();
@@ -529,7 +529,7 @@ pub async fn run() -> Result<()> {
     run_with_channels(ui_tx, llm_rx).await
 }
 
-#[cfg(feature = "llm")]
+#[cfg(any(feature = "llm-remote", feature = "llm-local"))]
 async fn initialize_llm_client() -> Result<arkavo_llm::LlmClient> {
     use arkavo_llm::{LlmClient, Message};
     use arkavo_memory::storage::MemoryStorage;
@@ -584,7 +584,7 @@ async fn initialize_llm_client() -> Result<arkavo_llm::LlmClient> {
     }
 }
 
-#[cfg(feature = "llm")]
+#[cfg(any(feature = "llm-remote", feature = "llm-local"))]
 async fn prompt_for_ollama_config(
     storage: Arc<arkavo_memory::storage::MemoryStorage>,
 ) -> Result<arkavo_llm::LlmClient> {
@@ -837,7 +837,7 @@ pub async fn run_with_string_channels(
     run_with_channels(new_ui_tx, new_llm_rx).await
 }
 
-#[cfg(feature = "llm")]
+#[cfg(any(feature = "llm-remote", feature = "llm-local"))]
 fn extract_tool_calls(response: &str) -> Vec<(String, String)> {
     let mut tool_calls = Vec::new();
 

--- a/crates/arkavo/Cargo.toml
+++ b/crates/arkavo/Cargo.toml
@@ -17,6 +17,7 @@ memory = ["arkavo-cli/memory"]
 embeddings = ["memory", "arkavo-cli/embeddings"]
 mdns = ["arkavo-cli/mdns"]
 local = ["arkavo-cli/local"]
+llm-remote = ["arkavo-cli/llm-remote"]
 
 [dependencies]
 arkavo-cli = { path = "../arkavo-cli", default-features = false }


### PR DESCRIPTION
## Summary
This PR splits the monolithic `llm` feature into two distinct features to enable more flexible deployment options:
- `llm-remote`: For remote LLM API support (Ollama, OpenAI, Anthropic)  
- `llm-local`: For local inference via Candle

## Motivation
The current `llm` feature flag is too broad, controlling both remote LLM support and local inference. This prevents musl builds from using remote LLM APIs even though only local inference has the problematic OpenSSL dependency.

## Changes
- ✅ Split `llm` feature into `llm-remote` and `llm-local` across all crates
- ✅ Update feature gates throughout the codebase
- ✅ Enable `llm-remote` for musl builds in CI workflows
- ✅ Add conditional compilation for provider factories based on features
- ✅ Update documentation to reflect new capabilities

## Benefits
- 🚀 Musl builds now support remote LLM APIs (Ollama, OpenAI, Anthropic)
- 📦 Smaller binary sizes for deployments that only need one type of LLM support
- 🎯 Clearer separation of concerns between remote and local functionality
- 🔧 More flexible feature selection for different deployment scenarios

## Testing
- Verified builds with `--features llm-remote` only
- Verified builds with `--features llm-local` only  
- Verified builds with both features enabled
- All existing tests pass

Fixes #139

🤖 Generated with [Claude Code](https://claude.ai/code)