### PR TITLE
SwarmKit: KAS-gated unwrap with policy verification (slice 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "chrono",
  "serde",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-config-bundle",
  "base64 0.22.1",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "git2",
  "tempfile",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "bindgen",
  "cc",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "lru",
  "serde",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "libc",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -1885,6 +1885,7 @@ dependencies = [
  "arkavo-swarmkit",
  "arkavo-tdf",
  "arkavo-test-macros",
+ "base64 0.22.1",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
@@ -1894,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1913,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1935,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1952,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -1976,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1987,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2000,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2012,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2021,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2040,7 +2041,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2055,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2080,7 +2081,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2090,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.73.7"
+version = "0.73.8"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.73.7"
+version = "0.73.8"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-swarmkit-runtime/Cargo.toml
+++ b/crates/arkavo-swarmkit-runtime/Cargo.toml
@@ -15,7 +15,7 @@ default = []
 # pulls in arkavo-agent-auth so role policies can bind to the running
 # agent's StoredToken DID (spec §6.3 dissemination list). Keep disabled
 # for headless / in-process flight orchestration.
-tdf = ["dep:arkavo-tdf", "dep:arkavo-agent-auth"]
+tdf = ["dep:arkavo-tdf", "dep:arkavo-agent-auth", "dep:base64"]
 
 [dependencies]
 arkavo-swarmkit = { path = "../arkavo-swarmkit" }
@@ -23,6 +23,7 @@ arkavo-arp = { path = "../arkavo-arp" }
 arkavo-arp-runtime = { path = "../arkavo-arp-runtime" }
 arkavo-tdf = { path = "../arkavo-tdf", default-features = false, features = ["opentdf"], optional = true }
 arkavo-agent-auth = { path = "../arkavo-agent-auth", optional = true }
+base64 = { workspace = true, optional = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }

--- a/crates/arkavo-swarmkit-runtime/src/lib.rs
+++ b/crates/arkavo-swarmkit-runtime/src/lib.rs
@@ -22,11 +22,12 @@ pub use flight::{FlightError, LaunchError, LaunchOptions, RoleRuntime, SwarmFlig
 
 #[cfg(feature = "tdf")]
 pub use tdf::{
-    SWARMKIT_TDF_EXTENSION, TdfEnvelopeError, load_current_agent_did, read_kit_tdf,
-    read_kit_tdf_from_path, role_policies, role_policies_for_current_agent, role_policy,
-    swarmkit_orchestrator_policy, swarmkit_orchestrator_policy_for_current_agent, unwrap_manifest,
-    unwrap_manifest_from_path, wrap_manifest, wrap_manifest_to_path, write_kit_tdf,
-    write_kit_tdf_to_path,
+    SWARMKIT_TDF_EXTENSION, TdfEnvelopeError, extract_embedded_policy, load_current_agent_did,
+    read_kit_tdf, read_kit_tdf_from_path, role_policies, role_policies_for_current_agent,
+    role_policy, swarmkit_orchestrator_policy, swarmkit_orchestrator_policy_for_current_agent,
+    unwrap_manifest, unwrap_manifest_from_path, unwrap_manifest_from_path_kas_gated,
+    unwrap_manifest_kas_gated, verify_embedded_policy_requires, wrap_manifest,
+    wrap_manifest_to_path, write_kit_tdf, write_kit_tdf_to_path,
 };
 
 /// Serialize a manifest to canonical JSON (sorted keys, no insignificant

--- a/crates/arkavo-swarmkit-runtime/src/tdf.rs
+++ b/crates/arkavo-swarmkit-runtime/src/tdf.rs
@@ -11,9 +11,10 @@
 //! tree. Per-role TDF policy construction (spec §6.4) is implemented
 //! via [`role_policy`] / [`role_policies`]. The `.swarmkit.tdf` file
 //! format is implemented via [`write_kit_tdf`] / [`read_kit_tdf`] and
-//! their path-based / one-shot variants. Out of scope for now:
-//! KAS-gated decryption enforcement (spec §6.3 orchestrator gate)
-//! and `.tdf`-aware auto-launch — those land in subsequent slices.
+//! their path-based / one-shot variants. KAS-gated unwrap (spec §6.3)
+//! is implemented via [`unwrap_manifest_kas_gated`] with embedded-policy
+//! verification + KAS health check before decrypt. Out of scope for
+//! now: `.tdf`-aware auto-launch — that lands in the final slice.
 //!
 //! Agent identity binding: every policy builder accepts an optional
 //! agent DID that is added to the policy's dissemination list. Callers
@@ -21,11 +22,28 @@
 //! [`swarmkit_orchestrator_policy_for_current_agent`] /
 //! [`role_policies_for_current_agent`] async helpers to load the
 //! locally-stored token from `arkavo-agent-auth` and bind to it.
+//!
+//! KAS gating: [`unwrap_manifest_kas_gated`] adds an explicit KAS health
+//! check + embedded-policy verification before invoking the underlying
+//! decrypt path. The opentdf-rs decryptor performs its own KAS rewrap
+//! internally; the SwarmKit gate complements that with fail-fast checks
+//! (KAS unreachable, policy attributes don't match what the orchestrator
+//! requires) so the orchestrator never attempts a decrypt that's
+//! guaranteed to be denied or that's against an unexpected policy.
+//!
+//! P2P transport: this module covers the **encryption / policy plane
+//! only**. For peer-to-peer distribution of `.swarmkit.tdf` blobs
+//! (staging, fetching, content addressing), compose with the existing
+//! [`arkavo-tdf-iroh`] crate's `IrohTransport` — do NOT re-implement
+//! transport here.
 
 use std::collections::HashMap;
 
 use arkavo_swarmkit::{Manifest, ParseError, TdfAttributeReleasePolicy, parse_json};
-use arkavo_tdf::{Policy, PolicyBuilder, TdfDecryptor, TdfEncryptor, TdfError, TdfManifest};
+use arkavo_tdf::{
+    KasClient, Policy, PolicyBuilder, TdfDecryptor, TdfEncryptor, TdfError, TdfManifest,
+};
+use base64::{Engine, engine::general_purpose::STANDARD as B64};
 
 use crate::canonical_full_manifest;
 
@@ -48,6 +66,15 @@ pub enum TdfEnvelopeError {
     Identity(String),
     #[error(".swarmkit.tdf I/O error: {0}")]
     Io(#[from] std::io::Error),
+    #[error("KAS unavailable: {0}")]
+    KasUnavailable(String),
+    #[error("embedded policy could not be parsed: {0}")]
+    EmbeddedPolicy(String),
+    #[error("embedded policy is missing required attribute {missing:?} (policy carries {found:?})")]
+    PolicyMismatch {
+        missing: Vec<String>,
+        found: Vec<String>,
+    },
 }
 
 /// Wrap a SwarmKit manifest in a TDF envelope per spec §6.
@@ -271,6 +298,124 @@ fn split_attribute(attr: &str) -> Option<(String, String)> {
         return None;
     }
     Some((fqn.to_string(), value.to_string()))
+}
+
+// --- KAS-gated unwrap ---------------------------------------------------
+
+/// Extract the policy embedded in a [`TdfManifest`] (spec §6.1
+/// `encryptionInformation.policy`, base64-encoded JSON) and parse it
+/// back into a [`Policy`]. Useful for inspecting what attributes a
+/// distributed `.swarmkit.tdf` actually requires before attempting to
+/// unwrap it.
+pub fn extract_embedded_policy(tdf: &TdfManifest) -> Result<Policy, TdfEnvelopeError> {
+    let raw = &tdf.encryption_information.policy;
+    let bytes = B64
+        .decode(raw)
+        .map_err(|e| TdfEnvelopeError::EmbeddedPolicy(format!("base64: {e}")))?;
+    let policy: Policy = serde_json::from_slice(&bytes)
+        .map_err(|e| TdfEnvelopeError::EmbeddedPolicy(format!("json: {e}")))?;
+    Ok(policy)
+}
+
+/// Verify that the embedded policy on a [`TdfManifest`] requires every
+/// attribute FQN listed in `required_fqns`. Returns
+/// [`TdfEnvelopeError::PolicyMismatch`] when one or more are missing.
+///
+/// Use this *before* attempting to unwrap a kit when the orchestrator
+/// has expectations about which attributes the wrapped content was
+/// gated on (e.g. a producer that always wraps under
+/// `https://attr.arkavo.com/role/orchestrator` can refuse kits that
+/// don't carry that requirement, distinguishing a misrouted kit from a
+/// genuine KAS denial at decrypt time).
+pub fn verify_embedded_policy_requires(
+    tdf: &TdfManifest,
+    required_fqns: &[&str],
+) -> Result<Policy, TdfEnvelopeError> {
+    let policy = extract_embedded_policy(tdf)?;
+    let found: Vec<String> = policy
+        .attributes
+        .iter()
+        .map(|a| a.attribute.clone())
+        .collect();
+    let missing: Vec<String> = required_fqns
+        .iter()
+        .filter(|fqn| !found.iter().any(|f| f == *fqn))
+        .map(|s| (*s).to_string())
+        .collect();
+    if !missing.is_empty() {
+        return Err(TdfEnvelopeError::PolicyMismatch { missing, found });
+    }
+    Ok(policy)
+}
+
+/// KAS-gated unwrap. Adds two pre-flight checks the bare
+/// [`unwrap_manifest`] path doesn't perform:
+///
+/// 1. **KAS health**: if `kas.health_check()` returns `Ok(false)` or
+///    errors, fail fast with [`TdfEnvelopeError::KasUnavailable`]
+///    instead of timing out inside the decryptor.
+/// 2. **Policy verification**: extract the policy embedded in the TDF
+///    and confirm it requires every FQN in `required_fqns`. Surfaces
+///    [`TdfEnvelopeError::PolicyMismatch`] for misrouted or
+///    misconfigured kits before any KAS round-trip.
+///
+/// Pass an empty `required_fqns` slice to skip the policy check and
+/// rely on KAS-side enforcement only. Pass
+/// `&["https://attr.arkavo.com/role"]` (or similar) for the
+/// orchestrator-gated baseline.
+///
+/// The KAS rewrap itself happens inside the underlying [`TdfDecryptor`]
+/// implementation (opentdf-rs talks to KAS during decrypt). The KAS
+/// client passed here is used only for the health check; SwarmKit
+/// doesn't currently re-implement the rewrap protocol.
+pub async fn unwrap_manifest_kas_gated<D, K>(
+    tdf: &TdfManifest,
+    decryptor: &D,
+    kas: &K,
+    required_fqns: &[&str],
+) -> Result<Manifest, TdfEnvelopeError>
+where
+    D: TdfDecryptor,
+    K: KasClient,
+{
+    // 1. Health gate — fail fast if KAS is unreachable so we don't
+    //    proceed into the decryptor's slower retry/timeout paths.
+    match kas.health_check().await {
+        Ok(true) => {}
+        Ok(false) => {
+            return Err(TdfEnvelopeError::KasUnavailable(
+                "health_check returned false".to_string(),
+            ));
+        }
+        Err(e) => return Err(TdfEnvelopeError::KasUnavailable(e.to_string())),
+    }
+
+    // 2. Embedded-policy verification — surface a distinct error when
+    //    the kit's policy doesn't carry the attributes the orchestrator
+    //    requires. This separates "I won't even try" from "I tried and
+    //    KAS denied me."
+    if !required_fqns.is_empty() {
+        verify_embedded_policy_requires(tdf, required_fqns)?;
+    }
+
+    // 3. Decrypt + parse + validate. KAS rewrap happens inside.
+    unwrap_manifest(tdf, decryptor).await
+}
+
+/// Convenience: KAS-gated unwrap that also reads from a path.
+pub async fn unwrap_manifest_from_path_kas_gated<D, K, P>(
+    decryptor: &D,
+    kas: &K,
+    path: P,
+    required_fqns: &[&str],
+) -> Result<Manifest, TdfEnvelopeError>
+where
+    D: TdfDecryptor,
+    K: KasClient,
+    P: AsRef<std::path::Path>,
+{
+    let tdf = read_kit_tdf_from_path(path)?;
+    unwrap_manifest_kas_gated(&tdf, decryptor, kas, required_fqns).await
 }
 
 // --- .swarmkit.tdf file format -----------------------------------------
@@ -609,6 +754,117 @@ provenance:
         assert_eq!(pols.len(), 1);
         assert!(pols.contains_key("with-arp"));
         assert!(!pols.contains_key("without-arp"));
+    }
+
+    // --- KAS-gated unwrap ------------------------------------------------
+
+    use arkavo_tdf::testing::MockKasClient;
+
+    #[spec("SK-058")]
+    #[tokio::test]
+    async fn extract_embedded_policy_decodes_base64_json() {
+        let manifest = parse_yaml(KIT).unwrap();
+        let svc = MockTdfService::new(0xC3);
+        let pol = swarmkit_orchestrator_policy(None, Some("did:web:gateway.example.com")).unwrap();
+        let tdf = wrap_manifest(&manifest, &svc, &pol).await.unwrap();
+
+        let recovered = extract_embedded_policy(&tdf).expect("decode policy");
+        assert_eq!(recovered.attributes.len(), 2);
+        assert!(
+            recovered
+                .attributes
+                .iter()
+                .any(|a| a.attribute.contains("/role"))
+        );
+        assert_eq!(
+            recovered.dissemination,
+            vec!["did:web:gateway.example.com".to_string()]
+        );
+    }
+
+    #[spec("SK-058")]
+    #[tokio::test]
+    async fn verify_embedded_policy_requires_passes_for_matching_attrs() {
+        let manifest = parse_yaml(KIT).unwrap();
+        let svc = MockTdfService::new(0xC3);
+        let pol = swarmkit_orchestrator_policy(None, None).unwrap();
+        let tdf = wrap_manifest(&manifest, &svc, &pol).await.unwrap();
+
+        verify_embedded_policy_requires(&tdf, &["https://attr.arkavo.com/role"])
+            .expect("policy carries the role attribute");
+    }
+
+    #[spec("SK-058")]
+    #[tokio::test]
+    async fn verify_embedded_policy_rejects_missing_attr() {
+        let manifest = parse_yaml(KIT).unwrap();
+        let svc = MockTdfService::new(0xC3);
+        let pol = swarmkit_orchestrator_policy(None, None).unwrap();
+        let tdf = wrap_manifest(&manifest, &svc, &pol).await.unwrap();
+
+        let err = verify_embedded_policy_requires(
+            &tdf,
+            &[
+                "https://attr.arkavo.com/role",
+                "https://attr.arkavo.com/region",
+            ],
+        )
+        .unwrap_err();
+        match err {
+            TdfEnvelopeError::PolicyMismatch { missing, found } => {
+                assert_eq!(missing, vec!["https://attr.arkavo.com/region".to_string()]);
+                assert!(found.iter().any(|a| a == "https://attr.arkavo.com/role"));
+            }
+            other => panic!("expected PolicyMismatch, got {other:?}"),
+        }
+    }
+
+    #[spec("SK-059")]
+    #[tokio::test]
+    async fn unwrap_manifest_kas_gated_succeeds_when_kas_healthy_and_policy_matches() {
+        let manifest = parse_yaml(KIT).unwrap();
+        let svc = MockTdfService::new(0xD1);
+        let pol = swarmkit_orchestrator_policy(None, None).unwrap();
+        let tdf = wrap_manifest(&manifest, &svc, &pol).await.unwrap();
+
+        let kas = MockKasClient::new();
+        let recovered =
+            unwrap_manifest_kas_gated(&tdf, &svc, &kas, &["https://attr.arkavo.com/role"])
+                .await
+                .expect("kas-gated unwrap");
+        assert_eq!(manifest, recovered);
+    }
+
+    #[spec("SK-060")]
+    #[tokio::test]
+    async fn unwrap_manifest_kas_gated_fails_fast_when_kas_unhealthy() {
+        let manifest = parse_yaml(KIT).unwrap();
+        let svc = MockTdfService::new(0xD2);
+        let pol = swarmkit_orchestrator_policy(None, None).unwrap();
+        let tdf = wrap_manifest(&manifest, &svc, &pol).await.unwrap();
+
+        let kas = MockKasClient::new();
+        kas.set_healthy(false);
+
+        let err = unwrap_manifest_kas_gated(&tdf, &svc, &kas, &[])
+            .await
+            .unwrap_err();
+        assert!(matches!(err, TdfEnvelopeError::KasUnavailable(_)));
+    }
+
+    #[spec("SK-060")]
+    #[tokio::test]
+    async fn unwrap_manifest_kas_gated_surfaces_policy_mismatch_before_decrypt() {
+        let manifest = parse_yaml(KIT).unwrap();
+        let svc = MockTdfService::new(0xD3);
+        let pol = swarmkit_orchestrator_policy(None, None).unwrap();
+        let tdf = wrap_manifest(&manifest, &svc, &pol).await.unwrap();
+
+        let kas = MockKasClient::new();
+        let err = unwrap_manifest_kas_gated(&tdf, &svc, &kas, &["https://attr.arkavo.com/region"])
+            .await
+            .unwrap_err();
+        assert!(matches!(err, TdfEnvelopeError::PolicyMismatch { .. }));
     }
 
     // --- .swarmkit.tdf file format ---------------------------------------

--- a/specs/arkavo-edge/index.yaml
+++ b/specs/arkavo-edge/index.yaml
@@ -564,7 +564,7 @@ components:
     module: arkavo_swarmkit
     description: SwarmKit manifest, runtime, and AG-UI gateway integration
     criticality: high
-    scenario_count: 30
+    scenario_count: 33
     invariants:
       - kit.id equals BLAKE3 of canonical manifest
       - SwarmFlight builds one ArpRuntime per role at launch
@@ -576,6 +576,7 @@ components:
       - role_policy splits attributes at the last "/" into (fqn, value)
       - Per-role policies bind to agent DIDs via the dissemination list (spec §6.3 example)
       - .swarmkit.tdf file format is canonical JSON of the TdfManifest struct
+      - unwrap_manifest_kas_gated fails fast on unhealthy KAS or policy mismatch before invoking the decryptor
 
   - name: ui-core
     file: ui-core.spec.yaml

--- a/specs/arkavo-edge/swarmkit.spec.yaml
+++ b/specs/arkavo-edge/swarmkit.spec.yaml
@@ -425,6 +425,53 @@ scenarios:
       - crates/arkavo-swarmkit-runtime/src/tdf.rs:154-194
     changed: "2026-05-01"
 
+  # --- KAS gate (spec §6.3) ------------------------------------------------
+
+  - id: SK-058
+    name: extract_embedded_policy decodes the policy carried in the TDF envelope
+    criticality: high
+    given:
+      - TdfManifest produced by wrap_manifest with a SwarmKit-level policy
+    when: extract_embedded_policy is called
+    then:
+      - encryption_information.policy is base64-decoded
+      - The decoded JSON is parsed into a Policy struct
+      - All attributes and dissemination entries from the wrap-time policy are recovered
+      - verify_embedded_policy_requires accepts FQNs the policy carries
+      - verify_embedded_policy_requires rejects FQNs that are absent with TdfEnvelopeError::PolicyMismatch listing missing and found
+    refs:
+      - crates/arkavo-swarmkit-runtime/src/tdf.rs:282-326
+    changed: "2026-05-01"
+
+  - id: SK-059
+    name: unwrap_manifest_kas_gated succeeds when KAS healthy and policy matches
+    criticality: critical
+    given:
+      - Healthy KasClient
+      - TdfManifest carrying the required attributes
+    when: unwrap_manifest_kas_gated is called
+    then:
+      - KAS health_check passes
+      - Embedded policy contains the required FQNs
+      - Underlying TdfDecryptor decrypts and the manifest is returned validated
+    refs:
+      - crates/arkavo-swarmkit-runtime/src/tdf.rs:344-382
+    changed: "2026-05-01"
+
+  - id: SK-060
+    name: unwrap_manifest_kas_gated fails fast on unhealthy KAS or policy mismatch
+    criticality: critical
+    given:
+      - KasClient that reports unhealthy OR a TdfManifest whose policy lacks the required attributes
+    when: unwrap_manifest_kas_gated is called
+    then:
+      - Unhealthy KAS returns TdfEnvelopeError::KasUnavailable WITHOUT calling the decryptor
+      - Policy mismatch returns TdfEnvelopeError::PolicyMismatch listing missing FQNs WITHOUT calling the decryptor
+      - Distinct variant from KAS-side denial during decrypt (which surfaces as TdfEnvelopeError::Decrypt)
+    refs:
+      - crates/arkavo-swarmkit-runtime/src/tdf.rs:355-365
+    changed: "2026-05-01"
+
   - id: SK-055
     name: write_kit_tdf and read_kit_tdf round-trip a TdfManifest losslessly
     criticality: high


### PR DESCRIPTION
## Summary

Slice 4 of TDF integration. Adds explicit KAS health + embedded-policy verification before invoking the underlying decrypt path. Complements the opentdf-rs internal KAS rewrap (which still happens during decrypt) with fail-fast checks at the SwarmKit level so the orchestrator never attempts a decrypt that's guaranteed to be denied or against an unexpected policy.

Stacked on `feature/swarmkit`. Patch bump 0.73.7 → 0.73.8.

## API additions (under the `tdf` feature)

| Function | Purpose |
|---|---|
| `extract_embedded_policy(tdf)` | Decode the base64-encoded JSON policy from the TDF |
| `verify_embedded_policy_requires(tdf, &[fqn])` | Confirm policy contains every required FQN; PolicyMismatch otherwise |
| `unwrap_manifest_kas_gated(tdf, decryptor, kas, required_fqns)` | Health-check + verify + unwrap |
| `unwrap_manifest_from_path_kas_gated(...)` | Path-based variant |

New `TdfEnvelopeError` variants: `KasUnavailable`, `EmbeddedPolicy`, `PolicyMismatch { missing, found }`. Distinct from `Decrypt`: this gate fires *before* decrypt; decrypt-time KAS denials still surface as `Decrypt`.

## Iroh non-duplication

Per the directive — verified that `arkavo-tdf-iroh` handles **transport only** (raw bytes via P2P, implementing `BlobTransport`). It does NOT do encryption or KAS. No overlap with this slice. The module docs now explicitly cross-reference `arkavo-tdf-iroh::IrohTransport` for callers wanting P2P distribution of `.swarmkit.tdf` blobs, so future work composes with it instead of re-implementing transport in this crate.

## Composition example

```rust
// Producer
let policy = swarmkit_orchestrator_policy(None, Some(&orchestrator_did))?;
wrap_manifest_to_path(&manifest, &encryptor, &policy, "kit.swarmkit.tdf").await?;

// Consumer (KAS-gated)
let manifest = unwrap_manifest_from_path_kas_gated(
    &decryptor,
    &kas,
    "kit.swarmkit.tdf",
    &["https://attr.arkavo.com/role"],
).await?;
```

## Out of scope (final TDF slice)

- Slice 5: Auto-launch path detects `.tdf` extension and unwraps before launching.

## Test plan

- [x] `cargo test -p arkavo-swarmkit-runtime --features tdf` — 32 lib + 2 integration tests pass (6 new in this slice)
- [x] `cargo test -p arkavo-swarmkit-runtime --no-default-features` — 11 lib + 2 integration tests pass (TDF still optional)
- [x] `cargo clippy --features tdf -- -D warnings` clean
- [x] `cargo clippy -- -D warnings` (no-default) clean
- [x] `cargo build -q --workspace --exclude golden-dataset` clean
- [x] Spec yaml validates (33 scenarios, +3 from SK-058/059/060)

🤖 Generated with [Claude Code](https://claude.com/claude-code)