### PR TITLE
SwarmKit: .swarmkit.tdf file-format read/write (slice 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "chrono",
  "serde",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-config-bundle",
  "base64 0.22.1",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "git2",
  "tempfile",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "bindgen",
  "cc",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "lru",
  "serde",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "libc",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -1886,6 +1886,7 @@ dependencies = [
  "arkavo-tdf",
  "arkavo-test-macros",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "uuid",
@@ -1893,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1912,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1934,7 +1935,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1951,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -1975,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1986,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -1999,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2011,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2020,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2039,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2054,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2079,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2089,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.73.6"
+version = "0.73.7"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.73.6"
+version = "0.73.7"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-swarmkit-runtime/Cargo.toml
+++ b/crates/arkavo-swarmkit-runtime/Cargo.toml
@@ -34,6 +34,7 @@ arkavo-agui = { path = "../arkavo-agui", default-features = false }
 arkavo-test-macros = { path = "../arkavo-test-macros" }
 arkavo-tdf = { path = "../arkavo-tdf", default-features = false, features = ["opentdf", "testing"] }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 
 [[example]]
 name = "swarm_flight_demo"

--- a/crates/arkavo-swarmkit-runtime/src/lib.rs
+++ b/crates/arkavo-swarmkit-runtime/src/lib.rs
@@ -22,9 +22,11 @@ pub use flight::{FlightError, LaunchError, LaunchOptions, RoleRuntime, SwarmFlig
 
 #[cfg(feature = "tdf")]
 pub use tdf::{
-    TdfEnvelopeError, load_current_agent_did, role_policies, role_policies_for_current_agent,
-    role_policy, swarmkit_orchestrator_policy, swarmkit_orchestrator_policy_for_current_agent,
-    unwrap_manifest, wrap_manifest,
+    SWARMKIT_TDF_EXTENSION, TdfEnvelopeError, load_current_agent_did, read_kit_tdf,
+    read_kit_tdf_from_path, role_policies, role_policies_for_current_agent, role_policy,
+    swarmkit_orchestrator_policy, swarmkit_orchestrator_policy_for_current_agent, unwrap_manifest,
+    unwrap_manifest_from_path, wrap_manifest, wrap_manifest_to_path, write_kit_tdf,
+    write_kit_tdf_to_path,
 };
 
 /// Serialize a manifest to canonical JSON (sorted keys, no insignificant

--- a/crates/arkavo-swarmkit-runtime/src/tdf.rs
+++ b/crates/arkavo-swarmkit-runtime/src/tdf.rs
@@ -9,10 +9,11 @@
 //! This module is gated behind the `tdf` feature so that headless /
 //! in-process flight orchestration can avoid the opentdf-rs dependency
 //! tree. Per-role TDF policy construction (spec §6.4) is implemented
-//! via [`role_policy`] / [`role_policies`]. Out of scope for now:
-//! KAS-gated decryption enforcement (spec §6.3 orchestrator gate),
-//! `.swarmkit.tdf` file-format serialization, and `.tdf`-aware
-//! auto-launch — those land in subsequent slices.
+//! via [`role_policy`] / [`role_policies`]. The `.swarmkit.tdf` file
+//! format is implemented via [`write_kit_tdf`] / [`read_kit_tdf`] and
+//! their path-based / one-shot variants. Out of scope for now:
+//! KAS-gated decryption enforcement (spec §6.3 orchestrator gate)
+//! and `.tdf`-aware auto-launch — those land in subsequent slices.
 //!
 //! Agent identity binding: every policy builder accepts an optional
 //! agent DID that is added to the policy's dissemination list. Callers
@@ -45,6 +46,8 @@ pub enum TdfEnvelopeError {
     Policy(TdfError),
     #[error("load agent identity: {0}")]
     Identity(String),
+    #[error(".swarmkit.tdf I/O error: {0}")]
+    Io(#[from] std::io::Error),
 }
 
 /// Wrap a SwarmKit manifest in a TDF envelope per spec §6.
@@ -268,6 +271,89 @@ fn split_attribute(attr: &str) -> Option<(String, String)> {
         return None;
     }
     Some((fqn.to_string(), value.to_string()))
+}
+
+// --- .swarmkit.tdf file format -----------------------------------------
+
+/// Recommended file extension for SwarmKit TDF envelopes on disk.
+pub const SWARMKIT_TDF_EXTENSION: &str = "swarmkit.tdf";
+
+/// Write a [`TdfManifest`] to disk as a `.swarmkit.tdf` file.
+///
+/// The on-disk format is the canonical JSON encoding of the
+/// [`TdfManifest`] struct itself — encryption metadata
+/// (`encryptionInformation`) and the inline base64 ciphertext
+/// (`payload`) live in a single self-contained JSON document. This is
+/// strictly equivalent to the in-memory `TdfManifest` and round-trips
+/// losslessly via [`read_kit_tdf`].
+///
+/// This is not the OpenTDF ZIP container format — that's a future
+/// interop slice when we need to exchange `.tdf` files with external
+/// OpenTDF tooling. For SwarmKit-internal storage and transport, the
+/// JSON form is simpler, scriptable, and sufficient.
+pub fn write_kit_tdf<W: std::io::Write>(
+    tdf: &TdfManifest,
+    mut writer: W,
+) -> Result<(), TdfEnvelopeError> {
+    let json = serde_json::to_vec_pretty(tdf)?;
+    writer.write_all(&json)?;
+    writer.write_all(b"\n")?;
+    Ok(())
+}
+
+/// Read a [`TdfManifest`] from a `.swarmkit.tdf` file written by
+/// [`write_kit_tdf`].
+pub fn read_kit_tdf<R: std::io::Read>(reader: R) -> Result<TdfManifest, TdfEnvelopeError> {
+    let tdf: TdfManifest = serde_json::from_reader(reader)?;
+    Ok(tdf)
+}
+
+/// Convenience: write a `.swarmkit.tdf` to a path, creating or
+/// truncating the file as needed.
+pub fn write_kit_tdf_to_path<P: AsRef<std::path::Path>>(
+    tdf: &TdfManifest,
+    path: P,
+) -> Result<(), TdfEnvelopeError> {
+    let file = std::fs::File::create(path.as_ref())?;
+    write_kit_tdf(tdf, std::io::BufWriter::new(file))
+}
+
+/// Convenience: read a `.swarmkit.tdf` from a path.
+pub fn read_kit_tdf_from_path<P: AsRef<std::path::Path>>(
+    path: P,
+) -> Result<TdfManifest, TdfEnvelopeError> {
+    let file = std::fs::File::open(path.as_ref())?;
+    read_kit_tdf(std::io::BufReader::new(file))
+}
+
+/// One-shot producer flow: encrypt a manifest and write it to a
+/// `.swarmkit.tdf` file in a single call.
+pub async fn wrap_manifest_to_path<E, P>(
+    manifest: &Manifest,
+    encryptor: &E,
+    policy: &Policy,
+    path: P,
+) -> Result<(), TdfEnvelopeError>
+where
+    E: TdfEncryptor,
+    P: AsRef<std::path::Path>,
+{
+    let tdf = wrap_manifest(manifest, encryptor, policy).await?;
+    write_kit_tdf_to_path(&tdf, path)
+}
+
+/// One-shot consumer flow: read a `.swarmkit.tdf` file and decrypt
+/// straight to a validated `Manifest`.
+pub async fn unwrap_manifest_from_path<D, P>(
+    decryptor: &D,
+    path: P,
+) -> Result<Manifest, TdfEnvelopeError>
+where
+    D: TdfDecryptor,
+    P: AsRef<std::path::Path>,
+{
+    let tdf = read_kit_tdf_from_path(path)?;
+    unwrap_manifest(&tdf, decryptor).await
 }
 
 #[cfg(test)]
@@ -524,6 +610,67 @@ provenance:
         assert!(pols.contains_key("with-arp"));
         assert!(!pols.contains_key("without-arp"));
     }
+
+    // --- .swarmkit.tdf file format ---------------------------------------
+
+    #[spec("SK-055")]
+    #[tokio::test]
+    async fn write_kit_tdf_round_trips_through_reader() {
+        let manifest = parse_yaml(KIT).unwrap();
+        let svc = MockTdfService::new(0x33);
+        let pol = policy();
+        let tdf = wrap_manifest(&manifest, &svc, &pol).await.unwrap();
+
+        let mut buf: Vec<u8> = Vec::new();
+        write_kit_tdf(&tdf, &mut buf).expect("write");
+        let recovered = read_kit_tdf(&buf[..]).expect("read");
+
+        // The TdfManifest is serde-equal across the round trip.
+        let a = serde_json::to_value(&tdf).unwrap();
+        let b = serde_json::to_value(&recovered).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[spec("SK-056")]
+    #[tokio::test]
+    async fn wrap_unwrap_via_path_round_trips_manifest() {
+        let manifest = parse_yaml(KIT).unwrap();
+        let svc = MockTdfService::new(0x77);
+        let pol = policy();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.swarmkit.tdf");
+
+        wrap_manifest_to_path(&manifest, &svc, &pol, &path)
+            .await
+            .expect("wrap to path");
+        let recovered = unwrap_manifest_from_path(&svc, &path)
+            .await
+            .expect("unwrap from path");
+
+        assert_eq!(manifest, recovered);
+    }
+
+    #[spec("SK-057")]
+    #[tokio::test]
+    async fn unwrap_from_path_surfaces_io_error_for_missing_file() {
+        let svc = MockTdfService::new(0x44);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.swarmkit.tdf");
+
+        let err = unwrap_manifest_from_path(&svc, &path).await.unwrap_err();
+        assert!(matches!(err, TdfEnvelopeError::Io(_)));
+    }
+
+    #[spec("SK-057")]
+    #[test]
+    fn read_kit_tdf_rejects_non_json() {
+        let bogus = b"this is not a tdf manifest";
+        let err = read_kit_tdf(&bogus[..]).unwrap_err();
+        assert!(matches!(err, TdfEnvelopeError::Serialize(_)));
+    }
+
+    // --- end file format -------------------------------------------------
 
     #[spec("SK-054")]
     #[test]

--- a/specs/arkavo-edge/index.yaml
+++ b/specs/arkavo-edge/index.yaml
@@ -564,7 +564,7 @@ components:
     module: arkavo_swarmkit
     description: SwarmKit manifest, runtime, and AG-UI gateway integration
     criticality: high
-    scenario_count: 27
+    scenario_count: 30
     invariants:
       - kit.id equals BLAKE3 of canonical manifest
       - SwarmFlight builds one ArpRuntime per role at launch
@@ -575,6 +575,7 @@ components:
       - TDF envelope round-trips the manifest losslessly under canonical-form serialization
       - role_policy splits attributes at the last "/" into (fqn, value)
       - Per-role policies bind to agent DIDs via the dissemination list (spec §6.3 example)
+      - .swarmkit.tdf file format is canonical JSON of the TdfManifest struct
 
   - name: ui-core
     file: ui-core.spec.yaml

--- a/specs/arkavo-edge/swarmkit.spec.yaml
+++ b/specs/arkavo-edge/swarmkit.spec.yaml
@@ -425,6 +425,48 @@ scenarios:
       - crates/arkavo-swarmkit-runtime/src/tdf.rs:154-194
     changed: "2026-05-01"
 
+  - id: SK-055
+    name: write_kit_tdf and read_kit_tdf round-trip a TdfManifest losslessly
+    criticality: high
+    given:
+      - TdfManifest produced by wrap_manifest
+    when: serialized via write_kit_tdf and parsed back via read_kit_tdf
+    then:
+      - On-disk format is canonical JSON of the TdfManifest struct
+      - Recovered TdfManifest is serde-equal to the original
+      - Encryption metadata (encryptionInformation) and inline base64 payload preserved
+    refs:
+      - crates/arkavo-swarmkit-runtime/src/tdf.rs:269-289
+    changed: "2026-05-01"
+
+  - id: SK-056
+    name: wrap_manifest_to_path / unwrap_manifest_from_path round-trip a Manifest
+    criticality: high
+    given:
+      - Manifest, encryptor, policy, and target path
+    when: wrap_manifest_to_path then unwrap_manifest_from_path are called
+    then:
+      - .swarmkit.tdf file written at the path
+      - File reads back cleanly through the consumer flow
+      - Recovered Manifest equals the original (kit.id, signatures, every field)
+    refs:
+      - crates/arkavo-swarmkit-runtime/src/tdf.rs:309-336
+    changed: "2026-05-01"
+
+  - id: SK-057
+    name: file-format readers report distinct errors for I/O vs parse failures
+    criticality: medium
+    given:
+      - Reader for a missing path or non-JSON content
+    when: read_kit_tdf or unwrap_manifest_from_path is invoked
+    then:
+      - Missing file produces TdfEnvelopeError::Io
+      - Malformed JSON produces TdfEnvelopeError::Serialize (serde_json failures map to that variant)
+      - No partially-constructed TdfManifest is ever returned from a failed read
+    refs:
+      - crates/arkavo-swarmkit-runtime/src/tdf.rs:291-307
+    changed: "2026-05-01"
+
   - id: SK-054
     name: role_policies extracts per-role policies and supports DID lookup
     criticality: high


### PR DESCRIPTION
## Summary

Slice 3 of TDF integration. Disk serialization for the TDF envelope: write a `TdfManifest` to a `.swarmkit.tdf` file in one call, read it back, and combined helpers go straight from a `Manifest` to/from a path.

Stacked on `feature/swarmkit`. Patch bump 0.73.6 → 0.73.7.

## API additions (under the `tdf` feature)

| Function | Purpose |
|---|---|
| `write_kit_tdf(tdf, writer)` / `read_kit_tdf(reader)` | Stream `TdfManifest` to/from any `Write`/`Read` |
| `write_kit_tdf_to_path` / `read_kit_tdf_from_path` | Path-based convenience built on the streaming variants |
| `wrap_manifest_to_path(manifest, encryptor, policy, path)` | One-shot producer flow: encrypt + write to disk |
| `unwrap_manifest_from_path(decryptor, path)` | One-shot consumer flow: read + decrypt + validate |
| `SWARMKIT_TDF_EXTENSION` | `"swarmkit.tdf"` constant for callers that want to standardize file naming |

Plus `TdfEnvelopeError::Io` (`#[from] std::io::Error`) so file-system failures surface distinctly from serialization or encryption errors.

## On-disk format

Single self-contained JSON document encoding the `TdfManifest` struct: encryption metadata + inline base64 ciphertext. This is *not* the OpenTDF ZIP container — that's a future interop slice when we need to exchange `.tdf` files with external OpenTDF tooling. For SwarmKit-internal storage and transport, JSON is simpler, scriptable, and round-trips losslessly.

## Out of scope (final TDF slice)

- KAS-gated decryption enforcement (§6.3 actual gate, not just policy attachment)
- Auto-launch path detects `.tdf` extension and unwraps before launching

## Test plan

- [x] `cargo test -p arkavo-swarmkit-runtime --features tdf` — 26 lib + 2 integration tests pass (4 new in this slice)
- [x] `cargo test -p arkavo-swarmkit-runtime --no-default-features` — 11 lib + 2 integration tests pass (TDF surface still genuinely optional)
- [x] `cargo clippy --features tdf -- -D warnings` clean
- [x] `cargo clippy -- -D warnings` (no-default) clean
- [x] `cargo build -q --workspace --exclude golden-dataset` clean
- [x] Spec yaml validates (30 scenarios, +3 from SK-055/056/057)

🤖 Generated with [Claude Code](https://claude.com/claude-code)