### PR TITLE
SwarmKit: TDF envelope wrap/unwrap (spec §6, slice 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "chrono",
  "serde",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-config-bundle",
  "base64 0.22.1",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "git2",
  "tempfile",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "bindgen",
  "cc",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "lru",
  "serde",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "libc",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1876,12 +1876,13 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-agui",
  "arkavo-arp",
  "arkavo-arp-runtime",
  "arkavo-swarmkit",
+ "arkavo-tdf",
  "arkavo-test-macros",
  "serde_json",
  "thiserror 2.0.18",
@@ -1891,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1910,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1932,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1949,7 +1950,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -1973,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1984,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -1997,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2009,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2018,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2037,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2052,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2077,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2087,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.73.4"
+version = "0.73.5"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.73.4"
+version = "0.73.5"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-swarmkit-runtime/Cargo.toml
+++ b/crates/arkavo-swarmkit-runtime/Cargo.toml
@@ -8,10 +8,18 @@ license.workspace = true
 repository.workspace = true
 description = "SwarmFlight runtime — per-role ARP runtime provisioning and DecisionTrace isolation"
 
+[features]
+default = []
+# Wrap/unwrap SwarmKit manifests through the OpenTDF envelope. Pulls in
+# opentdf-rs via arkavo-tdf for AES-256-GCM + RSA-OAEP key wrap. Keep
+# disabled for headless / in-process flight orchestration.
+tdf = ["dep:arkavo-tdf"]
+
 [dependencies]
 arkavo-swarmkit = { path = "../arkavo-swarmkit" }
 arkavo-arp = { path = "../arkavo-arp" }
 arkavo-arp-runtime = { path = "../arkavo-arp-runtime" }
+arkavo-tdf = { path = "../arkavo-tdf", default-features = false, features = ["opentdf"], optional = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
@@ -21,6 +29,7 @@ uuid = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
 arkavo-agui = { path = "../arkavo-agui", default-features = false }
 arkavo-test-macros = { path = "../arkavo-test-macros" }
+arkavo-tdf = { path = "../arkavo-tdf", default-features = false, features = ["opentdf", "testing"] }
 serde_json = { workspace = true }
 
 [[example]]

--- a/crates/arkavo-swarmkit-runtime/src/lib.rs
+++ b/crates/arkavo-swarmkit-runtime/src/lib.rs
@@ -14,9 +14,27 @@
 
 pub mod derive;
 pub mod flight;
+#[cfg(feature = "tdf")]
+pub mod tdf;
 
 pub use derive::{DeriveOptions, derive_arp_for_role};
 pub use flight::{FlightError, LaunchError, LaunchOptions, RoleRuntime, SwarmFlight};
+
+#[cfg(feature = "tdf")]
+pub use tdf::{TdfEnvelopeError, swarmkit_orchestrator_policy, unwrap_manifest, wrap_manifest};
+
+/// Serialize a manifest to canonical JSON (sorted keys, no insignificant
+/// whitespace) for hashing, signing, or TDF wrapping.
+///
+/// Distinct from `arkavo_swarmkit::canonical::kit_id_for` which strips
+/// `kit.id` and `provenance.signatures` before hashing — this helper
+/// preserves every field for round-trip reconstruction.
+pub fn canonical_full_manifest(
+    manifest: &arkavo_swarmkit::Manifest,
+) -> Result<String, serde_json::Error> {
+    let value = serde_json::to_value(manifest)?;
+    Ok(arkavo_swarmkit::canonical_json(&value))
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/arkavo-swarmkit-runtime/src/tdf.rs
+++ b/crates/arkavo-swarmkit-runtime/src/tdf.rs
@@ -1,0 +1,205 @@
+//! TDF envelope wrap/unwrap for SwarmKit manifests (spec §6).
+//!
+//! Producers serialize a `Manifest` to canonical JSON, encrypt the bytes
+//! through any [`TdfEncryptor`], and ship the resulting [`TdfManifest`]
+//! as a `.swarmkit.tdf` payload. Orchestrators reverse the flow: decrypt
+//! through a [`TdfDecryptor`], parse the canonical JSON back into a
+//! `Manifest`, and run cross-block validation before launching a flight.
+//!
+//! This module is gated behind the `tdf` feature so that headless /
+//! in-process flight orchestration can avoid the opentdf-rs dependency
+//! tree. Out of scope for now: KAS-gated decryption (spec §6.3),
+//! per-role TDF policy construction (spec §6.4), and `.swarmkit.tdf`
+//! file-format serialization. Those land in subsequent slices.
+
+use arkavo_swarmkit::{Manifest, ParseError, parse_json};
+use arkavo_tdf::{Policy, PolicyBuilder, TdfDecryptor, TdfEncryptor, TdfError, TdfManifest};
+
+use crate::canonical_full_manifest;
+
+/// Errors that can occur while wrapping or unwrapping a SwarmKit manifest.
+#[derive(Debug, thiserror::Error)]
+pub enum TdfEnvelopeError {
+    #[error("serialize manifest: {0}")]
+    Serialize(#[from] serde_json::Error),
+    #[error("encrypt manifest: {0}")]
+    Encrypt(TdfError),
+    #[error("decrypt manifest: {0}")]
+    Decrypt(TdfError),
+    #[error("parse decrypted manifest: {0}")]
+    Parse(#[from] ParseError),
+    #[error("decrypted payload is not valid UTF-8: {0}")]
+    Utf8(#[from] std::string::FromUtf8Error),
+}
+
+/// Wrap a SwarmKit manifest in a TDF envelope per spec §6.
+///
+/// The manifest is canonicalized (sorted keys, no insignificant
+/// whitespace) before encryption so the wrapped payload is deterministic
+/// for a given input. The supplied [`Policy`] is the §6.3 SwarmKit-level
+/// orchestrator gate — it controls who can request the wrapped key from
+/// the KAS and unwrap the manifest. Use [`swarmkit_orchestrator_policy`]
+/// for the spec's recommended baseline.
+pub async fn wrap_manifest<E: TdfEncryptor>(
+    manifest: &Manifest,
+    encryptor: &E,
+    policy: &Policy,
+) -> Result<TdfManifest, TdfEnvelopeError> {
+    let canonical = canonical_full_manifest(manifest)?;
+    encryptor
+        .encrypt(canonical.as_bytes(), policy)
+        .await
+        .map_err(TdfEnvelopeError::Encrypt)
+}
+
+/// Reverse of [`wrap_manifest`]: decrypt the TDF envelope, parse the
+/// resulting JSON back into a `Manifest`, and run cross-block validation.
+///
+/// The returned manifest is fully validated — same guarantees as
+/// [`arkavo_swarmkit::parse_json`].
+pub async fn unwrap_manifest<D: TdfDecryptor>(
+    tdf: &TdfManifest,
+    decryptor: &D,
+) -> Result<Manifest, TdfEnvelopeError> {
+    let plaintext = decryptor
+        .decrypt(tdf)
+        .await
+        .map_err(TdfEnvelopeError::Decrypt)?;
+    let json = String::from_utf8(plaintext)?;
+    Ok(parse_json(&json)?)
+}
+
+/// Build the spec §6.3 SwarmKit-level TDF Attribute Release Policy.
+///
+/// Gates orchestrator decryption on two attributes:
+/// * `https://attr.arkavo.com/role/orchestrator`
+/// * `https://attr.arkavo.com/clearance/<level>` (defaults to "internal")
+///
+/// Producers may construct their own policy with [`PolicyBuilder`] for
+/// tighter or looser controls; this is a sensible default that matches
+/// the spec example.
+pub fn swarmkit_orchestrator_policy(clearance: Option<&str>) -> Result<Policy, TdfError> {
+    let clearance = clearance.unwrap_or("internal");
+    PolicyBuilder::new()
+        .attribute_single("https://attr.arkavo.com/role", "orchestrator")
+        .attribute_single("https://attr.arkavo.com/clearance", clearance)
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arkavo_swarmkit::parse_yaml;
+    use arkavo_tdf::testing::MockTdfService;
+    use arkavo_test_macros::spec;
+
+    const KIT: &str = r#"
+spec_version: "1.0.0"
+kit:
+  id: ""
+  name: "tdf-roundtrip-kit"
+  version: "0.1.0"
+  authors: [{did: "did:web:example.com"}]
+  created: "2026-05-01T00:00:00Z"
+  expires: "2026-05-30T00:00:00Z"
+  nonce: "thz1Cz8aWOUURbyQQfvA0Q"
+objective:
+  goal: "exercise TDF envelope round-trip"
+  success_criteria: ["wrapped"]
+inputs: []
+deliverables: [{name: "out", type: "json"}]
+roles:
+  - id: "worker"
+    role_type: "specialist"
+    agent_provisioning: {}
+coordination:
+  topology: "hub-spoke"
+  routing: {strategy: "static"}
+constraints:
+  global_budget: {max_wallclock_seconds: 60, max_total_tokens: 8000, max_cost_usd: 0.05}
+  data_classifications: ["public"]
+  network: {egress_allowed: false, egress_allowlist: []}
+completion:
+  rules: ["all deliverables present"]
+  on_failure: "abort"
+  max_retries: 0
+provenance:
+  signatures: [{signer_did: "did:web:example.com", algorithm: "ed25519", signature: "AAA"}]
+"#;
+
+    fn policy() -> Policy {
+        swarmkit_orchestrator_policy(None).unwrap()
+    }
+
+    #[spec("SK-050")]
+    #[tokio::test]
+    async fn wrap_then_unwrap_round_trips_manifest() {
+        let manifest = parse_yaml(KIT).expect("parse manifest");
+        let svc = MockTdfService::new(0xA5);
+        let pol = policy();
+
+        let tdf = wrap_manifest(&manifest, &svc, &pol).await.expect("wrap");
+        let recovered = unwrap_manifest(&tdf, &svc).await.expect("unwrap");
+
+        assert_eq!(manifest, recovered);
+    }
+
+    #[spec("SK-050")]
+    #[tokio::test]
+    async fn wrapped_payload_is_deterministic_for_same_input() {
+        // Canonical-form serialization makes wrap output identical for
+        // identical inputs (modulo any non-deterministic IV the encryptor
+        // injects — MockTdfService has a deterministic XOR so the entire
+        // ciphertext matches).
+        let manifest = parse_yaml(KIT).unwrap();
+        let svc = MockTdfService::new(0x42);
+        let pol = policy();
+
+        let a = wrap_manifest(&manifest, &svc, &pol).await.unwrap();
+        let b = wrap_manifest(&manifest, &svc, &pol).await.unwrap();
+        assert_eq!(a.payload.value, b.payload.value);
+    }
+
+    #[spec("SK-051")]
+    #[tokio::test]
+    async fn unwrap_runs_cross_block_validation() {
+        // A tampered ciphertext that decrypts to bogus JSON surfaces as
+        // a Parse error from unwrap_manifest, not a silent corruption.
+        let manifest = parse_yaml(KIT).unwrap();
+        let svc = MockTdfService::new(0x11);
+        let pol = policy();
+
+        let mut tdf = wrap_manifest(&manifest, &svc, &pol).await.unwrap();
+        // Truncate the ciphertext to force a parse failure post-decrypt.
+        tdf.payload.value.truncate(20);
+
+        let err = unwrap_manifest(&tdf, &svc).await.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                TdfEnvelopeError::Parse(_)
+                    | TdfEnvelopeError::Utf8(_)
+                    | TdfEnvelopeError::Decrypt(_)
+            ),
+            "expected Parse / Utf8 / Decrypt error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn orchestrator_policy_has_required_attributes() {
+        let pol = swarmkit_orchestrator_policy(Some("confidential")).unwrap();
+        assert_eq!(pol.attributes.len(), 2);
+        let role_attr = pol
+            .attributes
+            .iter()
+            .find(|a| a.attribute.contains("/role"))
+            .expect("role attribute present");
+        assert_eq!(role_attr.values, vec!["orchestrator".to_string()]);
+        let clearance = pol
+            .attributes
+            .iter()
+            .find(|a| a.attribute.contains("/clearance"))
+            .expect("clearance attribute present");
+        assert_eq!(clearance.values, vec!["confidential".to_string()]);
+    }
+}

--- a/specs/arkavo-edge/index.yaml
+++ b/specs/arkavo-edge/index.yaml
@@ -564,7 +564,7 @@ components:
     module: arkavo_swarmkit
     description: SwarmKit manifest, runtime, and AG-UI gateway integration
     criticality: high
-    scenario_count: 22
+    scenario_count: 25
     invariants:
       - kit.id equals BLAKE3 of canonical manifest
       - SwarmFlight builds one ArpRuntime per role at launch
@@ -572,6 +572,7 @@ components:
       - ARKAVO_SWARMKIT_PATH auto-launch failures are non-fatal
       - requestStopFlight deregisters every role of a flight in one call
       - Identical ArpStatusUpdate payloads do not cause panel re-renders
+      - TDF envelope round-trips the manifest losslessly under canonical-form serialization
 
   - name: ui-core
     file: ui-core.spec.yaml

--- a/specs/arkavo-edge/swarmkit.spec.yaml
+++ b/specs/arkavo-edge/swarmkit.spec.yaml
@@ -356,6 +356,55 @@ scenarios:
       - crates/arkavo-agui/static/js/panels/arp.js:13-35
     changed: "2026-05-01"
 
+  # --- TDF envelope (spec §6) ----------------------------------------------
+
+  - id: SK-050
+    name: TDF envelope round-trips a SwarmKit manifest losslessly
+    criticality: critical
+    given:
+      - Validated SwarmKit manifest
+      - TdfEncryptor + TdfDecryptor pair (e.g. OpenTdfService or MockTdfService)
+      - SwarmKit-level orchestrator policy
+    when: wrap_manifest then unwrap_manifest are called in sequence
+    then:
+      - Manifest serialized via canonical_full_manifest (sorted keys, no whitespace)
+      - Encrypted bytes wrapped in TdfManifest with the policy bound
+      - Decrypted plaintext parses back into an equal Manifest (including kit.id and provenance.signatures)
+      - Wrap output is deterministic when the encryptor is deterministic
+    refs:
+      - crates/arkavo-swarmkit-runtime/src/tdf.rs:32-56
+      - crates/arkavo-swarmkit-runtime/src/tdf.rs:62-72
+    changed: "2026-05-01"
+
+  - id: SK-051
+    name: unwrap_manifest re-validates the recovered manifest
+    criticality: high
+    given:
+      - TdfManifest whose decrypted payload is corrupt or fails cross-block validation
+    when: unwrap_manifest is called
+    then:
+      - TdfEnvelopeError::Decrypt returned when ciphertext fails MAC/AEAD check
+      - TdfEnvelopeError::Utf8 returned when plaintext is not valid UTF-8
+      - TdfEnvelopeError::Parse returned when JSON does not validate against the manifest schema
+      - No partially-constructed Manifest is ever returned from a failed unwrap
+    refs:
+      - crates/arkavo-swarmkit-runtime/src/tdf.rs:74-86
+    changed: "2026-05-01"
+
+  - id: SK-052
+    name: swarmkit_orchestrator_policy emits the §6.3 baseline gate
+    criticality: medium
+    given:
+      - Optional clearance level (defaults to "internal")
+    when: swarmkit_orchestrator_policy is called
+    then:
+      - Policy includes attribute https://attr.arkavo.com/role with value "orchestrator"
+      - Policy includes attribute https://attr.arkavo.com/clearance with the supplied or default value
+      - PolicyBuilder validation succeeds (every attribute has at least one value, FQNs are URLs)
+    refs:
+      - crates/arkavo-swarmkit-runtime/src/tdf.rs:88-100
+    changed: "2026-05-01"
+
   # --- Operator controls ---------------------------------------------------
 
   - id: SK-040


### PR DESCRIPTION
## Summary

First slice of TDF integration. Adds spec §6 envelope: encrypt a SwarmKit manifest into a `TdfManifest` via opentdf-rs, and reverse the flow on the consumer side.

Stacked on `feature/swarmkit`. Patch bump 0.73.4 → 0.73.5.

## Design

- New module `arkavo-swarmkit-runtime/src/tdf.rs` gated behind a `tdf` feature flag.
- Reuses existing `arkavo-tdf` infrastructure (`TdfEncryptor` / `TdfDecryptor` traits + `OpenTdfService` from opentdf-rs). No new crypto code.
- Canonical-form JSON serialization (sorted keys, no whitespace) before encryption, so wrapped payloads are deterministic for identical inputs and signature-friendly.

## Public API

| Function | Purpose |
|---|---|
| `wrap_manifest(manifest, encryptor, policy)` | Canonicalize → encrypt → emit `TdfManifest` |
| `unwrap_manifest(tdf, decryptor)` | Decrypt → parse → cross-block validate → emit `Manifest` |
| `swarmkit_orchestrator_policy(clearance)` | Spec §6.3 baseline: role=orchestrator + clearance=internal |
| `canonical_full_manifest(manifest)` | Round-trip-safe canonical JSON (vs the §9.1 hashing canonicalization which strips fields) |

`TdfEnvelopeError` distinguishes Serialize / Encrypt / Decrypt / Parse / Utf8 failure modes so callers don't conflate causes.

## Out of scope (queued for follow-up patches)

| Slice | Work |
|---|---|
| 2 | Per-role TDF policy construction from `tdf_attribute_release_policy` blocks (§6.4) |
| 3 | `.swarmkit.tdf` file-format serialization |
| 4 | KAS-gated decryption (§6.3 orchestrator gate enforcement) |
| 5 | Auto-launch path supports `.tdf` extension |

Splitting these keeps each follow-up at patch scope and reviewable in isolation.

## Test plan

- [x] `cargo build -q -p arkavo-swarmkit-runtime --features tdf --tests` clean
- [x] `cargo test -p arkavo-swarmkit-runtime --features tdf` — 15 lib + 2 integration tests pass (4 new)
- [x] `cargo test -p arkavo-swarmkit-runtime --no-default-features` — 11 lib tests pass; TDF surface is genuinely optional
- [x] `cargo clippy -p arkavo-swarmkit-runtime --features tdf -- -D warnings` clean
- [x] `cargo clippy -p arkavo-swarmkit-runtime -- -D warnings` (no-default) clean
- [x] `cargo build -q --workspace --exclude golden-dataset` clean
- [x] Spec yaml validates (25 scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)