### PR TITLE
SwarmKit: per-role TDF policy construction (spec §6.4, slice 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "chrono",
  "serde",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-config-bundle",
  "base64 0.22.1",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "git2",
  "tempfile",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "bindgen",
  "cc",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "lru",
  "serde",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "libc",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1876,8 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
+ "arkavo-agent-auth",
  "arkavo-agui",
  "arkavo-arp",
  "arkavo-arp-runtime",
@@ -1892,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1911,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1933,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1950,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -1974,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1985,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -1998,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2010,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2019,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2038,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2053,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2078,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2088,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.73.5"
+version = "0.73.6"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.73.5"
+version = "0.73.6"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-swarmkit-runtime/Cargo.toml
+++ b/crates/arkavo-swarmkit-runtime/Cargo.toml
@@ -11,15 +11,18 @@ description = "SwarmFlight runtime — per-role ARP runtime provisioning and Dec
 [features]
 default = []
 # Wrap/unwrap SwarmKit manifests through the OpenTDF envelope. Pulls in
-# opentdf-rs via arkavo-tdf for AES-256-GCM + RSA-OAEP key wrap. Keep
-# disabled for headless / in-process flight orchestration.
-tdf = ["dep:arkavo-tdf"]
+# opentdf-rs via arkavo-tdf for AES-256-GCM + RSA-OAEP key wrap. Also
+# pulls in arkavo-agent-auth so role policies can bind to the running
+# agent's StoredToken DID (spec §6.3 dissemination list). Keep disabled
+# for headless / in-process flight orchestration.
+tdf = ["dep:arkavo-tdf", "dep:arkavo-agent-auth"]
 
 [dependencies]
 arkavo-swarmkit = { path = "../arkavo-swarmkit" }
 arkavo-arp = { path = "../arkavo-arp" }
 arkavo-arp-runtime = { path = "../arkavo-arp-runtime" }
 arkavo-tdf = { path = "../arkavo-tdf", default-features = false, features = ["opentdf"], optional = true }
+arkavo-agent-auth = { path = "../arkavo-agent-auth", optional = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }

--- a/crates/arkavo-swarmkit-runtime/src/lib.rs
+++ b/crates/arkavo-swarmkit-runtime/src/lib.rs
@@ -21,7 +21,11 @@ pub use derive::{DeriveOptions, derive_arp_for_role};
 pub use flight::{FlightError, LaunchError, LaunchOptions, RoleRuntime, SwarmFlight};
 
 #[cfg(feature = "tdf")]
-pub use tdf::{TdfEnvelopeError, swarmkit_orchestrator_policy, unwrap_manifest, wrap_manifest};
+pub use tdf::{
+    TdfEnvelopeError, load_current_agent_did, role_policies, role_policies_for_current_agent,
+    role_policy, swarmkit_orchestrator_policy, swarmkit_orchestrator_policy_for_current_agent,
+    unwrap_manifest, wrap_manifest,
+};
 
 /// Serialize a manifest to canonical JSON (sorted keys, no insignificant
 /// whitespace) for hashing, signing, or TDF wrapping.

--- a/crates/arkavo-swarmkit-runtime/src/tdf.rs
+++ b/crates/arkavo-swarmkit-runtime/src/tdf.rs
@@ -8,11 +8,22 @@
 //!
 //! This module is gated behind the `tdf` feature so that headless /
 //! in-process flight orchestration can avoid the opentdf-rs dependency
-//! tree. Out of scope for now: KAS-gated decryption (spec §6.3),
-//! per-role TDF policy construction (spec §6.4), and `.swarmkit.tdf`
-//! file-format serialization. Those land in subsequent slices.
+//! tree. Per-role TDF policy construction (spec §6.4) is implemented
+//! via [`role_policy`] / [`role_policies`]. Out of scope for now:
+//! KAS-gated decryption enforcement (spec §6.3 orchestrator gate),
+//! `.swarmkit.tdf` file-format serialization, and `.tdf`-aware
+//! auto-launch — those land in subsequent slices.
+//!
+//! Agent identity binding: every policy builder accepts an optional
+//! agent DID that is added to the policy's dissemination list. Callers
+//! supply the DID explicitly, or use the
+//! [`swarmkit_orchestrator_policy_for_current_agent`] /
+//! [`role_policies_for_current_agent`] async helpers to load the
+//! locally-stored token from `arkavo-agent-auth` and bind to it.
 
-use arkavo_swarmkit::{Manifest, ParseError, parse_json};
+use std::collections::HashMap;
+
+use arkavo_swarmkit::{Manifest, ParseError, TdfAttributeReleasePolicy, parse_json};
 use arkavo_tdf::{Policy, PolicyBuilder, TdfDecryptor, TdfEncryptor, TdfError, TdfManifest};
 
 use crate::canonical_full_manifest;
@@ -30,6 +41,10 @@ pub enum TdfEnvelopeError {
     Parse(#[from] ParseError),
     #[error("decrypted payload is not valid UTF-8: {0}")]
     Utf8(#[from] std::string::FromUtf8Error),
+    #[error("build policy: {0}")]
+    Policy(TdfError),
+    #[error("load agent identity: {0}")]
+    Identity(String),
 }
 
 /// Wrap a SwarmKit manifest in a TDF envelope per spec §6.
@@ -75,15 +90,184 @@ pub async fn unwrap_manifest<D: TdfDecryptor>(
 /// * `https://attr.arkavo.com/role/orchestrator`
 /// * `https://attr.arkavo.com/clearance/<level>` (defaults to "internal")
 ///
+/// When `orchestrator_did` is supplied, it is added to the policy's
+/// dissemination list — matching the spec §6.3 example
+/// `"dissem": ["did:web:orchestrator.arkavo.net"]` — so only the named
+/// DID's holder can request the wrapped key from the KAS.
+///
 /// Producers may construct their own policy with [`PolicyBuilder`] for
 /// tighter or looser controls; this is a sensible default that matches
-/// the spec example.
-pub fn swarmkit_orchestrator_policy(clearance: Option<&str>) -> Result<Policy, TdfError> {
+/// the spec example. Pair with [`swarmkit_orchestrator_policy_for_current_agent`]
+/// when you want the policy bound to the locally-stored agent identity.
+pub fn swarmkit_orchestrator_policy(
+    clearance: Option<&str>,
+    orchestrator_did: Option<&str>,
+) -> Result<Policy, TdfError> {
     let clearance = clearance.unwrap_or("internal");
-    PolicyBuilder::new()
+    let mut builder = PolicyBuilder::new()
         .attribute_single("https://attr.arkavo.com/role", "orchestrator")
-        .attribute_single("https://attr.arkavo.com/clearance", clearance)
-        .build()
+        .attribute_single("https://attr.arkavo.com/clearance", clearance);
+    if let Some(did) = orchestrator_did {
+        builder = builder.add_dissemination(did);
+    }
+    builder.build()
+}
+
+/// Load the running agent's DID from `arkavo-agent-auth`'s `StoredToken`
+/// and emit a §6.3 orchestrator-gate policy bound to it.
+///
+/// Returns `Identity` error when no token is on disk or when the token
+/// is expired. Use [`swarmkit_orchestrator_policy`] with an explicit DID
+/// when you want to build a policy without the side-effect of disk I/O.
+pub async fn swarmkit_orchestrator_policy_for_current_agent(
+    clearance: Option<&str>,
+) -> Result<Policy, TdfEnvelopeError> {
+    let did = load_current_agent_did().await?;
+    swarmkit_orchestrator_policy(clearance, Some(&did)).map_err(TdfEnvelopeError::Policy)
+}
+
+/// Convert a SwarmKit role's `tdf_attribute_release_policy` block into a
+/// runnable [`Policy`] per spec §6.4.
+///
+/// The orchestrator uses the returned policy to re-wrap data objects
+/// before passing them to the specialist. Each attribute string in the
+/// manifest is treated as `<fqn>/<value>` — the prefix up to the last
+/// `/` becomes the OpenTDF attribute FQN and the suffix becomes the
+/// value. Example:
+///
+/// * `"https://attr.arkavo.com/role/planner"` →
+///   FQN `"https://attr.arkavo.com/role"` + value `"planner"`
+///
+/// Attributes with the same FQN are merged (one OpenTDF [`Attribute`]
+/// with multiple values), so a manifest carrying
+/// `["https://.../role/planner", "https://.../role/critic"]` produces a
+/// single role attribute with both values.
+///
+/// `agent_did`, when supplied, is added to the policy's dissemination
+/// list so the policy binds to that specific specialist identity. Pass
+/// `None` for an identity-agnostic policy (any holder of the required
+/// attributes can decrypt).
+///
+/// The manifest's `rule` field (`AllOf` / `AnyOf` / `Hierarchy`) is
+/// metadata that the OpenTDF policy structure does not carry directly;
+/// rule semantics are evaluated KAS-side at attribute-definition time.
+/// Callers that need to honor `rule` differently should pass it through
+/// alongside the policy.
+pub fn role_policy(
+    role_id: &str,
+    arp: &TdfAttributeReleasePolicy,
+    agent_did: Option<&str>,
+) -> Result<Policy, TdfError> {
+    let mut by_fqn: Vec<(String, Vec<String>)> = Vec::new();
+    for attr in &arp.attributes {
+        let (fqn, value) = split_attribute(attr).ok_or_else(|| {
+            TdfError::Policy(format!(
+                "role {role_id:?}: attribute {attr:?} is not in the form '<fqn>/<value>'"
+            ))
+        })?;
+        match by_fqn.iter_mut().find(|(f, _)| f == &fqn) {
+            Some((_, vs)) => {
+                if !vs.iter().any(|v| v == &value) {
+                    vs.push(value);
+                }
+            }
+            None => by_fqn.push((fqn, vec![value])),
+        }
+    }
+    let mut builder = PolicyBuilder::new().id(&format!("swarmkit:role:{role_id}"));
+    for (fqn, values) in &by_fqn {
+        let refs: Vec<&str> = values.iter().map(String::as_str).collect();
+        builder = builder.attribute(fqn, &refs);
+    }
+    if let Some(did) = agent_did {
+        builder = builder.add_dissemination(did);
+    }
+    builder.build()
+}
+
+/// Build per-role policies for every role in the manifest that declares
+/// a `tdf_attribute_release_policy` block. Roles without one are
+/// omitted from the returned map — the caller decides whether to treat
+/// that as an error or to fall back to a permissive default.
+///
+/// `did_for` is a per-role lookup that the caller controls. Typical
+/// implementations:
+///
+/// * `|_| None` — identity-agnostic policies (attribute-only).
+/// * `|_| Some(orchestrator_did)` — bind every role's data to the
+///   orchestrator's own DID, since the orchestrator runs each role
+///   in-process for now (no specialist subprocess yet).
+/// * `|role_id| specialist_dids.get(role_id).cloned()` — once
+///   specialists are provisioned, look up each one's DID.
+pub fn role_policies<F>(
+    manifest: &Manifest,
+    mut did_for: F,
+) -> Result<HashMap<String, Policy>, TdfError>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let mut out = HashMap::new();
+    for role in &manifest.roles {
+        if let Some(arp) = &role.tdf_attribute_release_policy {
+            let did = did_for(&role.id);
+            let pol = role_policy(&role.id, arp, did.as_deref())?;
+            out.insert(role.id.clone(), pol);
+        }
+    }
+    Ok(out)
+}
+
+/// Convenience: build per-role policies, binding every role's data
+/// dissemination to the locally-stored agent identity from
+/// `arkavo-agent-auth`. Used when the orchestrator runs every role in
+/// its own process and decryption must scope to that single DID.
+pub async fn role_policies_for_current_agent(
+    manifest: &Manifest,
+) -> Result<HashMap<String, Policy>, TdfEnvelopeError> {
+    let did = load_current_agent_did().await?;
+    role_policies(manifest, |_| Some(did.clone())).map_err(TdfEnvelopeError::Policy)
+}
+
+/// Load the running agent's DID from `arkavo-agent-auth`'s on-disk
+/// `StoredToken`. Returns `Identity` error when no token exists or the
+/// token is expired.
+pub async fn load_current_agent_did() -> Result<String, TdfEnvelopeError> {
+    let stored = arkavo_agent_auth::load_token()
+        .await
+        .map_err(|e| TdfEnvelopeError::Identity(e.to_string()))?
+        .ok_or_else(|| {
+            TdfEnvelopeError::Identity(
+                "no StoredToken on disk; agent must register and authenticate first".to_string(),
+            )
+        })?;
+    if stored.is_expired() {
+        return Err(TdfEnvelopeError::Identity(format!(
+            "StoredToken for {did:?} expired at {expires}",
+            did = stored.did,
+            expires = stored.expires_at
+        )));
+    }
+    Ok(stored.did)
+}
+
+/// Split a SwarmKit attribute string at the last `/` into (fqn, value).
+/// Returns `None` if the input has no `/`, has nothing after the final
+/// `/`, or the prefix is not an http(s) URL — those would all fail
+/// `PolicyBuilder` validation downstream anyway.
+fn split_attribute(attr: &str) -> Option<(String, String)> {
+    let idx = attr.rfind('/')?;
+    if idx == 0 || idx == attr.len() - 1 {
+        return None;
+    }
+    let (fqn, rest) = attr.split_at(idx);
+    if !fqn.starts_with("http://") && !fqn.starts_with("https://") {
+        return None;
+    }
+    let value = &rest[1..];
+    if value.is_empty() {
+        return None;
+    }
+    Some((fqn.to_string(), value.to_string()))
 }
 
 #[cfg(test)]
@@ -128,7 +312,7 @@ provenance:
 "#;
 
     fn policy() -> Policy {
-        swarmkit_orchestrator_policy(None).unwrap()
+        swarmkit_orchestrator_policy(None, None).unwrap()
     }
 
     #[spec("SK-050")]
@@ -185,9 +369,10 @@ provenance:
         );
     }
 
+    #[spec("SK-052")]
     #[test]
     fn orchestrator_policy_has_required_attributes() {
-        let pol = swarmkit_orchestrator_policy(Some("confidential")).unwrap();
+        let pol = swarmkit_orchestrator_policy(Some("confidential"), None).unwrap();
         assert_eq!(pol.attributes.len(), 2);
         let role_attr = pol
             .attributes
@@ -201,5 +386,200 @@ provenance:
             .find(|a| a.attribute.contains("/clearance"))
             .expect("clearance attribute present");
         assert_eq!(clearance.values, vec!["confidential".to_string()]);
+        assert!(pol.dissemination.is_empty());
+    }
+
+    #[spec("SK-052")]
+    #[test]
+    fn orchestrator_policy_binds_to_supplied_did() {
+        let pol =
+            swarmkit_orchestrator_policy(None, Some("did:web:orchestrator.arkavo.net")).unwrap();
+        assert_eq!(
+            pol.dissemination,
+            vec!["did:web:orchestrator.arkavo.net".to_string()]
+        );
+    }
+
+    #[spec("SK-053")]
+    #[test]
+    fn role_policy_splits_attributes_at_last_slash() {
+        use arkavo_swarmkit::ArpRule;
+        let arp = TdfAttributeReleasePolicy {
+            attributes: vec![
+                "https://attr.arkavo.com/role/planner".to_string(),
+                "https://attr.arkavo.com/clearance/internal".to_string(),
+            ],
+            rule: ArpRule::AllOf,
+        };
+        let pol = role_policy("planner-1", &arp, None).unwrap();
+        assert_eq!(pol.attributes.len(), 2);
+        let role = pol
+            .attributes
+            .iter()
+            .find(|a| a.attribute == "https://attr.arkavo.com/role")
+            .unwrap();
+        assert_eq!(role.values, vec!["planner".to_string()]);
+        let clearance = pol
+            .attributes
+            .iter()
+            .find(|a| a.attribute == "https://attr.arkavo.com/clearance")
+            .unwrap();
+        assert_eq!(clearance.values, vec!["internal".to_string()]);
+        assert_eq!(pol.id.as_deref(), Some("swarmkit:role:planner-1"));
+    }
+
+    #[spec("SK-053")]
+    #[test]
+    fn role_policy_merges_repeated_fqns() {
+        use arkavo_swarmkit::ArpRule;
+        let arp = TdfAttributeReleasePolicy {
+            attributes: vec![
+                "https://attr.arkavo.com/role/planner".to_string(),
+                "https://attr.arkavo.com/role/critic".to_string(),
+            ],
+            rule: ArpRule::AnyOf,
+        };
+        let pol = role_policy("multi", &arp, None).unwrap();
+        assert_eq!(pol.attributes.len(), 1);
+        let mut values = pol.attributes[0].values.clone();
+        values.sort();
+        assert_eq!(values, vec!["critic".to_string(), "planner".to_string()]);
+    }
+
+    #[spec("SK-053")]
+    #[test]
+    fn role_policy_binds_to_agent_did_via_dissemination() {
+        use arkavo_swarmkit::ArpRule;
+        let arp = TdfAttributeReleasePolicy {
+            attributes: vec!["https://attr.arkavo.com/clearance/public".to_string()],
+            rule: ArpRule::AllOf,
+        };
+        let pol = role_policy("worker", &arp, Some("did:web:specialist.example.com")).unwrap();
+        assert_eq!(
+            pol.dissemination,
+            vec!["did:web:specialist.example.com".to_string()]
+        );
+    }
+
+    #[spec("SK-054")]
+    #[test]
+    fn role_policy_rejects_malformed_attribute() {
+        use arkavo_swarmkit::ArpRule;
+        let arp = TdfAttributeReleasePolicy {
+            // Missing a slash → cannot split into (fqn, value).
+            attributes: vec!["malformed".to_string()],
+            rule: ArpRule::AllOf,
+        };
+        let err = role_policy("r1", &arp, None).unwrap_err();
+        assert!(matches!(err, TdfError::Policy(_)));
+    }
+
+    #[spec("SK-054")]
+    #[test]
+    fn role_policies_extracts_only_roles_with_arp() {
+        // Reuse KIT (single role with arp omitted via empty agent_provisioning),
+        // build a manifest where only one of two roles has an ARP block.
+        let kit_with_two = r#"
+spec_version: "1.0.0"
+kit:
+  id: ""
+  name: "two-role-policy-kit"
+  version: "0.1.0"
+  authors: [{did: "did:web:example.com"}]
+  created: "2026-05-01T00:00:00Z"
+  expires: "2026-05-30T00:00:00Z"
+  nonce: "thz1Cz8aWOUURbyQQfvA0Q"
+objective:
+  goal: "exercise role_policies"
+  success_criteria: ["done"]
+inputs: []
+deliverables: [{name: "out", type: "json"}]
+roles:
+  - id: "with-arp"
+    role_type: "specialist"
+    agent_provisioning: {}
+    tdf_attribute_release_policy:
+      attributes: ["https://attr.arkavo.com/clearance/public"]
+      rule: "allOf"
+  - id: "without-arp"
+    role_type: "critic"
+    agent_provisioning: {}
+coordination:
+  topology: "pipeline"
+  routing: {strategy: "static"}
+constraints:
+  global_budget: {max_wallclock_seconds: 60, max_total_tokens: 8000, max_cost_usd: 0.05}
+  data_classifications: ["public"]
+  network: {egress_allowed: false, egress_allowlist: []}
+completion:
+  rules: ["all deliverables present"]
+  on_failure: "abort"
+  max_retries: 0
+provenance:
+  signatures: [{signer_did: "did:web:example.com", algorithm: "ed25519", signature: "AAA"}]
+"#;
+        let m = parse_yaml(kit_with_two).unwrap();
+        let pols = role_policies(&m, |_| None).unwrap();
+        assert_eq!(pols.len(), 1);
+        assert!(pols.contains_key("with-arp"));
+        assert!(!pols.contains_key("without-arp"));
+    }
+
+    #[spec("SK-054")]
+    #[test]
+    fn role_policies_did_lookup_per_role() {
+        let kit_with_two = r#"
+spec_version: "1.0.0"
+kit:
+  id: ""
+  name: "did-lookup-kit"
+  version: "0.1.0"
+  authors: [{did: "did:web:example.com"}]
+  created: "2026-05-01T00:00:00Z"
+  expires: "2026-05-30T00:00:00Z"
+  nonce: "thz1Cz8aWOUURbyQQfvA0Q"
+objective:
+  goal: "per-role DID binding"
+  success_criteria: ["done"]
+inputs: []
+deliverables: [{name: "out", type: "json"}]
+roles:
+  - id: "alpha"
+    role_type: "specialist"
+    agent_provisioning: {}
+    tdf_attribute_release_policy:
+      attributes: ["https://attr.arkavo.com/clearance/public"]
+      rule: "allOf"
+  - id: "beta"
+    role_type: "specialist"
+    agent_provisioning: {}
+    tdf_attribute_release_policy:
+      attributes: ["https://attr.arkavo.com/clearance/public"]
+      rule: "allOf"
+coordination:
+  topology: "pipeline"
+  routing: {strategy: "static"}
+constraints:
+  global_budget: {max_wallclock_seconds: 60, max_total_tokens: 8000, max_cost_usd: 0.05}
+  data_classifications: ["public"]
+  network: {egress_allowed: false, egress_allowlist: []}
+completion:
+  rules: ["all deliverables present"]
+  on_failure: "abort"
+  max_retries: 0
+provenance:
+  signatures: [{signer_did: "did:web:example.com", algorithm: "ed25519", signature: "AAA"}]
+"#;
+        let m = parse_yaml(kit_with_two).unwrap();
+        let pols =
+            role_policies(&m, |role_id| Some(format!("did:web:{role_id}.example.com"))).unwrap();
+        assert_eq!(
+            pols["alpha"].dissemination,
+            vec!["did:web:alpha.example.com".to_string()]
+        );
+        assert_eq!(
+            pols["beta"].dissemination,
+            vec!["did:web:beta.example.com".to_string()]
+        );
     }
 }

--- a/crates/arkavo-swarmkit/src/lib.rs
+++ b/crates/arkavo-swarmkit/src/lib.rs
@@ -23,8 +23,8 @@ pub use coordination::{
 };
 pub use manifest::{Author, DeliverableSpec, InputSpec, KitMetadata, Manifest, Objective};
 pub use role::{
-    AgentProvisioning, Budget, ContextScope, Failure, Handoff, Inference, McpToolGrant, Model,
-    Observability, RoleSpec, Skill, TdfAttributeReleasePolicy, ToolUse,
+    AgentProvisioning, ArpRule, Budget, ContextScope, Failure, Handoff, Inference, McpToolGrant,
+    Model, Observability, RoleSpec, Skill, TdfAttributeReleasePolicy, ToolUse,
 };
 pub use validate::{ValidationError, validate};
 

--- a/specs/arkavo-edge/index.yaml
+++ b/specs/arkavo-edge/index.yaml
@@ -564,7 +564,7 @@ components:
     module: arkavo_swarmkit
     description: SwarmKit manifest, runtime, and AG-UI gateway integration
     criticality: high
-    scenario_count: 25
+    scenario_count: 27
     invariants:
       - kit.id equals BLAKE3 of canonical manifest
       - SwarmFlight builds one ArpRuntime per role at launch
@@ -573,6 +573,8 @@ components:
       - requestStopFlight deregisters every role of a flight in one call
       - Identical ArpStatusUpdate payloads do not cause panel re-renders
       - TDF envelope round-trips the manifest losslessly under canonical-form serialization
+      - role_policy splits attributes at the last "/" into (fqn, value)
+      - Per-role policies bind to agent DIDs via the dissemination list (spec §6.3 example)
 
   - name: ui-core
     file: ui-core.spec.yaml

--- a/specs/arkavo-edge/swarmkit.spec.yaml
+++ b/specs/arkavo-edge/swarmkit.spec.yaml
@@ -396,13 +396,49 @@ scenarios:
     criticality: medium
     given:
       - Optional clearance level (defaults to "internal")
+      - Optional orchestrator DID
     when: swarmkit_orchestrator_policy is called
     then:
       - Policy includes attribute https://attr.arkavo.com/role with value "orchestrator"
       - Policy includes attribute https://attr.arkavo.com/clearance with the supplied or default value
+      - When orchestrator_did is Some, dissemination contains exactly that DID
+      - When orchestrator_did is None, dissemination is empty (attribute-only gating)
       - PolicyBuilder validation succeeds (every attribute has at least one value, FQNs are URLs)
     refs:
-      - crates/arkavo-swarmkit-runtime/src/tdf.rs:88-100
+      - crates/arkavo-swarmkit-runtime/src/tdf.rs:103-122
+    changed: "2026-05-01"
+
+  - id: SK-053
+    name: role_policy converts TdfAttributeReleasePolicy into a runnable Policy
+    criticality: high
+    given:
+      - role's tdf_attribute_release_policy from the manifest
+      - Optional agent DID for dissemination binding
+    when: role_policy is called
+    then:
+      - Each attribute string split at the last "/" into (fqn, value)
+      - Attributes sharing an FQN merged into a single OpenTDF attribute with multiple values
+      - Policy id set to "swarmkit:role:<role_id>"
+      - When agent_did is Some, dissemination contains exactly that DID
+      - When agent_did is None, dissemination is empty
+    refs:
+      - crates/arkavo-swarmkit-runtime/src/tdf.rs:154-194
+    changed: "2026-05-01"
+
+  - id: SK-054
+    name: role_policies extracts per-role policies and supports DID lookup
+    criticality: high
+    given:
+      - Manifest with some roles declaring tdf_attribute_release_policy
+      - Closure mapping role_id → Option<DID>
+    when: role_policies is called
+    then:
+      - Roles without an ARP block are omitted from the result
+      - Each role's policy carries the DID returned by the closure for that role_id
+      - role_policies_for_current_agent loads the agent DID from arkavo-agent-auth StoredToken and binds every role to it
+      - Malformed attribute strings (missing "/" or non-URL prefix) produce TdfError::Policy
+    refs:
+      - crates/arkavo-swarmkit-runtime/src/tdf.rs:212-245
     changed: "2026-05-01"
 
   # --- Operator controls ---------------------------------------------------


### PR DESCRIPTION
## Summary

Slice 2 of TDF integration. Converts each role's `tdf_attribute_release_policy` block in the manifest into a runnable `arkavo_tdf::Policy` that the orchestrator can bind to data objects passed to that role. Integrates with the existing `arkavo-agent-auth` identity mechanism so policies dissem-bind to the running agent's `StoredToken` DID per spec §6.3 example.

Stacked on `feature/swarmkit`. Patch bump 0.73.5 → 0.73.6.

## API additions (under the `tdf` feature)

| Function | Purpose |
|---|---|
| `role_policy(role_id, arp, agent_did)` | Convert one role's ARP block to a `Policy`. Splits attribute strings at last `/` into (fqn, value); merges repeated FQNs into multi-value attrs; binds DID via `dissemination`. |
| `role_policies(manifest, did_for: F)` | Closure-driven per-role extraction. Roles without ARP blocks omitted. |
| `role_policies_for_current_agent(manifest)` | Async helper: loads `StoredToken` via `arkavo_agent_auth` and binds every role to that DID. |
| `swarmkit_orchestrator_policy(clearance, orchestrator_did)` | Extended from slice 1 to take optional DID for dissemination. |
| `swarmkit_orchestrator_policy_for_current_agent(clearance)` | Async equivalent backed by `StoredToken`. |
| `load_current_agent_did()` | Identity-loading helper; surfaces `Identity` error when token absent / expired. |

## Agent identity integration

The user's directive — *"make sure to use the agent identity mechanism"* — drives the design here. Every policy builder accepts `agent_did: Option<&str>`; when supplied, it goes into the policy's `dissemination` list, matching the spec §6.3 example:

```json
"dissem": ["did:web:orchestrator.arkavo.net"]
```

The async `*_for_current_agent` helpers source the DID from the running agent's `arkavo-agent-auth::StoredToken`, with explicit error reporting when the token is absent or expired.

## Out of scope (queued for follow-up patches)

| Slice | Work |
|---|---|
| 3 | `.swarmkit.tdf` file-format serialization |
| 4 | KAS-gated decryption (§6.3 actual enforcement, not just policy attachment) |
| 5 | Auto-launch path supports `.tdf` extension |

## Test plan

- [x] `cargo build -q -p arkavo-swarmkit-runtime --features tdf --tests` clean
- [x] `cargo test -p arkavo-swarmkit-runtime --features tdf` — 22 lib + 2 integration tests pass (7 new in this slice)
- [x] `cargo test -p arkavo-swarmkit-runtime --no-default-features` — 11 lib + 2 integration tests pass (TDF surface still genuinely optional)
- [x] `cargo clippy -p arkavo-swarmkit-runtime --features tdf -- -D warnings` clean
- [x] `cargo clippy -p arkavo-swarmkit-runtime -- -D warnings` (no-default) clean
- [x] `cargo build -q --workspace --exclude golden-dataset` clean
- [x] Spec yaml validates (27 scenarios, +2 from SK-053 / SK-054)

🤖 Generated with [Claude Code](https://claude.com/claude-code)