### PR TITLE
SwarmKit panel: dedup ArpStatusUpdate re-renders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "chrono",
  "serde",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-config-bundle",
  "base64 0.22.1",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "git2",
  "tempfile",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "bindgen",
  "cc",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "lru",
  "serde",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "libc",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-agui",
  "arkavo-arp",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.73.2"
+version = "0.73.3"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.73.2"
+version = "0.73.3"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-agui/static/js/panels/arp.js
+++ b/crates/arkavo-agui/static/js/panels/arp.js
@@ -12,6 +12,24 @@ var VIOLATION_EVENT_TYPES = {
 
 function handleArpStatusUpdate(event) {
     AppState.arpStatus = event.snapshot;
+    // Dedup re-renders: the panel polls every 5s but most poll cycles
+    // return identical state. Comparing the serialized snapshot lets us
+    // skip the DOM rebuild — preserving <select> focus, table scroll
+    // position, and pill hover state — when nothing actually changed.
+    // The `timestamp` field is excluded from the comparison since it
+    // ticks every poll even when the rest of the snapshot is stable.
+    var snap = event.snapshot || {};
+    var withoutTs = {};
+    for (var k in snap) {
+        if (k !== 'timestamp' && Object.prototype.hasOwnProperty.call(snap, k)) {
+            withoutTs[k] = snap[k];
+        }
+    }
+    var fingerprint = JSON.stringify(withoutTs);
+    if (AppState.arpLastFingerprint === fingerprint) {
+        return;
+    }
+    AppState.arpLastFingerprint = fingerprint;
     renderArp();
 }
 

--- a/specs/arkavo-edge/index.yaml
+++ b/specs/arkavo-edge/index.yaml
@@ -564,13 +564,14 @@ components:
     module: arkavo_swarmkit
     description: SwarmKit manifest, runtime, and AG-UI gateway integration
     criticality: high
-    scenario_count: 21
+    scenario_count: 22
     invariants:
       - kit.id equals BLAKE3 of canonical manifest
       - SwarmFlight builds one ArpRuntime per role at launch
       - Per-role DecisionTrace and PolicyCache are isolated
       - ARKAVO_SWARMKIT_PATH auto-launch failures are non-fatal
       - requestStopFlight deregisters every role of a flight in one call
+      - Identical ArpStatusUpdate payloads do not cause panel re-renders
 
   - name: ui-core
     file: ui-core.spec.yaml

--- a/specs/arkavo-edge/swarmkit.spec.yaml
+++ b/specs/arkavo-edge/swarmkit.spec.yaml
@@ -340,6 +340,22 @@ scenarios:
       - crates/arkavo-agui/static/js/panels/arp.js:163-188
     changed: "2026-04-30"
 
+  - id: SK-033
+    name: ArpStatusUpdate skips re-render when snapshot is unchanged
+    criticality: low
+    given:
+      - ARP panel rendered with a known snapshot
+      - Server sends another ArpStatusUpdate whose payload is identical except for the timestamp field
+    when: handleArpStatusUpdate runs
+    then:
+      - JSON fingerprint of the snapshot (excluding timestamp) is computed
+      - Compared against AppState.arpLastFingerprint
+      - If equal, renderArp is NOT called — DOM stays stable so <select> focus, scroll position, and pill hover state are preserved
+      - If different (e.g. a flight stopped, a new outcome arrived), AppState.arpLastFingerprint is updated and renderArp runs
+    refs:
+      - crates/arkavo-agui/static/js/panels/arp.js:13-35
+    changed: "2026-05-01"
+
   # --- Operator controls ---------------------------------------------------
 
   - id: SK-040


### PR DESCRIPTION
## Summary

Stops the ARP panel from rebuilding its DOM on every 5-second poll when the snapshot hasn't actually changed. Preserves user state (focus, scroll, hover) across stable polls.

Stacked on `feature/swarmkit`. Patch bump 0.73.2 → 0.73.3.

## Changes

`handleArpStatusUpdate` now fingerprints the snapshot (everything except `timestamp`, which ticks every poll) and compares against `AppState.arpLastFingerprint`. If equal, skip `renderArp` entirely.

User-driven re-renders (pill click, dropdown change, stop button) call `renderArp` directly and remain unaffected.

New `SK-033` scenario in `swarmkit.spec.yaml`; `index.yaml` count 21 → 22.

## Test plan

- [x] `node -c arp.js` parses
- [x] Spec yaml validates (22 scenarios)
- [x] `cargo build -q -p arkavo-agui` clean
- [ ] Manual: focus the agent dropdown, wait two poll cycles, confirm focus is retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)