### PR TITLE
Build glibc binaries on Ubuntu 22.04 for better compatibility

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -24,7 +24,7 @@ jobs:
   # Version check from PR
   version-check:
     name: Verify Version Increment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
@@ -98,7 +98,7 @@ jobs:
   # Quick checks that can run in parallel
   format:
     name: Format Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -108,7 +108,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -131,7 +131,7 @@ jobs:
   # Tests and builds can run in parallel
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -159,7 +159,7 @@ jobs:
 
   build-linux:
     name: Build Linux (${{ matrix.target }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -268,7 +268,7 @@ jobs:
   # Performance check can run independently
   performance-check:
     name: Performance Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -310,12 +310,13 @@ jobs:
   smoke-test-linux:
     name: Smoke Test Linux (${{ matrix.container }})
     needs: build-linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         container:
           - alpine:latest
           - ubuntu:latest
+          - ubuntu:22.04
     container:
       image: ${{ matrix.container }}
     steps:
@@ -363,7 +364,7 @@ jobs:
   # Schema validation jobs
   validate-openrpc:
     name: Validate OpenRPC Schema
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -462,7 +463,7 @@ jobs:
 
   check-schema-backwards-compatibility:
     name: Check Schema Backwards Compatibility
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
@@ -539,7 +540,7 @@ jobs:
 
   validate-doc-snippets:
     name: Validate Documentation Code Snippets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -565,7 +566,7 @@ jobs:
 
   validate-xtask-schema:
     name: Validate Schemas with xtask
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -638,7 +639,7 @@ jobs:
   # Zero-config and portability verification
   zero-config-check:
     name: Zero Configuration Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       
@@ -676,7 +677,7 @@ jobs:
   release-readiness:
     name: Release Readiness
     needs: [version-check, format, clippy, test, smoke-test-linux, smoke-test-macos, performance-check, validate-openrpc, validate-doc-snippets, regression-tests, zero-config-check, validate-xtask-schema]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: always()
     steps:
       - name: Check job results

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ jobs:
   release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.version.outputs.version }}
       upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -80,7 +80,7 @@ jobs:
   build-linux-x86_64:
     needs: release
     name: Build Linux (x86_64)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -292,7 +292,7 @@ jobs:
   smoke-test-linux:
     needs: [release, build-linux-x86_64]
     name: Smoke Test Linux Binary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:
@@ -300,6 +300,9 @@ jobs:
             binary: arkavo-${{ needs.release.outputs.version }}-x86_64-linux-musl.tar.gz
             test_deb: false
           - container: ubuntu:latest
+            binary: arkavo-${{ needs.release.outputs.version }}-x86_64-linux.tar.gz
+            test_deb: true
+          - container: ubuntu:22.04
             binary: arkavo-${{ needs.release.outputs.version }}-x86_64-linux.tar.gz
             test_deb: true
     container:
@@ -347,7 +350,7 @@ jobs:
   publish-release:
     needs: [release, smoke-test-linux, smoke-test-macos]
     name: Publish Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,14 +165,14 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "arkavo-cli",
 ]
 
 [[package]]
 name = "arkavo-agui"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -254,11 +254,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-encryption"
-version = "0.24.1"
+version = "0.24.2"
 
 [[package]]
 name = "arkavo-git"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "git2",
  "tempfile",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "async-trait",
  "serde",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-core"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "arkavo-mcp",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ exclude = ["crates/arkavo-protocol/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.24.1"
+version = "0.24.2"
 edition = "2024"
 authors = ["Arkavo Edge Contributors"]
 license = "Apache-2.0"

--- a/crates/arkavo-test/src/mcp/axp_harness_builder/axp/compilation.rs
+++ b/crates/arkavo-test/src/mcp/axp_harness_builder/axp/compilation.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::process::Command;
 
 /// Handles compilation of AXP harness with various SDK configurations
-pub struct HarnessCompiler;
+pub(crate) struct HarnessCompiler;
 
 impl HarnessCompiler {
     /// Compile harness using Swift Package Manager

--- a/crates/arkavo-test/src/mcp/axp_harness_builder/axp/constants.rs
+++ b/crates/arkavo-test/src/mcp/axp_harness_builder/axp/constants.rs
@@ -1,5 +1,5 @@
 /// iOS 26 beta compilation guidance constants
-pub const IOS26_BETA_COMPILATION_GUIDANCE: &str = r#"
+pub(crate) const IOS26_BETA_COMPILATION_GUIDANCE: &str = r#"
 ## iOS 26 Beta Compilation Fix
 
 ### Problem
@@ -38,10 +38,10 @@ The harness builder automatically:
 "#;
 
 /// Error codes for AXP harness operations
-pub mod error_codes {
-    pub const IOS_SDK_MISSING: &str = "IOS_SDK_MISSING";
-    pub const INVALID_BUNDLE_ID: &str = "INVALID_BUNDLE_ID";
-    pub const COMPILATION_FAILED: &str = "COMPILATION_FAILED";
-    pub const BETA_COMPILATION_FAILED: &str = "BETA_COMPILATION_FAILED";
-    pub const SDK_NOT_FOUND: &str = "SDK_NOT_FOUND";
+pub(crate) mod error_codes {
+    pub(crate) const IOS_SDK_MISSING: &str = "IOS_SDK_MISSING";
+    pub(crate) const INVALID_BUNDLE_ID: &str = "INVALID_BUNDLE_ID";
+    pub(crate) const COMPILATION_FAILED: &str = "COMPILATION_FAILED";
+    pub(crate) const BETA_COMPILATION_FAILED: &str = "BETA_COMPILATION_FAILED";
+    pub(crate) const SDK_NOT_FOUND: &str = "SDK_NOT_FOUND";
 }

--- a/crates/arkavo-test/src/mcp/axp_harness_builder/axp/socket.rs
+++ b/crates/arkavo-test/src/mcp/axp_harness_builder/axp/socket.rs
@@ -6,7 +6,7 @@ use tokio::sync::Mutex;
 
 /// Manages AXP socket connections and cleanup
 #[allow(dead_code)]
-pub struct SocketManager {
+pub(crate) struct SocketManager {
     /// Cache of active socket paths (device_id -> socket_path)
     /// Using Mutex instead of RwLock to prevent race conditions
     socket_cache: Arc<Mutex<Option<(String, String)>>>,

--- a/crates/arkavo-test/src/mcp/axp_harness_builder/axp/version.rs
+++ b/crates/arkavo-test/src/mcp/axp_harness_builder/axp/version.rs
@@ -1,6 +1,6 @@
 /// iOS version parsing and detection utilities
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct IosVersion {
+pub(crate) struct IosVersion {
     pub major: u32,
     pub minor: u32,
     pub patch: Option<u32>,


### PR DESCRIPTION
## Summary
- Changed CI/CD runners from `ubuntu-latest` to `ubuntu-22.04` for all Linux builds
- Added Ubuntu 22.04 to smoke test matrix alongside `ubuntu:latest`
- Included previous version bump and clippy warning fixes

## Purpose
Fixes #141 - Ensures binaries built on CI work on older Linux distributions by building against glibc 2.35 (Ubuntu 22.04) instead of glibc 2.39 (ubuntu-latest).

## Changes
1. Updated `.github/workflows/feature.yaml` - all `ubuntu-latest` runners changed to `ubuntu-22.04`
2. Updated `.github/workflows/release.yaml` - all `ubuntu-latest` runners changed to `ubuntu-22.04`
3. Added `ubuntu:22.04` to smoke test matrix in both workflows to verify compatibility
4. Included version bump to 0.24.2 and clippy warning fixes from previous work

## Testing
- Smoke tests will run on:
  - `alpine:latest` (musl binary)
  - `ubuntu:latest` (glibc binary built on 22.04, testing forward compatibility)
  - `ubuntu:22.04` (glibc binary built on 22.04, testing same-version compatibility)

This ensures the glibc binary works on both the build platform and newer Ubuntu versions.

🤖 Generated with [Claude Code](https://claude.ai/code)