### PR TITLE
Handle ClaudeSonnet and ClaudeOpus in UI routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-bench"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-claude-code"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "arkavo-authorization",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-code-search"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "arkavo-llm",
  "serde",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "bincode",
  "chrono",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "git2",
  "tempfile",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "accelerate-src",
  "anyhow",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "async-trait",
  "serde",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-core"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "libc",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-workspace"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "arkavo-mcp",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ exclude = ["crates/arkavo-protocol/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.42.1"
+version = "0.42.2"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-cli/src/commands/ui.rs
+++ b/crates/arkavo-cli/src/commands/ui.rs
@@ -541,6 +541,18 @@ async fn create_client_from_routing(
                 Err("Gemini feature not enabled".into())
             }
         }
+        ModelChoice::ClaudeSonnet | ModelChoice::ClaudeOpus => {
+            #[cfg(feature = "llm-remote")]
+            {
+                use arkavo_llm::providers::AnthropicProvider;
+                let provider = Box::new(AnthropicProvider::from_env()?);
+                Ok(LlmClient::new(provider))
+            }
+            #[cfg(not(feature = "llm-remote"))]
+            {
+                Err("Anthropic support requires llm-remote feature".into())
+            }
+        }
         ModelChoice::LocalGemma270M
         | ModelChoice::LocalGemma4B
         | ModelChoice::LocalGemma12B


### PR DESCRIPTION
## Summary

- Add match arm for `ModelChoice::ClaudeSonnet` and `ModelChoice::ClaudeOpus` in `create_client_from_routing` function
- Creates `AnthropicProvider` client when routing selects Claude models in the CEF UI

## Test plan

- [x] `cargo build -p arkavo-cli --features cef-ui` compiles successfully
- [x] `cargo clippy -p arkavo-cli --features llm-remote -- -D warnings` passes

Fixes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)