### PR TITLE
SwarmKit: arp-showcase example gains parallel SwarmKit demo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "chrono",
  "serde",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-config-bundle",
  "base64 0.22.1",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "git2",
  "tempfile",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "bindgen",
  "cc",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "lru",
  "serde",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "libc",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-agui",
  "arkavo-arp",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.73.3"
+version = "0.73.4"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.73.3"
+version = "0.73.4"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/examples/arp-showcase/README.md
+++ b/examples/arp-showcase/README.md
@@ -1,15 +1,22 @@
 # ARP Showcase
 
-Boots the AG-UI web gateway with an Agent Runtime Policy (ARP) document loaded so the new **Agent Runtime Policy** panel renders real data.
+Boots the AG-UI web gateway with an Agent Runtime Policy (ARP) document loaded so the **Agent Runtime Policy** panel renders real data.
 
 The included `arkavo.arp.json` is a fully-validated ARP 0.1.0 document covering all four enforcement layers (cognitive, execution, data sovereignty, network) plus adaptation, feedback loops, budget, escalation, session, HITL, state storage, and observability sections.
+
+A companion `arkavo.swarmkit.yaml` declares a single-role SwarmKit so the same panel can render an **Active SwarmFlights** section alongside the rich `(local)` ARP agent. This is how the SwarmKit per-role ARP handoff (spec §1.2 / §5) appears in the UI — derived ARP runtime per role, isolated DecisionTrace, deregister via the panel's Stop button.
 
 ## Running
 
 ```bash
 # from repo root
 cargo build
+
+# Original showcase: just the (local) ARP agent.
 ./examples/arp-showcase/run.sh
+
+# Showcase + SwarmKit: (local) ARP agent + an Active SwarmFlight section.
+./examples/arp-showcase/run-swarmkit.sh
 ```
 
 Then open <http://127.0.0.1:7700> and click the scales icon in the left navigation.
@@ -23,12 +30,17 @@ Then open <http://127.0.0.1:7700> and click the scales icon in the left navigati
 - **Adaptation Engine** — live. The handler instantiates an `AdaptationEngine` and exposes Beta priors per tool entity. Each conductor tool call updates the prior — `alpha` grows on success above the quality gate, `beta` grows on failure or below-gate outcomes.
 - **Recent Decision Traces** — full trace stream (success and denied) for the selected agent. The runtime emits a `tool_invocation` entry per tool call with prior/posterior Beta state, latency, quality score, and an error type when an outcome is below the quality gate or fails outright. Standalone `arkavo ui` shows zero entries because there's no agent invoking tools.
 
+## Active SwarmFlights section
+
+When `ARKAVO_SWARMKIT_PATH` is set (as `run-swarmkit.sh` does), the gateway also auto-launches a SwarmFlight at boot. The showcase kit declares one role (`showcase`, `role_type: showcase_agent`), and the panel renders it as a clickable pill above the agent dropdown. Click the pill to inspect that role's derived ARP runtime; click the **Stop** button to drop the flight without disturbing the `(local)` ARP agent.
+
 ## Pointing at a different document
 
-The handler reads `ARKAVO_ARP_PATH`. Override before running:
+The handler reads `ARKAVO_ARP_PATH` and `ARKAVO_SWARMKIT_PATH`. Override before running:
 
 ```bash
 ARKAVO_ARP_PATH=/path/to/your.arp.json ./examples/arp-showcase/run.sh
+ARKAVO_SWARMKIT_PATH=/path/to/your.swarmkit.yaml ./examples/arp-showcase/run-swarmkit.sh
 ```
 
 If neither `ARKAVO_ARP_PATH` nor a `./arkavo.arp.json` is present, the panel shows `NOT LOADED` with no document body.

--- a/examples/arp-showcase/arkavo.swarmkit.yaml
+++ b/examples/arp-showcase/arkavo.swarmkit.yaml
@@ -1,0 +1,99 @@
+spec_version: "1.0.0"
+kit:
+  id: "blake3:fYvTdVeTyZ-zce8pzbtcWBIAf9y26Mqm7OetdYwZ7VY"
+  name: "ARP Showcase Kit"
+  version: "0.1.0"
+  description: >-
+    Single-role SwarmKit demo: pairs with the existing arkavo.arp.json
+    showcase. Setting both ARKAVO_ARP_PATH and ARKAVO_SWARMKIT_PATH lets
+    the panel render the fully-fleshed (local) ARP agent alongside this
+    flight role's derived ARP, so the SwarmKit handoff is visible in the
+    same UI as the original showcase.
+  authors:
+    - did: "did:web:arkavo.com"
+      name: "Arkavo"
+  created: "2026-05-01T00:00:00Z"
+  expires: "2026-07-30T00:00:00Z"
+  nonce: "PTFVsMS5pBJwnGyWcPq-cA"
+
+objective:
+  goal: "Demonstrate the SwarmKit per-role ARP handoff in the AG-UI ARP panel."
+  success_criteria:
+    - "panel renders a flight section above the agent dropdown"
+    - "single role appears as a clickable pill with derived ARP state"
+    - "stop button removes the flight without disrupting the (local) ARP agent"
+
+inputs: []
+deliverables:
+  - name: "panel_state"
+    type: "json"
+
+roles:
+  - id: "showcase"
+    role_type: "showcase_agent"
+    description: "Single specialist surfacing a derived ARP runtime in the panel."
+    agent_provisioning:
+      model:
+        family: "qwen3"
+        size: "0.8B"
+        backend: "llama.cpp"
+      inference:
+        max_tokens: 256
+        temperature: 0.2
+      budget:
+        max_inference_calls: 10
+        max_wallclock_ms: 30000
+        max_total_tokens: 4000
+      context:
+        max_context_tokens: 8000
+        persistence: "ephemeral"
+      isolation:
+        sandbox: "process"
+        network_egress: false
+    skills: []
+    mcp_tools: []
+    tdf_attribute_release_policy:
+      attributes:
+        - "https://attr.arkavo.com/clearance/public"
+      rule: "allOf"
+    handoffs: []
+    context_scope:
+      can_read: ["self"]
+      can_write: ["self"]
+
+coordination:
+  topology: "hub-spoke"
+  protocol: "a2a-jsonrpc-2.0"
+  routing:
+    strategy: "static"
+
+constraints:
+  global_budget:
+    max_wallclock_seconds: 60
+    max_total_tokens: 8000
+    max_cost_usd: 0.05
+  data_classifications:
+    - "public"
+  network:
+    egress_allowed: false
+    egress_allowlist: []
+
+evaluation:
+  rubric:
+    dimensions:
+      - name: "accuracy"
+        weight: 1.0
+        threshold: 0.7
+  critic_role: "showcase"
+
+completion:
+  rules:
+    - "panel renders flight role"
+  on_failure: "abort"
+  max_retries: 0
+
+provenance:
+  signatures:
+    - signer_did: "did:web:arkavo.com"
+      algorithm: "ed25519"
+      signature: "i_TEuEOJp97yBlK1dVTDECgJjQBTJD2POG3CIKRfjnMFCEmD4iLI33EAB-qr6xMqZIjl4nq7h_obv27af7JWug"

--- a/examples/arp-showcase/run-swarmkit.sh
+++ b/examples/arp-showcase/run-swarmkit.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# ARP Showcase + SwarmKit — boot the AG-UI gateway with BOTH:
+#   * the rich (local) ARP document (arkavo.arp.json), and
+#   * a single-role SwarmFlight derived from arkavo.swarmkit.yaml
+# so the panel renders the original ARP showcase agent alongside an
+# Active SwarmFlight section, demonstrating the SwarmKit per-role ARP
+# handoff in the same UI.
+#
+# Usage:
+#   ./run-swarmkit.sh           # default port 7700
+#   ./run-swarmkit.sh --port N  # custom port
+#
+# Open http://127.0.0.1:7700 then click the scales icon in the left nav.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BINARY="${SCRIPT_DIR}/../../target/debug/arkavo"
+
+PORT=7700
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --port) PORT="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+if [ ! -f "$BINARY" ]; then
+    echo "Error: arkavo binary not found at $BINARY"
+    echo "Build first:  cargo build"
+    exit 1
+fi
+
+export ARKAVO_ARP_PATH="${SCRIPT_DIR}/arkavo.arp.json"
+export ARKAVO_SWARMKIT_PATH="${SCRIPT_DIR}/arkavo.swarmkit.yaml"
+
+echo "ARP Showcase + SwarmKit"
+echo "======================="
+echo "ARP document: $ARKAVO_ARP_PATH"
+echo "SwarmKit:     $ARKAVO_SWARMKIT_PATH"
+echo "Web UI port:  $PORT"
+echo
+echo "Open http://127.0.0.1:${PORT} and click the scales (Agent Runtime Policy) nav button."
+echo "You should see an 'Active SwarmFlights' section above the (local) agent."
+echo
+
+exec "$BINARY" ui --port "$PORT"


### PR DESCRIPTION
## Summary

Adds a single-role SwarmKit alongside the rich ARP document in `examples/arp-showcase/`, so the AG-UI ARP panel can render the SwarmKit per-role handoff in the same demo that exhibits the `(local)` ARP agent.

Stacked on `feature/swarmkit`. Patch bump 0.73.3 → 0.73.4.

## Files

- `examples/arp-showcase/arkavo.swarmkit.yaml` — single-role kit (role_id `showcase`, role_type `showcase_agent`), self-verified `kit.id` (`blake3:fYvTdVeTyZ-zce8pzbtcWBIAf9y26Mqm7OetdYwZ7VY`).
- `examples/arp-showcase/run-swarmkit.sh` — exports BOTH `ARKAVO_ARP_PATH` and `ARKAVO_SWARMKIT_PATH`, so the gateway boots with the (local) ARP agent and a SwarmFlight registered side-by-side.
- README updated to document both run scripts, the new Active SwarmFlights section, and the Stop button affordance.

## Why parallel (not replacement)

The original `arkavo.arp.json` is a fully-fleshed ARP document covering cognitive layer, escalation, HITL, observability, etc. Migrating it into a SwarmKit would require either (a) a manifest schema change to embed/reference an external ARP doc, or (b) accepting the loss of those rich sections and using the auto-derived ARP. (a) is a spec change out of scope for a patch; (b) regresses the demo.

Parallel keeps both paths working: ARP-only runs via `run.sh`, ARP + SwarmFlight via `run-swarmkit.sh`.

## Test plan

- [x] `cargo run -p arkavo-swarmkit --example validate_kit` — kit validates, BLAKE3 round-trips
- [x] `cargo build -q --workspace --exclude golden-dataset` clean
- [ ] Manual: `./run-swarmkit.sh`, confirm panel shows both `(local)` and the flight role pill
- [ ] Manual: click Stop on the flight pill, confirm `(local)` agent persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)