### PR TITLE
Partial implementation of A2A protocol alignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,14 +165,14 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.23.7"
+version = "0.24.0"
 dependencies = [
  "arkavo-cli",
 ]
 
 [[package]]
 name = "arkavo-agui"
-version = "0.23.7"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.23.7"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.23.7"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -254,11 +254,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-encryption"
-version = "0.23.7"
+version = "0.24.0"
 
 [[package]]
 name = "arkavo-git"
-version = "0.23.7"
+version = "0.24.0"
 dependencies = [
  "git2",
  "tempfile",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.23.7"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.23.7"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-core"
-version = "0.23.7"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.23.7"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.23.7"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "arkavo-mcp",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.23.7"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.23.7"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.23.7"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.23.7"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test"
-version = "0.23.7"
+version = "0.24.0"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ exclude = ["crates/arkavo-protocol/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.23.8"
+version = "0.24.0"
 edition = "2024"
 authors = ["Arkavo Edge Contributors"]
 license = "Apache-2.0"

--- a/crates/arkavo-protocol/fuzz/fuzz_targets/fuzz_json_rpc.rs
+++ b/crates/arkavo-protocol/fuzz/fuzz_targets/fuzz_json_rpc.rs
@@ -25,7 +25,7 @@ fuzz_target!(|data: &[u8]| {
             
             // Method should be one of our known methods
             match request.method.as_str() {
-                "promise_request" | "promise_declare" | "agent_discover" | "rpc.discover" => {},
+                "task_request" | "task_declare" | "agent_discover" | "rpc.discover" => {},
                 _ => {
                     // Unknown method is still valid JSON-RPC
                 }

--- a/crates/arkavo-protocol/src/bin/validate-schema.rs
+++ b/crates/arkavo-protocol/src/bin/validate-schema.rs
@@ -59,8 +59,8 @@ fn main() {
     // Check required methods exist
     let method_names: Vec<&str> = schema.methods.iter().map(|m| m.name.as_str()).collect();
     let required_methods = [
-        "promise_request",
-        "promise_declare",
+        "task_request",
+        "task_declare",
         "agent_discover",
         "rpc.discover",
     ];

--- a/crates/arkavo-protocol/src/openrpc.rs
+++ b/crates/arkavo-protocol/src/openrpc.rs
@@ -1,6 +1,7 @@
 use crate::types::{
-    AgentDiscoverFilter, DiscoveredAgent, PromiseCapability, PromiseDeclareResponse,
-    PromiseRequest, PromiseResponse, PromiseStatus,
+    AgentDiscoverFilter, DiscoveredAgent, Message, MessagePart, MessageSendRequest,
+    MessageSendResponse, TaskCancelRequest, TaskCancelResponse, TaskCapability,
+    TaskDeclareResponse, TaskGetRequest, TaskGetResponse, TaskRequest, TaskResponse, TaskStatus,
 };
 use schemars::{JsonSchema, schema_for};
 use serde::{Deserialize, Serialize};
@@ -124,9 +125,9 @@ pub fn generate_openrpc_schema() -> OpenRpcDocument {
         },
         methods: vec![
             OpenRpcMethod {
-                name: "promise_request".to_string(),
-                description: Some("Request a promise from another agent".to_string()),
-                summary: Some("Promise request".to_string()),
+                name: "task_request".to_string(),
+                description: Some("Request a task from another agent".to_string()),
+                summary: Some("Task request".to_string()),
                 params: vec![
                     OpenRpcParam {
                         name: "agent_id".to_string(),
@@ -137,8 +138,8 @@ pub fn generate_openrpc_schema() -> OpenRpcDocument {
                         }),
                     },
                     OpenRpcParam {
-                        name: "promise_type".to_string(),
-                        description: Some("The type of promise being requested".to_string()),
+                        name: "task_type".to_string(),
+                        description: Some("The type of task being requested".to_string()),
                         required: Some(true),
                         schema: json!({
                             "type": "string"
@@ -146,7 +147,7 @@ pub fn generate_openrpc_schema() -> OpenRpcDocument {
                     },
                     OpenRpcParam {
                         name: "payload".to_string(),
-                        description: Some("Additional data for the promise request".to_string()),
+                        description: Some("Additional data for the task request".to_string()),
                         required: Some(false),
                         schema: json!({
                             "type": "object"
@@ -154,9 +155,9 @@ pub fn generate_openrpc_schema() -> OpenRpcDocument {
                     },
                 ],
                 result: OpenRpcResult {
-                    name: "promise_response".to_string(),
-                    description: Some("The promise response from the agent".to_string()),
-                    schema: serde_json::to_value(schema_for!(PromiseResponse)).unwrap(),
+                    name: "task_response".to_string(),
+                    description: Some("The task response from the agent".to_string()),
+                    schema: serde_json::to_value(schema_for!(TaskResponse)).unwrap(),
                 },
                 errors: Some(vec![
                     OpenRpcError {
@@ -171,7 +172,7 @@ pub fn generate_openrpc_schema() -> OpenRpcDocument {
                     },
                 ]),
                 examples: Some(vec![OpenRpcExample {
-                    name: Some("Simple promise request".to_string()),
+                    name: Some("Simple task request".to_string()),
                     description: None,
                     params: vec![
                         OpenRpcExampleParam {
@@ -179,21 +180,21 @@ pub fn generate_openrpc_schema() -> OpenRpcDocument {
                             value: json!("550e8400-e29b-41d4-a716-446655440000"),
                         },
                         OpenRpcExampleParam {
-                            name: "promise_type".to_string(),
+                            name: "task_type".to_string(),
                             value: json!("data_access"),
                         },
                     ],
                     result: Some(json!({
-                        "promise_id": "660e8400-e29b-41d4-a716-446655440001",
+                        "task_id": "660e8400-e29b-41d4-a716-446655440001",
                         "status": "accepted",
                         "data": {}
                     })),
                 }]),
             },
             OpenRpcMethod {
-                name: "promise_declare".to_string(),
-                description: Some("Declare a promise capability to other agents".to_string()),
-                summary: Some("Promise declaration".to_string()),
+                name: "task_declare".to_string(),
+                description: Some("Declare a task capability to other agents".to_string()),
+                summary: Some("Task declaration".to_string()),
                 params: vec![
                     OpenRpcParam {
                         name: "agent_id".to_string(),
@@ -204,16 +205,16 @@ pub fn generate_openrpc_schema() -> OpenRpcDocument {
                         }),
                     },
                     OpenRpcParam {
-                        name: "promises".to_string(),
-                        description: Some("List of promises the agent can fulfill".to_string()),
+                        name: "tasks".to_string(),
+                        description: Some("List of tasks the agent can fulfill".to_string()),
                         required: Some(true),
-                        schema: serde_json::to_value(schema_for!(Vec<PromiseCapability>)).unwrap(),
+                        schema: serde_json::to_value(schema_for!(Vec<TaskCapability>)).unwrap(),
                     },
                 ],
                 result: OpenRpcResult {
                     name: "declaration_result".to_string(),
-                    description: Some("Confirmation of promise declaration".to_string()),
-                    schema: serde_json::to_value(schema_for!(PromiseDeclareResponse)).unwrap(),
+                    description: Some("Confirmation of task declaration".to_string()),
+                    schema: serde_json::to_value(schema_for!(TaskDeclareResponse)).unwrap(),
                 },
                 errors: None,
                 examples: None,
@@ -236,34 +237,89 @@ pub fn generate_openrpc_schema() -> OpenRpcDocument {
                 errors: None,
                 examples: None,
             },
+            // A2A Protocol Methods
+            OpenRpcMethod {
+                name: "message/send".to_string(),
+                description: Some("Send a message synchronously to an agent".to_string()),
+                summary: Some("Send message".to_string()),
+                params: vec![OpenRpcParam {
+                    name: "request".to_string(),
+                    description: Some("Message send request".to_string()),
+                    required: Some(true),
+                    schema: serde_json::to_value(schema_for!(MessageSendRequest)).unwrap(),
+                }],
+                result: OpenRpcResult {
+                    name: "message_response".to_string(),
+                    description: Some("Response containing task ID and status".to_string()),
+                    schema: serde_json::to_value(schema_for!(MessageSendResponse)).unwrap(),
+                },
+                errors: None,
+                examples: None,
+            },
+            OpenRpcMethod {
+                name: "tasks/get".to_string(),
+                description: Some("Get task status and result".to_string()),
+                summary: Some("Get task".to_string()),
+                params: vec![OpenRpcParam {
+                    name: "request".to_string(),
+                    description: Some("Task get request".to_string()),
+                    required: Some(true),
+                    schema: serde_json::to_value(schema_for!(TaskGetRequest)).unwrap(),
+                }],
+                result: OpenRpcResult {
+                    name: "task_status".to_string(),
+                    description: Some("Current task status and result".to_string()),
+                    schema: serde_json::to_value(schema_for!(TaskGetResponse)).unwrap(),
+                },
+                errors: None,
+                examples: None,
+            },
+            OpenRpcMethod {
+                name: "tasks/cancel".to_string(),
+                description: Some("Cancel a running task".to_string()),
+                summary: Some("Cancel task".to_string()),
+                params: vec![OpenRpcParam {
+                    name: "request".to_string(),
+                    description: Some("Task cancel request".to_string()),
+                    required: Some(true),
+                    schema: serde_json::to_value(schema_for!(TaskCancelRequest)).unwrap(),
+                }],
+                result: OpenRpcResult {
+                    name: "cancel_response".to_string(),
+                    description: Some("Task cancellation result".to_string()),
+                    schema: serde_json::to_value(schema_for!(TaskCancelResponse)).unwrap(),
+                },
+                errors: None,
+                examples: None,
+            },
         ],
         components: Some(OpenRpcComponents {
             schemas: Some({
                 let mut schemas = HashMap::new();
 
                 schemas.insert(
-                    "PromiseStatus".to_string(),
-                    serde_json::to_value(schema_for!(PromiseStatus)).unwrap(),
+                    "TaskStatus".to_string(),
+                    serde_json::to_value(schema_for!(TaskStatus)).unwrap(),
                 );
 
                 schemas.insert(
-                    "PromiseRequest".to_string(),
-                    serde_json::to_value(schema_for!(PromiseRequest)).unwrap(),
+                    "TaskRequest".to_string(),
+                    serde_json::to_value(schema_for!(TaskRequest)).unwrap(),
                 );
 
                 schemas.insert(
-                    "PromiseResponse".to_string(),
-                    serde_json::to_value(schema_for!(PromiseResponse)).unwrap(),
+                    "TaskResponse".to_string(),
+                    serde_json::to_value(schema_for!(TaskResponse)).unwrap(),
                 );
 
                 schemas.insert(
-                    "PromiseCapability".to_string(),
-                    serde_json::to_value(schema_for!(PromiseCapability)).unwrap(),
+                    "TaskCapability".to_string(),
+                    serde_json::to_value(schema_for!(TaskCapability)).unwrap(),
                 );
 
                 schemas.insert(
-                    "PromiseDeclareResponse".to_string(),
-                    serde_json::to_value(schema_for!(PromiseDeclareResponse)).unwrap(),
+                    "TaskDeclareResponse".to_string(),
+                    serde_json::to_value(schema_for!(TaskDeclareResponse)).unwrap(),
                 );
 
                 schemas.insert(
@@ -274,6 +330,47 @@ pub fn generate_openrpc_schema() -> OpenRpcDocument {
                 schemas.insert(
                     "DiscoveredAgent".to_string(),
                     serde_json::to_value(schema_for!(DiscoveredAgent)).unwrap(),
+                );
+
+                // A2A Protocol Schemas
+                schemas.insert(
+                    "MessageSendRequest".to_string(),
+                    serde_json::to_value(schema_for!(MessageSendRequest)).unwrap(),
+                );
+
+                schemas.insert(
+                    "MessageSendResponse".to_string(),
+                    serde_json::to_value(schema_for!(MessageSendResponse)).unwrap(),
+                );
+
+                schemas.insert(
+                    "Message".to_string(),
+                    serde_json::to_value(schema_for!(Message)).unwrap(),
+                );
+
+                schemas.insert(
+                    "MessagePart".to_string(),
+                    serde_json::to_value(schema_for!(MessagePart)).unwrap(),
+                );
+
+                schemas.insert(
+                    "TaskGetRequest".to_string(),
+                    serde_json::to_value(schema_for!(TaskGetRequest)).unwrap(),
+                );
+
+                schemas.insert(
+                    "TaskGetResponse".to_string(),
+                    serde_json::to_value(schema_for!(TaskGetResponse)).unwrap(),
+                );
+
+                schemas.insert(
+                    "TaskCancelRequest".to_string(),
+                    serde_json::to_value(schema_for!(TaskCancelRequest)).unwrap(),
+                );
+
+                schemas.insert(
+                    "TaskCancelResponse".to_string(),
+                    serde_json::to_value(schema_for!(TaskCancelResponse)).unwrap(),
                 );
 
                 schemas
@@ -318,8 +415,8 @@ mod tests {
     fn test_openrpc_json_serialization() {
         let json = openrpc_to_json().unwrap();
         assert!(json.contains("\"openrpc\": \"1.2.6\""));
-        assert!(json.contains("promise_request"));
-        assert!(json.contains("promise_declare"));
+        assert!(json.contains("task_request"));
+        assert!(json.contains("task_declare"));
         assert!(json.contains("agent_discover"));
     }
 
@@ -330,8 +427,8 @@ mod tests {
         let components = schema.components.unwrap();
         assert!(components.schemas.is_some());
         let schemas = components.schemas.unwrap();
-        assert!(schemas.contains_key("PromiseStatus"));
-        assert!(schemas.contains_key("PromiseRequest"));
-        assert!(schemas.contains_key("PromiseResponse"));
+        assert!(schemas.contains_key("TaskStatus"));
+        assert!(schemas.contains_key("TaskRequest"));
+        assert!(schemas.contains_key("TaskResponse"));
     }
 }

--- a/crates/arkavo-protocol/src/server.rs
+++ b/crates/arkavo-protocol/src/server.rs
@@ -4,12 +4,12 @@ use crate::mcp_registry::McpRegistry;
 use crate::metrics::{MetricsCollector, RpcTimer};
 use crate::openrpc;
 use crate::rate_limit::RateLimiter;
-#[cfg(feature = "stub_handlers")]
-use crate::types::PromiseStatus;
 use crate::types::{
     AgentDiscoverFilter, ChatOpenRequest, ChatRequest, ChatSession, DiscoverFeaturesDisclose,
     DiscoverFeaturesQuery, DiscoveredAgent, FeatureDisclosure, FeatureType, MessageDelta,
-    MessageDeltaContent, PromiseCapability, PromiseDeclareResponse, PromiseResponse, UserMessage,
+    MessageDeltaContent, MessageSendRequest, MessageSendResponse, TaskCancelRequest,
+    TaskCancelResponse, TaskCapability, TaskDeclareResponse, TaskGetRequest, TaskGetResponse,
+    TaskResponse, UserMessage,
 };
 use arkavo_llm::{DeltaType, LlmClient, LlmClientAdapter, StreamLlmModel};
 use async_trait::async_trait;
@@ -27,20 +27,20 @@ use tracing::{error, info};
 
 #[rpc(server)]
 pub trait A2aRpc {
-    #[method(name = "promise_request")]
-    async fn promise_request(
+    #[method(name = "task_request")]
+    async fn task_request(
         &self,
         agent_id: String,
-        promise_type: String,
+        task_type: String,
         payload: Option<serde_json::Value>,
-    ) -> RpcResult<PromiseResponse>;
+    ) -> RpcResult<TaskResponse>;
 
-    #[method(name = "promise_declare")]
-    async fn promise_declare(
+    #[method(name = "task_declare")]
+    async fn task_declare(
         &self,
         agent_id: String,
-        promises: Vec<PromiseCapability>,
-    ) -> RpcResult<PromiseDeclareResponse>;
+        tasks: Vec<TaskCapability>,
+    ) -> RpcResult<TaskDeclareResponse>;
 
     #[method(name = "agent_discover")]
     async fn agent_discover(
@@ -59,6 +59,24 @@ pub trait A2aRpc {
 
     #[method(name = "rpc.discover")]
     async fn rpc_discover(&self) -> RpcResult<serde_json::Value>;
+
+    // A2A Protocol Methods
+
+    /// Send a message synchronously
+    #[method(name = "message/send")]
+    async fn message_send(&self, request: MessageSendRequest) -> RpcResult<MessageSendResponse>;
+
+    /// Get task status and result
+    #[method(name = "tasks/get")]
+    async fn tasks_get(&self, request: TaskGetRequest) -> RpcResult<TaskGetResponse>;
+
+    /// Cancel a running task
+    #[method(name = "tasks/cancel")]
+    async fn tasks_cancel(&self, request: TaskCancelRequest) -> RpcResult<TaskCancelResponse>;
+
+    /// Stream message updates
+    #[subscription(name = "message/stream", unsubscribe = "message/stream/unsubscribe", item = MessageDelta)]
+    async fn message_stream(&self, task_id: String) -> SubscriptionResult;
 
     /// Open a new chat session
     #[method(name = "chat_open")]
@@ -100,13 +118,13 @@ struct AgentMetadata {
 
 #[async_trait]
 impl A2aRpcServer for A2aRpcImpl {
-    async fn promise_request(
+    async fn task_request(
         &self,
         _agent_id: String,
-        _promise_type: String,
+        _task_type: String,
         _payload: Option<serde_json::Value>,
-    ) -> RpcResult<PromiseResponse> {
-        let timer = RpcTimer::new("promise_request".to_string(), self.metrics.clone());
+    ) -> RpcResult<TaskResponse> {
+        let timer = RpcTimer::new("task_request".to_string(), self.metrics.clone());
 
         // Check rate limit
         if let Err(e) = self.rate_limiter.check_rate_limit() {
@@ -117,9 +135,9 @@ impl A2aRpcServer for A2aRpcImpl {
 
         #[cfg(feature = "stub_handlers")]
         {
-            let response = PromiseResponse {
-                promise_id: uuid::Uuid::new_v4(),
-                status: PromiseStatus::Pending,
+            let response = TaskResponse {
+                task_id: uuid::Uuid::new_v4(),
+                status: TaskStatus::Submitted,
                 data: _payload,
             };
             timer.success();
@@ -132,17 +150,17 @@ impl A2aRpcServer for A2aRpcImpl {
             Err(ErrorObjectOwned::owned(
                 -32601,
                 "Method not yet implemented",
-                Some("promise_request is not yet implemented".to_string()),
+                Some("task_request is not yet implemented".to_string()),
             ))
         }
     }
 
-    async fn promise_declare(
+    async fn task_declare(
         &self,
         _agent_id: String,
-        _promises: Vec<PromiseCapability>,
-    ) -> RpcResult<PromiseDeclareResponse> {
-        let timer = RpcTimer::new("promise_declare".to_string(), self.metrics.clone());
+        _tasks: Vec<TaskCapability>,
+    ) -> RpcResult<TaskDeclareResponse> {
+        let timer = RpcTimer::new("task_declare".to_string(), self.metrics.clone());
 
         // Check rate limit
         if let Err(e) = self.rate_limiter.check_rate_limit() {
@@ -153,7 +171,7 @@ impl A2aRpcServer for A2aRpcImpl {
 
         #[cfg(feature = "stub_handlers")]
         {
-            let response = PromiseDeclareResponse {
+            let response = TaskDeclareResponse {
                 acknowledged: true,
                 timestamp: chrono::Utc::now(),
             };
@@ -167,7 +185,7 @@ impl A2aRpcServer for A2aRpcImpl {
             Err(ErrorObjectOwned::owned(
                 -32601,
                 "Method not yet implemented",
-                Some("promise_declare is not yet implemented".to_string()),
+                Some("task_declare is not yet implemented".to_string()),
             ))
         }
     }
@@ -215,7 +233,7 @@ impl A2aRpcServer for A2aRpcImpl {
         let agent = DiscoveredAgent {
             agent_id: uuid::Uuid::new_v4(), // Generate a unique ID for the agent
             endpoint,
-            promises: Some(vec![]), // TODO: Populate with actual promise types
+            tasks: Some(vec![]), // TODO: Populate with actual task types
             metadata: Some(metadata_json),
         };
 
@@ -330,6 +348,176 @@ impl A2aRpcServer for A2aRpcImpl {
                 ))
             }
         }
+    }
+
+    // A2A Protocol Method Implementations
+
+    async fn message_send(&self, _request: MessageSendRequest) -> RpcResult<MessageSendResponse> {
+        let timer = RpcTimer::new("message/send".to_string(), self.metrics.clone());
+
+        // Check rate limit
+        if let Err(e) = self.rate_limiter.check_rate_limit() {
+            self.metrics.record_rate_limit_blocked(None);
+            timer.error();
+            return Err(e);
+        }
+
+        #[cfg(feature = "stub_handlers")]
+        {
+            // Create a new task for this message
+            let task_id = uuid::Uuid::new_v4().to_string();
+            let response = MessageSendResponse {
+                task_id,
+                status: TaskStatus::Submitted,
+                response: None, // Async processing, no immediate response
+            };
+            timer.success();
+            Ok(response)
+        }
+
+        #[cfg(not(feature = "stub_handlers"))]
+        {
+            timer.error();
+            Err(ErrorObjectOwned::owned(
+                -32601,
+                "Method not yet implemented",
+                Some("message/send is not yet implemented".to_string()),
+            ))
+        }
+    }
+
+    async fn tasks_get(&self, _request: TaskGetRequest) -> RpcResult<TaskGetResponse> {
+        let timer = RpcTimer::new("tasks/get".to_string(), self.metrics.clone());
+
+        // Check rate limit
+        if let Err(e) = self.rate_limiter.check_rate_limit() {
+            self.metrics.record_rate_limit_blocked(None);
+            timer.error();
+            return Err(e);
+        }
+
+        #[cfg(feature = "stub_handlers")]
+        {
+            // Return a mock task status
+            let response = TaskGetResponse {
+                task_id: _request.task_id,
+                status: TaskStatus::Working,
+                result: None,
+                error: None,
+                progress: None,
+            };
+            timer.success();
+            Ok(response)
+        }
+
+        #[cfg(not(feature = "stub_handlers"))]
+        {
+            timer.error();
+            Err(ErrorObjectOwned::owned(
+                -32601,
+                "Method not yet implemented",
+                Some("tasks/get is not yet implemented".to_string()),
+            ))
+        }
+    }
+
+    async fn tasks_cancel(&self, _request: TaskCancelRequest) -> RpcResult<TaskCancelResponse> {
+        let timer = RpcTimer::new("tasks/cancel".to_string(), self.metrics.clone());
+
+        // Check rate limit
+        if let Err(e) = self.rate_limiter.check_rate_limit() {
+            self.metrics.record_rate_limit_blocked(None);
+            timer.error();
+            return Err(e);
+        }
+
+        #[cfg(feature = "stub_handlers")]
+        {
+            // Return a mock cancellation response
+            let response = TaskCancelResponse {
+                success: true,
+                status: TaskStatus::Canceled,
+                message: Some(format!("Task {} canceled", _request.task_id)),
+            };
+            timer.success();
+            Ok(response)
+        }
+
+        #[cfg(not(feature = "stub_handlers"))]
+        {
+            timer.error();
+            Err(ErrorObjectOwned::owned(
+                -32601,
+                "Method not yet implemented",
+                Some("tasks/cancel is not yet implemented".to_string()),
+            ))
+        }
+    }
+
+    async fn message_stream(
+        &self,
+        sink: PendingSubscriptionSink,
+        _task_id: String,
+    ) -> SubscriptionResult {
+        let timer = RpcTimer::new("message/stream".to_string(), self.metrics.clone());
+
+        // Check rate limit
+        if let Err(_e) = self.rate_limiter.check_rate_limit() {
+            self.metrics.record_rate_limit_blocked(None);
+            timer.error();
+            return Ok(());
+        }
+
+        // Accept the subscription
+        let _sink = match sink.accept().await {
+            Ok(sink) => sink,
+            Err(_) => {
+                timer.error();
+                return Ok(());
+            }
+        };
+
+        #[cfg(feature = "stub_handlers")]
+        {
+            // Send a few mock updates
+            tokio::spawn(async move {
+                // Send initial status
+                let delta = MessageDelta {
+                    session_id: _task_id.clone(),
+                    message_id: uuid::Uuid::new_v4().to_string(),
+                    sequence: 0,
+                    delta: MessageDeltaContent::Text {
+                        text: "Processing task...".to_string(),
+                    },
+                    timestamp: chrono::Utc::now(),
+                };
+
+                if let Ok(msg) = SubscriptionMessage::from_json(&delta) {
+                    let _ = _sink.send(msg).await;
+                }
+
+                // Simulate some processing time
+                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+                // Send completion
+                let delta = MessageDelta {
+                    session_id: _task_id,
+                    message_id: uuid::Uuid::new_v4().to_string(),
+                    sequence: 1,
+                    delta: MessageDeltaContent::StreamEnd {
+                        reason: crate::types::StreamEndReason::Complete,
+                    },
+                    timestamp: chrono::Utc::now(),
+                };
+
+                if let Ok(msg) = SubscriptionMessage::from_json(&delta) {
+                    let _ = _sink.send(msg).await;
+                }
+            });
+        }
+
+        timer.success();
+        Ok(())
     }
 
     async fn chat_open(&self, _request: ChatOpenRequest) -> RpcResult<ChatSession> {
@@ -721,7 +909,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_promise_request_handler() {
+    async fn test_task_request_handler() {
         let mut config = crate::rate_limit::RateLimitConfig::default();
         config.max_requests_per_second = 100;
         let rate_limiter = Arc::new(crate::rate_limit::RateLimiter::new(config));
@@ -735,7 +923,7 @@ mod tests {
             chat_sessions: Arc::new(crate::chat_session::ChatSessionManager::new(None)),
         };
         let result = impl_instance
-            .promise_request(
+            .task_request(
                 "test-agent".to_string(),
                 "data_access".to_string(),
                 Some(serde_json::json!({"key": "value"})),
@@ -745,8 +933,8 @@ mod tests {
         #[cfg(feature = "stub_handlers")]
         {
             let result = result.unwrap();
-            assert!(result.promise_id.to_string().len() > 0);
-            assert!(matches!(result.status, PromiseStatus::Pending));
+            assert!(result.task_id.to_string().len() > 0);
+            assert!(matches!(result.status, TaskStatus::Submitted));
         }
 
         #[cfg(not(feature = "stub_handlers"))]
@@ -759,7 +947,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_promise_declare_handler() {
+    async fn test_task_declare_handler() {
         let mut config = crate::rate_limit::RateLimitConfig::default();
         config.max_requests_per_second = 100;
         let rate_limiter = Arc::new(crate::rate_limit::RateLimiter::new(config));
@@ -773,10 +961,10 @@ mod tests {
             chat_sessions: Arc::new(crate::chat_session::ChatSessionManager::new(None)),
         };
         let result = impl_instance
-            .promise_declare(
+            .task_declare(
                 "test-agent".to_string(),
-                vec![PromiseCapability {
-                    promise_type: "compute".to_string(),
+                vec![TaskCapability {
+                    task_type: "compute".to_string(),
                     constraints: None,
                     metadata: None,
                 }],
@@ -827,8 +1015,8 @@ mod tests {
             .filter_map(|m| m.get("name").and_then(|n| n.as_str()))
             .collect();
 
-        assert!(method_names.contains(&"promise_request"));
-        assert!(method_names.contains(&"promise_declare"));
+        assert!(method_names.contains(&"task_request"));
+        assert!(method_names.contains(&"task_declare"));
         assert!(method_names.contains(&"agent_discover"));
     }
 

--- a/crates/arkavo-protocol/src/types.rs
+++ b/crates/arkavo-protocol/src/types.rs
@@ -3,74 +3,80 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-/// Request to make a promise from another agent
+/// Request to make a task from another agent
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct PromiseRequest {
+pub struct TaskRequest {
     /// The ID of the requesting agent
     #[serde(rename = "agent_id")]
     #[schemars(example = "example_agent_id")]
     pub agent_id: String,
 
-    /// The type of promise being requested
-    #[serde(rename = "promise_type")]
-    #[schemars(example = "example_promise_type")]
-    pub promise_type: String,
+    /// The type of task being requested
+    #[serde(rename = "task_type")]
+    #[schemars(example = "example_task_type")]
+    pub task_type: String,
 
-    /// Additional data for the promise request
+    /// Additional data for the task request
     #[serde(rename = "payload", skip_serializing_if = "Option::is_none")]
     pub payload: Option<serde_json::Value>,
 }
 
-/// Response to a promise request
+/// Response to a task request
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct PromiseResponse {
-    /// Unique identifier for the promise
-    #[serde(rename = "promise_id")]
-    pub promise_id: Uuid,
+pub struct TaskResponse {
+    /// Unique identifier for the task
+    #[serde(rename = "task_id")]
+    pub task_id: Uuid,
 
-    /// Current status of the promise
-    pub status: PromiseStatus,
+    /// Current status of the task
+    pub status: TaskStatus,
 
     /// Additional data in the response
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<serde_json::Value>,
 }
 
-/// Status of a promise
+/// Status of a task
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum PromiseStatus {
-    /// Promise has been accepted
-    Accepted,
-    /// Promise has been rejected
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    /// Task has been submitted
+    Submitted,
+    /// Task is being worked on
+    Working,
+    /// Task requires input from the requester
+    InputRequired,
+    /// Task has been completed successfully
+    Completed,
+    /// Task has been canceled
+    Canceled,
+    /// Task has failed
+    Failed,
+    /// Task has been rejected
     Rejected,
-    /// Promise is pending
-    Pending,
-    /// Promise has been fulfilled
-    Fulfilled,
-    /// Promise has been broken
-    Broken,
+    /// Task requires authentication
+    AuthRequired,
 }
 
-/// Declaration of promises an agent can fulfill
+/// Declaration of tasks an agent can fulfill
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct PromiseDeclareRequest {
+pub struct TaskDeclareRequest {
     /// The ID of the declaring agent
     #[serde(rename = "agent_id")]
     pub agent_id: String,
 
-    /// List of promises the agent can fulfill
-    pub promises: Vec<PromiseCapability>,
+    /// List of tasks the agent can fulfill
+    pub tasks: Vec<TaskCapability>,
 }
 
-/// A promise capability that an agent can fulfill
+/// A task capability that an agent can fulfill
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct PromiseCapability {
-    /// Type of promise
+pub struct TaskCapability {
+    /// Type of task
     #[serde(rename = "type")]
-    pub promise_type: String,
+    pub task_type: String,
 
-    /// Constraints on the promise
+    /// Constraints on the task
     #[serde(skip_serializing_if = "Option::is_none")]
     pub constraints: Option<serde_json::Value>,
 
@@ -79,9 +85,9 @@ pub struct PromiseCapability {
     pub metadata: Option<serde_json::Value>,
 }
 
-/// Response to a promise declaration
+/// Response to a task declaration
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct PromiseDeclareResponse {
+pub struct TaskDeclareResponse {
     /// Whether the declaration was acknowledged
     pub acknowledged: bool,
 
@@ -100,9 +106,9 @@ pub struct AgentDiscoverRequest {
 /// Filter criteria for agent discovery
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AgentDiscoverFilter {
-    /// Filter by promise types
+    /// Filter by task types
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub promise_types: Option<Vec<String>>,
+    pub task_types: Option<Vec<String>>,
 
     /// Filter by tags
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -118,9 +124,9 @@ pub struct DiscoveredAgent {
     /// Network endpoint for the agent
     pub endpoint: String,
 
-    /// Promise types the agent supports
+    /// Task types the agent supports
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub promises: Option<Vec<String>>,
+    pub tasks: Option<Vec<String>>,
 
     /// Additional metadata about the agent
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -185,12 +191,110 @@ pub enum FeatureType {
     McpServer,
 }
 
+/// Agent Card - JSON metadata document describing an agent
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AgentCard {
+    /// Agent identity information
+    pub identity: AgentIdentity,
+
+    /// Agent capabilities
+    pub capabilities: Vec<AgentCapability>,
+
+    /// Authentication requirements
+    pub authentication: AuthenticationRequirements,
+
+    /// Supported interaction modes
+    pub interaction_modes: Vec<InteractionMode>,
+
+    /// Optional metadata
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Agent identity information
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AgentIdentity {
+    /// Unique agent ID
+    pub id: String,
+
+    /// Human-readable name
+    pub name: String,
+
+    /// Agent description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Agent version
+    pub version: String,
+
+    /// Organization or owner
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub organization: Option<String>,
+}
+
+/// Agent capability description
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AgentCapability {
+    /// Skill or capability name
+    pub name: String,
+
+    /// Capability description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Input schema for this capability
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_schema: Option<serde_json::Value>,
+
+    /// Output schema for this capability
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<serde_json::Value>,
+}
+
+/// Authentication requirements
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AuthenticationRequirements {
+    /// Supported authentication methods
+    pub methods: Vec<AuthMethod>,
+
+    /// Whether authentication is required
+    pub required: bool,
+}
+
+/// Authentication method
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthMethod {
+    /// OAuth2 authentication
+    OAuth2,
+    /// JWT bearer token
+    JwtBearer,
+    /// API key
+    ApiKey,
+    /// mTLS client certificate
+    Mtls,
+    /// Basic authentication
+    Basic,
+}
+
+/// Interaction mode supported by the agent
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum InteractionMode {
+    /// Synchronous request/response
+    Synchronous,
+    /// Server-sent events streaming
+    Streaming,
+    /// Asynchronous with push notifications
+    Asynchronous,
+}
+
 // Helper function for examples
 fn example_agent_id() -> &'static str {
     "550e8400-e29b-41d4-a716-446655440000"
 }
 
-fn example_promise_type() -> &'static str {
+fn example_task_type() -> &'static str {
     "data_access"
 }
 
@@ -351,4 +455,156 @@ pub enum StreamEndReason {
     Error,
     /// Session closed
     SessionClosed,
+}
+
+// A2A Protocol Types
+
+/// Message send request
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct MessageSendRequest {
+    /// The message content
+    pub message: Message,
+
+    /// Optional task context
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+}
+
+/// Message for A2A communication
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct Message {
+    /// Message parts
+    pub parts: Vec<MessagePart>,
+
+    /// Optional metadata
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Part of a message
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MessagePart {
+    /// Text content
+    Text {
+        /// The text content
+        content: String,
+    },
+    /// File content
+    File {
+        /// File name
+        name: String,
+        /// MIME type
+        mime_type: String,
+        /// File data (base64 encoded) or URI
+        data: String,
+        /// Whether data is a URI (true) or base64 (false)
+        #[serde(default)]
+        is_uri: bool,
+    },
+    /// Structured data
+    Data {
+        /// Data schema identifier
+        schema: String,
+        /// The actual data
+        content: serde_json::Value,
+    },
+}
+
+/// Message send response
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct MessageSendResponse {
+    /// Task ID for this message
+    pub task_id: String,
+
+    /// Initial task status
+    pub status: TaskStatus,
+
+    /// Optional immediate response
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response: Option<Message>,
+}
+
+/// Task get request
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TaskGetRequest {
+    /// Task ID to retrieve
+    pub task_id: String,
+}
+
+/// Task get response
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TaskGetResponse {
+    /// Task ID
+    pub task_id: String,
+
+    /// Current task status
+    pub status: TaskStatus,
+
+    /// Task result if completed
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Message>,
+
+    /// Error details if failed
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<TaskError>,
+
+    /// Progress information
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub progress: Option<TaskProgress>,
+}
+
+/// Task error information
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TaskError {
+    /// Error code
+    pub code: String,
+
+    /// Error message
+    pub message: String,
+
+    /// Additional error details
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
+}
+
+/// Task progress information
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TaskProgress {
+    /// Progress percentage (0-100)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub percentage: Option<u8>,
+
+    /// Progress message
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+
+    /// Estimated time remaining in seconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eta_seconds: Option<u64>,
+}
+
+/// Task cancel request
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TaskCancelRequest {
+    /// Task ID to cancel
+    pub task_id: String,
+
+    /// Reason for cancellation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Task cancel response
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TaskCancelResponse {
+    /// Whether the cancellation was successful
+    pub success: bool,
+
+    /// Final task status
+    pub status: TaskStatus,
+
+    /// Optional message
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
 }

--- a/crates/arkavo-protocol/tests/metrics_integration.rs
+++ b/crates/arkavo-protocol/tests/metrics_integration.rs
@@ -11,8 +11,8 @@ async fn test_metrics_collection() {
     let collector = Arc::new(MetricsCollector::new(true));
 
     // Record some RPC requests
-    collector.record_rpc_request("promise_request", true);
-    collector.record_rpc_request("promise_request", false);
+    collector.record_rpc_request("task_request", true);
+    collector.record_rpc_request("task_request", false);
     collector.record_rpc_request("agent_discover", true);
 
     // Record rate limit blocks
@@ -23,7 +23,7 @@ async fn test_metrics_collection() {
     collector.record_mdns_discovery();
 
     // Record latency
-    collector.record_rpc_latency("promise_request", Duration::from_millis(100));
+    collector.record_rpc_latency("task_request", Duration::from_millis(100));
 
     // Update gauge
     collector.update_rate_limit_entries(42);

--- a/crates/arkavo-protocol/tests/openrpc_integration.rs
+++ b/crates/arkavo-protocol/tests/openrpc_integration.rs
@@ -14,8 +14,8 @@ async fn test_openrpc_schema_generation() {
     assert!(schema.methods.len() >= 3);
     let method_names: Vec<&str> = schema.methods.iter().map(|m| m.name.as_str()).collect();
 
-    assert!(method_names.contains(&"promise_request"));
-    assert!(method_names.contains(&"promise_declare"));
+    assert!(method_names.contains(&"task_request"));
+    assert!(method_names.contains(&"task_declare"));
     assert!(method_names.contains(&"agent_discover"));
 
     // Verify components


### PR DESCRIPTION
## Summary
This PR partially addresses issue #154 by implementing the foundational changes needed to align arkavo-protocol with the A2A specification.

## Changes Implemented
### Phase 1: Terminology Alignment ✅
- Renamed all Promise-related types to Task types
- Updated RPC method names from `promise_*` to `task_*`
- Aligned TaskStatus enum with A2A spec states (Submitted, Working, InputRequired, Completed, Canceled, Failed, Rejected, AuthRequired)

### Phase 2: Core Protocol Implementation ✅
- Created AgentCard struct with identity, capabilities, authentication requirements, and interaction modes
- Implemented A2A protocol methods:
  - `message/send` - Synchronous message sending
  - `message/stream` - Server-sent events streaming
  - `tasks/get` - Get task status and result
  - `tasks/cancel` - Cancel running tasks
- Added multi-modal content support (text, files, structured data) via MessagePart enum
- Updated OpenRPC schema to include new A2A methods

## Remaining Work (Not in this PR)
- Phase 3: Add authentication support (OAuth2/JWT, mTLS)
- Phase 4: Implement WebSocket support for async notifications
- Phase 4: Add mDNS/DNS-SRV discovery mechanisms
- Phase 5: Remove stub handlers and implement real task execution
- Phase 5: Create SDK compatibility tests

## Related Issues
Partially addresses #154 - **This PR does not close the issue** as significant work remains for full A2A compliance.

## Testing
- All existing tests pass
- Code compiles without errors
- Ran cargo fmt and clippy

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>