### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,9 +50,10 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.version }}
-          name: Release ${{ steps.version.outputs.version }}
+          name: ${{ steps.version.outputs.version }}
           draft: false
           prerelease: true
+          make_latest: false  # Don't mark as latest until smoke tests pass
           generate_release_notes: true
           body: |
             ## Arkavo Edge ${{ steps.version.outputs.version }}
@@ -359,19 +360,25 @@ jobs:
         run: |
           VERSION="${{ needs.release.outputs.version }}"
           
-          # Trigger workflow in homebrew-arkavo repo to update formula
-          # This assumes the tap repo has a workflow that listens for repository_dispatch events
-          curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/arkavo-org/homebrew-arkavo/dispatches \
-            -d "{\"event_type\": \"update-formula\", \"client_payload\": {\"version\": \"${VERSION}\"}}" || \
-            echo "Note: Homebrew tap repository not yet created or dispatch failed"
+          # Use PAT if available, otherwise fall back to manual trigger
+          if [ -n "${{ secrets.HOMEBREW_UPDATE_TOKEN }}" ]; then
+            echo "Using HOMEBREW_UPDATE_TOKEN to trigger workflow"
+            curl -X POST \
+              -H "Authorization: token ${{ secrets.HOMEBREW_UPDATE_TOKEN }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/repos/arkavo-org/homebrew-arkavo/dispatches \
+              -d "{\"event_type\": \"update-formula\", \"client_payload\": {\"version\": \"${VERSION}\"}}"
+          else
+            echo "⚠️ HOMEBREW_UPDATE_TOKEN not configured. Please manually trigger the Homebrew formula update."
+            echo "To fix: Add a Personal Access Token with 'repo' scope as HOMEBREW_UPDATE_TOKEN secret"
+            echo "Manual trigger: gh workflow run 'Update Formula' --repo arkavo-org/homebrew-arkavo -f version=${VERSION}"
+          fi
 
-      - name: Update release to published
+      - name: Update release to published and latest
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.release.outputs.version }}
           prerelease: false
+          make_latest: true  # Mark as latest after all tests pass
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,14 +171,14 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "arkavo-cli",
 ]
 
 [[package]]
 name = "arkavo-agui"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -333,11 +333,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-encryption"
-version = "0.25.10"
+version = "0.25.11"
 
 [[package]]
 name = "arkavo-events"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "anyhow",
  "bincode",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "git2",
  "tempfile",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "anyhow",
  "arkavo-kimi",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "async-trait",
  "serde",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-core"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test"
-version = "0.25.10"
+version = "0.25.11"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = ["crates/arkavo-protocol/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.25.10"
+version = "0.25.11"
 edition = "2024"
 authors = ["Arkavo Edge Contributors"]
 license = "Apache-2.0"


### PR DESCRIPTION
- Remove 'Release' prefix from release names (just use version number)
- Add support for HOMEBREW_UPDATE_TOKEN to trigger tap updates
- Mark release as 'latest' after smoke tests pass
- Provide fallback instructions when PAT is not configured
- Bump version to 0.25.11