### PR TITLE
MCP tools fixes

### DIFF
--- a/ARKAVO_EDGE_2.0_ROADMAP.md
+++ b/ARKAVO_EDGE_2.0_ROADMAP.md
@@ -1,0 +1,66 @@
+# Arkavo Edge 2.0 Roadmap: From Powerful Tool to Intelligent Platform
+
+## 1. Introduction: The Vision for 2.0
+
+Version 1.0 of Arkavo Edge established a powerful and unique foundation: a secure, performant, and portable runtime for developer-focused AI agents. It carved out a niche by integrating deeply with developer workflows, particularly for complex tasks like iOS automation, and by prioritizing a production-ready, self-hostable architecture.
+
+The vision for **Arkavo Edge 2.0** is to build on this foundation, evolving from a powerful command-line tool into a more accessible, intelligent, and versatile platform. The focus will be on expanding its reach to new platforms, deepening its agentic intelligence with multi-modality, and dramatically improving the developer experience for building and managing complex agents.
+
+This roadmap is informed by our market analysis and focuses on the immediate needs of the AI and development industry over the next 3-6 months.
+
+## 2. Recap of 1.0 Strengths (Our Foundation)
+
+Our market position is defined by these key differentiators, which will be enhanced in 2.0:
+
+*   **Deep System Integration:** Unmatched, high-performance bridges for iOS automation (XCTest/FFI).
+*   **Secure, Production-Ready Runtime:** A single, portable binary built in Rust with `rustls`, featuring a secure `chat-v2` protocol ready for production.
+*   **AI-Driven, Zero-Configuration:** A dynamic agent that discovers its environment and manages its own configuration, eliminating the need for static files.
+
+## 3. Core Themes and Features for Arkavo Edge 2.0
+
+We will organize the 2.0 effort around four core themes.
+
+### Theme 1: Expanding Platform Reach
+The goal is to make Arkavo Edge the go-to agentic framework for all mobile development.
+
+*   **Feature: First-Class Android Automation Support**
+    *   **Description:** Implement a robust bridge for Android automation, equivalent to the existing XCTest bridge for iOS. This would likely involve integration with `adb` and potentially the UI Automator framework.
+    *   **Market Rationale:** Android represents over 70% of the global mobile market. Supporting it is the single most impactful step to expanding Arkavo's addressable market. It positions Arkavo as a comprehensive mobile automation platform, directly competing with the feature sets of tools like Appium and Maestro but with superior agentic capabilities.
+    *   **Success Criteria:** An agent can reliably perform core UI interactions (tap element, read screen text, take screenshot) on an Android emulator or physical device. Feature parity with the iOS bridge is the ultimate goal.
+
+### Theme 2: Deepening Agent Intelligence
+The industry is rapidly moving beyond text-only agents. 2.0 will embrace multi-modality and provide crucial tools for understanding agent behavior.
+
+*   **Feature: Multi-modal Vision Capabilities**
+    *   **Description:** Integrate vision models (like GPT-4o or LLaVA) directly into the dataflow engine. The agent must be able to "see" and interpret graphical user interfaces.
+    *   **Market Rationale:** The release of models like GPT-4o has made vision a baseline expectation for advanced agents. For a tool focused on UI automation, this is not a luxury—it's a necessity. It allows for powerful new workflows, such as "Look at this screen and find the 'submit' button" or "Verify that the branding in the app matches this logo file."
+    *   **Success Criteria:**
+        1.  An agent can take a screenshot of a mobile app.
+        2.  The screenshot can be passed as input to an LLM node in a dataflow blueprint.
+        3.  The agent can answer questions about the UI based on the image, such as "What is the color of the login button?" or "Is there an error message visible on the screen?"
+
+*   **Feature: Agent Observability & Traceability Hub**
+    *   **Description:** Create a dedicated tool or UI for tracing an agent's decision-making process. For any given task, a developer should be able to see the full tree of operations: the initial prompt, the chosen dataflow blueprint, each LLM call with its prompt and response, every tool call with its parameters and results, and how the final output was generated.
+    *   **Market Rationale:** As agents move from prototypes to production, "debugging the black box" has become a critical industry-wide problem. Frameworks that provide strong observability tools (like LangChain's LangSmith) offer immense value to developers. By providing a secure, self-hostable solution, Arkavo can offer a compelling alternative.
+    *   **Success Criteria:** A `arkavo trace <task_id>` command that outputs a detailed, human-readable log of the agent's entire reasoning and execution process for a given task.
+
+### Theme 3: Enhancing the Developer Experience
+Powerful tools are only useful if they are accessible. 2.0 will focus on lowering the barrier to entry for building and managing agents.
+
+*   **Feature: Visual Dataflow Blueprint Builder**
+    *   **Description:** A simple, web-based UI where developers can drag and drop nodes (LLMs, tools, routers, etc.) and connect them to visually build and edit dataflow blueprints. The UI would generate the corresponding JSON/YAML for the Arkavo runtime.
+    *   **Market Rationale:** Building complex JSON or YAML pipelines by hand is tedious and error-prone. A visual builder makes the most powerful feature of Arkavo—the dataflow engine—dramatically more accessible and faster to use, appealing to a broader range of developers.
+    *   **Success Criteria:** A developer can create and deploy a multi-step agentic workflow using only the visual UI, without writing any JSON by hand.
+
+*   **Feature: Official SDKs for Python and Rust**
+    *   **Description:** Publish official client libraries on PyPI (for Python) and Crates.io (for Rust). These SDKs would handle the complexities of the `chat-v2` protocol, allowing developers to easily integrate and interact with the Arkavo runtime from their own applications.
+    *   **Market Rationale:** Python is the lingua franca of AI development. A Python SDK is essential for adoption. A Rust SDK enables high-performance, native integrations. This moves Arkavo from being just a CLI tool to being a true platform that other applications can build on top of.
+    *   **Success Criteria:** SDKs are published to their respective package managers with clear documentation and examples for opening sessions, sending messages, and calling tools.
+
+### Theme 4: Production-Hardening
+The goal is to enable agents to run truly autonomously and reliably.
+
+*   **Feature: Autonomous Operation Mode with Resource Management**
+    *   **Description:** Introduce a "fire-and-forget" mode where an agent can be given a long-running task and will operate autonomously in the background. This mode must include robust resource management controls (e.g., max CPU/memory usage, task timeouts, and budget tracking for API calls) to ensure it can run safely without supervision.
+    *   **Market Rationale:** The ultimate goal of agentics is trusted, autonomous operation. Providing built-in safety and resource management features is a critical step towards production deployments and addresses major enterprise concerns about runaway AI processes.
+    *   **Success Criteria:** A user can launch an agent with a command like `arkavo agent run --autonomous --max-budget 5.00 --timeout 24h "Monitor the production iOS app for crashes and file a detailed bug report with logs and screenshots."` and have it run reliably within those constraints.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,14 +171,14 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "arkavo-cli",
 ]
 
 [[package]]
 name = "arkavo-agui"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -257,6 +257,8 @@ dependencies = [
  "arkavo-kimi",
  "arkavo-llm",
  "arkavo-mcp",
+ "arkavo-mcp-core",
+ "arkavo-mcp-runtime",
  "arkavo-memory",
  "arkavo-protocol",
  "arkavo-repo",
@@ -283,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -315,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -333,11 +335,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-encryption"
-version = "0.25.12"
+version = "0.25.13"
 
 [[package]]
 name = "arkavo-events"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "anyhow",
  "bincode",
@@ -351,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "git2",
  "tempfile",
@@ -360,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -382,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "anyhow",
  "arkavo-kimi",
@@ -419,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "async-trait",
  "serde",
@@ -428,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-core"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -438,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -455,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -476,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -493,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -535,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -554,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -578,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test"
-version = "0.25.12"
+version = "0.25.13"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = ["crates/arkavo-protocol/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.25.12"
+version = "0.25.13"
 edition = "2024"
 authors = ["Arkavo Edge Contributors"]
 license = "Apache-2.0"

--- a/DEMO_USE_CASES.md
+++ b/DEMO_USE_CASES.md
@@ -1,0 +1,77 @@
+# Arkavo Edge: Demo Use Cases & Market Comparison
+
+This document outlines compelling demonstration scenarios for Arkavo Edge and provides a market comparison to highlight its unique position and key differentiators.
+
+## 1. Demo Use Cases
+
+These demos are designed to showcase the core strengths of Arkavo Edge, from its deep iOS integration to its secure, agentic runtime.
+
+### 1.1. iOS UI Automation and Intelligent Testing
+
+This category highlights Arkavo's most unique and powerful features.
+
+*   **Demo: Resilient UI Automation with the XCTest Bridge**
+    *   **Scenario:** Launch an iOS app in the simulator. Use the `ui_interaction` tool to reliably tap a specific button by its accessibility identifier. During the demo, resize the simulator window and move it around the screen to show that the tap succeeds every time, proving it is not reliant on fragile screen coordinates.
+    *   **Why it's Compelling:** Directly addresses a major pain point in mobile testing. It showcases the robustness of the XCTest bridge, a core differentiator described in `docs/IOS_AUTOMATION_REFACTOR_PLAN.md`.
+
+*   **Demo: AI-Driven, "Zero-Touch" Bug Discovery**
+    *   **Scenario:** Point Arkavo at an iOS application's source code. The agent first analyzes the code to understand its structure. Then, it injects a test harness at runtime to intelligently explore the app's UI, discover a non-obvious bug (e.g., a crash after a specific sequence of inputs), and report it, all without human-written test scripts.
+    *   **Why it's Compelling:** This is a "wow" demo that showcases the ultimate vision of the project. It combines AI-driven analysis, runtime injection, and intelligent testing, as outlined in `docs/longterm-memory.md`.
+
+*   **Demo: Automated IDB Companion Recovery**
+    *   **Scenario:** While running an iOS UI test, manually find and kill the `idb_companion` process. The demo shows the agent's UI interaction failing, but then Arkavo's monitoring system automatically detects the failure, triggers the recovery process, and successfully resumes the test.
+    *   **Why it's Compelling:** Demonstrates the self-healing, resilient, and production-ready nature of the platform, as detailed in `docs/IDB_COMPANION_MONITORING.md`.
+
+### 1.2. LLM & Agentic Capabilities
+
+These demos showcase the flexibility and power of the agentic framework.
+
+*   **Demo: Dynamic, Zero-Configuration LLM Provider Setup**
+    *   **Scenario:** Start with a fresh Arkavo instance. Run the `discover_llm_providers` tool to find a local Ollama instance running on the network. Use `configure_llm_providers` to instantly add it to the agent's available resources. Finally, call `list_available_models` to prove the agent now has access to the Ollama models.
+    *   **Why it's Compelling:** Perfectly illustrates the "AI-Driven, Zero-Configuration" principle. It shows the agent dynamically adapting to its environment without needing any static config files.
+
+*   **Demo: Intelligent, Multi-Provider LLM Routing**
+    *   **Scenario:** Use `generate_llm_blueprint` to create a dataflow pipeline. Feed it two different prompts: one with a code snippet to review, and another asking a general knowledge question. The demo shows the agent's router automatically sending the code review task to a specialized model like `Codestral` and the general question to a model like `Llama 3.2`.
+    *   **Why it's Compelling:** Highlights the power of the dataflow engine and the multi-provider LLM router, a key feature from `docs/LLM_DATAFLOW_GUIDE.md`.
+
+### 1.3. Secure, Self-Hosted Operations
+
+*   **Demo: Secure, Authenticated Chat Session with Streaming Tool Calls**
+    *   **Scenario:** Start the Arkavo server. From a client, initiate a `chat_open` request with a JWT to establish a secure, authenticated session. Ask the agent to perform a task that requires a tool. The demo shows the tool call itself being streamed back to the client in real-time, delta by delta, just like text tokens.
+    *   **Why it's Compelling:** Showcases the production-grade security (JWT auth) and advanced real-time communication features of the Bidirectional Chat Protocol v2.
+
+*   **Demo: Atomic, Safeguarded Git Commits**
+    *   **Scenario:** Instruct the agent to make several code changes across multiple files. Configure a pre-commit hook to run a linter. The linter fails. The demo shows Arkavo's `RepoGuard` feature automatically and atomically rolling back all file changes, preventing a broken commit and leaving the repository clean.
+    *   **Why it's Compelling:** Demonstrates the safety and reliability of the deep Git integration, which is critical for developer-focused agents.
+
+## 2. Market Comparison
+
+Arkavo Edge is not a direct clone of existing agent frameworks. It occupies a specific, high-value niche focused on providing a **secure, performant, and portable runtime for developer-focused agents** that perform complex, system-level tasks.
+
+### 2.1. Competitive Landscape
+
+| Tool/Platform | Primary Focus | Deep iOS Automation (XCTest/FFI Bridge) | LLM Agnosticism & Routing | Self-Hosting & Security | Architecture / Core Tech | Configuration Model |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **Arkavo Edge** | **Agentic CLI & Secure Runtime** | ✅ **Yes (Core Feature)** | ✅ **Yes (Multi-provider router)** | ✅ **Yes (Production-grade, mTLS)** | **Rust** (Single, portable binary) | **AI-Driven & In-Memory** |
+| **LangChain** | General-purpose LLM App Framework | ❌ No | ✅ Yes (Extensive integrations) | Possible, but requires user setup | Python / JS | Files, Environment Vars |
+| **LlamaIndex** | RAG & Connecting Data to LLMs | ❌ No | ✅ Yes (Focus on RAG pipelines) | Possible, but requires user setup | Python / JS | Files, Environment Vars |
+| **Microsoft Autogen** | Multi-Agent Conversations | ❌ No | ✅ Yes (Designed for agent collaboration) | Possible, but requires user setup | Python | Files, JSON |
+| **Appium / Maestro** | Mobile UI Test Automation | ✅ Yes (But as a standalone tool) | ❌ **No (Not an agent framework)** | N/A | Java / Kotlin / etc. | Files, CLI flags |
+| **Ollama** | Local LLM Serving | ❌ No | ❌ **No (It's an LLM provider, not a framework)** | ✅ **Yes (Core Feature)** | Go / C++ | CLI, API |
+
+### 2.2. Key Differentiators
+
+#### vs. General Agent Frameworks (LangChain, LlamaIndex)
+*   **Deep System Integration:** Arkavo's biggest advantage is its built-in, high-performance bridge for iOS automation (XCTest/FFI). This enables sophisticated, AI-driven testing and automation use cases that are impossible for other frameworks.
+*   **Secure, Production-Ready Runtime:** Built in Rust with `rustls` (no OpenSSL), Arkavo compiles to a single, portable binary. Its `chat-v2` protocol, with JWT auth, mTLS, and back-pressure management, is designed for secure, self-hosted deployments out-of-the-box.
+*   **AI-Driven Configuration:** Arkavo's ability to discover its environment (like finding Ollama servers) and store configuration in its own memory system is unique. It's more dynamic and resilient than relying on static config files or environment variables.
+
+#### vs. UI Test Automation Tools (Appium, Maestro)
+*   **Agentic Intelligence:** Appium and Maestro are tools that execute pre-defined scripts. Arkavo Edge is an **agent framework that has testing as a core capability**. It can use its LLM to *decide what to test*, analyze results, and perform exploratory testing without human-written scripts, turning the test tool into a primitive for an intelligent agent.
+
+#### vs. LLM Infrastructure (Ollama)
+*   **Orchestration and Application Layer:** Ollama serves LLMs; Arkavo Edge is a consumer and orchestrator of them. It adds the critical layers on top: a multi-provider router, a secure communication protocol, a dataflow engine for complex workflows, and a suite of integrated developer tools.
+
+### 2.3. Ideal User Profile
+
+Arkavo Edge is built for developers and organizations that need to create **high-reliability, secure, and performant AI agents that interact deeply with their development and testing environments.** This includes AI-powered QA teams, DevOps engineers building automation agents, and security researchers.

--- a/crates/arkavo-cli/Cargo.toml
+++ b/crates/arkavo-cli/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities", "development-tools"]
 
 
 [features]
-default = ["memory", "mdns", "local"]
+default = ["memory", "embeddings", "mdns", "local"]
 memory = ["arkavo-test/memory"]
 embeddings = ["memory", "arkavo-memory/embeddings", "arkavo-test/embeddings"]
 mdns = ["zeroconf", "arkavo-agui/mdns", "arkavo-protocol/mdns"]

--- a/crates/arkavo-cli/Cargo.toml
+++ b/crates/arkavo-cli/Cargo.toml
@@ -28,6 +28,8 @@ arkavo-test = { path = "../arkavo-test" }
 arkavo-llm = { path = "../arkavo-llm", optional = true }
 arkavo-memory = { path = "../arkavo-memory", default-features = false }
 arkavo-mcp = { path = "../arkavo-mcp" }
+arkavo-mcp-core = { path = "../arkavo-mcp-core" }
+arkavo-mcp-runtime = { path = "../arkavo-mcp-runtime" }
 arkavo-dataflow = { path = "../arkavo-dataflow", default-features = false, features = ["nl", "sandbox", "llm-remote"] }
 arkavo-protocol = { path = "../arkavo-protocol" }
 arkavo-repo = { path = "../arkavo-repo" }

--- a/crates/arkavo-cli/src/builtin_mcp.rs
+++ b/crates/arkavo-cli/src/builtin_mcp.rs
@@ -8,6 +8,8 @@ use std::sync::Arc;
 /// Built-in MCP connection that provides default tools
 pub struct BuiltinMcpConnection {
     tools: HashMap<String, Arc<dyn Tool>>,
+    // Optional delegate for test tools
+    test_connection: Option<crate::mcp_integration::McpConnection>,
 }
 
 impl BuiltinMcpConnection {
@@ -27,7 +29,43 @@ impl BuiltinMcpConnection {
         // Note: UiControlTool and UiInspectTool require UI channels and should be
         // registered separately when a UI is available
 
-        Self { tools }
+        // Note: Test tools initialization is deferred to avoid runtime conflicts
+        // They will be initialized lazily when needed
+        Self {
+            tools,
+            test_connection: None,
+        }
+    }
+    
+    pub async fn new_with_test_tools() -> Self {
+        let mut tools: HashMap<String, Arc<dyn Tool>> = HashMap::new();
+
+        // Register built-in tools that don't require external dependencies
+        let echo_tool = Arc::new(EchoTool::new());
+        tools.insert("echo".to_string(), echo_tool);
+
+        let health_tool = Arc::new(HealthTool::new());
+        tools.insert("health".to_string(), health_tool);
+
+        let ollama_config = Arc::new(OllamaConfigTool::new());
+        tools.insert("ollama_config".to_string(), ollama_config);
+
+        // Try to initialize test tools if available
+        let test_connection = match crate::mcp_integration::McpConnection::new_in_process_async().await {
+            Ok(conn) => {
+                eprintln!("Registered MCP test tools from arkavo-test");
+                Some(conn)
+            }
+            Err(e) => {
+                eprintln!("Could not initialize MCP test tools: {e}");
+                None
+            }
+        };
+
+        Self {
+            tools,
+            test_connection,
+        }
     }
 }
 
@@ -41,6 +79,7 @@ impl McpConnectionTrait for BuiltinMcpConnection {
     fn list_tools(&self) -> Result<Vec<RegistryTool>, Box<dyn std::error::Error>> {
         let mut tools = Vec::new();
 
+        // Add built-in runtime tools
         for (name, tool) in &self.tools {
             let schema = tool.schema();
             tools.push(RegistryTool {
@@ -50,6 +89,24 @@ impl McpConnectionTrait for BuiltinMcpConnection {
             });
         }
 
+        // Add test tools if available
+        if let Some(ref test_conn) = self.test_connection {
+            match test_conn.list_tools() {
+                Ok(test_tools) => {
+                    for tool in test_tools {
+                        tools.push(RegistryTool {
+                            name: tool.name,
+                            description: tool.description,
+                            input_schema: Some(tool.input_schema),
+                        });
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Warning: Could not list test tools: {e}");
+                }
+            }
+        }
+
         Ok(tools)
     }
 
@@ -57,8 +114,9 @@ impl McpConnectionTrait for BuiltinMcpConnection {
         &self,
         tool_name: &str,
         arguments: Value,
-        _llm_provider: &str,
+        llm_provider: &str,
     ) -> Result<Value, Box<dyn std::error::Error>> {
+        // First check built-in tools
         if let Some(tool) = self.tools.get(tool_name) {
             // Use blocking to execute the async tool
             #[allow(clippy::disallowed_methods)]
@@ -66,6 +124,10 @@ impl McpConnectionTrait for BuiltinMcpConnection {
             #[allow(clippy::disallowed_methods)]
             let result = handle.block_on(tool.execute(arguments))?;
             Ok(result)
+        }
+        // Then check test tools if available
+        else if let Some(ref test_conn) = self.test_connection {
+            test_conn.call_tool(tool_name, arguments, llm_provider)
         } else {
             Err(format!("Tool '{tool_name}' not found").into())
         }

--- a/crates/arkavo-cli/src/builtin_mcp.rs
+++ b/crates/arkavo-cli/src/builtin_mcp.rs
@@ -1,0 +1,73 @@
+use arkavo_mcp_core::Tool;
+use arkavo_mcp_runtime::tools::{EchoTool, HealthTool, OllamaConfigTool};
+use arkavo_protocol::mcp_registry::{McpConnectionTrait, Tool as RegistryTool};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Built-in MCP connection that provides default tools
+pub struct BuiltinMcpConnection {
+    tools: HashMap<String, Arc<dyn Tool>>,
+}
+
+impl BuiltinMcpConnection {
+    pub fn new() -> Self {
+        let mut tools: HashMap<String, Arc<dyn Tool>> = HashMap::new();
+
+        // Register built-in tools that don't require external dependencies
+        let echo_tool = Arc::new(EchoTool::new());
+        tools.insert("echo".to_string(), echo_tool);
+
+        let health_tool = Arc::new(HealthTool::new());
+        tools.insert("health".to_string(), health_tool);
+
+        let ollama_config = Arc::new(OllamaConfigTool::new());
+        tools.insert("ollama_config".to_string(), ollama_config);
+
+        // Note: UiControlTool and UiInspectTool require UI channels and should be
+        // registered separately when a UI is available
+
+        Self { tools }
+    }
+}
+
+impl Default for BuiltinMcpConnection {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl McpConnectionTrait for BuiltinMcpConnection {
+    fn list_tools(&self) -> Result<Vec<RegistryTool>, Box<dyn std::error::Error>> {
+        let mut tools = Vec::new();
+
+        for (name, tool) in &self.tools {
+            let schema = tool.schema();
+            tools.push(RegistryTool {
+                name: name.clone(),
+                description: schema.description.clone(),
+                input_schema: Some(schema.parameters.clone()),
+            });
+        }
+
+        Ok(tools)
+    }
+
+    fn call_tool(
+        &self,
+        tool_name: &str,
+        arguments: Value,
+        _llm_provider: &str,
+    ) -> Result<Value, Box<dyn std::error::Error>> {
+        if let Some(tool) = self.tools.get(tool_name) {
+            // Use blocking to execute the async tool
+            #[allow(clippy::disallowed_methods)]
+            let handle = tokio::runtime::Handle::current();
+            #[allow(clippy::disallowed_methods)]
+            let result = handle.block_on(tool.execute(arguments))?;
+            Ok(result)
+        } else {
+            Err(format!("Tool '{tool_name}' not found").into())
+        }
+    }
+}

--- a/crates/arkavo-cli/src/builtin_mcp.rs
+++ b/crates/arkavo-cli/src/builtin_mcp.rs
@@ -1,5 +1,5 @@
 use arkavo_mcp_core::Tool;
-use arkavo_mcp_runtime::tools::{EchoTool, HealthTool, OllamaConfigTool};
+use arkavo_mcp_runtime::tools::{HealthTool, OllamaConfigTool};
 use arkavo_protocol::mcp_registry::{McpConnectionTrait, Tool as RegistryTool};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -17,9 +17,6 @@ impl BuiltinMcpConnection {
         let mut tools: HashMap<String, Arc<dyn Tool>> = HashMap::new();
 
         // Register built-in tools that don't require external dependencies
-        let echo_tool = Arc::new(EchoTool::new());
-        tools.insert("echo".to_string(), echo_tool);
-
         let health_tool = Arc::new(HealthTool::new());
         tools.insert("health".to_string(), health_tool);
 
@@ -36,14 +33,11 @@ impl BuiltinMcpConnection {
             test_connection: None,
         }
     }
-    
+
     pub async fn new_with_test_tools() -> Self {
         let mut tools: HashMap<String, Arc<dyn Tool>> = HashMap::new();
 
         // Register built-in tools that don't require external dependencies
-        let echo_tool = Arc::new(EchoTool::new());
-        tools.insert("echo".to_string(), echo_tool);
-
         let health_tool = Arc::new(HealthTool::new());
         tools.insert("health".to_string(), health_tool);
 
@@ -51,16 +45,17 @@ impl BuiltinMcpConnection {
         tools.insert("ollama_config".to_string(), ollama_config);
 
         // Try to initialize test tools if available
-        let test_connection = match crate::mcp_integration::McpConnection::new_in_process_async().await {
-            Ok(conn) => {
-                eprintln!("Registered MCP test tools from arkavo-test");
-                Some(conn)
-            }
-            Err(e) => {
-                eprintln!("Could not initialize MCP test tools: {e}");
-                None
-            }
-        };
+        let test_connection =
+            match crate::mcp_integration::McpConnection::new_in_process_async().await {
+                Ok(conn) => {
+                    eprintln!("Registered MCP test tools from arkavo-test");
+                    Some(conn)
+                }
+                Err(e) => {
+                    eprintln!("Could not initialize MCP test tools: {e}");
+                    None
+                }
+            };
 
         Self {
             tools,

--- a/crates/arkavo-cli/src/commands/agent.rs
+++ b/crates/arkavo-cli/src/commands/agent.rs
@@ -493,9 +493,9 @@ pub async fn start_agent_server(config: &AgentConfig) -> Result<(), Box<dyn std:
         // Use the async version to avoid runtime conflicts
         let builtin_connection = BuiltinMcpConnection::new_with_test_tools().await;
         mcp_registry
-            .register("builtin".to_string(), Box::new(builtin_connection))
+            .register("arkavo".to_string(), Box::new(builtin_connection))
             .await;
-        println!("Registered built-in MCP tools and test server tools");
+        println!("Registered Arkavo MCP tools (runtime and test tools)");
     }
 
     for mcp_config in &config.mcp_servers {

--- a/crates/arkavo-cli/src/commands/agent.rs
+++ b/crates/arkavo-cli/src/commands/agent.rs
@@ -481,6 +481,17 @@ pub async fn start_agent_server(config: &AgentConfig) -> Result<(), Box<dyn std:
 
     // Initialize MCP connections
     let mcp_registry = server.mcp_registry();
+
+    // Register built-in MCP tools first
+    {
+        use crate::builtin_mcp::BuiltinMcpConnection;
+        let builtin_connection = BuiltinMcpConnection::new();
+        mcp_registry
+            .register("builtin".to_string(), Box::new(builtin_connection))
+            .await;
+        println!("Registered built-in MCP tools (echo, health, ollama_config)");
+    }
+
     for mcp_config in &config.mcp_servers {
         println!("Initializing MCP server: {}", mcp_config.name);
 

--- a/crates/arkavo-cli/src/commands/agent.rs
+++ b/crates/arkavo-cli/src/commands/agent.rs
@@ -439,9 +439,14 @@ pub fn parse_agents_config(content: &str) -> Result<Vec<AgentConfig>, Box<dyn st
 pub async fn start_agent_server(config: &AgentConfig) -> Result<(), Box<dyn std::error::Error>> {
     use crate::mcp_spawner::McpProcessManager;
     use arkavo_protocol::{config::ServerConfig, rate_limit::RateLimitConfig, server::A2aServer};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     // Create process manager for MCP servers
     let process_manager = McpProcessManager::new();
+
+    // Create shutdown flag for mDNS thread
+    let shutdown_flag = Arc::new(AtomicBool::new(false));
 
     // Parse listen address
     let parts: Vec<&str> = config.listen.split(':').collect();
@@ -580,21 +585,24 @@ pub async fn start_agent_server(config: &AgentConfig) -> Result<(), Box<dyn std:
     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
 
     // Start mDNS broadcasting if enabled
-    if config.mdns_enabled {
+    let mdns_thread_handle = if config.mdns_enabled {
         println!("Starting mDNS broadcasting...");
         let config_clone = config.clone();
+        let shutdown_flag_clone = shutdown_flag.clone();
         // Use std::thread since zeroconf is not Send
-        std::thread::spawn(move || {
+        let handle = std::thread::spawn(move || {
             println!("mDNS thread spawned");
-            if let Err(e) = broadcast_agent_mdns_sync(&config_clone) {
+            if let Err(e) = broadcast_agent_mdns_sync(&config_clone, shutdown_flag_clone) {
                 eprintln!("mDNS broadcast error: {e}");
             }
         });
         // Give the mDNS thread a moment to start
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        Some(handle)
     } else {
         println!("mDNS broadcasting disabled");
-    }
+        None
+    };
 
     println!("Agent server started on {}", config.listen);
     println!("Press Ctrl+C to stop");
@@ -604,18 +612,41 @@ pub async fn start_agent_server(config: &AgentConfig) -> Result<(), Box<dyn std:
 
     println!("Shutting down agent server...");
 
+    // Signal the mDNS thread to stop
+    shutdown_flag.store(true, Ordering::Relaxed);
+
     // Stop the A2A server
     handle.stop()?;
 
     // Shutdown all MCP processes
     process_manager.shutdown_all()?;
 
+    // Wait for mDNS thread to finish (with timeout)
+    if let Some(handle) = mdns_thread_handle {
+        println!("Waiting for mDNS thread to stop...");
+        // Give it 2 seconds to stop gracefully
+        let timeout = std::time::Duration::from_secs(2);
+        let start = std::time::Instant::now();
+
+        while !handle.is_finished() && start.elapsed() < timeout {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+
+        if !handle.is_finished() {
+            eprintln!("Warning: mDNS thread did not stop within timeout");
+            // Thread will be forcefully terminated when process exits
+        }
+    }
+
     println!("Agent server stopped.");
-    Ok(())
+
+    // Explicitly exit to ensure all threads are terminated
+    std::process::exit(0);
 }
 
 fn broadcast_agent_mdns_sync(
     #[allow(unused_variables)] config: &AgentConfig,
+    #[allow(unused_variables)] shutdown_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "mdns")]
     {
@@ -674,22 +705,29 @@ fn broadcast_agent_mdns_sync(
 
         // The service automatically unregisters when it goes out of scope.
         // We need to keep it alive.
-        loop {
-            thread::sleep(Duration::from_secs(30));
+        use std::sync::atomic::Ordering;
+        while !shutdown_flag.load(Ordering::Relaxed) {
+            thread::sleep(Duration::from_secs(1));
             // Keep reference to prevent dropping
             let _ = &service;
         }
+
+        println!("mDNS service shutting down...");
+        // Service will be unregistered when it goes out of scope
     }
 
     #[cfg(not(feature = "mdns"))]
     {
         println!("mDNS support not compiled in (disabled for musl builds)");
         println!("Agent will run without mDNS discovery");
-        // Keep the thread alive so the agent doesn't exit
-        loop {
-            std::thread::sleep(std::time::Duration::from_secs(60));
+        // Keep the thread alive until shutdown is signaled
+        use std::sync::atomic::Ordering;
+        while !shutdown_flag.load(Ordering::Relaxed) {
+            std::thread::sleep(std::time::Duration::from_secs(1));
         }
     }
+
+    Ok(())
 }
 
 // Wrapper to implement McpConnectionTrait for arkavo-cli's McpConnection

--- a/crates/arkavo-cli/src/commands/agent.rs
+++ b/crates/arkavo-cli/src/commands/agent.rs
@@ -490,11 +490,12 @@ pub async fn start_agent_server(config: &AgentConfig) -> Result<(), Box<dyn std:
     // Register built-in MCP tools first
     {
         use crate::builtin_mcp::BuiltinMcpConnection;
-        let builtin_connection = BuiltinMcpConnection::new();
+        // Use the async version to avoid runtime conflicts
+        let builtin_connection = BuiltinMcpConnection::new_with_test_tools().await;
         mcp_registry
             .register("builtin".to_string(), Box::new(builtin_connection))
             .await;
-        println!("Registered built-in MCP tools (echo, health, ollama_config)");
+        println!("Registered built-in MCP tools and test server tools");
     }
 
     for mcp_config in &config.mcp_servers {

--- a/crates/arkavo-cli/src/lib.rs
+++ b/crates/arkavo-cli/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod builtin_mcp;
 pub mod commands;
 pub mod conversation_manager;
 pub mod log;

--- a/crates/arkavo-cli/src/mcp_integration.rs
+++ b/crates/arkavo-cli/src/mcp_integration.rs
@@ -41,6 +41,23 @@ impl McpConnection {
 
         Ok(Self::InProcess(base_connection))
     }
+    
+    pub async fn new_in_process_async() -> Result<Self, Box<dyn std::error::Error>> {
+        // Initialize memory tools first
+        eprintln!("Initializing memory tools...");
+        
+        // Initialize memory asynchronously
+        let memory_integration = MemoryIntegration::new().await?;
+        
+        // Get memory tools
+        let additional_tools = memory_integration.get_tools();
+
+        // Create the base MCP connection with additional tools
+        let base_connection =
+            base::McpConnection::new_in_process_with_additional_tools(additional_tools)?;
+
+        Ok(Self::InProcess(base_connection))
+    }
 
     pub fn new_external(mcp_url: Option<String>) -> Result<Self, Box<dyn std::error::Error>> {
         if let Some(url) = mcp_url {

--- a/crates/arkavo-cli/src/mcp_integration.rs
+++ b/crates/arkavo-cli/src/mcp_integration.rs
@@ -41,14 +41,14 @@ impl McpConnection {
 
         Ok(Self::InProcess(base_connection))
     }
-    
+
     pub async fn new_in_process_async() -> Result<Self, Box<dyn std::error::Error>> {
         // Initialize memory tools first
         eprintln!("Initializing memory tools...");
-        
+
         // Initialize memory asynchronously
         let memory_integration = MemoryIntegration::new().await?;
-        
+
         // Get memory tools
         let additional_tools = memory_integration.get_tools();
 

--- a/crates/arkavo/Cargo.toml
+++ b/crates/arkavo/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities", "development-tools"]
 
 
 [features]
-default = ["memory", "mdns", "local"]
+default = ["memory", "embeddings", "mdns", "local"]
 memory = ["arkavo-cli/memory"]
 embeddings = ["memory", "arkavo-cli/embeddings"]
 mdns = ["arkavo-cli/mdns"]


### PR DESCRIPTION
## Summary
This PR addresses multiple issues with MCP tools and agent shutdown:
- Registers built-in MCP tools by default when starting an agent
- Exposes McpTestServer tools for testing and automation
- Fixes agent shutdown not terminating properly on Ctrl+C
- Enables embeddings feature by default for semantic memory search
- Removes redundant echo tool to reduce clutter

## Changes

### 1. Agent Shutdown Fix
- Added shutdown flag for mDNS thread to signal termination
- Replaced infinite loops with condition checks on shutdown flag
- Added timeout for mDNS thread termination (2 seconds)
- Use `std::process::exit(0)` to ensure full process termination

### 2. MCP Tools Registration
- Created `BuiltinMcpConnection` to provide default MCP tools
- Automatically registers built-in tools (health, ollama_config)
- Integrates test server tools from arkavo-test when available
- Fixed runtime panic by using async initialization path
- Changed tool prefix from "builtin" to "arkavo" for clarity

### 3. Embeddings Feature
- Added "embeddings" to default features in both arkavo and arkavo-cli
- Enables semantic search and vector database functionality
- Memory tools can now perform similarity matching and retrieval

### 4. Code Cleanup
- Removed echo tool as it's redundant with health tool available
- Cleaned up unnecessary imports

## Testing
- Built and tested with `cargo build`
- Ran `cargo clippy` - no warnings
- Ran `cargo fmt` - code formatted
- Verified agent starts and shuts down cleanly with Ctrl+C
- Confirmed MCP tools are registered and available

Fixes #213

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>