### PR TITLE
Windows release fix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -325,8 +325,11 @@ jobs:
           targets: x86_64-pc-windows-msvc
 
       - name: Install CMake
+        shell: pwsh
         run: |
-          choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'
+          choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y
+          # Refresh environment variables in PowerShell
+          Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
           refreshenv
 
       - name: Build Windows binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -345,11 +345,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-encryption"
-version = "0.28.0"
+version = "0.28.1"
 
 [[package]]
 name = "arkavo-events"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "git2",
  "tempfile",
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "accelerate-src",
  "anyhow",
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "async-trait",
  "serde",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-core"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ exclude = ["crates/arkavo-protocol/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.28.0"
+version = "0.28.1"
 edition = "2024"
 authors = ["Arkavo Edge Contributors"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
Fixes the Windows x86_64 release build failure caused by refreshenv not working in PowerShell context.

## Problem
The Windows build was failing with:
```
RefreshEnv.cmd does not work when run from this process. 
If you're in PowerShell, please 'Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1' and try again.
Process completed with exit code 1.
```

## Solution
- Use `pwsh` shell explicitly for CMake installation step
- Import Chocolatey profile module before calling refreshenv
- Add `-y` flag to auto-approve Chocolatey installation

## Testing
- This follows Chocolatey's official guidance for PowerShell environments
- The same pattern is used successfully in other GitHub Actions workflows

🤖 Generated with [Claude Code](https://claude.ai/code)