### PR TITLE
Add LlmConfig to replace unsafe env var mutations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "aligned"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377e4c0ba83e4431b10df45c1d4666f178ea9c552cac93e60c3a88bf32785923"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
 dependencies = [
  "as-slice",
 ]
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-bench"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-claude-code"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "arkavo-authorization",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-code-search"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "chrono",
  "serde",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "arkavo-config-bundle",
  "base64 0.22.1",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "arkavo-llm",
  "serde",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "bincode",
  "chrono",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "git2",
  "tempfile",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "criterion",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "bindgen",
  "cmake",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "async-trait",
  "serde",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-core"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mesh-tools"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "arkavo-mcp",
  "arkavo-mcp-tools",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -928,14 +928,14 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.17",
  "tokio",
- "tower-http 0.6.7",
+ "tower-http 0.6.8",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "libc",
@@ -1074,13 +1074,13 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
  "futures",
- "opentdf 0.8.0",
+ "opentdf 0.9.0",
  "reqwest",
  "serde",
  "serde_json",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-workspace"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1380,9 +1380,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5ce75405893cd713f9ab8e297d8e438f624dde7d706108285f7e17a25a180f"
+checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -1391,9 +1391,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "179c3777a8b5e70e90ea426114ffc565b2c1a9f82f6c4a0c5a34aa6ef5e781b6"
+checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
 dependencies = [
  "cc",
  "cmake",
@@ -1482,7 +1482,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1707,9 +1707,9 @@ checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytecount"
@@ -1893,7 +1893,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2020,9 +2020,9 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
@@ -2122,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
+checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -3431,16 +3431,17 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605183a538e3e2a9c1038635cc5c2d194e2ee8fd0d1b66b8349fad7dbacce5a2"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "log",
  "rustversion",
- "windows 0.61.3",
+ "windows-link",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4192,9 +4193,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -4206,9 +4207,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -4330,7 +4331,7 @@ dependencies = [
  "rgb",
  "tiff",
  "zune-core 0.5.0",
- "zune-jpeg 0.5.5",
+ "zune-jpeg 0.5.7",
 ]
 
 [[package]]
@@ -4388,7 +4389,7 @@ version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
- "console 0.16.1",
+ "console 0.16.2",
  "portable-atomic",
  "unicode-width 0.2.0",
  "unit-prefix",
@@ -5272,7 +5273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5283,13 +5284,13 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.6.0",
 ]
 
 [[package]]
@@ -5658,9 +5659,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80986bbbcf925ebd3be54c26613d861255284584501595cf418320c078945608"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -6321,16 +6322,16 @@ dependencies = [
 
 [[package]]
 name = "opentdf"
-version = "0.8.0"
-source = "git+https://github.com/arkavo-org/opentdf-rs#f7cff313e8daec2404a1a65fb0ea81802e06332a"
+version = "0.9.0"
+source = "git+https://github.com/arkavo-org/opentdf-rs#47d086cab5345862026ea90751c46f4c6afe04b0"
 dependencies = [
  "aes-gcm",
  "aws-lc-rs",
  "base64 0.22.1",
  "chrono",
  "jsonwebtoken",
- "opentdf-crypto 0.8.0",
- "opentdf-protocol 0.8.0",
+ "opentdf-crypto 0.9.0",
+ "opentdf-protocol 0.9.0",
  "pem",
  "rand 0.8.5",
  "reqwest",
@@ -6373,8 +6374,8 @@ dependencies = [
 
 [[package]]
 name = "opentdf-crypto"
-version = "0.8.0"
-source = "git+https://github.com/arkavo-org/opentdf-rs#f7cff313e8daec2404a1a65fb0ea81802e06332a"
+version = "0.9.0"
+source = "git+https://github.com/arkavo-org/opentdf-rs#47d086cab5345862026ea90751c46f4c6afe04b0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -6384,7 +6385,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "k256",
- "opentdf-protocol 0.8.0",
+ "opentdf-protocol 0.9.0",
  "p256",
  "p384",
  "p521",
@@ -6416,8 +6417,8 @@ dependencies = [
 
 [[package]]
 name = "opentdf-protocol"
-version = "0.8.0"
-source = "git+https://github.com/arkavo-org/opentdf-rs#f7cff313e8daec2404a1a65fb0ea81802e06332a"
+version = "0.9.0"
+source = "git+https://github.com/arkavo-org/opentdf-rs#47d086cab5345862026ea90751c46f4c6afe04b0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -6525,9 +6526,9 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -7011,7 +7012,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.23.9",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -7423,6 +7424,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec96166dafa0886eb81fe1c0a388bece180fbef2135f97c1e2cf8302e74b43b5"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7520,9 +7530,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7556,7 +7566,7 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.2",
- "tower-http 0.6.7",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -7748,9 +7758,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "web-time",
  "zeroize",
@@ -8230,9 +8240,9 @@ checksum = "2a0251c9d6468f4ba853b6352b190fb7c1e405087779917c238445eb03993826"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simd_helpers"
@@ -9216,9 +9226,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "0.7.4+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "fe3cea6b2aa3b910092f6abd4053ea464fab5f9c170ba5e9a6aead16ec4af2b6"
 dependencies = [
  "serde_core",
 ]
@@ -9239,21 +9249,21 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.9"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap 2.12.1",
- "toml_datetime 0.7.3",
+ "toml_datetime 0.7.4+spec-1.0.0",
  "toml_parser",
  "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.0.5+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "4c03bee5ce3696f31250db0bbaff18bc43301ce0e8db2ed1f07cbb2acf89984c"
 dependencies = [
  "winnow",
 ]
@@ -9352,9 +9362,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
@@ -9500,9 +9510,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-language"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
+checksum = "4ae62f7eae5eb549c71b76658648b72cc6111f2d87d24a1e31fa907f4943e3ce"
 
 [[package]]
 name = "tree-sitter-python"
@@ -10116,36 +10126,14 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections 0.2.0",
- "windows-core 0.61.2",
- "windows-future 0.2.1",
- "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.2",
+ "windows-collections",
  "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -10172,39 +10160,15 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement 0.60.2",
  "windows-interface 0.59.3",
- "windows-link 0.2.1",
+ "windows-link",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -10214,8 +10178,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
  "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -10264,25 +10228,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-numerics"
@@ -10291,7 +10239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -10300,7 +10248,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
 ]
@@ -10316,20 +10264,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -10344,20 +10283,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -10411,7 +10341,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -10466,7 +10396,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -10479,20 +10409,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -11008,9 +10929,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fb7703e32e9a07fb3f757360338b3a567a5054f21b5f52a666752e333d58e"
+checksum = "51d915729b0e7d5fe35c2f294c5dc10b30207cc637920e5b59077bfa3da63f28"
 dependencies = [
  "zune-core 0.5.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,8 @@ exclude = ["crates/arkavo-protocol/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.47.2"
+
+version = "0.47.3"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-cli/src/commands/chat.rs
+++ b/crates/arkavo-cli/src/commands/chat.rs
@@ -1,6 +1,6 @@
 use crate::conversation_manager::ConversationManager;
 use crate::mcp_integration::McpConnection;
-use arkavo_llm::{LlmClient, Message, encode_image_file};
+use arkavo_llm::{LlmClient, LlmConfig, Message, encode_image_file};
 use arkavo_memory::storage::MemoryStorage;
 use arkavo_repo::repository_context::RepositoryContextManager;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -1735,12 +1735,13 @@ async fn initialize_llm_client(
 ) -> Result<LlmClient, Box<dyn std::error::Error>> {
     // Check if model_name specifies a provider directly
     if model_name == "deepseek" {
-        // Set environment variable for DeepSeek provider
-        // SAFETY: This is safe as we're only setting the env var once during initialization
-        unsafe {
-            std::env::set_var("LLM_PROVIDER", "deepseek");
-        }
-        if let Ok(client) = LlmClient::from_env() {
+        // Create config for DeepSeek provider (reads API key from env at startup)
+        let config = LlmConfig::from_env();
+        let config = LlmConfig {
+            provider: "deepseek".to_string(),
+            ..config
+        };
+        if let Ok(client) = LlmClient::from_config(&config) {
             if !print_mode {
                 println!("✓ Connected to DeepSeek API");
             }
@@ -1749,12 +1750,13 @@ async fn initialize_llm_client(
             println!("Failed to connect to DeepSeek. Check DEEPSEEK_API_KEY environment variable.");
         }
     } else if model_name == "kimi" {
-        // Set environment variable for Kimi provider
-        // SAFETY: This is safe as we're only setting the env var once during initialization
-        unsafe {
-            std::env::set_var("LLM_PROVIDER", "kimi");
-        }
-        if let Ok(client) = LlmClient::from_env() {
+        // Create config for Kimi provider
+        let config = LlmConfig::from_env();
+        let config = LlmConfig {
+            provider: "kimi".to_string(),
+            ..config
+        };
+        if let Ok(client) = LlmClient::from_config(&config) {
             if !print_mode {
                 println!("✓ Connected to Kimi API");
             }
@@ -1763,15 +1765,13 @@ async fn initialize_llm_client(
             println!("Failed to connect to Kimi. Check MOONSHOT_API_KEY environment variable.");
         }
     } else if model_name == "gemini" || model_name.starts_with("gemini-") {
-        // Set environment variable for Gemini provider
-        // SAFETY: This is safe as we're only setting the env var once during initialization
-        unsafe {
-            std::env::set_var("LLM_PROVIDER", "gemini");
-            if model_name.starts_with("gemini-") {
-                std::env::set_var("GEMINI_MODEL", model_name);
-            }
+        // Create config for Gemini provider
+        let mut config = LlmConfig::from_env();
+        config.provider = "gemini".to_string();
+        if model_name.starts_with("gemini-") {
+            config.model = Some(model_name.to_string());
         }
-        if let Ok(client) = LlmClient::from_env() {
+        if let Ok(client) = LlmClient::from_config(&config) {
             if !print_mode {
                 println!("✓ Connected to Gemini API");
             }
@@ -1782,11 +1782,8 @@ async fn initialize_llm_client(
     }
 
     // Try to connect to Ollama for other models
-    // SAFETY: This is safe as we're only setting the env var once during initialization
-    unsafe {
-        std::env::set_var("LLM_PROVIDER", "ollama");
-    }
-    if let Ok(client) = LlmClient::from_env()
+    let config = LlmConfig::ollama();
+    if let Ok(client) = LlmClient::from_config(&config)
         && client.complete(vec![Message::user("ping")]).await.is_ok()
     {
         if !print_mode {

--- a/crates/arkavo-llm/src/client.rs
+++ b/crates/arkavo-llm/src/client.rs
@@ -1,4 +1,5 @@
 use crate::chat::ChatRequest;
+use crate::config::LlmConfig;
 #[cfg(feature = "llm-remote")]
 use crate::ollama::OllamaClient;
 use crate::{Error, Message, Provider, Result, StreamResponse};
@@ -43,6 +44,53 @@ impl LlmClient {
                 // Try to create Gemini provider, but return error if API key is missing
                 // The error message now indicates this is optional and will fallback
                 let provider = Box::new(GeminiProvider::new()?);
+                Ok(Self::new(provider))
+            }
+            _ => {
+                #[cfg(any(
+                    feature = "llm-remote",
+                    feature = "kimi",
+                    feature = "deepseek",
+                    feature = "gemini"
+                ))]
+                return Err(Error::Config(format!("Unknown provider: {provider_name}")));
+
+                #[cfg(not(any(feature = "llm-remote", feature = "kimi", feature = "deepseek", feature = "gemini")))]
+                return Err(Error::Config(
+                    "No LLM providers available. Build with 'llm-remote', 'kimi', 'deepseek', 'gemini', or 'llama-cpp' feature enabled.".to_string()
+                ));
+            }
+        }
+    }
+
+    /// Creates an LlmClient from an LlmConfig struct.
+    ///
+    /// This is the preferred method as it avoids the need for unsafe env var manipulation.
+    pub fn from_config(config: &LlmConfig) -> Result<Self> {
+        let provider_name = config.provider.to_lowercase();
+
+        match provider_name.as_str() {
+            #[cfg(feature = "llm-remote")]
+            "ollama" => {
+                let provider = Box::new(OllamaClient::from_config(config)?);
+                Ok(Self::new(provider))
+            }
+            #[cfg(feature = "kimi")]
+            "kimi" => {
+                use crate::KimiProvider;
+                let provider = Box::new(KimiProvider::from_config(config)?);
+                Ok(Self::new(provider))
+            }
+            #[cfg(feature = "deepseek")]
+            "deepseek" => {
+                use crate::DeepSeekProvider;
+                let provider = Box::new(DeepSeekProvider::from_config(config)?);
+                Ok(Self::new(provider))
+            }
+            #[cfg(feature = "gemini")]
+            "gemini" => {
+                use crate::GeminiProvider;
+                let provider = Box::new(GeminiProvider::from_config(config)?);
                 Ok(Self::new(provider))
             }
             _ => {

--- a/crates/arkavo-llm/src/config.rs
+++ b/crates/arkavo-llm/src/config.rs
@@ -1,0 +1,220 @@
+use std::collections::HashMap;
+
+/// Configuration for LLM providers.
+///
+/// This struct centralizes all LLM-related configuration, replacing the
+/// previous pattern of setting environment variables at runtime.
+#[derive(Debug, Clone, Default)]
+pub struct LlmConfig {
+    /// Provider name: "ollama", "kimi", "deepseek", "gemini", "anthropic", "qwen"
+    pub provider: String,
+    /// Base URL for the provider's API
+    pub base_url: Option<String>,
+    /// Model name to use
+    pub model: Option<String>,
+    /// API keys by provider/service name
+    pub api_keys: HashMap<String, String>,
+}
+
+impl LlmConfig {
+    /// Creates a new config with the specified provider.
+    pub fn new(provider: impl Into<String>) -> Self {
+        Self {
+            provider: provider.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Creates config for Ollama provider.
+    pub fn ollama() -> Self {
+        Self::new("ollama")
+    }
+
+    /// Creates config for Ollama with custom settings.
+    pub fn ollama_with(base_url: impl Into<String>, model: impl Into<String>) -> Self {
+        Self {
+            provider: "ollama".to_string(),
+            base_url: Some(base_url.into()),
+            model: Some(model.into()),
+            api_keys: HashMap::new(),
+        }
+    }
+
+    /// Creates config for Kimi provider.
+    pub fn kimi(api_key: impl Into<String>) -> Self {
+        let mut api_keys = HashMap::new();
+        api_keys.insert("MOONSHOT_API_KEY".to_string(), api_key.into());
+        Self {
+            provider: "kimi".to_string(),
+            base_url: None,
+            model: None,
+            api_keys,
+        }
+    }
+
+    /// Creates config for DeepSeek provider.
+    pub fn deepseek(api_key: impl Into<String>) -> Self {
+        let mut api_keys = HashMap::new();
+        api_keys.insert("DEEPSEEK_API_KEY".to_string(), api_key.into());
+        Self {
+            provider: "deepseek".to_string(),
+            base_url: None,
+            model: None,
+            api_keys,
+        }
+    }
+
+    /// Creates config for Gemini provider.
+    pub fn gemini(api_key: impl Into<String>) -> Self {
+        let mut api_keys = HashMap::new();
+        api_keys.insert("GEMINI_API_KEY".to_string(), api_key.into());
+        Self {
+            provider: "gemini".to_string(),
+            base_url: None,
+            model: None,
+            api_keys,
+        }
+    }
+
+    /// Creates config for Anthropic provider.
+    pub fn anthropic(api_key: impl Into<String>) -> Self {
+        let mut api_keys = HashMap::new();
+        api_keys.insert("ANTHROPIC_API_KEY".to_string(), api_key.into());
+        Self {
+            provider: "anthropic".to_string(),
+            base_url: None,
+            model: None,
+            api_keys,
+        }
+    }
+
+    /// Creates config for Qwen provider.
+    pub fn qwen(api_key: impl Into<String>) -> Self {
+        let mut api_keys = HashMap::new();
+        api_keys.insert("DASHSCOPE_API_KEY".to_string(), api_key.into());
+        Self {
+            provider: "qwen".to_string(),
+            base_url: None,
+            model: None,
+            api_keys,
+        }
+    }
+
+    /// Sets the base URL.
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = Some(url.into());
+        self
+    }
+
+    /// Sets the model name.
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Adds an API key.
+    pub fn with_api_key(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.api_keys.insert(key.into(), value.into());
+        self
+    }
+
+    /// Loads configuration from environment variables (read-only, safe).
+    ///
+    /// This reads env vars once at startup, avoiding the need for unsafe set_var calls.
+    pub fn from_env() -> Self {
+        let provider = std::env::var("LLM_PROVIDER")
+            .ok()
+            .unwrap_or_else(|| "ollama".to_string());
+
+        let base_url = match provider.as_str() {
+            "ollama" => std::env::var("OLLAMA_BASE_URL").ok(),
+            "kimi" => std::env::var("KIMI_API_BASE").ok(),
+            "deepseek" => std::env::var("DEEPSEEK_BASE_URL").ok(),
+            "qwen" => std::env::var("DASHSCOPE_BASE_URL").ok(),
+            _ => None,
+        };
+
+        let model = match provider.as_str() {
+            "ollama" => std::env::var("OLLAMA_MODEL").ok(),
+            "kimi" => std::env::var("KIMI_MODEL").ok(),
+            "deepseek" => std::env::var("DEEPSEEK_MODEL").ok(),
+            "gemini" => std::env::var("GEMINI_MODEL").ok(),
+            "anthropic" => std::env::var("ANTHROPIC_MODEL").ok(),
+            "qwen" => std::env::var("QWEN_MODEL").ok(),
+            _ => None,
+        };
+
+        let mut api_keys = HashMap::new();
+        let env_keys = [
+            "MOONSHOT_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "GEMINI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "DASHSCOPE_API_KEY",
+            "OPENAI_API_KEY",
+        ];
+
+        for key in env_keys {
+            if let Ok(value) = std::env::var(key) {
+                api_keys.insert(key.to_string(), value);
+            }
+        }
+
+        Self {
+            provider,
+            base_url,
+            model,
+            api_keys,
+        }
+    }
+
+    /// Gets an API key by name.
+    pub fn get_api_key(&self, key: &str) -> Option<&String> {
+        self.api_keys.get(key)
+    }
+
+    /// Gets the primary API key for this provider.
+    pub fn primary_api_key(&self) -> Option<&String> {
+        match self.provider.as_str() {
+            "kimi" => self.api_keys.get("MOONSHOT_API_KEY"),
+            "deepseek" => self.api_keys.get("DEEPSEEK_API_KEY"),
+            "gemini" => self.api_keys.get("GEMINI_API_KEY"),
+            "anthropic" => self.api_keys.get("ANTHROPIC_API_KEY"),
+            "qwen" => self.api_keys.get("DASHSCOPE_API_KEY"),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ollama_config() {
+        let config = LlmConfig::ollama_with("http://localhost:11434", "qwen3:0.6b");
+        assert_eq!(config.provider, "ollama");
+        assert_eq!(config.base_url.as_deref(), Some("http://localhost:11434"));
+        assert_eq!(config.model.as_deref(), Some("qwen3:0.6b"));
+    }
+
+    #[test]
+    fn test_builder_pattern() {
+        let config = LlmConfig::new("gemini")
+            .with_model("gemini-pro")
+            .with_api_key("GEMINI_API_KEY", "test-key");
+
+        assert_eq!(config.provider, "gemini");
+        assert_eq!(config.model.as_deref(), Some("gemini-pro"));
+        assert_eq!(
+            config.get_api_key("GEMINI_API_KEY"),
+            Some(&"test-key".to_string())
+        );
+    }
+
+    #[test]
+    fn test_primary_api_key() {
+        let config = LlmConfig::kimi("my-api-key");
+        assert_eq!(config.primary_api_key(), Some(&"my-api-key".to_string()));
+    }
+}

--- a/crates/arkavo-llm/src/deepseek_adapter.rs
+++ b/crates/arkavo-llm/src/deepseek_adapter.rs
@@ -1,7 +1,7 @@
 //! Adapter to use arkavo-deepseek provider with arkavo-llm
 
 use crate::tool_parser::ParsedToolCall;
-use crate::{Error, Message, Provider, ProviderResponse, Result, Role, StreamResponse};
+use crate::{Error, LlmConfig, Message, Provider, ProviderResponse, Result, Role, StreamResponse};
 use arkavo_deepseek::{
     ChatMessage, DeepSeekConfig, DeepSeekProvider as InnerDeepSeekProvider, MessageContent, Tool,
     ToolFunction, V32_SPECIALE_BASE_URL, V32_SPECIALE_EXPIRATION,
@@ -39,6 +39,28 @@ impl DeepSeekProvider {
         })?;
 
         Ok(Self { inner })
+    }
+
+    /// Create from LlmConfig
+    pub fn from_config(config: &LlmConfig) -> Result<Self> {
+        let api_key = config
+            .get_api_key("DEEPSEEK_API_KEY")
+            .ok_or_else(|| Error::Config("DEEPSEEK_API_KEY not provided in config".to_string()))?;
+
+        let mut deepseek_config = DeepSeekConfig {
+            api_key: api_key.clone(),
+            ..Default::default()
+        };
+
+        if let Some(base_url) = &config.base_url {
+            deepseek_config.base_url.clone_from(base_url);
+        }
+
+        if let Some(model) = &config.model {
+            deepseek_config.model.clone_from(model);
+        }
+
+        Self::new(deepseek_config)
     }
 
     /// Set temperature for generation

--- a/crates/arkavo-llm/src/gemini_adapter.rs
+++ b/crates/arkavo-llm/src/gemini_adapter.rs
@@ -1,3 +1,4 @@
+use crate::config::LlmConfig;
 use crate::error::{Error, Result};
 use crate::message::Message;
 use crate::provider::{Provider, ProviderResponse};
@@ -29,6 +30,22 @@ impl GeminiProvider {
     /// Try to create a Gemini provider, returning None if API key is not available
     pub fn try_new() -> Option<Self> {
         Self::new().ok()
+    }
+
+    /// Create from LlmConfig
+    pub fn from_config(config: &LlmConfig) -> Result<Self> {
+        let api_key = config
+            .get_api_key("GEMINI_API_KEY")
+            .ok_or_else(|| Error::Config("GEMINI_API_KEY not provided in config".to_string()))?;
+
+        let model = config
+            .model
+            .clone()
+            .unwrap_or_else(|| "gemini-flash-latest".to_string());
+
+        Ok(Self {
+            client: RestClient::new(api_key.clone(), model),
+        })
     }
 }
 

--- a/crates/arkavo-llm/src/kimi_adapter.rs
+++ b/crates/arkavo-llm/src/kimi_adapter.rs
@@ -1,6 +1,6 @@
 //! Adapter to use arkavo-kimi provider with arkavo-llm
 
-use crate::{Error, Message, Provider, Result, Role, StreamResponse};
+use crate::{Error, LlmConfig, Message, Provider, Result, Role, StreamResponse};
 use arkavo_kimi::{KimiConfig, KimiProvider as InnerKimiProvider};
 use async_trait::async_trait;
 use tokio_stream::Stream;
@@ -31,6 +31,33 @@ impl KimiProvider {
         })?;
 
         Ok(Self { inner })
+    }
+
+    /// Create from LlmConfig
+    pub fn from_config(config: &LlmConfig) -> Result<Self> {
+        let api_key = config
+            .get_api_key("MOONSHOT_API_KEY")
+            .ok_or_else(|| Error::Config("MOONSHOT_API_KEY not provided in config".to_string()))?;
+
+        let mut kimi_config = KimiConfig {
+            api_key: api_key.clone(),
+            ..Default::default()
+        };
+
+        if let Some(base_url) = &config.base_url {
+            kimi_config.base_url.clone_from(base_url);
+        }
+
+        if let Some(model) = &config.model {
+            kimi_config.model = match model.as_str() {
+                "moonshot-v1-8k" => arkavo_kimi::Model::MoonshotV1_8k,
+                "moonshot-v1-32k" => arkavo_kimi::Model::MoonshotV1_32k,
+                "moonshot-v1-128k" => arkavo_kimi::Model::MoonshotV1_128k,
+                _ => arkavo_kimi::Model::MoonshotV1_8k,
+            };
+        }
+
+        Self::new(kimi_config)
     }
 
     /// Set temperature for generation

--- a/crates/arkavo-llm/src/lib.rs
+++ b/crates/arkavo-llm/src/lib.rs
@@ -2,6 +2,7 @@ pub mod chat;
 pub mod client;
 #[cfg(feature = "llm-remote")]
 pub mod common;
+pub mod config;
 pub mod error;
 pub mod image;
 pub mod mcp_converter;
@@ -19,6 +20,7 @@ pub mod tool_parser;
 
 pub use chat::ChatRequest;
 pub use client::LlmClient;
+pub use config::LlmConfig;
 pub use error::{Error, Result};
 pub use image::{ImageFormat, decode_image, encode_image_bytes, encode_image_file};
 pub use mcp_converter::{LocalToolFormat, McpConverter};

--- a/crates/arkavo-llm/src/ollama/client.rs
+++ b/crates/arkavo-llm/src/ollama/client.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use tokio_stream::Stream;
 
 use super::types::{ChatRequest, ChatResponse};
-use crate::{Error, Message, Provider, Result, StreamResponse};
+use crate::{Error, LlmConfig, Message, Provider, Result, StreamResponse};
 
 #[derive(Debug, Deserialize)]
 struct ModelInfo {
@@ -37,6 +37,10 @@ impl OllamaClient {
         let base_url = std::env::var("OLLAMA_BASE_URL").ok();
         let model = std::env::var("OLLAMA_MODEL").ok();
         Ok(Self::new(base_url, model))
+    }
+
+    pub fn from_config(config: &LlmConfig) -> Result<Self> {
+        Ok(Self::new(config.base_url.clone(), config.model.clone()))
     }
 
     pub async fn list_models(&self) -> Result<Vec<String>> {

--- a/crates/arkavo-protocol/src/server.rs
+++ b/crates/arkavo-protocol/src/server.rs
@@ -18,7 +18,7 @@ use crate::types::{
     TaskDeclareResponse, TaskGetRequest, TaskGetResponse, TaskResponse, TaskStatus, UserMessage,
 };
 use arkavo_events::{Event, EventPayload, EventWriter, EventWriterConfig};
-use arkavo_llm::{DeltaType, LlmClient, LlmClientAdapter, StreamLlmModel};
+use arkavo_llm::{DeltaType, LlmClient, LlmClientAdapter, LlmConfig, StreamLlmModel};
 use async_trait::async_trait;
 use futures::StreamExt;
 use jsonrpsee::server::{ServerBuilder, ServerHandle};
@@ -1812,14 +1812,8 @@ impl A2aRpcImpl {
             // Note: listen address is stored in endpoint field
             metadata.endpoint.clone_from(&new_config.listen);
 
-            // Update API keys in metadata and environment
+            // Update API keys in metadata (no longer setting env vars - use LlmConfig instead)
             metadata.api_keys.clone_from(&new_config.api_keys);
-            for (key, value) in &new_config.api_keys {
-                // SAFETY: We control the key and value from our config file
-                unsafe {
-                    std::env::set_var(key, value);
-                }
-            }
 
             info!("Updated agent metadata for '{}'", metadata.name);
             info!("  Purpose: {}", metadata.purpose);
@@ -1987,15 +1981,8 @@ async fn reload_configuration_for_watcher(
         let mut metadata = agent_metadata.write().await;
         metadata.purpose.clone_from(&new_config.purpose);
         metadata.endpoint.clone_from(&new_config.listen);
+        // Update API keys in metadata (no longer setting env vars - use LlmConfig instead)
         metadata.api_keys.clone_from(&new_config.api_keys);
-
-        // Update environment variables
-        for (key, value) in &new_config.api_keys {
-            // SAFETY: We control the key and value from our config file
-            unsafe {
-                std::env::set_var(key, value);
-            }
-        }
 
         info!("Updated agent metadata for '{}'", metadata.name);
         info!("  Purpose: {}", metadata.purpose);
@@ -2329,16 +2316,11 @@ impl A2aServer {
         if let Some((provider, rest)) = model_url.split_once("://") {
             match provider {
                 "ollama" => {
-                    // Set environment variables for Ollama client
+                    // Create config for Ollama client
                     if let Some((host_port, model_name)) = rest.rsplit_once('/') {
-                        unsafe {
-                            std::env::set_var("LLM_PROVIDER", "ollama");
-                            std::env::set_var("OLLAMA_BASE_URL", format!("http://{host_port}"));
-                            std::env::set_var("OLLAMA_MODEL", model_name);
-                        }
-
-                        // Create LLM client from environment
-                        let client = LlmClient::from_env().map_err(|e| {
+                        let config =
+                            LlmConfig::ollama_with(format!("http://{host_port}"), model_name);
+                        let client = LlmClient::from_config(&config).map_err(|e| {
                             A2aError::InvalidRequest(format!("Failed to create LLM client: {e}"))
                         })?;
                         Ok(Arc::new(LlmClientAdapter::new(client)))
@@ -2350,21 +2332,24 @@ impl A2aServer {
                 }
                 "kimi" => {
                     // KIMI format: kimi://model-name (e.g., kimi://moonshot-v1-128k)
-                    unsafe {
-                        std::env::set_var("LLM_PROVIDER", "kimi");
-                        // Extract model name from rest (e.g., moonshot-v1-128k)
-                        if !rest.is_empty() {
-                            // Model name is already in the correct format
-                            std::env::set_var("KIMI_MODEL", rest);
-                        }
+                    let api_key = api_keys
+                        .get("MOONSHOT_API_KEY")
+                        .cloned()
+                        .or_else(|| std::env::var("MOONSHOT_API_KEY").ok());
 
-                        // Set API key from agent config if available
-                        if let Some(api_key) = api_keys.get("MOONSHOT_API_KEY") {
-                            std::env::set_var("MOONSHOT_API_KEY", api_key);
-                        }
+                    let mut config = if let Some(key) = api_key {
+                        LlmConfig::kimi(key)
+                    } else {
+                        return Err(A2aError::InvalidRequest(
+                            "MOONSHOT_API_KEY not provided in config or environment".to_string(),
+                        ));
+                    };
+
+                    if !rest.is_empty() {
+                        config.model = Some(rest.to_string());
                     }
-                    // Create LLM client from environment
-                    let client = LlmClient::from_env().map_err(|e| {
+
+                    let client = LlmClient::from_config(&config).map_err(|e| {
                         A2aError::InvalidRequest(format!("Failed to create KIMI client: {e}"))
                     })?;
                     Ok(Arc::new(LlmClientAdapter::new(client)))
@@ -2380,8 +2365,9 @@ impl A2aServer {
                 model_url
             );
 
-            // Try to create client from environment variables (LLM_PROVIDER, etc.)
-            let client = LlmClient::from_env().map_err(|e| {
+            // Try to create client from environment config (reads env vars once at startup)
+            let config = LlmConfig::from_env();
+            let client = LlmClient::from_config(&config).map_err(|e| {
                 A2aError::InvalidRequest(format!(
                     "Failed to create LLM client for model '{model_url}' from environment: {e}. \
                      Either use format 'provider://host:port/model' or set LLM_PROVIDER env var"

--- a/crates/arkavo-terminal/src/lib.rs
+++ b/crates/arkavo-terminal/src/lib.rs
@@ -525,7 +525,7 @@ pub async fn run() -> Result<()> {
 
 #[cfg(any(feature = "llm-remote", feature = "llama-cpp"))]
 async fn initialize_llm_client() -> Result<arkavo_llm::LlmClient> {
-    use arkavo_llm::{LlmClient, Message};
+    use arkavo_llm::{LlmClient, LlmConfig, Message};
     use arkavo_memory::storage::MemoryStorage;
     use std::sync::Arc;
 
@@ -543,14 +543,12 @@ async fn initialize_llm_client() -> Result<arkavo_llm::LlmClient> {
         .find(|c| c.memory.content != "CLEARED" && c.memory.content.starts_with("http"));
 
     if let Some(config) = valid_config {
-        // Use saved configuration
+        // Use saved configuration with LlmConfig
         let server_url = &config.memory.content;
-        unsafe {
-            std::env::set_var("OLLAMA_BASE_URL", server_url);
-        }
+        let llm_config = LlmConfig::new("ollama").with_base_url(server_url);
 
         // Try to connect with saved URL
-        if let Ok(client) = LlmClient::from_env() {
+        if let Ok(client) = LlmClient::from_config(&llm_config) {
             let test_message = vec![Message::user("ping")];
             if client.complete(test_message).await.is_ok() {
                 return Ok(client);
@@ -559,7 +557,8 @@ async fn initialize_llm_client() -> Result<arkavo_llm::LlmClient> {
     }
 
     // Try default localhost first
-    match LlmClient::from_env() {
+    let default_config = LlmConfig::ollama();
+    match LlmClient::from_config(&default_config) {
         Ok(client) => {
             // Test if the client can connect
             let test_message = vec![Message::user("ping")];
@@ -582,7 +581,7 @@ async fn initialize_llm_client() -> Result<arkavo_llm::LlmClient> {
 async fn prompt_for_ollama_config(
     storage: Arc<arkavo_memory::storage::MemoryStorage>,
 ) -> Result<arkavo_llm::LlmClient> {
-    use arkavo_llm::{LlmClient, Message};
+    use arkavo_llm::{LlmClient, LlmConfig, Message};
     use std::io::{self, Write};
 
     eprintln!("⚠️  Could not connect to Ollama at localhost:11434");
@@ -606,13 +605,11 @@ async fn prompt_for_ollama_config(
         format!("http://{input}")
     };
 
-    // Set the environment variable
-    unsafe {
-        std::env::set_var("OLLAMA_BASE_URL", &base_url);
-    }
+    // Create config with the provided URL
+    let llm_config = LlmConfig::new("ollama").with_base_url(&base_url);
 
     // Try to create client and test it
-    match LlmClient::from_env() {
+    match LlmClient::from_config(&llm_config) {
         Ok(client) => {
             let test_message = vec![Message::user("ping")];
             match client.complete(test_message).await {


### PR DESCRIPTION
## Summary
- Add `LlmConfig` struct with builder pattern to centralize LLM provider configuration
- Add `from_config()` methods to `LlmClient` and all provider adapters (Ollama, Kimi, DeepSeek, Gemini)
- Remove unsafe `set_var` calls from production code in arkavo-cli, arkavo-protocol, and arkavo-terminal
- Eliminates data race risk from runtime environment variable mutations

## Test plan
- [x] All existing tests pass
- [x] New config module unit tests pass
- [ ] Manual test with different providers (ollama, gemini, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)