### PR TITLE
SwarmKit: split LaunchError from FlightError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "chrono",
  "serde",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-config-bundle",
  "base64 0.22.1",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "git2",
  "tempfile",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "bindgen",
  "cc",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "lru",
  "serde",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "libc",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-agui",
  "arkavo-arp",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.73.1"
+version = "0.73.2"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-swarmkit-runtime/src/flight.rs
+++ b/crates/arkavo-swarmkit-runtime/src/flight.rs
@@ -16,13 +16,26 @@ use uuid::Uuid;
 
 use crate::derive::{DeriveOptions, derive_arp_for_role};
 
-/// Errors that can occur while launching a SwarmFlight.
+/// Errors that can occur while *launching* a SwarmFlight. These reflect
+/// validation against the manifest at flight construction time — once a
+/// flight is launched, runtime operations against it use [`FlightError`]
+/// instead.
 #[derive(Debug, thiserror::Error)]
 pub enum LaunchError {
     #[error("override role_id {0:?} does not appear in the manifest")]
     UnknownOverrideRole(String),
     #[error("manifest has no roles")]
     NoRoles,
+}
+
+/// Errors that can occur while *operating* on a launched SwarmFlight —
+/// e.g. recording a tool outcome against a role that does not exist.
+/// Distinct from [`LaunchError`] so callers can distinguish a misconfigured
+/// flight from a misuse of an already-launched one.
+#[derive(Debug, thiserror::Error)]
+pub enum FlightError {
+    #[error("role_id {0:?} is not a role in this flight")]
+    UnknownRole(String),
 }
 
 /// Options applied at SwarmFlight launch time.
@@ -179,11 +192,11 @@ impl SwarmFlight {
         tool_name: &str,
         success: bool,
         quality: f64,
-    ) -> Result<(), LaunchError> {
+    ) -> Result<(), FlightError> {
         let role = self
             .roles
             .get(role_id)
-            .ok_or_else(|| LaunchError::UnknownOverrideRole(role_id.to_string()))?;
+            .ok_or_else(|| FlightError::UnknownRole(role_id.to_string()))?;
         let ctx = ToolOutcomeContext::new()
             .with_task_id(self.flight_id)
             .with_agent_id(role_id);
@@ -306,7 +319,11 @@ provenance:
             .record_tool_outcome("ghost", "x", true, 0.9)
             .await
             .unwrap_err();
-        assert!(matches!(err, LaunchError::UnknownOverrideRole(_)));
+        // Runtime lookup failure on a launched flight surfaces as
+        // FlightError::UnknownRole, distinct from LaunchError so callers
+        // can tell construction-time misconfiguration apart from runtime
+        // misuse.
+        assert!(matches!(err, FlightError::UnknownRole(_)));
     }
 
     #[spec("SK-014")]

--- a/crates/arkavo-swarmkit-runtime/src/lib.rs
+++ b/crates/arkavo-swarmkit-runtime/src/lib.rs
@@ -16,7 +16,7 @@ pub mod derive;
 pub mod flight;
 
 pub use derive::{DeriveOptions, derive_arp_for_role};
-pub use flight::{LaunchError, LaunchOptions, RoleRuntime, SwarmFlight};
+pub use flight::{FlightError, LaunchError, LaunchOptions, RoleRuntime, SwarmFlight};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

Addresses review item **G3** from #575: `SwarmFlight::record_tool_outcome` returned `LaunchError::UnknownOverrideRole` for runtime lookup failures, conflating two distinct failure modes.

Stacked on `feature/swarmkit` (long-lived integration branch). Patch bump 0.73.1 → 0.73.2.

## Changes

- New `FlightError` enum with `UnknownRole(String)` variant.
- `LaunchError` retains `NoRoles` + `UnknownOverrideRole` — manifest-validation-time failures only.
- `record_tool_outcome` now returns `Result<(), FlightError>` so callers can pattern-match on the failure mode that actually happened.
- Re-export added to `lib.rs`.

## Test plan

- [x] `cargo build -q -p arkavo-swarmkit-runtime --tests` clean
- [x] `cargo clippy -q -p arkavo-swarmkit-runtime -- -D warnings` clean
- [x] `cargo test -p arkavo-swarmkit-runtime` — 11 lib + 2 integration tests pass
- [x] `cargo fmt --all -- --check` clean

## API impact

This is a public-API change in `arkavo-swarmkit-runtime`. The crate has no external dependents yet (only the Campaign Kit demo + integration test), so no migration shim needed. If we want to soft-land this, we'd add a `#[deprecated]` re-export of the old name — happy to do that if the surface is wider than I think.

🤖 Generated with [Claude Code](https://claude.com/claude-code)