### PR TITLE
Remove OpenSSL dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,14 +171,14 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "arkavo-cli",
 ]
 
 [[package]]
 name = "arkavo-agui"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -333,11 +333,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-encryption"
-version = "0.25.6"
+version = "0.25.7"
 
 [[package]]
 name = "arkavo-events"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "git2",
  "tempfile",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "arkavo-kimi",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "async-trait",
  "serde",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-core"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -3889,7 +3889,6 @@ checksum = "1c42fe03df2bd3c53a3a9c7317ad91d80c81cd1fb0caec8d7cc4cd2bfa10c222"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
  "pkg-config",
 ]
@@ -3928,20 +3927,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = ["crates/arkavo-protocol/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.25.6"
+version = "0.25.7"
 edition = "2024"
 authors = ["Arkavo Edge Contributors"]
 license = "Apache-2.0"
@@ -110,7 +110,7 @@ zeroconf = "0.14"
 
 # LLM and ML
 tokenizers = { version = "0.21.2", default-features = false, features = ["fancy-regex"] }
-hf-hub = { version = "0.4.3", features = ["tokio"] }
+hf-hub = { version = "0.4.3", default-features = false, features = ["tokio", "rustls-tls"] }
 candle-core = "0.9.1"
 candle-nn = "0.9.1"
 candle-transformers = "0.9.1"

--- a/crates/arkavo-git/Cargo.toml
+++ b/crates/arkavo-git/Cargo.toml
@@ -21,7 +21,6 @@ tempfile.workspace = true
 [dev-dependencies]
 
 [features]
-# Optional: make openssl an opt-in feature for people who still need SSH
-ssh = ["git2/ssh"]
+# Features section kept for future extensions
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- Configured `hf-hub` to use rustls instead of native-tls 
- Removed optional ssh feature from arkavo-git that depended on OpenSSL
- Bumped version from 0.25.6 to 0.25.7

## Motivation
Per CLAUDE.md requirements, the project should have **no OpenSSL dependency** and use rustls for TLS to ensure cross-compilation compatibility, especially for musl targets.

## Changes
1. **Updated hf-hub configuration** in workspace Cargo.toml:
   - Added `default-features = false` 
   - Added `rustls-tls` feature
   - This removes the default `native-tls` dependency which uses OpenSSL on Linux

2. **Removed ssh feature** from arkavo-git:
   - The ssh feature depended on `git2/ssh` which pulls in `libssh2-sys` → `openssl-sys`
   - Feature section kept for future extensions

3. **Version bump**: 0.25.6 → 0.25.7 (patch version)

## Verification
- ✅ `cargo build` passes
- ✅ `cargo clippy` clean
- ✅ `cargo fmt` applied
- ✅ Verified OpenSSL is no longer a dependency:
  - `cargo tree --target all -i openssl-sys` returns "package ID specification \`openssl-sys\` did not match any packages"
  - Only `openssl-probe` remains, which is a small probe utility used by rustls-native-certs (doesn't depend on OpenSSL itself)

## Impact
- Improved cross-compilation compatibility
- Easier static linking for musl targets
- Reduced binary dependencies
- No functional changes - all TLS operations continue to work via rustls

🤖 Generated with [Claude Code](https://claude.ai/code)