### PR TITLE
Qwen-3 provider with vision support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -394,11 +394,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-encryption"
-version = "0.31.1"
+version = "0.32.0"
 
 [[package]]
 name = "arkavo-events"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "git2",
  "tempfile",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -458,13 +458,14 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "accelerate-src",
  "anyhow",
  "arkavo-deepseek",
  "arkavo-kimi",
  "arkavo-llama-cpp",
+ "arkavo-qwen",
  "async-trait",
  "base64 0.22.1",
  "bytemuck",
@@ -501,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -510,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-core"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -520,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -549,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -566,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -590,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -611,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -628,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -669,8 +670,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "arkavo-qwen"
+version = "0.32.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "tempfile",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "wiremock",
+]
+
+[[package]]
 name = "arkavo-repo"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -689,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/arkavo-llm",
     "crates/arkavo-kimi",
     "crates/arkavo-deepseek",
+    "crates/arkavo-qwen",
     "crates/arkavo-memory",
     "crates/arkavo-mcp",
     "crates/arkavo-mcp-core",
@@ -32,7 +33,7 @@ exclude = ["crates/arkavo-protocol/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.31.1"
+version = "0.32.0"
 edition = "2024"
 authors = ["Arkavo Edge Contributors"]
 license = "Apache-2.0"

--- a/crates/arkavo-llm/Cargo.toml
+++ b/crates/arkavo-llm/Cargo.toml
@@ -16,6 +16,7 @@ llm-remote = ["dep:reqwest", "dep:serde_json", "dep:tokio", "dep:async-trait", "
 llm-local = ["dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:hf-hub", "dep:tokenizers", "dep:tracing", "dep:bytemuck", "dep:cfg-if", "dep:sha2", "dep:indicatif", "dep:dirs", "dep:toml"]
 kimi = ["dep:arkavo-kimi", "dep:reqwest", "dep:serde_json", "dep:tokio", "dep:async-trait", "dep:futures", "dep:tokio-stream", "dep:serde", "dep:thiserror", "dep:log", "dep:anyhow"]
 deepseek = ["dep:arkavo-deepseek", "dep:reqwest", "dep:serde_json", "dep:tokio", "dep:async-trait", "dep:futures", "dep:tokio-stream", "dep:serde", "dep:thiserror", "dep:log", "dep:anyhow"]
+qwen = ["dep:arkavo-qwen", "dep:reqwest", "dep:serde_json", "dep:tokio", "dep:async-trait", "dep:futures", "dep:tokio-stream", "dep:serde", "dep:thiserror", "dep:log", "dep:anyhow"]
 llama-cpp = ["dep:arkavo-llama-cpp", "dep:tokio", "dep:async-trait", "dep:tokio-stream", "dep:tracing", "dep:serde", "dep:thiserror", "dep:scopeguard", "dep:tokio-util"]
 local = ["llm-local"]
 metal = ["candle-core/metal", "candle-transformers/metal"]
@@ -53,6 +54,7 @@ rand = { workspace = true }
 # Provider integrations
 arkavo-kimi = { path = "../arkavo-kimi", optional = true }
 arkavo-deepseek = { path = "../arkavo-deepseek", optional = true }
+arkavo-qwen = { path = "../arkavo-qwen", optional = true }
 arkavo-llama-cpp = { path = "../arkavo-llama-cpp", optional = true }
 
 # Provider dependencies

--- a/crates/arkavo-llm/src/lib.rs
+++ b/crates/arkavo-llm/src/lib.rs
@@ -33,6 +33,11 @@ mod deepseek_adapter;
 #[cfg(feature = "deepseek")]
 pub use deepseek_adapter::DeepSeekProvider;
 
+#[cfg(feature = "qwen")]
+mod qwen_adapter;
+#[cfg(feature = "qwen")]
+pub use qwen_adapter::QwenProvider;
+
 #[cfg(all(feature = "llama-cpp", not(target_env = "musl")))]
 mod llamacpp_provider;
 #[cfg(all(feature = "llama-cpp", not(target_env = "musl")))]

--- a/crates/arkavo-llm/src/qwen_adapter.rs
+++ b/crates/arkavo-llm/src/qwen_adapter.rs
@@ -1,0 +1,118 @@
+use crate::{Message, Provider, Result, Role, StreamResponse};
+use async_trait::async_trait;
+use tokio_stream::Stream;
+
+pub struct QwenProvider {
+    inner: arkavo_qwen::QwenProvider,
+}
+
+impl QwenProvider {
+    pub fn new(config: arkavo_qwen::QwenConfig) -> Result<Self> {
+        let inner = arkavo_qwen::QwenProvider::new(config)
+            .map_err(|e| crate::Error::Provider(e.to_string()))?;
+        Ok(Self { inner })
+    }
+
+    pub fn from_env() -> Result<Self> {
+        let inner = arkavo_qwen::QwenProvider::from_env()
+            .map_err(|e| crate::Error::Provider(e.to_string()))?;
+        Ok(Self { inner })
+    }
+
+    pub fn with_temperature(mut self, temperature: f32) -> Self {
+        self.inner = self.inner.with_temperature(temperature);
+        self
+    }
+
+    pub fn with_top_p(mut self, top_p: f32) -> Self {
+        self.inner = self.inner.with_top_p(top_p);
+        self
+    }
+
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+        self.inner = self.inner.with_max_tokens(max_tokens);
+        self
+    }
+}
+
+fn convert_message(msg: Message) -> arkavo_qwen::Message {
+    let role = match msg.role {
+        Role::System => arkavo_qwen::MessageRole::System,
+        Role::User => arkavo_qwen::MessageRole::User,
+        Role::Assistant => arkavo_qwen::MessageRole::Assistant,
+    };
+
+    arkavo_qwen::Message {
+        role,
+        content: msg.content,
+        images: msg.images,
+    }
+}
+
+fn convert_stream_response(resp: arkavo_qwen::StreamResponse) -> crate::StreamResponse {
+    crate::StreamResponse {
+        content: resp.content,
+        done: resp.done,
+    }
+}
+
+#[async_trait]
+impl Provider for QwenProvider {
+    async fn complete(&self, messages: Vec<Message>) -> Result<String> {
+        let qwen_messages: Vec<arkavo_qwen::Message> =
+            messages.into_iter().map(convert_message).collect();
+
+        self.inner
+            .complete(qwen_messages)
+            .await
+            .map_err(|e| crate::Error::Provider(e.to_string()))
+    }
+
+    async fn stream(
+        &self,
+        messages: Vec<Message>,
+    ) -> Result<Box<dyn Stream<Item = Result<StreamResponse>> + Send + Unpin>> {
+        let qwen_messages: Vec<arkavo_qwen::Message> =
+            messages.into_iter().map(convert_message).collect();
+
+        let stream = self
+            .inner
+            .stream(qwen_messages)
+            .await
+            .map_err(|e| crate::Error::Provider(e.to_string()))?;
+
+        let mapped_stream = futures::StreamExt::map(stream, |result| {
+            result
+                .map(convert_stream_response)
+                .map_err(|e| crate::Error::Stream(e.to_string()))
+        });
+
+        Ok(Box::new(Box::pin(mapped_stream)))
+    }
+
+    fn name(&self) -> &str {
+        "qwen"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Message;
+
+    #[test]
+    fn test_message_conversion() {
+        let msg = Message::user("Hello");
+        let qwen_msg = convert_message(msg);
+        assert_eq!(qwen_msg.content, "Hello");
+        assert!(matches!(qwen_msg.role, arkavo_qwen::MessageRole::User));
+    }
+
+    #[test]
+    fn test_message_with_images() {
+        let msg = Message::user_with_images("Describe this", vec!["img1".to_string()]);
+        let qwen_msg = convert_message(msg);
+        assert_eq!(qwen_msg.content, "Describe this");
+        assert_eq!(qwen_msg.images, Some(vec!["img1".to_string()]));
+    }
+}

--- a/crates/arkavo-llm/src/qwen_adapter.rs
+++ b/crates/arkavo-llm/src/qwen_adapter.rs
@@ -1,4 +1,5 @@
 use crate::{Message, Provider, Result, Role, StreamResponse};
+use arkavo_qwen::Provider as QwenProviderTrait;
 use async_trait::async_trait;
 use tokio_stream::Stream;
 
@@ -87,10 +88,10 @@ impl Provider for QwenProvider {
                 .map_err(|e| crate::Error::Stream(e.to_string()))
         });
 
-        Ok(Box::new(Box::pin(mapped_stream)))
+        Ok(Box::new(futures::stream::StreamExt::boxed(mapped_stream)))
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "qwen"
     }
 }

--- a/crates/arkavo-qwen/Cargo.toml
+++ b/crates/arkavo-qwen/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "arkavo-qwen"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Qwen-3 (Instruct + Vision) provider via DashScope OpenAI-compatible API for Arkavo Edge"
+keywords = ["qwen", "dashscope", "llm", "vision", "ai"]
+categories = ["api-bindings", "asynchronous"]
+
+[dependencies]
+tokio = { workspace = true, features = ["rt", "macros", "sync"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+reqwest = { workspace = true }
+futures = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+async-trait = { workspace = true }
+tokio-stream = { workspace = true }
+anyhow = { workspace = true }
+chrono = { workspace = true }
+bytes = { workspace = true }
+url = { workspace = true }
+base64 = { workspace = true }
+
+[dev-dependencies]
+wiremock = "0.6"
+tempfile = { workspace = true }
+serial_test = "3"
+
+[lints]
+workspace = true

--- a/crates/arkavo-qwen/README.md
+++ b/crates/arkavo-qwen/README.md
@@ -7,7 +7,7 @@ Qwen-3 (Instruct + Vision) provider for Arkavo Edge via DashScope's OpenAI-compa
 - **Text/Instruct Models**: Full Qwen-3 series support (qwen3-235b-a22b, qwen3-32b, qwen3-14b, etc.)
 - **Vision Models**: Qwen-VL and Qwen3-VL support for image understanding
 - **Streaming**: Server-sent events (SSE) streaming for real-time responses
-- **Function Calling**: Tool/function calling support for agentic workflows
+- **Function Calling**: Type definitions and low-level API support (high-level integration planned)
 - **Regional Endpoints**: Support for both International and China regions
 - **OpenAI-Compatible**: Uses DashScope's OpenAI-compatible API
 
@@ -250,6 +250,22 @@ validate_image_size(&base64_data, 10)?;
 // Create vision content part
 let part = create_image_part(&base64_data);
 ```
+
+## Limitations
+
+### Tool Calling / Function Calling
+
+The crate includes type definitions and infrastructure for tool/function calling (`Tool`, `ToolChoice`, `ToolCall`), but the high-level provider API does not yet expose methods to pass tools to requests. Tool calling can be accessed through the low-level `QwenClient` API:
+
+```rust
+use arkavo_qwen::{QwenClient, QwenConfig, Tool, ToolChoice};
+
+let client = QwenClient::new(config)?;
+let tools = vec![/* your tool definitions */];
+let response = client.complete(messages, Some(tools), Some(ToolChoice::Auto)).await?;
+```
+
+Integration with the `Provider` trait for tool calling is planned for a future release.
 
 ## Testing
 

--- a/crates/arkavo-qwen/README.md
+++ b/crates/arkavo-qwen/README.md
@@ -1,0 +1,285 @@
+# arkavo-qwen
+
+Qwen-3 (Instruct + Vision) provider for Arkavo Edge via DashScope's OpenAI-compatible API.
+
+## Features
+
+- **Text/Instruct Models**: Full Qwen-3 series support (qwen3-235b-a22b, qwen3-32b, qwen3-14b, etc.)
+- **Vision Models**: Qwen-VL and Qwen3-VL support for image understanding
+- **Streaming**: Server-sent events (SSE) streaming for real-time responses
+- **Function Calling**: Tool/function calling support for agentic workflows
+- **Regional Endpoints**: Support for both International and China regions
+- **OpenAI-Compatible**: Uses DashScope's OpenAI-compatible API
+
+## Installation
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+arkavo-qwen = { path = "../arkavo-qwen" }
+```
+
+Or with `arkavo-llm`:
+
+```toml
+[dependencies]
+arkavo-llm = { path = "../arkavo-llm", features = ["qwen"] }
+```
+
+## Quick Start
+
+### Basic Chat Completion
+
+```rust
+use arkavo_qwen::{QwenProvider, QwenConfig, QwenRegion, Message, MessageRole, Provider};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = QwenConfig {
+        api_key: std::env::var("DASHSCOPE_API_KEY")?,
+        region: QwenRegion::International,
+        model: "qwen3-32b".to_string(),
+        ..Default::default()
+    };
+
+    let provider = QwenProvider::new(config)?;
+
+    let messages = vec![
+        Message {
+            role: MessageRole::System,
+            content: "You are a helpful assistant.".to_string(),
+            images: None,
+        },
+        Message {
+            role: MessageRole::User,
+            content: "What is Rust?".to_string(),
+            images: None,
+        },
+    ];
+
+    let response = provider.complete(messages).await?;
+    println!("{}", response);
+
+    Ok(())
+}
+```
+
+### Vision (Image Understanding)
+
+```rust
+use arkavo_qwen::{QwenProvider, QwenConfig, Message, MessageRole, Provider};
+use arkavo_qwen::vision::encode_image_file;
+use std::path::Path;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = QwenConfig {
+        api_key: std::env::var("DASHSCOPE_API_KEY")?,
+        model: "qwen-vl-max-latest".to_string(),
+        ..Default::default()
+    };
+
+    let provider = QwenProvider::new(config)?;
+
+    // Encode image from file
+    let image_base64 = encode_image_file(Path::new("photo.jpg"))?;
+
+    let messages = vec![
+        Message {
+            role: MessageRole::User,
+            content: "Describe this image in detail.".to_string(),
+            images: Some(vec![image_base64]),
+        },
+    ];
+
+    let response = provider.complete(messages).await?;
+    println!("{}", response);
+
+    Ok(())
+}
+```
+
+### Streaming Responses
+
+```rust
+use arkavo_qwen::{QwenProvider, QwenConfig, Message, MessageRole, Provider};
+use futures::StreamExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = QwenConfig::default();
+    let provider = QwenProvider::new(config)?;
+
+    let messages = vec![
+        Message {
+            role: MessageRole::User,
+            content: "Write a short poem about Rust programming.".to_string(),
+            images: None,
+        },
+    ];
+
+    let mut stream = provider.stream(messages).await?;
+
+    while let Some(result) = stream.next().await {
+        let response = result?;
+        print!("{}", response.content);
+        if response.done {
+            break;
+        }
+    }
+
+    Ok(())
+}
+```
+
+### Environment Configuration
+
+```rust
+use arkavo_qwen::{QwenProvider, Provider};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Requires DASHSCOPE_API_KEY environment variable
+    // Optional: DASHSCOPE_REGION (intl or cn)
+    // Optional: QWEN_MODEL
+    let provider = QwenProvider::from_env()?;
+
+    // Use provider...
+    Ok(())
+}
+```
+
+## Supported Models
+
+### Text/Instruct Models
+
+- `qwen3-235b-a22b` - Largest open-source Qwen-3 model
+- `qwen3-32b` - Balanced performance and efficiency (default)
+- `qwen3-30b-a3b` - MoE variant
+- `qwen3-14b`, `qwen3-8b`, `qwen3-4b` - Smaller models
+- `qwen3-1.7b`, `qwen3-0.6b` - Tiny models for edge deployment
+- `qwen-max`, `qwen-plus`, `qwen-turbo` - Commercial snapshots
+
+### Vision Models
+
+- `qwen-vl-max`, `qwen-vl-max-latest` - Production vision model
+- `qwen-vl-plus`, `qwen-vl-plus-latest` - Balanced vision model
+- `qwen3-vl-plus` - Latest Qwen-3 vision (supports thinking mode)
+- `qwen3-vl-235b-a22b-thinking` - Open-source with thinking
+- `qwen3-vl-235b-a22b-instruct` - Open-source instruct
+
+## Regional Endpoints
+
+### International (Default)
+
+```rust
+use arkavo_qwen::{QwenConfig, QwenRegion};
+
+let config = QwenConfig {
+    region: QwenRegion::International, // Uses https://dashscope-intl.aliyuncs.com
+    ..Default::default()
+};
+```
+
+### China
+
+```rust
+let config = QwenConfig {
+    region: QwenRegion::China, // Uses https://dashscope.aliyuncs.com
+    ..Default::default()
+};
+```
+
+Or via environment variable:
+
+```bash
+export DASHSCOPE_REGION=cn  # or "intl"
+```
+
+## Environment Variables
+
+- `DASHSCOPE_API_KEY` - DashScope API key (required)
+- `DASHSCOPE_BASE_URL` - Override base URL (optional)
+- `DASHSCOPE_REGION` - Region: `intl` or `cn` (optional, default: `intl`)
+- `QWEN_MODEL` - Default model name (optional, default: `qwen3-32b`)
+
+## Builder Pattern
+
+```rust
+use arkavo_qwen::{QwenConfig, QwenProvider};
+
+let provider = QwenProvider::new(QwenConfig::default())?
+    .with_temperature(0.8)
+    .with_top_p(0.9)
+    .with_max_tokens(2048);
+```
+
+## Error Handling
+
+```rust
+use arkavo_qwen::{QwenError, Result};
+
+match provider.complete(messages).await {
+    Ok(response) => println!("{}", response),
+    Err(QwenError::AuthenticationFailed { message }) => {
+        eprintln!("Auth error: {}", message);
+    }
+    Err(QwenError::RateLimitExceeded { message, retry_after }) => {
+        eprintln!("Rate limit: {}, retry after: {:?}s", message, retry_after);
+    }
+    Err(QwenError::ModelNotFound { model }) => {
+        eprintln!("Model not found: {}", model);
+    }
+    Err(e) => eprintln!("Error: {}", e),
+}
+```
+
+## Vision Helpers
+
+```rust
+use arkavo_qwen::vision::{create_image_part, create_image_url_from_file, validate_image_size};
+use std::path::Path;
+
+// Encode image from file with auto-detected MIME type
+let image_url = create_image_url_from_file(Path::new("photo.jpg"))?;
+
+// Validate image size (max 10MB)
+validate_image_size(&base64_data, 10)?;
+
+// Create vision content part
+let part = create_image_part(&base64_data);
+```
+
+## Testing
+
+```bash
+# Run unit tests
+cargo test
+
+# Run integration tests (requires mock server)
+cargo test --test integration_test
+
+# Run all tests with output
+cargo test -- --nocapture
+```
+
+## Examples
+
+See `tests/integration_test.rs` for complete examples including:
+
+- Basic chat completion
+- Vision with images
+- Streaming responses
+- Error handling
+- Region configuration
+
+## License
+
+Apache-2.0
+
+## Links
+
+- [DashScope Documentation](https://help.aliyun.com/zh/dashscope/)
+- [Qwen-3 Release](https://qwenlm.github.io/blog/qwen3/)
+- [Qwen-VL Models](https://help.aliyun.com/zh/dashscope/developer-reference/qwen-vl-api)

--- a/crates/arkavo-qwen/src/client.rs
+++ b/crates/arkavo-qwen/src/client.rs
@@ -1,0 +1,329 @@
+use crate::error::{QwenError, Result};
+use crate::models::QwenModel;
+use crate::stream::SseStream;
+use crate::types::{
+    ChatCompletionRequest, ChatCompletionResponse, ChatMessage, ErrorResponse, Tool, ToolChoice,
+};
+use reqwest::{Client, StatusCode};
+use std::time::Duration;
+use tracing::debug;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum QwenRegion {
+    #[default]
+    International,
+    China,
+}
+
+impl QwenRegion {
+    pub fn base_url(&self) -> &'static str {
+        match self {
+            QwenRegion::International => "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+            QwenRegion::China => "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "intl" | "international" => Some(QwenRegion::International),
+            "cn" | "china" => Some(QwenRegion::China),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct QwenConfig {
+    pub api_key: String,
+    pub base_url: String,
+    pub model: String,
+    pub region: QwenRegion,
+    pub max_tokens: Option<u32>,
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
+    pub timeout: Duration,
+    pub max_retries: u32,
+}
+
+impl Default for QwenConfig {
+    fn default() -> Self {
+        let region = QwenRegion::default();
+        Self {
+            api_key: String::new(),
+            base_url: region.base_url().to_string(),
+            model: QwenModel::default().as_str().to_string(),
+            region,
+            max_tokens: Some(4096),
+            temperature: Some(0.7),
+            top_p: None,
+            timeout: Duration::from_secs(60),
+            max_retries: 3,
+        }
+    }
+}
+
+pub struct QwenClient {
+    config: QwenConfig,
+    client: Client,
+}
+
+impl QwenClient {
+    pub fn new(config: QwenConfig) -> Result<Self> {
+        url::Url::parse(&config.base_url).map_err(|e| QwenError::ConfigError {
+            message: format!("Invalid base URL '{}': {}", config.base_url, e),
+        })?;
+
+        let client = Client::builder()
+            .timeout(config.timeout)
+            .build()
+            .map_err(|e| QwenError::ConfigError {
+                message: format!("Failed to create HTTP client: {e}"),
+            })?;
+
+        Ok(Self { config, client })
+    }
+
+    pub fn from_env() -> Result<Self> {
+        let api_key = std::env::var("DASHSCOPE_API_KEY").map_err(|_| QwenError::ConfigError {
+            message: "DASHSCOPE_API_KEY environment variable not set".to_string(),
+        })?;
+
+        let region = std::env::var("DASHSCOPE_REGION")
+            .ok()
+            .and_then(|r| QwenRegion::parse(&r))
+            .unwrap_or_default();
+
+        let base_url =
+            std::env::var("DASHSCOPE_BASE_URL").unwrap_or_else(|_| region.base_url().to_string());
+
+        let model = std::env::var("QWEN_MODEL")
+            .unwrap_or_else(|_| QwenModel::default().as_str().to_string());
+
+        let config = QwenConfig {
+            api_key,
+            base_url,
+            model,
+            region,
+            ..Default::default()
+        };
+
+        Self::new(config)
+    }
+
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.config.model = model.into();
+        self
+    }
+
+    pub fn with_temperature(mut self, temperature: f32) -> Self {
+        self.config.temperature = Some(temperature);
+        self
+    }
+
+    pub fn with_top_p(mut self, top_p: f32) -> Self {
+        self.config.top_p = Some(top_p);
+        self
+    }
+
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+        self.config.max_tokens = Some(max_tokens);
+        self
+    }
+
+    pub async fn complete(
+        &self,
+        messages: Vec<ChatMessage>,
+        tools: Option<Vec<Tool>>,
+        tool_choice: Option<ToolChoice>,
+    ) -> Result<ChatCompletionResponse> {
+        let request = ChatCompletionRequest {
+            model: self.config.model.clone(),
+            messages,
+            tools,
+            tool_choice,
+            temperature: self.config.temperature,
+            top_p: self.config.top_p,
+            max_tokens: self.config.max_tokens,
+            stream: Some(false),
+            stop: None,
+        };
+
+        self.send_request(request).await
+    }
+
+    pub async fn stream(
+        &self,
+        messages: Vec<ChatMessage>,
+        tools: Option<Vec<Tool>>,
+        tool_choice: Option<ToolChoice>,
+    ) -> Result<SseStream> {
+        let request = ChatCompletionRequest {
+            model: self.config.model.clone(),
+            messages,
+            tools,
+            tool_choice,
+            temperature: self.config.temperature,
+            top_p: self.config.top_p,
+            max_tokens: self.config.max_tokens,
+            stream: Some(true),
+            stop: None,
+        };
+
+        self.send_stream_request(request).await
+    }
+
+    async fn send_request(&self, request: ChatCompletionRequest) -> Result<ChatCompletionResponse> {
+        let url = format!("{}/chat/completions", self.config.base_url);
+
+        debug!("Sending request to Qwen API: {}", url);
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.config.api_key))
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await?;
+
+        let status = response.status();
+
+        if !status.is_success() {
+            let error_text = response.text().await?;
+
+            if let Ok(error_response) = serde_json::from_str::<ErrorResponse>(&error_text) {
+                return Err(self.map_api_error(status, error_response));
+            }
+
+            return Err(QwenError::ApiError {
+                status: status.as_u16(),
+                message: error_text,
+            });
+        }
+
+        let completion: ChatCompletionResponse = response.json().await?;
+        Ok(completion)
+    }
+
+    async fn send_stream_request(&self, request: ChatCompletionRequest) -> Result<SseStream> {
+        let url = format!("{}/chat/completions", self.config.base_url);
+
+        debug!("Sending streaming request to Qwen API: {}", url);
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.config.api_key))
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await?;
+
+        let status = response.status();
+
+        if !status.is_success() {
+            let error_text = response.text().await?;
+
+            if let Ok(error_response) = serde_json::from_str::<ErrorResponse>(&error_text) {
+                return Err(self.map_api_error(status, error_response));
+            }
+
+            return Err(QwenError::ApiError {
+                status: status.as_u16(),
+                message: error_text,
+            });
+        }
+
+        let stream = response.bytes_stream();
+        Ok(SseStream::new(stream))
+    }
+
+    fn map_api_error(&self, status: StatusCode, error: ErrorResponse) -> QwenError {
+        match status {
+            StatusCode::UNAUTHORIZED => QwenError::AuthenticationFailed {
+                message: error.error.message,
+            },
+            StatusCode::TOO_MANY_REQUESTS => QwenError::RateLimitExceeded {
+                message: error.error.message,
+                retry_after: None,
+            },
+            StatusCode::NOT_FOUND => {
+                if error.error.message.to_lowercase().contains("model") {
+                    QwenError::ModelNotFound {
+                        model: self.config.model.clone(),
+                    }
+                } else {
+                    QwenError::ApiError {
+                        status: status.as_u16(),
+                        message: error.error.message,
+                    }
+                }
+            }
+            StatusCode::BAD_REQUEST => QwenError::InvalidRequest {
+                message: error.error.message,
+            },
+            _ => QwenError::ApiError {
+                status: status.as_u16(),
+                message: error.error.message,
+            },
+        }
+    }
+
+    pub fn config(&self) -> &QwenConfig {
+        &self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_region_base_urls() {
+        assert_eq!(
+            QwenRegion::International.base_url(),
+            "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+        );
+        assert_eq!(
+            QwenRegion::China.base_url(),
+            "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        );
+    }
+
+    #[test]
+    fn test_region_parse() {
+        assert_eq!(QwenRegion::parse("intl"), Some(QwenRegion::International));
+        assert_eq!(QwenRegion::parse("cn"), Some(QwenRegion::China));
+        assert_eq!(QwenRegion::parse("invalid"), None);
+    }
+
+    #[test]
+    fn test_config_builder() {
+        let config = QwenConfig::default();
+        let client = QwenClient::new(config).unwrap();
+
+        let client = client
+            .with_model("qwen3-14b")
+            .with_temperature(0.8)
+            .with_top_p(0.9)
+            .with_max_tokens(2048);
+
+        assert_eq!(client.config.model, "qwen3-14b");
+        assert_eq!(client.config.temperature, Some(0.8));
+        assert_eq!(client.config.top_p, Some(0.9));
+        assert_eq!(client.config.max_tokens, Some(2048));
+    }
+
+    #[test]
+    fn test_default_config() {
+        let config = QwenConfig::default();
+        assert_eq!(config.region, QwenRegion::International);
+        assert_eq!(
+            config.base_url,
+            "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+        );
+        assert_eq!(config.model, "qwen3-32b");
+        assert_eq!(config.max_tokens, Some(4096));
+        assert_eq!(config.temperature, Some(0.7));
+    }
+}

--- a/crates/arkavo-qwen/src/client.rs
+++ b/crates/arkavo-qwen/src/client.rs
@@ -93,11 +93,15 @@ impl QwenClient {
             .and_then(|r| QwenRegion::parse(&r))
             .unwrap_or_default();
 
-        let base_url =
-            std::env::var("DASHSCOPE_BASE_URL").unwrap_or_else(|_| region.base_url().to_string());
+        let base_url = match std::env::var("DASHSCOPE_BASE_URL") {
+            Ok(url) => url,
+            Err(_) => region.base_url().to_string(),
+        };
 
-        let model = std::env::var("QWEN_MODEL")
-            .unwrap_or_else(|_| QwenModel::default().as_str().to_string());
+        let model = match std::env::var("QWEN_MODEL") {
+            Ok(m) => m,
+            Err(_) => QwenModel::default().as_str().to_string(),
+        };
 
         let config = QwenConfig {
             api_key,
@@ -173,6 +177,32 @@ impl QwenClient {
     }
 
     async fn send_request(&self, request: ChatCompletionRequest) -> Result<ChatCompletionResponse> {
+        let mut last_error = None;
+
+        for attempt in 0..=self.config.max_retries {
+            if attempt > 0 {
+                let backoff = self.calculate_backoff(attempt, last_error.as_ref());
+                debug!("Retry attempt {}/{}, waiting {}ms", attempt, self.config.max_retries, backoff.as_millis());
+                tokio::time::sleep(backoff).await;
+            }
+
+            match self.try_send_request(&request).await {
+                Ok(response) => return Ok(response),
+                Err(e) if e.is_retryable() && attempt < self.config.max_retries => {
+                    debug!("Request failed with retryable error: {}", e);
+                    last_error = Some(e);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| QwenError::ApiError {
+            status: 500,
+            message: "Max retries exceeded".to_string(),
+        }))
+    }
+
+    async fn try_send_request(&self, request: &ChatCompletionRequest) -> Result<ChatCompletionResponse> {
         let url = format!("{}/chat/completions", self.config.base_url);
 
         debug!("Sending request to Qwen API: {}", url);
@@ -182,17 +212,18 @@ impl QwenClient {
             .post(&url)
             .header("Authorization", format!("Bearer {}", self.config.api_key))
             .header("Content-Type", "application/json")
-            .json(&request)
+            .json(request)
             .send()
             .await?;
 
         let status = response.status();
+        let headers = response.headers().clone();
 
         if !status.is_success() {
             let error_text = response.text().await?;
 
             if let Ok(error_response) = serde_json::from_str::<ErrorResponse>(&error_text) {
-                return Err(self.map_api_error(status, error_response));
+                return Err(self.map_api_error(status, error_response, &headers));
             }
 
             return Err(QwenError::ApiError {
@@ -203,6 +234,18 @@ impl QwenClient {
 
         let completion: ChatCompletionResponse = response.json().await?;
         Ok(completion)
+    }
+
+    fn calculate_backoff(&self, attempt: u32, error: Option<&QwenError>) -> Duration {
+        if let Some(QwenError::RateLimitExceeded { retry_after: Some(seconds), .. }) = error {
+            return Duration::from_secs(*seconds);
+        }
+
+        let base_ms = 1000u64;
+        let backoff_ms = base_ms * 2u64.pow(attempt - 1);
+        let max_backoff_ms = 60_000u64;
+
+        Duration::from_millis(backoff_ms.min(max_backoff_ms))
     }
 
     async fn send_stream_request(&self, request: ChatCompletionRequest) -> Result<SseStream> {
@@ -220,12 +263,13 @@ impl QwenClient {
             .await?;
 
         let status = response.status();
+        let headers = response.headers().clone();
 
         if !status.is_success() {
             let error_text = response.text().await?;
 
             if let Ok(error_response) = serde_json::from_str::<ErrorResponse>(&error_text) {
-                return Err(self.map_api_error(status, error_response));
+                return Err(self.map_api_error(status, error_response, &headers));
             }
 
             return Err(QwenError::ApiError {
@@ -238,14 +282,21 @@ impl QwenClient {
         Ok(SseStream::new(stream))
     }
 
-    fn map_api_error(&self, status: StatusCode, error: ErrorResponse) -> QwenError {
+    fn map_api_error(&self, status: StatusCode, error: ErrorResponse, headers: &reqwest::header::HeaderMap) -> QwenError {
         match status {
             StatusCode::UNAUTHORIZED => QwenError::AuthenticationFailed {
                 message: error.error.message,
             },
-            StatusCode::TOO_MANY_REQUESTS => QwenError::RateLimitExceeded {
-                message: error.error.message,
-                retry_after: None,
+            StatusCode::TOO_MANY_REQUESTS => {
+                let retry_after = headers
+                    .get("retry-after")
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|s| s.parse::<u64>().ok());
+
+                QwenError::RateLimitExceeded {
+                    message: error.error.message,
+                    retry_after,
+                }
             },
             StatusCode::NOT_FOUND => {
                 if error.error.message.to_lowercase().contains("model") {

--- a/crates/arkavo-qwen/src/client.rs
+++ b/crates/arkavo-qwen/src/client.rs
@@ -182,7 +182,12 @@ impl QwenClient {
         for attempt in 0..=self.config.max_retries {
             if attempt > 0 {
                 let backoff = self.calculate_backoff(attempt, last_error.as_ref());
-                debug!("Retry attempt {}/{}, waiting {}ms", attempt, self.config.max_retries, backoff.as_millis());
+                debug!(
+                    "Retry attempt {}/{}, waiting {}ms",
+                    attempt,
+                    self.config.max_retries,
+                    backoff.as_millis()
+                );
                 tokio::time::sleep(backoff).await;
             }
 
@@ -202,7 +207,10 @@ impl QwenClient {
         }))
     }
 
-    async fn try_send_request(&self, request: &ChatCompletionRequest) -> Result<ChatCompletionResponse> {
+    async fn try_send_request(
+        &self,
+        request: &ChatCompletionRequest,
+    ) -> Result<ChatCompletionResponse> {
         let url = format!("{}/chat/completions", self.config.base_url);
 
         debug!("Sending request to Qwen API: {}", url);
@@ -237,7 +245,11 @@ impl QwenClient {
     }
 
     fn calculate_backoff(&self, attempt: u32, error: Option<&QwenError>) -> Duration {
-        if let Some(QwenError::RateLimitExceeded { retry_after: Some(seconds), .. }) = error {
+        if let Some(QwenError::RateLimitExceeded {
+            retry_after: Some(seconds),
+            ..
+        }) = error
+        {
             return Duration::from_secs(*seconds);
         }
 
@@ -282,7 +294,12 @@ impl QwenClient {
         Ok(SseStream::new(stream))
     }
 
-    fn map_api_error(&self, status: StatusCode, error: ErrorResponse, headers: &reqwest::header::HeaderMap) -> QwenError {
+    fn map_api_error(
+        &self,
+        status: StatusCode,
+        error: ErrorResponse,
+        headers: &reqwest::header::HeaderMap,
+    ) -> QwenError {
         match status {
             StatusCode::UNAUTHORIZED => QwenError::AuthenticationFailed {
                 message: error.error.message,
@@ -297,7 +314,7 @@ impl QwenClient {
                     message: error.error.message,
                     retry_after,
                 }
-            },
+            }
             StatusCode::NOT_FOUND => {
                 if error.error.message.to_lowercase().contains("model") {
                     QwenError::ModelNotFound {

--- a/crates/arkavo-qwen/src/error.rs
+++ b/crates/arkavo-qwen/src/error.rs
@@ -1,0 +1,132 @@
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, QwenError>;
+
+#[derive(Error, Debug)]
+pub enum QwenError {
+    #[error("Configuration error: {message}")]
+    ConfigError { message: String },
+
+    #[error("Authentication failed: {message}")]
+    AuthenticationFailed { message: String },
+
+    #[error("Rate limit exceeded: {message}, retry_after: {retry_after:?}")]
+    RateLimitExceeded {
+        message: String,
+        retry_after: Option<u64>,
+    },
+
+    #[error("Model not found: {model}")]
+    ModelNotFound { model: String },
+
+    #[error("Invalid request: {message}")]
+    InvalidRequest { message: String },
+
+    #[error("API error: {status} - {message}")]
+    ApiError { status: u16, message: String },
+
+    #[error("Network error: {0}")]
+    NetworkError(#[from] reqwest::Error),
+
+    #[error("JSON error: {0}")]
+    JsonError(#[from] serde_json::Error),
+
+    #[error("Stream error: {message}")]
+    StreamError { message: String },
+
+    #[error("Vision not supported: {model}")]
+    VisionNotSupported { model: String },
+
+    #[error("Tools not supported: {model}")]
+    ToolsNotSupported { model: String },
+
+    #[error("Internal error: {message}")]
+    InternalError { message: String },
+
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+}
+
+impl QwenError {
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            QwenError::RateLimitExceeded { .. } => true,
+            QwenError::ApiError { status, .. } if *status >= 500 => true,
+            QwenError::NetworkError(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn retry_after(&self) -> Option<u64> {
+        match self {
+            QwenError::RateLimitExceeded { retry_after, .. } => *retry_after,
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_display() {
+        let err = QwenError::ConfigError {
+            message: "Invalid API key".to_string(),
+        };
+        assert_eq!(err.to_string(), "Configuration error: Invalid API key");
+
+        let err = QwenError::ModelNotFound {
+            model: "qwen3-999b".to_string(),
+        };
+        assert_eq!(err.to_string(), "Model not found: qwen3-999b");
+    }
+
+    #[test]
+    fn test_retryable_errors() {
+        assert!(
+            QwenError::RateLimitExceeded {
+                message: "Too many requests".to_string(),
+                retry_after: Some(60),
+            }
+            .is_retryable()
+        );
+
+        assert!(
+            QwenError::ApiError {
+                status: 503,
+                message: "Service unavailable".to_string(),
+            }
+            .is_retryable()
+        );
+
+        assert!(
+            !QwenError::ConfigError {
+                message: "Bad config".to_string(),
+            }
+            .is_retryable()
+        );
+
+        assert!(
+            !QwenError::ApiError {
+                status: 400,
+                message: "Bad request".to_string(),
+            }
+            .is_retryable()
+        );
+    }
+
+    #[test]
+    fn test_retry_after() {
+        let err = QwenError::RateLimitExceeded {
+            message: "Rate limited".to_string(),
+            retry_after: Some(120),
+        };
+        assert_eq!(err.retry_after(), Some(120));
+
+        let err = QwenError::ConfigError {
+            message: "Bad config".to_string(),
+        };
+        assert_eq!(err.retry_after(), None);
+    }
+}

--- a/crates/arkavo-qwen/src/lib.rs
+++ b/crates/arkavo-qwen/src/lib.rs
@@ -1,0 +1,15 @@
+pub mod client;
+pub mod error;
+pub mod models;
+pub mod provider;
+pub mod stream;
+pub mod types;
+pub mod vision;
+
+pub use client::{QwenClient, QwenConfig, QwenRegion};
+pub use error::{QwenError, Result};
+pub use models::QwenModel;
+pub use provider::{Message, MessageRole, Provider, QwenProvider};
+pub use stream::StreamResponse;
+pub use types::{ChatMessage, Role, Tool, ToolChoice, ToolFunction};
+pub use vision::{create_image_part, create_image_url_from_file, encode_image_file};

--- a/crates/arkavo-qwen/src/models.rs
+++ b/crates/arkavo-qwen/src/models.rs
@@ -1,0 +1,173 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub enum QwenModel {
+    Qwen3_235bA22b,
+    #[default]
+    Qwen3_32b,
+    Qwen3_30bA3b,
+    Qwen3_14b,
+    Qwen3_8b,
+    Qwen3_4b,
+    Qwen3_1_7b,
+    Qwen3_0_6b,
+    QwenMax,
+    QwenPlus,
+    QwenTurbo,
+    QwenVlMax,
+    QwenVlMaxLatest,
+    QwenVlPlus,
+    QwenVlPlusLatest,
+    Qwen3VlPlus,
+    Qwen3Vl235bA22bThinking,
+    Qwen3Vl235bA22bInstruct,
+    Custom(String),
+}
+
+impl QwenModel {
+    pub fn as_str(&self) -> &str {
+        match self {
+            QwenModel::Qwen3_235bA22b => "qwen3-235b-a22b",
+            QwenModel::Qwen3_32b => "qwen3-32b",
+            QwenModel::Qwen3_30bA3b => "qwen3-30b-a3b",
+            QwenModel::Qwen3_14b => "qwen3-14b",
+            QwenModel::Qwen3_8b => "qwen3-8b",
+            QwenModel::Qwen3_4b => "qwen3-4b",
+            QwenModel::Qwen3_1_7b => "qwen3-1.7b",
+            QwenModel::Qwen3_0_6b => "qwen3-0.6b",
+            QwenModel::QwenMax => "qwen-max",
+            QwenModel::QwenPlus => "qwen-plus",
+            QwenModel::QwenTurbo => "qwen-turbo",
+            QwenModel::QwenVlMax => "qwen-vl-max",
+            QwenModel::QwenVlMaxLatest => "qwen-vl-max-latest",
+            QwenModel::QwenVlPlus => "qwen-vl-plus",
+            QwenModel::QwenVlPlusLatest => "qwen-vl-plus-latest",
+            QwenModel::Qwen3VlPlus => "qwen3-vl-plus",
+            QwenModel::Qwen3Vl235bA22bThinking => "qwen3-vl-235b-a22b-thinking",
+            QwenModel::Qwen3Vl235bA22bInstruct => "qwen3-vl-235b-a22b-instruct",
+            QwenModel::Custom(s) => s.as_str(),
+        }
+    }
+
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "qwen3-235b-a22b" => QwenModel::Qwen3_235bA22b,
+            "qwen3-32b" => QwenModel::Qwen3_32b,
+            "qwen3-30b-a3b" => QwenModel::Qwen3_30bA3b,
+            "qwen3-14b" => QwenModel::Qwen3_14b,
+            "qwen3-8b" => QwenModel::Qwen3_8b,
+            "qwen3-4b" => QwenModel::Qwen3_4b,
+            "qwen3-1.7b" => QwenModel::Qwen3_1_7b,
+            "qwen3-0.6b" => QwenModel::Qwen3_0_6b,
+            "qwen-max" => QwenModel::QwenMax,
+            "qwen-plus" => QwenModel::QwenPlus,
+            "qwen-turbo" => QwenModel::QwenTurbo,
+            "qwen-vl-max" => QwenModel::QwenVlMax,
+            "qwen-vl-max-latest" => QwenModel::QwenVlMaxLatest,
+            "qwen-vl-plus" => QwenModel::QwenVlPlus,
+            "qwen-vl-plus-latest" => QwenModel::QwenVlPlusLatest,
+            "qwen3-vl-plus" => QwenModel::Qwen3VlPlus,
+            "qwen3-vl-235b-a22b-thinking" => QwenModel::Qwen3Vl235bA22bThinking,
+            "qwen3-vl-235b-a22b-instruct" => QwenModel::Qwen3Vl235bA22bInstruct,
+            other => QwenModel::Custom(other.to_string()),
+        }
+    }
+
+    pub fn supports_vision(&self) -> bool {
+        matches!(
+            self,
+            QwenModel::QwenVlMax
+                | QwenModel::QwenVlMaxLatest
+                | QwenModel::QwenVlPlus
+                | QwenModel::QwenVlPlusLatest
+                | QwenModel::Qwen3VlPlus
+                | QwenModel::Qwen3Vl235bA22bThinking
+                | QwenModel::Qwen3Vl235bA22bInstruct
+        )
+    }
+
+    pub fn supports_tools(&self) -> bool {
+        !matches!(
+            self,
+            QwenModel::Qwen3Vl235bA22bThinking | QwenModel::Custom(_)
+        )
+    }
+
+    pub fn supports_thinking(&self) -> bool {
+        matches!(
+            self,
+            QwenModel::Qwen3Vl235bA22bThinking | QwenModel::Qwen3VlPlus
+        )
+    }
+
+    pub fn is_text_only(&self) -> bool {
+        !self.supports_vision()
+    }
+}
+
+impl std::fmt::Display for QwenModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_model_serialization() {
+        assert_eq!(QwenModel::Qwen3_32b.as_str(), "qwen3-32b");
+        assert_eq!(QwenModel::QwenVlMaxLatest.as_str(), "qwen-vl-max-latest");
+        assert_eq!(
+            QwenModel::Qwen3Vl235bA22bThinking.as_str(),
+            "qwen3-vl-235b-a22b-thinking"
+        );
+    }
+
+    #[test]
+    fn test_model_parsing() {
+        assert_eq!(QwenModel::parse("qwen3-32b"), QwenModel::Qwen3_32b);
+        assert_eq!(
+            QwenModel::parse("qwen-vl-max-latest"),
+            QwenModel::QwenVlMaxLatest
+        );
+        assert_eq!(
+            QwenModel::parse("custom-model"),
+            QwenModel::Custom("custom-model".to_string())
+        );
+    }
+
+    #[test]
+    fn test_vision_support() {
+        assert!(QwenModel::QwenVlMax.supports_vision());
+        assert!(QwenModel::Qwen3VlPlus.supports_vision());
+        assert!(!QwenModel::Qwen3_32b.supports_vision());
+        assert!(!QwenModel::QwenMax.supports_vision());
+    }
+
+    #[test]
+    fn test_tool_support() {
+        assert!(QwenModel::Qwen3_32b.supports_tools());
+        assert!(QwenModel::QwenMax.supports_tools());
+        assert!(!QwenModel::Qwen3Vl235bA22bThinking.supports_tools());
+    }
+
+    #[test]
+    fn test_thinking_support() {
+        assert!(QwenModel::Qwen3Vl235bA22bThinking.supports_thinking());
+        assert!(QwenModel::Qwen3VlPlus.supports_thinking());
+        assert!(!QwenModel::Qwen3_32b.supports_thinking());
+    }
+
+    #[test]
+    fn test_default_model() {
+        assert_eq!(QwenModel::default(), QwenModel::Qwen3_32b);
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(format!("{}", QwenModel::Qwen3_14b), "qwen3-14b");
+        assert_eq!(format!("{}", QwenModel::QwenVlMax), "qwen-vl-max");
+    }
+}

--- a/crates/arkavo-qwen/src/provider.rs
+++ b/crates/arkavo-qwen/src/provider.rs
@@ -1,0 +1,269 @@
+use crate::client::{QwenClient, QwenConfig};
+use crate::error::{QwenError, Result};
+use crate::models::QwenModel;
+use crate::stream::StreamResponse;
+use crate::types::{ChatMessage, MessageContent, Role};
+use crate::vision::create_image_part;
+use async_trait::async_trait;
+use futures::Stream;
+
+pub type LlmError = QwenError;
+pub type LlmResult<T> = Result<T>;
+
+#[async_trait]
+pub trait Provider: Send + Sync {
+    async fn complete(&self, messages: Vec<Message>) -> LlmResult<String>;
+    async fn stream(
+        &self,
+        messages: Vec<Message>,
+    ) -> LlmResult<Box<dyn Stream<Item = LlmResult<StreamResponse>> + Send + Unpin>>;
+    fn name(&self) -> &'static str;
+}
+
+#[derive(Debug, Clone)]
+pub struct Message {
+    pub role: MessageRole,
+    pub content: String,
+    pub images: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MessageRole {
+    System,
+    User,
+    Assistant,
+}
+
+pub struct QwenProvider {
+    client: QwenClient,
+    model: QwenModel,
+}
+
+impl QwenProvider {
+    pub fn new(config: QwenConfig) -> LlmResult<Self> {
+        let model_str = config.model.clone();
+        let client = QwenClient::new(config)?;
+        let model = QwenModel::parse(&model_str);
+        Ok(Self { client, model })
+    }
+
+    pub fn from_env() -> LlmResult<Self> {
+        let client = QwenClient::from_env()?;
+        let model = QwenModel::parse(&client.config().model);
+        Ok(Self { client, model })
+    }
+
+    pub fn with_temperature(mut self, temperature: f32) -> Self {
+        self.client = self.client.with_temperature(temperature);
+        self
+    }
+
+    pub fn with_top_p(mut self, top_p: f32) -> Self {
+        self.client = self.client.with_top_p(top_p);
+        self
+    }
+
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+        self.client = self.client.with_max_tokens(max_tokens);
+        self
+    }
+
+    pub fn client(&self) -> &QwenClient {
+        &self.client
+    }
+
+    fn convert_messages(&self, messages: Vec<Message>) -> LlmResult<Vec<ChatMessage>> {
+        messages
+            .into_iter()
+            .map(|msg| self.convert_message(msg))
+            .collect()
+    }
+
+    fn convert_message(&self, msg: Message) -> LlmResult<ChatMessage> {
+        let role = match msg.role {
+            MessageRole::System => Role::System,
+            MessageRole::User => Role::User,
+            MessageRole::Assistant => Role::Assistant,
+        };
+
+        let content = if let Some(images) = msg.images {
+            if !self.model.supports_vision() {
+                return Err(QwenError::VisionNotSupported {
+                    model: self.model.to_string(),
+                });
+            }
+
+            let mut parts = vec![];
+            if !msg.content.is_empty() {
+                parts.push(crate::types::ContentPart::Text { text: msg.content });
+            }
+
+            for image in images {
+                parts.push(create_image_part(&image));
+            }
+
+            MessageContent::Parts(parts)
+        } else {
+            MessageContent::Text(msg.content)
+        };
+
+        Ok(ChatMessage {
+            role,
+            content,
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+        })
+    }
+}
+
+#[async_trait]
+impl Provider for QwenProvider {
+    async fn complete(&self, messages: Vec<Message>) -> LlmResult<String> {
+        let qwen_messages = self.convert_messages(messages)?;
+
+        let response = self.client.complete(qwen_messages, None, None).await?;
+
+        if let Some(choice) = response.choices.first() {
+            match &choice.message.content {
+                MessageContent::Text(text) => Ok(text.clone()),
+                MessageContent::Parts(parts) => {
+                    let text = parts
+                        .iter()
+                        .filter_map(|p| match p {
+                            crate::types::ContentPart::Text { text } => Some(text.as_str()),
+                            _ => None,
+                        })
+                        .collect::<Vec<_>>()
+                        .join("");
+                    Ok(text)
+                }
+            }
+        } else {
+            Err(QwenError::InternalError {
+                message: "No choices in response".to_string(),
+            })
+        }
+    }
+
+    async fn stream(
+        &self,
+        messages: Vec<Message>,
+    ) -> LlmResult<Box<dyn Stream<Item = LlmResult<StreamResponse>> + Send + Unpin>> {
+        let qwen_messages = self.convert_messages(messages)?;
+
+        let stream = self.client.stream(qwen_messages, None, None).await?;
+
+        Ok(Box::new(Box::pin(stream)))
+    }
+
+    fn name(&self) -> &'static str {
+        "qwen"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::QwenRegion;
+
+    #[test]
+    fn test_message_conversion_text_only() {
+        let config = QwenConfig {
+            api_key: "test_key".to_string(),
+            base_url: QwenRegion::International.base_url().to_string(),
+            model: "qwen3-32b".to_string(),
+            region: QwenRegion::International,
+            ..Default::default()
+        };
+
+        let provider = QwenProvider::new(config).unwrap();
+
+        let messages = vec![
+            Message {
+                role: MessageRole::System,
+                content: "You are a helpful assistant".to_string(),
+                images: None,
+            },
+            Message {
+                role: MessageRole::User,
+                content: "Hello".to_string(),
+                images: None,
+            },
+        ];
+
+        let converted = provider.convert_messages(messages).unwrap();
+        assert_eq!(converted.len(), 2);
+        assert_eq!(converted[0].role, Role::System);
+        assert_eq!(converted[1].role, Role::User);
+    }
+
+    #[test]
+    fn test_message_conversion_with_vision() {
+        let config = QwenConfig {
+            api_key: "test_key".to_string(),
+            base_url: QwenRegion::International.base_url().to_string(),
+            model: "qwen-vl-max".to_string(),
+            region: QwenRegion::International,
+            ..Default::default()
+        };
+
+        let provider = QwenProvider::new(config).unwrap();
+
+        let messages = vec![Message {
+            role: MessageRole::User,
+            content: "What's in this image?".to_string(),
+            images: Some(vec!["iVBORw0KGg==".to_string()]),
+        }];
+
+        let converted = provider.convert_messages(messages).unwrap();
+        assert_eq!(converted.len(), 1);
+
+        match &converted[0].content {
+            MessageContent::Parts(parts) => {
+                assert_eq!(parts.len(), 2);
+            }
+            _ => panic!("Expected Parts content"),
+        }
+    }
+
+    #[test]
+    fn test_vision_not_supported_error() {
+        let config = QwenConfig {
+            api_key: "test_key".to_string(),
+            base_url: QwenRegion::International.base_url().to_string(),
+            model: "qwen3-32b".to_string(),
+            region: QwenRegion::International,
+            ..Default::default()
+        };
+
+        let provider = QwenProvider::new(config).unwrap();
+
+        let messages = vec![Message {
+            role: MessageRole::User,
+            content: "What's in this image?".to_string(),
+            images: Some(vec!["iVBORw0KGg==".to_string()]),
+        }];
+
+        let result = provider.convert_messages(messages);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            QwenError::VisionNotSupported { .. }
+        ));
+    }
+
+    #[test]
+    fn test_builder_pattern() {
+        let config = QwenConfig::default();
+        let provider = QwenProvider::new(config)
+            .unwrap()
+            .with_temperature(0.8)
+            .with_top_p(0.9)
+            .with_max_tokens(2048);
+
+        assert_eq!(provider.client.config().temperature, Some(0.8));
+        assert_eq!(provider.client.config().top_p, Some(0.9));
+        assert_eq!(provider.client.config().max_tokens, Some(2048));
+    }
+}

--- a/crates/arkavo-qwen/src/provider.rs
+++ b/crates/arkavo-qwen/src/provider.rs
@@ -3,7 +3,7 @@ use crate::error::{QwenError, Result};
 use crate::models::QwenModel;
 use crate::stream::StreamResponse;
 use crate::types::{ChatMessage, MessageContent, Role};
-use crate::vision::create_image_part;
+use crate::vision::{create_image_part, validate_image_size};
 use async_trait::async_trait;
 use futures::Stream;
 
@@ -99,6 +99,7 @@ impl QwenProvider {
             }
 
             for image in images {
+                validate_image_size(&image, 10)?;
                 parts.push(create_image_part(&image));
             }
 

--- a/crates/arkavo-qwen/src/stream.rs
+++ b/crates/arkavo-qwen/src/stream.rs
@@ -1,0 +1,182 @@
+use crate::error::{QwenError, Result};
+use crate::types::{StreamChunk, ToolCall};
+use bytes::Bytes;
+use futures::{Stream, StreamExt};
+use serde::{Deserialize, Serialize};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::sync::mpsc;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamResponse {
+    pub content: String,
+    pub done: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+}
+
+pub struct SseStream {
+    rx: mpsc::Receiver<Result<StreamResponse>>,
+}
+
+impl SseStream {
+    pub fn new(body: impl Stream<Item = reqwest::Result<Bytes>> + Send + 'static) -> Self {
+        let (tx, rx) = mpsc::channel(100);
+
+        tokio::spawn(async move {
+            let mut buffer = String::new();
+            let mut stream = Box::pin(body);
+
+            while let Some(chunk_result) = stream.next().await {
+                match chunk_result {
+                    Ok(bytes) => {
+                        buffer.push_str(&String::from_utf8_lossy(&bytes));
+
+                        while let Some(newline_pos) = buffer.find('\n') {
+                            let line = buffer[..newline_pos].trim().to_string();
+                            buffer.drain(..=newline_pos);
+
+                            if line.is_empty() {
+                                continue;
+                            }
+
+                            if let Some(data) = line.strip_prefix("data: ") {
+                                if data.trim() == "[DONE]" {
+                                    let _ = tx
+                                        .send(Ok(StreamResponse {
+                                            content: String::new(),
+                                            done: true,
+                                            tool_calls: None,
+                                        }))
+                                        .await;
+                                    return;
+                                }
+
+                                match serde_json::from_str::<StreamChunk>(data) {
+                                    Ok(chunk) => {
+                                        for choice in chunk.choices {
+                                            if let Some(content) = choice.delta.content {
+                                                let response = StreamResponse {
+                                                    content,
+                                                    done: choice.finish_reason.is_some(),
+                                                    tool_calls: choice.delta.tool_calls,
+                                                };
+
+                                                if tx.send(Ok(response)).await.is_err() {
+                                                    return;
+                                                }
+                                            }
+                                        }
+                                    }
+                                    Err(e) => {
+                                        let _ = tx
+                                            .send(Err(QwenError::StreamError {
+                                                message: format!("Failed to parse chunk: {e}"),
+                                            }))
+                                            .await;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        let _ = tx.send(Err(QwenError::NetworkError(e))).await;
+                        return;
+                    }
+                }
+            }
+        });
+
+        Self { rx }
+    }
+}
+
+impl Stream for SseStream {
+    type Item = Result<StreamResponse>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.rx.poll_recv(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+
+    #[tokio::test]
+    async fn test_sse_stream_simple_content() {
+        let data = r#"data: {"id":"1","object":"chat.completion.chunk","created":1234567890,"model":"qwen3-32b","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}
+
+data: {"id":"1","object":"chat.completion.chunk","created":1234567890,"model":"qwen3-32b","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}
+
+data: [DONE]
+"#;
+
+        let body_stream = stream::once(async move { Ok(Bytes::from(data)) });
+        let mut sse_stream = SseStream::new(body_stream);
+
+        let mut responses = Vec::new();
+        while let Some(result) = sse_stream.next().await {
+            responses.push(result.unwrap());
+        }
+
+        assert_eq!(responses.len(), 3);
+        assert_eq!(responses[0].content, "Hello");
+        assert!(!responses[0].done);
+        assert_eq!(responses[1].content, " world");
+        assert!(!responses[1].done);
+        assert!(responses[2].done);
+    }
+
+    #[tokio::test]
+    async fn test_sse_stream_empty_lines() {
+        let data = "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"qwen3-32b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Test\"},\"finish_reason\":null}]}\n\n\ndata: [DONE]\n";
+
+        let body_stream = stream::once(async move { Ok(Bytes::from(data)) });
+        let mut sse_stream = SseStream::new(body_stream);
+
+        let mut responses = Vec::new();
+        while let Some(result) = sse_stream.next().await {
+            responses.push(result.unwrap());
+        }
+
+        assert_eq!(responses.len(), 2);
+        assert_eq!(responses[0].content, "Test");
+        assert!(responses[1].done);
+    }
+
+    #[tokio::test]
+    async fn test_sse_stream_invalid_json() {
+        let data = "data: {invalid json}\ndata: [DONE]\n";
+
+        let body_stream = stream::once(async move { Ok(Bytes::from(data)) });
+        let mut sse_stream = SseStream::new(body_stream);
+
+        let mut got_error = false;
+        while let Some(result) = sse_stream.next().await {
+            if result.is_err() {
+                got_error = true;
+            }
+        }
+
+        assert!(got_error);
+    }
+
+    #[tokio::test]
+    async fn test_sse_stream_immediate_done() {
+        let data = "data: [DONE]\n";
+
+        let body_stream = stream::once(async move { Ok(Bytes::from(data)) });
+        let mut sse_stream = SseStream::new(body_stream);
+
+        let mut responses = Vec::new();
+        while let Some(result) = sse_stream.next().await {
+            responses.push(result.unwrap());
+        }
+
+        assert_eq!(responses.len(), 1);
+        assert!(responses[0].done);
+        assert!(responses[0].content.is_empty());
+    }
+}

--- a/crates/arkavo-qwen/src/types.rs
+++ b/crates/arkavo-qwen/src/types.rs
@@ -1,0 +1,253 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Role {
+    System,
+    User,
+    Assistant,
+    Tool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatMessage {
+    pub role: Role,
+    pub content: MessageContent,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum MessageContent {
+    Text(String),
+    Parts(Vec<ContentPart>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ContentPart {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "image_url")]
+    ImageUrl { image_url: ImageUrl },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImageUrl {
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Tool {
+    #[serde(rename = "type")]
+    pub tool_type: String,
+    pub function: ToolFunction,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolFunction {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub parameters: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub tool_type: String,
+    pub function: FunctionCall,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionCall {
+    pub name: String,
+    pub arguments: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ToolChoice {
+    Auto,
+    None,
+    Required,
+    Function { name: String },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ChatCompletionRequest {
+    pub model: String,
+    pub messages: Vec<ChatMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<Tool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<ToolChoice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ChatCompletionResponse {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    pub choices: Vec<Choice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Usage>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Choice {
+    pub index: u32,
+    pub message: ChatMessage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Usage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StreamChunk {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    pub choices: Vec<StreamChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StreamChoice {
+    pub index: u32,
+    pub delta: StreamDelta,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StreamDelta {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<Role>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ErrorResponse {
+    pub error: ErrorDetail,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ErrorDetail {
+    pub message: String,
+    #[serde(rename = "type")]
+    pub error_type: Option<String>,
+    pub code: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_message_content_text() {
+        let content = MessageContent::Text("Hello".to_string());
+        let json = serde_json::to_string(&content).unwrap();
+        assert_eq!(json, r#""Hello""#);
+    }
+
+    #[test]
+    fn test_message_content_parts() {
+        let parts = vec![
+            ContentPart::Text {
+                text: "Describe this image:".to_string(),
+            },
+            ContentPart::ImageUrl {
+                image_url: ImageUrl {
+                    url: "https://example.com/image.jpg".to_string(),
+                    detail: Some("high".to_string()),
+                },
+            },
+        ];
+        let content = MessageContent::Parts(parts);
+        let _json = serde_json::to_string(&content).unwrap();
+    }
+
+    #[test]
+    fn test_role_serialization() {
+        let role = Role::User;
+        let json = serde_json::to_string(&role).unwrap();
+        assert_eq!(json, r#""user""#);
+
+        let role = Role::Assistant;
+        let json = serde_json::to_string(&role).unwrap();
+        assert_eq!(json, r#""assistant""#);
+    }
+
+    #[test]
+    fn test_tool_serialization() {
+        let tool = Tool {
+            tool_type: "function".to_string(),
+            function: ToolFunction {
+                name: "get_weather".to_string(),
+                description: Some("Get weather for a location".to_string()),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string"}
+                    }
+                }),
+            },
+        };
+        let json = serde_json::to_string(&tool).unwrap();
+        assert!(json.contains("get_weather"));
+    }
+
+    #[test]
+    fn test_chat_request_minimal() {
+        let request = ChatCompletionRequest {
+            model: "qwen3-32b".to_string(),
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content: MessageContent::Text("Hello".to_string()),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            tools: None,
+            tool_choice: None,
+            temperature: None,
+            top_p: None,
+            max_tokens: None,
+            stream: None,
+            stop: None,
+        };
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(json.contains("qwen3-32b"));
+        assert!(json.contains("Hello"));
+    }
+}

--- a/crates/arkavo-qwen/src/vision.rs
+++ b/crates/arkavo-qwen/src/vision.rs
@@ -1,0 +1,156 @@
+use crate::error::{QwenError, Result};
+use crate::types::{ContentPart, ImageUrl};
+use base64::{Engine, engine::general_purpose::STANDARD};
+use std::path::Path;
+
+pub fn create_image_part(base64_data: &str) -> ContentPart {
+    let url = if base64_data.starts_with("data:") {
+        base64_data.to_string()
+    } else {
+        format!("data:image/png;base64,{base64_data}")
+    };
+
+    ContentPart::ImageUrl {
+        image_url: ImageUrl { url, detail: None },
+    }
+}
+
+pub fn create_image_part_with_detail(base64_data: &str, detail: &str) -> ContentPart {
+    let url = if base64_data.starts_with("data:") {
+        base64_data.to_string()
+    } else {
+        format!("data:image/png;base64,{base64_data}")
+    };
+
+    ContentPart::ImageUrl {
+        image_url: ImageUrl {
+            url,
+            detail: Some(detail.to_string()),
+        },
+    }
+}
+
+pub fn create_text_part(text: impl Into<String>) -> ContentPart {
+    ContentPart::Text { text: text.into() }
+}
+
+pub fn encode_image_file(path: &Path) -> Result<String> {
+    let bytes = std::fs::read(path)?;
+    Ok(STANDARD.encode(&bytes))
+}
+
+pub fn create_image_url_from_file(path: &Path) -> Result<String> {
+    let bytes = std::fs::read(path)?;
+    let base64_data = STANDARD.encode(&bytes);
+
+    let extension = path.extension().and_then(|s| s.to_str()).unwrap_or("png");
+
+    let mime_type = match extension.to_lowercase().as_str() {
+        "jpg" | "jpeg" => "image/jpeg",
+        "png" => "image/png",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        _ => "image/png",
+    };
+
+    Ok(format!("data:{mime_type};base64,{base64_data}"))
+}
+
+pub fn validate_image_size(base64_data: &str, max_size_mb: usize) -> Result<()> {
+    let data = if base64_data.starts_with("data:") {
+        base64_data.split(',').nth(1).unwrap_or(base64_data)
+    } else {
+        base64_data
+    };
+
+    let decoded_size = (data.len() * 3) / 4;
+    let max_size_bytes = max_size_mb * 1024 * 1024;
+
+    if decoded_size > max_size_bytes {
+        return Err(QwenError::InvalidRequest {
+            message: format!(
+                "Image size ({} MB) exceeds maximum allowed size ({} MB)",
+                decoded_size / (1024 * 1024),
+                max_size_mb
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_image_part() {
+        let base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+        let part = create_image_part(base64);
+
+        match part {
+            ContentPart::ImageUrl { image_url } => {
+                assert!(image_url.url.starts_with("data:image/png;base64,"));
+                assert_eq!(image_url.detail, None);
+            }
+            _ => panic!("Expected ImageUrl part"),
+        }
+    }
+
+    #[test]
+    fn test_create_image_part_with_existing_data_uri() {
+        let data_uri = "data:image/jpeg;base64,/9j/4AAQSkZJRg==";
+        let part = create_image_part(data_uri);
+
+        match part {
+            ContentPart::ImageUrl { image_url } => {
+                assert_eq!(image_url.url, data_uri);
+            }
+            _ => panic!("Expected ImageUrl part"),
+        }
+    }
+
+    #[test]
+    fn test_create_image_part_with_detail() {
+        let base64 = "iVBORw0KGg==";
+        let part = create_image_part_with_detail(base64, "high");
+
+        match part {
+            ContentPart::ImageUrl { image_url } => {
+                assert!(image_url.url.contains(base64));
+                assert_eq!(image_url.detail, Some("high".to_string()));
+            }
+            _ => panic!("Expected ImageUrl part"),
+        }
+    }
+
+    #[test]
+    fn test_create_text_part() {
+        let part = create_text_part("Hello, world!");
+
+        match part {
+            ContentPart::Text { text } => {
+                assert_eq!(text, "Hello, world!");
+            }
+            _ => panic!("Expected Text part"),
+        }
+    }
+
+    #[test]
+    fn test_validate_image_size_valid() {
+        let small_base64 = "iVBORw0KGg==";
+        assert!(validate_image_size(small_base64, 10).is_ok());
+    }
+
+    #[test]
+    fn test_validate_image_size_with_data_uri() {
+        let data_uri = "data:image/png;base64,iVBORw0KGg==";
+        assert!(validate_image_size(data_uri, 10).is_ok());
+    }
+
+    #[test]
+    fn test_encode_image_file_nonexistent() {
+        let result = encode_image_file(Path::new("/nonexistent/file.png"));
+        assert!(result.is_err());
+    }
+}

--- a/crates/arkavo-qwen/tests/integration_test.rs
+++ b/crates/arkavo-qwen/tests/integration_test.rs
@@ -1,0 +1,214 @@
+use arkavo_qwen::{
+    Message as QwenMessage, MessageRole, Provider, QwenClient, QwenConfig, QwenProvider, QwenRegion,
+};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn test_complete_basic() {
+    let mock_server = MockServer::start().await;
+
+    let response_body = serde_json::json!({
+        "id": "chatcmpl-123",
+        "object": "chat.completion",
+        "created": 1234567890_u64,
+        "model": "qwen3-32b",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "Hello! How can I help you today?"
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30
+        }
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(header("authorization", "Bearer test_api_key"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
+        .mount(&mock_server)
+        .await;
+
+    let config = QwenConfig {
+        api_key: "test_api_key".to_string(),
+        base_url: mock_server.uri(),
+        model: "qwen3-32b".to_string(),
+        region: QwenRegion::International,
+        ..Default::default()
+    };
+
+    let provider = QwenProvider::new(config).unwrap();
+
+    let messages = vec![QwenMessage {
+        role: MessageRole::User,
+        content: "Hello".to_string(),
+        images: None,
+    }];
+
+    let response = provider.complete(messages).await.unwrap();
+    assert!(response.contains("Hello!"));
+}
+
+#[tokio::test]
+async fn test_authentication_error() {
+    let mock_server = MockServer::start().await;
+
+    let error_response = serde_json::json!({
+        "error": {
+            "message": "Invalid API key",
+            "type": "invalid_request_error"
+        }
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(error_response))
+        .mount(&mock_server)
+        .await;
+
+    let config = QwenConfig {
+        api_key: "invalid_key".to_string(),
+        base_url: mock_server.uri(),
+        model: "qwen3-32b".to_string(),
+        region: QwenRegion::International,
+        ..Default::default()
+    };
+
+    let provider = QwenProvider::new(config).unwrap();
+
+    let messages = vec![QwenMessage {
+        role: MessageRole::User,
+        content: "Hello".to_string(),
+        images: None,
+    }];
+
+    let result = provider.complete(messages).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_model_not_found_error() {
+    let mock_server = MockServer::start().await;
+
+    let error_response = serde_json::json!({
+        "error": {
+            "message": "Model not found: qwen3-999b",
+            "type": "invalid_request_error"
+        }
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(error_response))
+        .mount(&mock_server)
+        .await;
+
+    let config = QwenConfig {
+        api_key: "test_key".to_string(),
+        base_url: mock_server.uri(),
+        model: "qwen3-999b".to_string(),
+        region: QwenRegion::International,
+        ..Default::default()
+    };
+
+    let provider = QwenProvider::new(config).unwrap();
+
+    let messages = vec![QwenMessage {
+        role: MessageRole::User,
+        content: "Hello".to_string(),
+        images: None,
+    }];
+
+    let result = provider.complete(messages).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_streaming_basic() {
+    let mock_server = MockServer::start().await;
+
+    let stream_data = "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"qwen3-32b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\ndata: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"qwen3-32b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" world\"},\"finish_reason\":null}]}\n\ndata: [DONE]\n";
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(stream_data))
+        .mount(&mock_server)
+        .await;
+
+    let config = QwenConfig {
+        api_key: "test_key".to_string(),
+        base_url: mock_server.uri(),
+        model: "qwen3-32b".to_string(),
+        region: QwenRegion::International,
+        ..Default::default()
+    };
+
+    let provider = QwenProvider::new(config).unwrap();
+
+    let messages = vec![QwenMessage {
+        role: MessageRole::User,
+        content: "Hello".to_string(),
+        images: None,
+    }];
+
+    use futures::StreamExt;
+    let mut stream = provider.stream(messages).await.unwrap();
+
+    let mut responses = Vec::new();
+    while let Some(result) = stream.next().await {
+        responses.push(result.unwrap());
+    }
+
+    assert!(responses.len() >= 2);
+    assert_eq!(responses[0].content, "Hello");
+    assert_eq!(responses[1].content, " world");
+}
+
+#[tokio::test]
+async fn test_client_builder() {
+    let config = QwenConfig::default();
+    let client = QwenClient::new(config).unwrap();
+
+    let client = client
+        .with_model("qwen3-14b")
+        .with_temperature(0.8)
+        .with_top_p(0.9)
+        .with_max_tokens(2048);
+
+    assert_eq!(client.config().model, "qwen3-14b");
+    assert_eq!(client.config().temperature, Some(0.8));
+    assert_eq!(client.config().top_p, Some(0.9));
+    assert_eq!(client.config().max_tokens, Some(2048));
+}
+
+#[tokio::test]
+async fn test_region_configuration() {
+    let intl_config = QwenConfig {
+        api_key: "test_key".to_string(),
+        region: QwenRegion::International,
+        ..Default::default()
+    };
+
+    assert_eq!(
+        intl_config.base_url,
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+    );
+
+    let cn_config = QwenConfig {
+        api_key: "test_key".to_string(),
+        base_url: QwenRegion::China.base_url().to_string(),
+        region: QwenRegion::China,
+        ..Default::default()
+    };
+
+    assert_eq!(
+        cn_config.base_url,
+        "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    );
+}

--- a/crates/arkavo-qwen/tests/integration_test.rs
+++ b/crates/arkavo-qwen/tests/integration_test.rs
@@ -212,3 +212,222 @@ async fn test_region_configuration() {
         "https://dashscope.aliyuncs.com/compatible-mode/v1"
     );
 }
+
+#[tokio::test]
+async fn test_retry_on_rate_limit() {
+    let mock_server = MockServer::start().await;
+
+    let error_response = serde_json::json!({
+        "error": {
+            "message": "Rate limit exceeded",
+            "type": "rate_limit_error"
+        }
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .set_body_json(&error_response)
+                .insert_header("retry-after", "1"),
+        )
+        .expect(3)
+        .mount(&mock_server)
+        .await;
+
+    let config = QwenConfig {
+        api_key: "test_key".to_string(),
+        base_url: mock_server.uri(),
+        model: "qwen3-32b".to_string(),
+        region: QwenRegion::International,
+        max_retries: 2,
+        ..Default::default()
+    };
+
+    let provider = QwenProvider::new(config).unwrap();
+
+    let messages = vec![QwenMessage {
+        role: MessageRole::User,
+        content: "Hello".to_string(),
+        images: None,
+    }];
+
+    let result = provider.complete(messages).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_retry_on_server_error_then_success() {
+    let mock_server = MockServer::start().await;
+
+    let error_response = serde_json::json!({
+        "error": {
+            "message": "Internal server error",
+            "type": "server_error"
+        }
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(&error_response))
+        .up_to_n_times(1)
+        .mount(&mock_server)
+        .await;
+
+    let success_response = serde_json::json!({
+        "id": "chatcmpl-123",
+        "object": "chat.completion",
+        "created": 1234567890_u64,
+        "model": "qwen3-32b",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "Success after retry"
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30
+        }
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_response))
+        .mount(&mock_server)
+        .await;
+
+    let config = QwenConfig {
+        api_key: "test_key".to_string(),
+        base_url: mock_server.uri(),
+        model: "qwen3-32b".to_string(),
+        region: QwenRegion::International,
+        max_retries: 2,
+        ..Default::default()
+    };
+
+    let provider = QwenProvider::new(config).unwrap();
+
+    let messages = vec![QwenMessage {
+        role: MessageRole::User,
+        content: "Hello".to_string(),
+        images: None,
+    }];
+
+    let result = provider.complete(messages).await;
+    assert!(result.is_ok());
+    assert!(result.unwrap().contains("Success after retry"));
+}
+
+#[tokio::test]
+async fn test_no_retry_on_auth_error() {
+    let mock_server = MockServer::start().await;
+
+    let error_response = serde_json::json!({
+        "error": {
+            "message": "Invalid API key",
+            "type": "invalid_request_error"
+        }
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(error_response))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let config = QwenConfig {
+        api_key: "invalid_key".to_string(),
+        base_url: mock_server.uri(),
+        model: "qwen3-32b".to_string(),
+        region: QwenRegion::International,
+        max_retries: 2,
+        ..Default::default()
+    };
+
+    let provider = QwenProvider::new(config).unwrap();
+
+    let messages = vec![QwenMessage {
+        role: MessageRole::User,
+        content: "Hello".to_string(),
+        images: None,
+    }];
+
+    let result = provider.complete(messages).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_concurrent_streaming() {
+    let mock_server = MockServer::start().await;
+
+    let stream_data = "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"qwen3-32b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\ndata: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"qwen3-32b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" world\"},\"finish_reason\":null}]}\n\ndata: [DONE]\n";
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(stream_data))
+        .mount(&mock_server)
+        .await;
+
+    let config = QwenConfig {
+        api_key: "test_key".to_string(),
+        base_url: mock_server.uri(),
+        model: "qwen3-32b".to_string(),
+        region: QwenRegion::International,
+        ..Default::default()
+    };
+
+    let provider = QwenProvider::new(config).unwrap();
+
+    let messages = vec![QwenMessage {
+        role: MessageRole::User,
+        content: "Hello".to_string(),
+        images: None,
+    }];
+
+    use futures::StreamExt;
+
+    let stream1 = provider.stream(messages.clone()).await.unwrap();
+    let stream2 = provider.stream(messages.clone()).await.unwrap();
+    let stream3 = provider.stream(messages).await.unwrap();
+
+    let task1 = tokio::spawn(async move {
+        let mut count = 0;
+        let mut stream = stream1;
+        while let Some(result) = stream.next().await {
+            result.unwrap();
+            count += 1;
+        }
+        count
+    });
+
+    let task2 = tokio::spawn(async move {
+        let mut count = 0;
+        let mut stream = stream2;
+        while let Some(result) = stream.next().await {
+            result.unwrap();
+            count += 1;
+        }
+        count
+    });
+
+    let task3 = tokio::spawn(async move {
+        let mut count = 0;
+        let mut stream = stream3;
+        while let Some(result) = stream.next().await {
+            result.unwrap();
+            count += 1;
+        }
+        count
+    });
+
+    let (count1, count2, count3) = tokio::join!(task1, task2, task3);
+
+    assert_eq!(count1.unwrap(), 3);
+    assert_eq!(count2.unwrap(), 3);
+    assert_eq!(count3.unwrap(), 3);
+}


### PR DESCRIPTION
## Summary

Implements Qwen-3 (Instruct + Vision) provider integration via DashScope's OpenAI-compatible API per issue #243.

## Features

### Text/Instruct Models
- qwen3-235b-a22b, qwen3-32b, qwen3-30b-a3b, qwen3-14b, qwen3-8b, qwen3-4b
- qwen3-1.7b, qwen3-0.6b (edge deployment)
- qwen-max, qwen-plus, qwen-turbo (commercial)

### Vision Models  
- qwen-vl-max, qwen-vl-plus (production)
- qwen3-vl-plus (with thinking mode)
- qwen3-vl-235b-a22b-thinking, qwen3-vl-235b-a22b-instruct (open-source)

### Capabilities
- SSE streaming responses
- Function/tool calling support
- Image understanding with base64 encoding
- Regional endpoints (International & China)
- OpenAI-compatible API design

## Implementation

Created `arkavo-qwen` crate following existing provider patterns:
- **client.rs** (329 LoC) - DashScope HTTP client with regional endpoints
- **provider.rs** (269 LoC) - Provider trait implementation
- **types.rs** (253 LoC) - OpenAI-compatible request/response types
- **stream.rs** (182 LoC) - SSE streaming support
- **models.rs** (173 LoC) - Model registry with 18+ models
- **vision.rs** (156 LoC) - Image encoding and validation
- **error.rs** (132 LoC) - Comprehensive error handling
- **lib.rs** (15 LoC) - Public exports

Integration with arkavo-llm via adapter pattern (118 LoC)

## Test Coverage
- 40 passing tests (34 unit + 6 integration)
- Mock server tests for API interactions
- Vision input validation
- Streaming and error handling

## Environment Variables
- `DASHSCOPE_API_KEY` - DashScope API key (required)
- `DASHSCOPE_BASE_URL` - Override base URL (optional)
- `DASHSCOPE_REGION` - Region: intl or cn (default: intl)
- `QWEN_MODEL` - Default model (default: qwen3-32b)

## Quality
✅ All files under 400 LoC  
✅ Zero clippy warnings  
✅ Comprehensive documentation  
✅ Integration tests with wiremock  
✅ Follows existing provider patterns

## Version
Bumped to 0.32.0 per semver (new feature)

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)