### PR TITLE
telemetry, benchmarking

### DIFF
--- a/.cargo/xtask/src/binary_size.rs
+++ b/.cargo/xtask/src/binary_size.rs
@@ -10,10 +10,16 @@ pub fn check(limit_mb: u64, package: Option<String>) -> Result<()> {
     let status = Command::new("cargo")
         .args(["build", "--release", "-p", &package_name])
         .status()
-        .context("failed to build release binary")?;
+        .with_context(|| format!("failed to build release binary for '{package_name}'"))?;
 
     if !status.success() {
-        return Err(anyhow!("release build failed"));
+        let code = status.code().map_or_else(
+            || "terminated by signal".to_string(),
+            |c| format!("exit code {c}"),
+        );
+        return Err(anyhow!(
+            "release build failed for package '{package_name}' ({code})"
+        ));
     }
 
     let binary_path = release_binary_path(&package_name)?;

--- a/.cargo/xtask/src/binary_size.rs
+++ b/.cargo/xtask/src/binary_size.rs
@@ -1,0 +1,57 @@
+use anyhow::{anyhow, Context, Result};
+use std::path::PathBuf;
+use std::process::Command;
+
+const DEFAULT_BINARY: &str = "arkavo";
+
+pub fn check(limit_mb: u64, package: Option<String>) -> Result<()> {
+    let package_name = package.unwrap_or_else(|| DEFAULT_BINARY.to_string());
+
+    let status = Command::new("cargo")
+        .args(["build", "--release", "-p", &package_name])
+        .status()
+        .context("failed to build release binary")?;
+
+    if !status.success() {
+        return Err(anyhow!("release build failed"));
+    }
+
+    let binary_path = release_binary_path(&package_name)?;
+    let metadata = std::fs::metadata(&binary_path)
+        .with_context(|| format!("missing binary: {binary_path:?}"))?;
+
+    let size_bytes = metadata.len();
+    let size_mb = size_bytes as f64 / (1024.0 * 1024.0);
+
+    println!(
+        "Binary {} size: {:.2} MiB (limit {} MiB)",
+        binary_path.display(),
+        size_mb,
+        limit_mb
+    );
+
+    if size_mb > limit_mb as f64 {
+        Err(anyhow!(
+            "binary {} exceeds limit: {:.2} MiB > {} MiB",
+            binary_path.display(),
+            size_mb,
+            limit_mb
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn release_binary_path(package_name: &str) -> Result<PathBuf> {
+    let mut path = PathBuf::from("target");
+    path.push("release");
+
+    let binary_name = if cfg!(target_os = "windows") {
+        format!("{package_name}.exe")
+    } else {
+        package_name.to_string()
+    };
+
+    path.push(binary_name);
+    Ok(path)
+}

--- a/.cargo/xtask/src/main.rs
+++ b/.cargo/xtask/src/main.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::disallowed_methods)] // False positive in clippy
 
+mod binary_size;
 mod demo;
 mod schema;
 
@@ -34,6 +35,13 @@ enum Commands {
         #[arg(long, help = "Generate wire protocol schemas")]
         wire: bool,
     },
+    #[command(about = "Build release binary and verify size against the workspace budget")]
+    CheckBinarySize {
+        #[arg(long, default_value_t = 60, help = "Maximum allowed size in MiB")]
+        limit_mb: u64,
+        #[arg(long, help = "Package name to build (defaults to arkavo)")]
+        package: Option<String>,
+    },
 }
 
 #[tokio::main]
@@ -56,6 +64,9 @@ async fn main() -> Result<()> {
             wire,
         } => {
             schema::generate_schemas(check, config, wire)?;
+        }
+        Commands::CheckBinarySize { limit_mb, package } => {
+            binary_size::check(limit_mb, package)?;
         }
     }
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -394,11 +394,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-encryption"
-version = "0.30.0"
+version = "0.30.1"
 
 [[package]]
 name = "arkavo-events"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "git2",
  "tempfile",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "accelerate-src",
  "anyhow",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "serde",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-core"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,9 @@ dependencies = [
  "arkavo-mcp-tools",
  "arkavo-memory",
  "chrono",
+ "criterion",
  "crossterm",
+ "metrics",
  "ratatui",
  "regex",
  "semver",
@@ -708,6 +710,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tracing",
  "unicode-width 0.2.0",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ exclude = ["crates/arkavo-protocol/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.30.0"
+version = "0.30.1"
 edition = "2024"
 authors = ["Arkavo Edge Contributors"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -115,3 +115,42 @@ cargo build --release
 ```
 
 The default build includes mDNS discovery using a pure Rust implementation (`mdns-sd` crate) that doesn't require system libraries like Avahi or Bonjour. This provides true portability across all platforms.
+
+## Local Development Environment
+
+- **Rust toolchain:** Install the latest stable toolchain with `rustup` and add `rustfmt`/`clippy` components (`rustup component add rustfmt clippy`).
+- **Clone and bootstrap:**
+  ```bash
+  git clone https://github.com/arkavo-org/arkavo-edge.git
+  cd arkavo-edge
+  git submodule update --init --recursive   # pulls vendor/llama.cpp for llama.cpp builds
+  ```
+- **Optional iOS tooling:** macOS builds embed Meta’s idb companion for simulator automation. Download the prebuilt bundle and reuse it locally:
+  ```bash
+  mkdir -p vendor/idb-prebuilt
+  curl -L https://github.com/arkavo-org/idb/releases/download/1.4.0-arkavo/idb_companion-1.4.0-arkavo-macos-arm64.tar.gz \
+    -o vendor/idb-prebuilt/idb_companion-1.4.0-macos-arm64.tar.gz
+  curl -L https://github.com/arkavo-org/idb/releases/download/1.4.0-arkavo/idb_companion-1.4.0-arkavo-macos-arm64.tar.gz.sha256 \
+    -o vendor/idb-prebuilt/idb_companion-1.4.0-macos-arm64.tar.gz.sha256
+  (cd vendor/idb-prebuilt && shasum -c idb_companion-1.4.0-macos-arm64.tar.gz.sha256)
+  tar -xzf vendor/idb-prebuilt/idb_companion-1.4.0-macos-arm64.tar.gz -C vendor/idb-prebuilt
+  ```
+  Then export `ARKAVO_IDB_VENDOR_DIR=$(pwd)/vendor/idb-prebuilt` (or `ARKAVO_SKIP_IDB_DOWNLOAD=1` with the same directory) before building so `build.rs` uses the local artifacts.
+- **Workspace diagnostics:**
+  ```bash
+  cargo fmt
+  cargo check --workspace
+  cargo clippy --workspace --all-features
+  ```
+- **Lightweight checks without optional vendors:** When Metal/llama.cpp or idb assets are unavailable (CI sandboxes, e.g.), you can focus on core crates:
+  ```bash
+  cargo check -p arkavo-terminal
+  cargo check -p arkavo-protocol --features metrics
+  cargo check --workspace --exclude arkavo-mcp-macos --exclude arkavo-llama-cpp-sys
+  ```
+
+### Useful Developer Commands
+
+- Validate release sizes locally: `cargo xtask check-binary-size --limit-mb 60 --package arkavo`
+- Profile diff rendering: `cargo bench -p arkavo-terminal diff_render`
+- Inspect performance telemetry in the TUI by running `arkavo terminal` and watching the status bar for diff and router latency budgets.

--- a/crates/arkavo-cli/src/commands/chat.rs
+++ b/crates/arkavo-cli/src/commands/chat.rs
@@ -1647,11 +1647,11 @@ fn list_files(path: &str) -> Option<String> {
 async fn initialize_llm_client(
     print_mode: bool,
     model_name: &str,
-    _temperature: f32,
-    _top_p: f32,
-    _top_k: i32,
-    _max_tokens: u32,
-    _seed: u32,
+    temperature: f32,
+    top_p: f32,
+    top_k: i32,
+    max_tokens: u32,
+    seed: u32,
 ) -> Result<LlmClient, Box<dyn std::error::Error>> {
     // Check if model_name specifies a provider directly
     if model_name == "deepseek" {
@@ -1852,6 +1852,7 @@ async fn initialize_llm_client(
 
     #[cfg(not(feature = "llama-cpp"))]
     {
+        let _ = (model_name, temperature, top_p, top_k, max_tokens, seed);
         Err(
             "No LLM provider available. Please install Ollama or enable the 'llama-cpp' feature."
                 .into(),

--- a/crates/arkavo-cli/src/commands/chat.rs
+++ b/crates/arkavo-cli/src/commands/chat.rs
@@ -1647,11 +1647,11 @@ fn list_files(path: &str) -> Option<String> {
 async fn initialize_llm_client(
     print_mode: bool,
     model_name: &str,
-    temperature: f32,
-    top_p: f32,
-    top_k: i32,
-    max_tokens: u32,
-    seed: u32,
+    _temperature: f32,
+    _top_p: f32,
+    _top_k: i32,
+    _max_tokens: u32,
+    _seed: u32,
 ) -> Result<LlmClient, Box<dyn std::error::Error>> {
     // Check if model_name specifies a provider directly
     if model_name == "deepseek" {

--- a/crates/arkavo-cli/src/commands/terminal.rs
+++ b/crates/arkavo-cli/src/commands/terminal.rs
@@ -267,11 +267,11 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
 async fn initialize_llm_client(
     print_mode: bool,
     model_name: &str,
-    _temperature: f32,
-    _top_p: f32,
-    _top_k: i32,
-    _max_tokens: u32,
-    _seed: u32,
+    temperature: f32,
+    top_p: f32,
+    top_k: i32,
+    max_tokens: u32,
+    seed: u32,
 ) -> Result<LlmClient, Box<dyn std::error::Error>> {
     #[cfg(not(feature = "llama-cpp"))]
     let _ = model_name;
@@ -345,6 +345,7 @@ async fn initialize_llm_client(
 
     #[cfg(not(feature = "llama-cpp"))]
     {
+        let _ = (model_name, temperature, top_p, top_k, max_tokens, seed);
         Err(
             "No LLM provider available. Please install Ollama or enable the 'llama-cpp' feature."
                 .into(),

--- a/crates/arkavo-cli/src/commands/terminal.rs
+++ b/crates/arkavo-cli/src/commands/terminal.rs
@@ -267,12 +267,15 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
 async fn initialize_llm_client(
     print_mode: bool,
     model_name: &str,
-    temperature: f32,
-    top_p: f32,
-    top_k: i32,
-    max_tokens: u32,
-    seed: u32,
+    _temperature: f32,
+    _top_p: f32,
+    _top_k: i32,
+    _max_tokens: u32,
+    _seed: u32,
 ) -> Result<LlmClient, Box<dyn std::error::Error>> {
+    #[cfg(not(feature = "llama-cpp"))]
+    let _ = model_name;
+
     // Try to connect to Ollama first
     if let Ok(client) = LlmClient::from_env()
         && client.complete(vec![Message::user("ping")]).await.is_ok()

--- a/crates/arkavo-cli/src/conversation_manager.rs
+++ b/crates/arkavo-cli/src/conversation_manager.rs
@@ -63,7 +63,7 @@ impl ConversationManager {
 
         // Count and balance triple backticks
         let fence_count = sanitized.matches("```").count();
-        if fence_count % 2 != 0 {
+        if !fence_count.is_multiple_of(2) {
             // Odd number of fences - close the last one
             sanitized.push_str("\n```\n");
         }

--- a/crates/arkavo-llama-cpp-sys/build.rs
+++ b/crates/arkavo-llama-cpp-sys/build.rs
@@ -52,11 +52,6 @@ fn main() {
         .define("GGML_ASSERTS", "OFF") // Disable asserts for performance
         .define("LLAMA_CURL", "OFF"); // Disable CURL requirement (not needed for local inference)
 
-    if env::var("GGML_CCACHE").is_err() {
-        env::set_var("GGML_CCACHE", "OFF");
-        config.define("GGML_CCACHE", "OFF");
-    }
-
     let dst = config.build();
 
     let lib_dir = dst.join("lib");

--- a/crates/arkavo-llama-cpp-sys/build.rs
+++ b/crates/arkavo-llama-cpp-sys/build.rs
@@ -52,6 +52,11 @@ fn main() {
         .define("GGML_ASSERTS", "OFF") // Disable asserts for performance
         .define("LLAMA_CURL", "OFF"); // Disable CURL requirement (not needed for local inference)
 
+    if env::var("GGML_CCACHE").is_err() {
+        env::set_var("GGML_CCACHE", "OFF");
+        config.define("GGML_CCACHE", "OFF");
+    }
+
     let dst = config.build();
 
     let lib_dir = dst.join("lib");

--- a/crates/arkavo-mcp-macos/build.rs
+++ b/crates/arkavo-mcp-macos/build.rs
@@ -60,7 +60,7 @@ fn setup_idb_companion() {
     let frameworks_archive = out_path.join("frameworks.tar.gz");
 
     let mut populated_from_local = false;
-    if let Some(local_vendor_dir) = env::var("ARKAVO_IDB_VENDOR_DIR").ok() {
+    if let Ok(local_vendor_dir) = env::var("ARKAVO_IDB_VENDOR_DIR") {
         let local_path = Path::new(&local_vendor_dir);
         if try_copy_from_local(local_path, &idb_binary, &frameworks_archive) {
             populated_from_local = true;
@@ -82,14 +82,13 @@ fn setup_idb_companion() {
             })
             .unwrap_or(false);
 
-        if skip_download {
-            panic!(
-                "ARKAVO_SKIP_IDB_DOWNLOAD is set, but idb_companion artifacts are missing. \
+        assert!(
+            !skip_download,
+            "ARKAVO_SKIP_IDB_DOWNLOAD is set, but idb_companion artifacts are missing. \
 Provide ARKAVO_IDB_VENDOR_DIR or pre-populate {} and {} before building.",
-                idb_binary.display(),
-                frameworks_archive.display()
-            );
-        }
+            idb_binary.display(),
+            frameworks_archive.display()
+        );
 
         download_and_extract_idb(&idb_binary, &frameworks_archive);
     }
@@ -266,9 +265,10 @@ fn try_copy_from_local(
         .status()
         .expect("Failed to create frameworks archive from ARKAVO_IDB_VENDOR_DIR");
 
-    if !status.success() {
-        panic!("Failed to create frameworks archive from ARKAVO_IDB_VENDOR_DIR");
-    }
+    assert!(
+        status.success(),
+        "Failed to create frameworks archive from ARKAVO_IDB_VENDOR_DIR"
+    );
 
     true
 }

--- a/crates/arkavo-mcp-macos/build.rs
+++ b/crates/arkavo-mcp-macos/build.rs
@@ -59,7 +59,38 @@ fn setup_idb_companion() {
     let idb_binary = out_path.join("idb_companion");
     let frameworks_archive = out_path.join("frameworks.tar.gz");
 
-    if !idb_binary.exists() || !frameworks_archive.exists() {
+    let mut populated_from_local = false;
+    if let Some(local_vendor_dir) = env::var("ARKAVO_IDB_VENDOR_DIR").ok() {
+        let local_path = Path::new(&local_vendor_dir);
+        if try_copy_from_local(local_path, &idb_binary, &frameworks_archive) {
+            populated_from_local = true;
+        } else {
+            eprintln!(
+                "[build.rs] ARKAVO_IDB_VENDOR_DIR provided, but expected files were not found in {}",
+                local_path.display()
+            );
+        }
+    }
+
+    if !populated_from_local && (!idb_binary.exists() || !frameworks_archive.exists()) {
+        let skip_download = env::var("ARKAVO_SKIP_IDB_DOWNLOAD")
+            .map(|value| {
+                matches!(
+                    value.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "y"
+                )
+            })
+            .unwrap_or(false);
+
+        if skip_download {
+            panic!(
+                "ARKAVO_SKIP_IDB_DOWNLOAD is set, but idb_companion artifacts are missing. \
+Provide ARKAVO_IDB_VENDOR_DIR or pre-populate {} and {} before building.",
+                idb_binary.display(),
+                frameworks_archive.display()
+            );
+        }
+
         download_and_extract_idb(&idb_binary, &frameworks_archive);
     }
 
@@ -78,7 +109,7 @@ fn download_and_extract_idb(binary_path: &Path, frameworks_archive_path: &Path) 
     eprintln!("Downloading IDB companion and frameworks...");
 
     // Download the combined archive
-    let download_url = "https://github.com/arkavo-org/idb/releases/download/1.2.0-arkavo.0/idb_companion-1.2.0-arkavo.0-macos-arm64.tar.gz";
+    let download_url = "https://github.com/arkavo-org/idb/releases/download/1.4.0-arkavo/idb_companion-1.4.0-arkavo-macos-arm64.tar.gz";
     let temp_dir = env::temp_dir();
     let tar_path = temp_dir.join("idb-companion-combined.tar.gz");
 
@@ -186,4 +217,58 @@ fn download_and_extract_idb(binary_path: &Path, frameworks_archive_path: &Path) 
     let _ = fs::remove_dir_all(&extract_dir);
 
     eprintln!("Successfully downloaded and extracted IDB companion");
+}
+
+fn try_copy_from_local(
+    local_dir: &Path,
+    binary_path: &Path,
+    frameworks_archive_path: &Path,
+) -> bool {
+    let local_binary = local_dir.join("bin").join("idb_companion");
+    if !local_binary.exists() {
+        return false;
+    }
+
+    if let Some(parent) = binary_path.parent() {
+        fs::create_dir_all(parent).expect("Failed to create output directory for idb_companion");
+    }
+
+    fs::copy(&local_binary, binary_path)
+        .expect("Failed to copy idb_companion binary from ARKAVO_IDB_VENDOR_DIR");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(binary_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(binary_path, perms).unwrap();
+    }
+
+    let local_frameworks_archive = local_dir.join("frameworks.tar.gz");
+    if local_frameworks_archive.exists() {
+        fs::copy(local_frameworks_archive, frameworks_archive_path)
+            .expect("Failed to copy frameworks archive from ARKAVO_IDB_VENDOR_DIR");
+        return true;
+    }
+
+    let frameworks_dir = local_dir.join("Frameworks");
+    if !frameworks_dir.exists() {
+        return false;
+    }
+
+    let status = Command::new("tar")
+        .current_dir(local_dir)
+        .args([
+            "-czf",
+            frameworks_archive_path.to_str().unwrap(),
+            "Frameworks",
+        ])
+        .status()
+        .expect("Failed to create frameworks archive from ARKAVO_IDB_VENDOR_DIR");
+
+    if !status.success() {
+        panic!("Failed to create frameworks archive from ARKAVO_IDB_VENDOR_DIR");
+    }
+
+    true
 }

--- a/crates/arkavo-mcp-tools/src/tui/interaction.rs
+++ b/crates/arkavo-mcp-tools/src/tui/interaction.rs
@@ -345,13 +345,8 @@ impl TuiInteractionKit {
                 .to_string();
 
             // Check expected content
-            let mut all_checks_passed = true;
-
-            if let Some(expected) = expected_content
-                && !last_content.contains(expected)
-            {
-                all_checks_passed = false;
-            }
+            let mut all_checks_passed =
+                expected_content.is_none_or(|expected| last_content.contains(expected));
 
             if let Some(texts) = contains_text {
                 for text in texts {

--- a/crates/arkavo-protocol/src/metrics.rs
+++ b/crates/arkavo-protocol/src/metrics.rs
@@ -100,12 +100,23 @@ impl MetricsCollector {
         {
             histogram!("rpc_latency_seconds", "method" => method.to_string())
                 .record(duration.as_secs_f64());
+
+            if method == "message/send" {
+                histogram!("arkavo_a2a_round_trip_ms").record(duration.as_secs_f64() * 1000.0);
+            }
         }
 
         #[cfg(not(feature = "metrics"))]
         {
             let _ = (method, duration); // Suppress unused warnings
         }
+
+        tracing::debug!(
+            target = "arkavo.performance",
+            event = "rpc_latency",
+            method,
+            latency_ms = duration.as_secs_f64() * 1000.0
+        );
     }
 
     /// Update rate limiter entry count gauge

--- a/crates/arkavo-terminal/Cargo.toml
+++ b/crates/arkavo-terminal/Cargo.toml
@@ -23,6 +23,8 @@ crossterm = { workspace = true }
 syntect = { workspace = true, features = ["parsing", "regex-onig", "default-themes", "default-syntaxes"] }
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 anyhow = { workspace = true }
+tracing = { workspace = true }
+metrics = { workspace = true }
 unicode-width = "0.2"
 chrono = { workspace = true }
 serde = { workspace = true }
@@ -40,6 +42,14 @@ uuid = { workspace = true }
 
 # For Helix editor integration
 tempfile = { workspace = true }
+
+# Benchmarks
+[dev-dependencies]
+criterion = { workspace = true }
+
+[[bench]]
+name = "diff_render"
+harness = false
 
 # macOS-only dependency
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/arkavo-terminal/benches/diff_render.rs
+++ b/crates/arkavo-terminal/benches/diff_render.rs
@@ -1,0 +1,48 @@
+use arkavo_terminal::DiffRenderer;
+use criterion::{Criterion, criterion_group, criterion_main};
+use ratatui::{buffer::Buffer, layout::Rect};
+
+fn build_buffer(area: Rect, marker: &str) -> Buffer {
+    let mut buffer = Buffer::empty(area);
+    let width = area.width;
+    for y in 0..area.height {
+        for x in 0..width {
+            if (x + y) % 17 == 0 {
+                buffer
+                    .get_mut(area.left() + x, area.top() + y)
+                    .set_symbol(marker)
+                    .set_style(ratatui::style::Style::default().fg(ratatui::style::Color::Cyan));
+            }
+        }
+    }
+    buffer
+}
+
+fn diff_renderer_benchmark(c: &mut Criterion) {
+    let area = Rect::new(0, 0, 120, 40);
+    let baseline = build_buffer(area, "·");
+    let mut renderer = DiffRenderer::new();
+
+    // Prime renderer with initial frame so subsequent iterations simulate diff updates.
+    renderer.render_diff(&baseline, area);
+
+    c.bench_function("diff_renderer_120x40_sparse", |b| {
+        b.iter(|| {
+            let mut frame = baseline.clone();
+
+            // Apply modifications comparable to diff hunks.
+            for (idx, y) in (0..area.height).enumerate().step_by(4) {
+                let offset_x = (idx as u16 * 7) % area.width;
+                frame
+                    .get_mut(area.left() + offset_x, area.top() + y)
+                    .set_symbol("+")
+                    .set_style(ratatui::style::Style::default().fg(ratatui::style::Color::Green));
+            }
+
+            renderer.render_diff(&frame, area);
+        });
+    });
+}
+
+criterion_group!(name = diff; config = Criterion::default().configure_from_args(); targets = diff_renderer_benchmark);
+criterion_main!(diff);

--- a/crates/arkavo-terminal/src/app.rs
+++ b/crates/arkavo-terminal/src/app.rs
@@ -1899,8 +1899,30 @@ Scrolling (when in scroll mode):
 
         let streaming_indicator = if is_streaming { " ● Streaming" } else { "" };
 
+        let diff_render_ms = self
+            .diff_view
+            .last_render_duration()
+            .map(|d| d.as_secs_f64() * 1000.0);
+        let router_latency_ms = self
+            .diff_view
+            .last_router_latency()
+            .map(|d| d.as_secs_f64() * 1000.0);
+
+        let diff_render_text = diff_render_ms
+            .map(|v| format!("{v:.1} ms"))
+            .unwrap_or_else(|| "n/a".to_string());
+
+        let router_latency_text = router_latency_ms
+            .map(|v| format!("{v:.1} ms"))
+            .unwrap_or_else(|| "n/a".to_string());
+
+        self.telemetry.update_diff_metrics(
+            diff_render_ms.map_or(0, |v| v.round() as u64),
+            router_latency_ms.map_or(0, |v| v.round() as u64),
+        );
+
         let perf_text = format!(
-            " {fps} FPS | Sent: {messages_sent} | Received: {messages_received}{streaming_indicator}"
+            " {fps} FPS | Sent: {messages_sent} | Received: {messages_received} | Diff: {diff_render_text} | Router→Diff: {router_latency_text}{streaming_indicator}"
         );
 
         let color = if fps >= 100 {

--- a/crates/arkavo-terminal/src/renderer.rs
+++ b/crates/arkavo-terminal/src/renderer.rs
@@ -1,6 +1,8 @@
+use metrics::histogram;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use std::time::{Duration, Instant};
+use tracing::trace;
 
 pub struct RenderMetrics {
     pub frame_time: Duration,
@@ -59,6 +61,7 @@ impl Default for DiffRenderer {
 
 impl DiffRenderer {
     pub fn render_diff(&mut self, current: &Buffer, area: Rect) -> Vec<(u16, u16)> {
+        let render_start = Instant::now();
         let mut changed_cells = Vec::new();
 
         if let Some(ref prev) = self.previous_buffer {
@@ -81,6 +84,15 @@ impl DiffRenderer {
 
         self.previous_buffer = Some(current.clone());
         self.metrics.update();
+
+        let duration = render_start.elapsed();
+        histogram!("arkavo_diff_renderer_ms").record(duration.as_secs_f64() * 1000.0);
+        trace!(
+            target = "arkavo.performance",
+            event = "diff_renderer",
+            ?duration,
+            changed = changed_cells.len()
+        );
 
         changed_cells
     }

--- a/crates/arkavo-terminal/src/telemetry.rs
+++ b/crates/arkavo-terminal/src/telemetry.rs
@@ -22,6 +22,8 @@ pub struct UITelemetryReport {
     pub key_events: u64,
     pub portrait_mode_time_ms: u64,
     pub tabbed_mode_time_ms: u64,
+    pub last_diff_render_ms: u64,
+    pub last_router_to_diff_ms: u64,
 }
 
 #[derive(Clone)]
@@ -36,6 +38,8 @@ pub struct UITelemetry {
     tabbed_mode_time_ms: Arc<AtomicU64>,
     last_mode_switch: Arc<std::sync::Mutex<DateTime<Utc>>>,
     is_portrait: Arc<std::sync::Mutex<bool>>,
+    last_diff_render_ms: Arc<AtomicU64>,
+    last_router_to_diff_ms: Arc<AtomicU64>,
 }
 
 impl UITelemetry {
@@ -52,6 +56,8 @@ impl UITelemetry {
             tabbed_mode_time_ms: Arc::new(AtomicU64::new(0)),
             last_mode_switch: Arc::new(std::sync::Mutex::new(now)),
             is_portrait: Arc::new(std::sync::Mutex::new(false)),
+            last_diff_render_ms: Arc::new(AtomicU64::new(0)),
+            last_router_to_diff_ms: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -96,6 +102,12 @@ impl UITelemetry {
         self.key_events.fetch_add(1, Ordering::Relaxed);
     }
 
+    pub fn update_diff_metrics(&self, diff_ms: u64, router_ms: u64) {
+        self.last_diff_render_ms.store(diff_ms, Ordering::Relaxed);
+        self.last_router_to_diff_ms
+            .store(router_ms, Ordering::Relaxed);
+    }
+
     pub fn generate_report(&self) -> UITelemetryReport {
         let now = Utc::now();
         let session_duration = (now - self.session_start).num_milliseconds() as u64;
@@ -125,6 +137,8 @@ impl UITelemetry {
             key_events: self.key_events.load(Ordering::Relaxed),
             portrait_mode_time_ms: portrait_time,
             tabbed_mode_time_ms: tabbed_time,
+            last_diff_render_ms: self.last_diff_render_ms.load(Ordering::Relaxed),
+            last_router_to_diff_ms: self.last_router_to_diff_ms.load(Ordering::Relaxed),
         }
     }
 }
@@ -151,6 +165,7 @@ mod tests {
         telemetry.track_message_sent();
         telemetry.track_message_received();
         telemetry.track_pane_focus_change();
+        telemetry.update_diff_metrics(42, 55);
 
         // Switch layouts
         telemetry.track_layout_switch(true);
@@ -165,5 +180,7 @@ mod tests {
         assert_eq!(report.pane_focus_changes, 1);
         assert_eq!(report.layout_mode_switches, 2);
         assert!(report.portrait_mode_time_ms >= 100);
+        assert_eq!(report.last_diff_render_ms, 42);
+        assert_eq!(report.last_router_to_diff_ms, 55);
     }
 }

--- a/crates/arkavo-terminal/src/ui/diff.rs
+++ b/crates/arkavo-terminal/src/ui/diff.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use metrics::histogram;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -8,6 +9,8 @@ use ratatui::{
 
 use crate::event::AppEvent;
 use crate::renderer::Renderable;
+use std::time::{Duration, Instant};
+use tracing::{trace, warn};
 
 #[derive(Debug, Clone)]
 pub struct DiffHunk {
@@ -70,6 +73,9 @@ pub struct DiffView {
     pub(crate) view_mode: DiffViewMode,
     pub(crate) needs_redraw: bool,
     pub(crate) current_hunk: usize,
+    last_render_duration: Option<Duration>,
+    pending_diff_render: Option<Instant>,
+    last_router_latency: Option<Duration>,
 }
 
 impl DiffView {
@@ -81,6 +87,9 @@ impl DiffView {
             view_mode: DiffViewMode::Unified,
             needs_redraw: true,
             current_hunk: 0,
+            last_render_duration: None,
+            pending_diff_render: None,
+            last_router_latency: None,
         }
     }
 }
@@ -98,6 +107,7 @@ impl DiffView {
         self.scroll_offset = 0;
         self.current_hunk = 0;
         self.needs_redraw = true;
+        self.pending_diff_render = Some(Instant::now());
     }
 
     pub fn parse_unified_diff(&mut self, diff_text: &str) {
@@ -200,6 +210,15 @@ impl DiffView {
 
         self.hunks = hunks;
         self.needs_redraw = true;
+        self.pending_diff_render = Some(Instant::now());
+    }
+
+    pub fn last_render_duration(&self) -> Option<Duration> {
+        self.last_render_duration
+    }
+
+    pub fn last_router_latency(&self) -> Option<Duration> {
+        self.last_router_latency
     }
 
     fn render_unified(&self, frame: &mut ratatui::Frame, area: Rect) {
@@ -407,12 +426,59 @@ impl DiffView {
 
 impl Renderable for DiffView {
     fn render(&mut self, frame: &mut ratatui::Frame, area: Rect) {
+        let render_start = Instant::now();
+
         match self.view_mode {
             DiffViewMode::Unified => self.render_unified(frame, area),
             DiffViewMode::SideBySide => self.render_side_by_side(frame, area),
         }
 
         self.needs_redraw = false;
+
+        let render_duration = render_start.elapsed();
+        self.last_render_duration = Some(render_duration);
+        histogram!("arkavo_diff_render_ms").record(render_duration.as_secs_f64() * 1000.0);
+        trace!(
+            target = "arkavo.performance",
+            event = "diff_render",
+            ?render_duration,
+            file = %self.file_path,
+            mode = ?self.view_mode
+        );
+
+        const RENDER_BUDGET: Duration = Duration::from_millis(50);
+        if render_duration > RENDER_BUDGET {
+            warn!(
+                target = "arkavo.performance",
+                event = "diff_render_over_budget",
+                ?render_duration,
+                file = %self.file_path,
+                budget_ms = RENDER_BUDGET.as_millis()
+            );
+        }
+
+        if let Some(start) = self.pending_diff_render.take() {
+            let latency = render_start.duration_since(start);
+            self.last_router_latency = Some(latency);
+            histogram!("arkavo_router_to_diff_ms").record(latency.as_secs_f64() * 1000.0);
+            trace!(
+                target = "arkavo.performance",
+                event = "router_to_diff",
+                ?latency,
+                file = %self.file_path
+            );
+
+            const ROUTER_LATENCY_BUDGET: Duration = Duration::from_millis(50);
+            if latency > ROUTER_LATENCY_BUDGET {
+                warn!(
+                    target = "arkavo.performance",
+                    event = "router_to_diff_over_budget",
+                    ?latency,
+                    file = %self.file_path,
+                    budget_ms = ROUTER_LATENCY_BUDGET.as_millis()
+                );
+            }
+        }
     }
 
     fn needs_redraw(&self) -> bool {

--- a/crates/arkavo-terminal/src/ui/diff.rs
+++ b/crates/arkavo-terminal/src/ui/diff.rs
@@ -437,6 +437,9 @@ impl Renderable for DiffView {
 
         let render_duration = render_start.elapsed();
         self.last_render_duration = Some(render_duration);
+        const RENDER_BUDGET_MS: u64 = 50;
+        const ROUTER_LATENCY_BUDGET_MS: u64 = 50;
+
         histogram!("arkavo_diff_render_ms").record(render_duration.as_secs_f64() * 1000.0);
         trace!(
             target = "arkavo.performance",
@@ -447,13 +450,13 @@ impl Renderable for DiffView {
         );
 
         const RENDER_BUDGET: Duration = Duration::from_millis(50);
-        if render_duration > RENDER_BUDGET {
+        if render_duration > Duration::from_millis(RENDER_BUDGET_MS) {
             warn!(
                 target = "arkavo.performance",
                 event = "diff_render_over_budget",
                 ?render_duration,
                 file = %self.file_path,
-                budget_ms = RENDER_BUDGET.as_millis()
+                budget_ms = RENDER_BUDGET_MS
             );
         }
 
@@ -468,14 +471,13 @@ impl Renderable for DiffView {
                 file = %self.file_path
             );
 
-            const ROUTER_LATENCY_BUDGET: Duration = Duration::from_millis(50);
-            if latency > ROUTER_LATENCY_BUDGET {
+            if latency > Duration::from_millis(ROUTER_LATENCY_BUDGET_MS) {
                 warn!(
                     target = "arkavo.performance",
                     event = "router_to_diff_over_budget",
                     ?latency,
                     file = %self.file_path,
-                    budget_ms = ROUTER_LATENCY_BUDGET.as_millis()
+                    budget_ms = ROUTER_LATENCY_BUDGET_MS
                 );
             }
         }

--- a/crates/arkavo-terminal/src/ui/diff.rs
+++ b/crates/arkavo-terminal/src/ui/diff.rs
@@ -449,7 +449,6 @@ impl Renderable for DiffView {
             mode = ?self.view_mode
         );
 
-        const RENDER_BUDGET: Duration = Duration::from_millis(50);
         if render_duration > Duration::from_millis(RENDER_BUDGET_MS) {
             warn!(
                 target = "arkavo.performance",

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,27 @@
+# Performance Instrumentation
+
+Arkavo Edge now exposes dedicated telemetry for latency-sensitive paths. These measurements feed both interactive dashboards and future CI gates.
+
+## Router To Diff Rendering
+- `DiffView::set_diff` starts a timer and final rendering records a histogram (`arkavo_router_to_diff_ms`).
+- Per-frame render durations are emitted via `arkavo_diff_render_ms` and surfaced in the terminal status bar.
+- Logs are tagged with the `arkavo.performance` tracing target for quick filtering.
+- When latencies exceed the 50 ms budget, `WARN` entries (`diff_render_over_budget`, `router_to_diff_over_budget`) appear, making breaches easy to spot in log streams.
+
+## A2A Round Trips
+- `MetricsCollector::record_rpc_latency` records RPC timings and publishes `arkavo_a2a_round_trip_ms` when the `message/send` method completes.
+- Every call emits a debug trace with the measured latency in milliseconds.
+
+## Benchmarks
+- Run `cargo bench -p arkavo-terminal diff_render` to profile the diff renderer against a synthetic workload.
+- Criterion captures the distribution, enabling regression detection when paired with CI artifact comparison.
+
+## Binary Size Guard
+- Execute `cargo xtask check-binary-size --limit-mb 60 --package arkavo` to build the release binary and validate it against the 60 MiB target.
+- The command prints the measured size and fails if the threshold is exceeded, allowing straightforward CI wiring.
+
+## Operational Notes
+- The new metrics default to no-ops when a recorder is not installed, keeping local runs lightweight.
+- Use `RUST_LOG=arkavo.performance=debug` to stream latency logs during exploratory profiling.
+- For macOS Metal validation, pair the diff latency traces with `cargo bench` output to confirm GPU acceleration stays within budget.
+- The UI telemetry report now exports `last_diff_render_ms` and `last_router_to_diff_ms`, enabling AG-UI or external dashboards to plot recent samples per session.


### PR DESCRIPTION
Fixes #198

## Summary
- Instrument the terminal diff pipeline to emit latency metrics/histograms, surface them in the status bar, and export the most recent samples via telemetry/logging
- Add a Criterion bench for the diff renderer plus a reusable cargo xtask check-binary-size helper, documenting the workflow in docs/performance.md
- Allow macOS builds to reuse a prebuilt idb_companion bundle via ARKAVO_IDB_VENDOR_DIR / ARKAVO_SKIP_IDB_DOWNLOAD, updating README instructions accordingly (no more Objective‑C rebuilds)

## Testing
- cargo fmt
- cargo check
- cargo check -p arkavo-terminal
- cargo check -p arkavo-protocol --features metrics
- cargo check -p xtask
- ARKAVO_IDB_VENDOR_DIR=$(pwd)/vendor/idb-prebuilt ARKAVO_SKIP_IDB_DOWNLOAD=1 cargo test -p arkavo-terminal telemetry

## Notes
- Staged artifacts were downloaded from https://github.com/arkavo-org/idb/releases/download/1.4.0-arkavo/idb_companion-1.4.0-arkavo-macos-arm64.tar.gz so the build script skips network access
- Performance budgets (50ms) are now extracted as constants for better maintainability
- Enhanced error messages in binary_size checker for clearer CI feedback