### PR TITLE
SwarmKit: stop-flight WebSocket control + UI button

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "chrono",
  "serde",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-config-bundle",
  "base64 0.22.1",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "git2",
  "tempfile",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "bindgen",
  "cc",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "lru",
  "serde",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "libc",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-agui",
  "arkavo-arp",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.73.0"
+version = "0.73.1"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-agui/src/gateway_ws.rs
+++ b/crates/arkavo-agui/src/gateway_ws.rs
@@ -31,6 +31,7 @@ pub async fn websocket_handler(
             state.lesson_store,
             state.context_topology_cache,
             state.arp_handler,
+            state.swarm_flights,
         )
     })
 }
@@ -52,6 +53,7 @@ async fn handle_websocket(
     lesson_store: Arc<RwLock<Vec<arkavo_router::learning::Lesson>>>,
     context_topology_cache: Arc<RwLock<HashMap<String, serde_json::Value>>>,
     arp_handler: Arc<ArpHandler>,
+    swarm_flights: Arc<crate::swarm_flight_registry::SwarmFlightRegistry>,
 ) {
     use futures::sink::SinkExt;
     use futures::stream::StreamExt;
@@ -110,6 +112,7 @@ async fn handle_websocket(
             &lesson_store,
             &context_topology_cache,
             &arp_handler,
+            &swarm_flights,
             &tx,
         )
         .await
@@ -139,6 +142,7 @@ async fn handle_websocket(
                         &lesson_store,
                         &context_topology_cache,
                         &arp_handler,
+                        &swarm_flights,
                         &tx,
                     )
                     .await
@@ -191,6 +195,7 @@ async fn dispatch_event(
     lesson_store: &Arc<RwLock<Vec<arkavo_router::learning::Lesson>>>,
     context_topology_cache: &Arc<RwLock<HashMap<String, serde_json::Value>>>,
     arp_handler: &Arc<ArpHandler>,
+    swarm_flights: &Arc<crate::swarm_flight_registry::SwarmFlightRegistry>,
     tx: &mpsc::Sender<AgUiEvent>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("AG-UI: Received {:?}", std::mem::discriminant(&event));
@@ -346,6 +351,35 @@ async fn dispatch_event(
                 event_id: uuid::Uuid::new_v4().to_string(),
             })
             .await?;
+        }
+        AgUiEvent::RequestStopFlight { flight_id } => {
+            let response = match uuid::Uuid::parse_str(&flight_id) {
+                Ok(parsed_id) => {
+                    swarm_flights.deregister(parsed_id, arp_handler).await;
+                    AgUiEvent::FlightStopped {
+                        flight_id,
+                        error: None,
+                    }
+                }
+                Err(e) => AgUiEvent::FlightStopped {
+                    flight_id,
+                    error: Some(format!("invalid flight_id: {e}")),
+                },
+            };
+            tx.send(response).await?;
+
+            // Also push a fresh ArpStatusUpdate so any panel that has the
+            // stopped flight selected drops it on the same render cycle
+            // instead of waiting for the next 5s poll.
+            let snapshot = arp_handler.snapshot().await;
+            tx.send(AgUiEvent::ArpStatusUpdate {
+                snapshot,
+                event_id: uuid::Uuid::new_v4().to_string(),
+            })
+            .await?;
+        }
+        AgUiEvent::FlightStopped { .. } => {
+            // Server-emitted event; ignore if it ever round-trips back.
         }
         AgUiEvent::RequestLearningStatus => {
             let lesson_count = lesson_store.read().await.len();

--- a/crates/arkavo-agui/src/types.rs
+++ b/crates/arkavo-agui/src/types.rs
@@ -548,6 +548,23 @@ pub enum AgUiEvent {
         event_id: String,
     },
 
+    /// Operator request to stop an active SwarmFlight. The gateway
+    /// deregisters every role of the flight from the ArpHandler and
+    /// drops the flight from the registry. Stopping a non-existent or
+    /// already-stopped flight is a no-op (`FlightStopped` reports success).
+    RequestStopFlight {
+        #[serde(rename = "flightId")]
+        flight_id: String,
+    },
+    FlightStopped {
+        #[serde(rename = "flightId")]
+        flight_id: String,
+        /// `None` on success; `Some(message)` if the flight_id failed to
+        /// parse as a UUID or some other server-side error occurred.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+
     // Task management events
     RequestTaskList,
     TaskList {

--- a/crates/arkavo-agui/static/js/panels/arp.js
+++ b/crates/arkavo-agui/static/js/panels/arp.js
@@ -97,6 +97,21 @@ function renderArp() {
             renderArp();
         });
     });
+
+    // Stop buttons send a requestStopFlight event; the gateway responds
+    // with FlightStopped + an ArpStatusUpdate so the panel re-renders
+    // without the dropped flight.
+    var stops = document.querySelectorAll('.arp-flight-stop');
+    Array.prototype.forEach.call(stops, function(btn) {
+        btn.addEventListener('click', function(e) {
+            e.stopPropagation();
+            var fid = btn.getAttribute('data-flight-id');
+            if (!fid) return;
+            btn.disabled = true;
+            btn.textContent = 'Stopping…';
+            wsSend({ type: 'requestStopFlight', flightId: fid });
+        });
+    });
 }
 
 function renderArpAgentSelector(agents) {
@@ -193,8 +208,14 @@ function renderArpFlightsSection(agents) {
 
         rolesCell += '</div>';
 
+        var stopBtn =
+            '<button type="button" class="arp-flight-stop"' +
+            ' data-flight-id="' + escapeHtml(flight.flightId) + '"' +
+            ' title="Stop this SwarmFlight and remove its roles from the panel">' +
+            'Stop</button>';
+
         html += '<tr><td>' +
-            '<strong>' + escapeHtml(flight.kitName) + '</strong>' +
+            '<strong>' + escapeHtml(flight.kitName) + '</strong> ' + stopBtn +
             '<div class="arp-flight-meta">flight <code>' + escapeHtml(shortId) + '…</code>' +
             ' · ' + flight.roles.length + ' role' + (flight.roles.length === 1 ? '' : 's') + '</div>' +
             '</td><td>' + rolesCell + '</td></tr>';

--- a/crates/arkavo-agui/static/styles/panels.css
+++ b/crates/arkavo-agui/static/styles/panels.css
@@ -823,3 +823,25 @@
     color: var(--text-secondary);
     font-size: 10px;
 }
+.arp-flight-stop {
+    font-size: 10px;
+    font-family: monospace;
+    padding: 2px 8px;
+    margin-left: 6px;
+    background: rgba(255, 99, 99, 0.10);
+    color: var(--warning, #ff9f43);
+    border: 1px solid rgba(255, 99, 99, 0.35);
+    border-radius: 4px;
+    cursor: pointer;
+    vertical-align: middle;
+    transition: background 0.1s, border-color 0.1s;
+}
+.arp-flight-stop:hover:not(:disabled) {
+    background: rgba(255, 99, 99, 0.22);
+    border-color: #ff6b6b;
+    color: #ff6b6b;
+}
+.arp-flight-stop:disabled {
+    opacity: 0.55;
+    cursor: progress;
+}

--- a/specs/arkavo-edge/index.yaml
+++ b/specs/arkavo-edge/index.yaml
@@ -564,12 +564,13 @@ components:
     module: arkavo_swarmkit
     description: SwarmKit manifest, runtime, and AG-UI gateway integration
     criticality: high
-    scenario_count: 20
+    scenario_count: 21
     invariants:
       - kit.id equals BLAKE3 of canonical manifest
       - SwarmFlight builds one ArpRuntime per role at launch
       - Per-role DecisionTrace and PolicyCache are isolated
       - ARKAVO_SWARMKIT_PATH auto-launch failures are non-fatal
+      - requestStopFlight deregisters every role of a flight in one call
 
   - name: ui-core
     file: ui-core.spec.yaml

--- a/specs/arkavo-edge/swarmkit.spec.yaml
+++ b/specs/arkavo-edge/swarmkit.spec.yaml
@@ -339,3 +339,27 @@ scenarios:
     refs:
       - crates/arkavo-agui/static/js/panels/arp.js:163-188
     changed: "2026-04-30"
+
+  # --- Operator controls ---------------------------------------------------
+
+  - id: SK-040
+    name: requestStopFlight deregisters the flight and pushes a fresh snapshot
+    criticality: high
+    given:
+      - WebSocket session connected
+      - One or more SwarmFlights registered
+    when: client sends requestStopFlight with a valid flight_id
+    then:
+      - SwarmFlightRegistry::deregister called with the parsed UUID
+      - Every role of that flight removed from ArpHandler
+      - FlightStopped emitted with error=None
+      - ArpStatusUpdate emitted immediately so the panel re-renders without the stopped flight
+    refs:
+      - crates/arkavo-agui/src/gateway_ws.rs:351-385
+      - crates/arkavo-agui/src/swarm_flight_registry.rs:60-65
+    changed: "2026-05-01"
+    edge_cases:
+      - condition: flight_id is not a valid UUID
+        expected: FlightStopped with error=Some(...) explaining the parse failure; no deregister call
+      - condition: flight_id is a valid UUID but no flight is registered with it
+        expected: FlightStopped with error=None (deregister is idempotent)


### PR DESCRIPTION
## Summary

First follow-up to PR #575. Adds the operator affordance to stop a running SwarmFlight from the AG-UI ARP panel — completes the panel CRUD loop (auto-launch in #575 already handles registration; this handles teardown).

Stacked on `feature/swarmkit`, base set accordingly. Will rebase to `main` once #575 merges.

## Changes

**Wire protocol** (`arkavo-agui::types`)
- New `AgUiEvent::RequestStopFlight { flight_id: String }` (client → server)
- New `AgUiEvent::FlightStopped { flight_id, error: Option<String> }` (server → client)

**Gateway** (`gateway_ws.rs`)
- `SwarmFlightRegistry` threaded through `dispatch_event` (matches the existing per-arg threading pattern).
- `RequestStopFlight` parses the UUID, calls `registry.deregister(uuid, &arp_handler)`, emits `FlightStopped`, and pushes a fresh `ArpStatusUpdate` immediately so the panel re-renders the same cycle rather than waiting for the next 5s poll.
- Idempotent: stopping a non-existent flight is a no-op success.
- UUID parse failure produces `FlightStopped { error: Some(\"…\") }` without touching the registry.

**Panel** (`arp.js` + `panels.css`)
- Stop button next to the kit name in the Active SwarmFlights card.
- Click sends `requestStopFlight`; button disables and shows \"Stopping…\" while the round-trip completes; server's `ArpStatusUpdate` drives the row removal.
- New `.arp-flight-stop` class with destructive-action styling consistent with the existing `--warning` palette.

**Behavior spec**
- New `SK-040` scenario in `swarmkit.spec.yaml` covering the happy path and both edge cases (invalid UUID, unknown flight_id).
- `index.yaml` scenario count bumped from 20 → 21.

**Version**
- Patch bump 0.73.0 → 0.73.1 per the project convention.

## Test plan

- [x] `cargo build -q --workspace --exclude golden-dataset` clean
- [x] `cargo clippy -q -p arkavo-agui -- -D warnings` clean
- [x] `cargo test -p arkavo-agui` — all 99 lib tests + integration tests pass
- [x] `cargo fmt --all -- --check` clean
- [x] `node -c arp.js` parses
- [x] Spec yaml validates against `specs/schema.json`
- [ ] Manual smoke: launch with `ARKAVO_SWARMKIT_PATH=examples/campaign-kit/campaign-kit.swarmkit.yaml`, click Stop, confirm the flight section disappears and the ARP panel falls back to mesh agents

## Out of scope (future patches)

- TDF envelope and KAS unwrap (spec §6) — separate minor-bump PR.
- A2A delegation envelope on the wire (spec §7.2) — depends on TDF.
- Specialist process spawning + model loading — separate large PR.
- Confirmation dialog before stop — could be added as a small follow-up; current behavior is single-click stop with disable-while-pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)