### PR TITLE
Fix agent loop issues and audit warnings

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -18,4 +18,14 @@ ignore = [
     "RUSTSEC-2026-0119",
     # hickory-net NSEC3 closest-encloser proof unbounded loop. Same blocker as above.
     "RUSTSEC-2026-0120",
+    # atomic-polyfill unmaintained — transitive via heapless -> postcard -> irpc -> iroh-blobs.
+    # Blocked on iroh updating to postcard 2.x which drops heapless 0.7.
+    "RUSTSEC-2023-0089",
+    # bincode unmaintained — transitive via hnsw_rs -> arkavo-memory.
+    # hnsw_rs 0.3.4 is the latest published version; no upgrade path available.
+    "RUSTSEC-2025-0141",
+    # paste unmaintained — widely used transitive macro crate. No direct usage.
+    "RUSTSEC-2024-0436",
+    # proc-macro-error unmaintained — widely used transitive proc-macro crate.
+    "RUSTSEC-2024-0370",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "chrono",
  "serde",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-config-bundle",
  "base64 0.22.1",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "git2",
  "tempfile",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "bindgen",
  "cc",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1458,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "lru",
  "serde",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "libc",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -1969,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "alloy-primitives",
  "bip39",
@@ -3555,7 +3555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7562,15 +7562,14 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -7594,9 +7593,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -9162,28 +9161,20 @@ checksum = "528d42f8176e6e5e71ea69182b17d1d0a19a6b3b894b564678b74cd7cab13cfa"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "bytes",
  "chrono",
  "futures",
- "http",
- "http-body",
- "http-body-util",
  "pastey 0.2.1",
  "pin-project-lite",
  "process-wrap",
- "rand 0.9.4",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "sse-stream",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower-service",
  "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -10328,19 +10319,6 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
-]
-
-[[package]]
-name = "sse-stream"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
-dependencies = [
- "bytes",
- "futures-util",
- "http-body",
- "http-body-util",
- "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.74.0"
+version = "0.74.1"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/anthropic-agent-sdk/Cargo.toml
+++ b/crates/anthropic-agent-sdk/Cargo.toml
@@ -45,7 +45,7 @@ reqwest = { workspace = true }
 getrandom = "0.2"
 
 # Optional dependencies
-rmcp = { version = "0.12.0", optional = true, features = ["server", "client", "transport-io", "transport-child-process", "transport-streamable-http-server", "transport-worker", "macros"] }
+rmcp = { version = "0.12.0", optional = true, features = ["server", "client", "transport-io", "transport-child-process", "transport-worker", "macros"] }
 schemars = { version = "1.1.0", optional = true }
 
 [features]

--- a/crates/arkavo-hrm/src/conductor/loop_detector.rs
+++ b/crates/arkavo-hrm/src/conductor/loop_detector.rs
@@ -48,25 +48,23 @@ impl LoopDetector {
     pub fn record_failure(&mut self, description: &str) -> Option<u32> {
         let hash = Self::hash_description(description);
 
-        // Check for exact hash match first
+        // Increment exact hash count
         let count = self.failure_counts.entry(hash).or_insert(0);
         *count += 1;
 
-        if *count >= MAX_IDENTICAL_FAILURES {
-            return Some(*count);
+        // Calculate total failures for this pattern (exact + similar descriptions)
+        let mut total = *count;
+        for (prev_hash, prev_desc) in &self.recent_descriptions {
+            if *prev_hash != hash
+                && similarity(description, prev_desc) >= SIMILARITY_THRESHOLD
+                && let Some(similar_count) = self.failure_counts.get(prev_hash)
+            {
+                total += similar_count;
+            }
         }
 
-        // Check for similar descriptions
-        for (prev_hash, prev_desc) in &self.recent_descriptions {
-            if *prev_hash != hash && similarity(description, prev_desc) >= SIMILARITY_THRESHOLD {
-                // Similar but not identical - count as same failure pattern
-                let similar_count = self.failure_counts.entry(*prev_hash).or_insert(0);
-                *similar_count += 1;
-
-                if *similar_count >= MAX_IDENTICAL_FAILURES {
-                    return Some(*similar_count);
-                }
-            }
+        if total >= MAX_IDENTICAL_FAILURES {
+            return Some(total);
         }
 
         // Store this description
@@ -89,27 +87,21 @@ impl LoopDetector {
     pub fn would_thrash(&self, description: &str) -> bool {
         let hash = Self::hash_description(description);
 
-        if self
-            .failure_counts
-            .get(&hash)
-            .is_some_and(|&count| count >= MAX_IDENTICAL_FAILURES - 1)
-        {
-            return true;
-        }
+        let exact_count = self.failure_counts.get(&hash).copied().unwrap_or(0);
+        // +1 for the potential new failure being recorded
+        let mut total = exact_count + 1;
 
-        // Check similar descriptions
+        // Include similar descriptions in the cluster total
         for (prev_hash, prev_desc) in &self.recent_descriptions {
-            if similarity(description, prev_desc) >= SIMILARITY_THRESHOLD
-                && self
-                    .failure_counts
-                    .get(prev_hash)
-                    .is_some_and(|&count| count >= MAX_IDENTICAL_FAILURES - 1)
+            if *prev_hash != hash
+                && similarity(description, prev_desc) >= SIMILARITY_THRESHOLD
+                && let Some(similar_count) = self.failure_counts.get(prev_hash)
             {
-                return true;
+                total += similar_count;
             }
         }
 
-        false
+        total >= MAX_IDENTICAL_FAILURES
     }
 
     /// Get the failure count for a description
@@ -210,6 +202,34 @@ mod tests {
                 .record_failure("Refactor the database layer")
                 .is_none()
         );
+    }
+
+    #[test]
+    fn test_no_double_counting_across_similar_descriptions() {
+        let mut detector = LoopDetector::new();
+
+        // Fail task A once
+        assert!(
+            detector
+                .record_failure("Fix the auth bug in login")
+                .is_none()
+        );
+        assert_eq!(detector.failure_count("Fix the auth bug in login"), 1);
+
+        // Fail a similar task B once.
+        // Similarity: 6 shared words / 7 union = ~0.86 (> 0.85 threshold).
+        // This should NOT inflate A's exact counter — the previous bug did exactly that.
+        assert!(
+            detector
+                .record_failure("Fix the auth bug in login page")
+                .is_none()
+        );
+        assert_eq!(detector.failure_count("Fix the auth bug in login"), 1);
+
+        // Fail A again — cluster total is now 3 (A=2 + B=1), so this should trigger.
+        let result = detector.record_failure("Fix the auth bug in login");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), 3);
     }
 
     #[test]

--- a/crates/arkavo-protocol/src/a2a_mcp_bridge.rs
+++ b/crates/arkavo-protocol/src/a2a_mcp_bridge.rs
@@ -93,16 +93,29 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    // Each test gets an isolated SQLite path via MemoryStorage::new_test() —
+    // sharing the default path causes "database is locked" under parallel test runs.
+    async fn test_bridge() -> A2aMcpBridge {
+        let storage = Arc::new(
+            MemoryStorage::new_test()
+                .await
+                .expect("Failed to create test storage"),
+        );
+        A2aMcpBridge {
+            registry: Arc::new(RwLock::new(ToolRegistry::new(storage))),
+        }
+    }
+
     #[tokio::test]
     async fn test_bridge_creation() {
-        let bridge = A2aMcpBridge::new().await.expect("Failed to create bridge");
+        let bridge = test_bridge().await;
         let tools = bridge.list_tools().await;
         assert!(!tools.is_empty());
     }
 
     #[tokio::test]
     async fn test_call_get_agent_time() {
-        let bridge = A2aMcpBridge::new().await.expect("Failed to create bridge");
+        let bridge = test_bridge().await;
         let request = McpToolRequest {
             tool_name: "get_agent_time".to_string(),
             params: json!({"format": "unix"}),
@@ -116,7 +129,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_call_nonexistent_tool() {
-        let bridge = A2aMcpBridge::new().await.expect("Failed to create bridge");
+        let bridge = test_bridge().await;
         let request = McpToolRequest {
             tool_name: "nonexistent_tool".to_string(),
             params: json!({}),
@@ -130,7 +143,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_tools_includes_time_tools() {
-        let bridge = A2aMcpBridge::new().await.expect("Failed to create bridge");
+        let bridge = test_bridge().await;
         let tools = bridge.list_tools().await;
 
         assert!(tools.contains(&"get_agent_time".to_string()));
@@ -140,7 +153,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_tool_schema() {
-        let bridge = A2aMcpBridge::new().await.expect("Failed to create bridge");
+        let bridge = test_bridge().await;
         let schema = bridge.get_tool_schema("get_agent_time").await;
 
         assert!(schema.is_some());

--- a/crates/arkavo-protocol/src/agent_specialization.rs
+++ b/crates/arkavo-protocol/src/agent_specialization.rs
@@ -296,7 +296,6 @@ mod tdf_io {
     mod tests {
         use super::super::tests::sample_bundle;
         use super::{BundleError, BundleTdfError, unwrap_bundle, wrap_bundle};
-        use crate::AgentSpecializationBundle;
         use arkavo_tdf::testing::MockTdfService;
 
         #[tokio::test]

--- a/crates/arkavo-server/src/server/a2a_server.rs
+++ b/crates/arkavo-server/src/server/a2a_server.rs
@@ -1041,7 +1041,15 @@ impl A2aServer {
         if let Some(bus) = self.learning_bus().await {
             let lc = learning_context.clone();
             tokio::spawn(async move {
+                let mut iterations = 0u64;
                 loop {
+                    iterations += 1;
+                    if iterations > 1_000_000 {
+                        tracing::warn!(
+                            "Learning context updater reached iteration limit, stopping"
+                        );
+                        break;
+                    }
                     let guidance = bus.get_behavior_guidance(None).await;
                     let trends = bus.get_quality_trends().await;
                     let lesson_count = bus.behavior_lesson_count().await;
@@ -1075,7 +1083,13 @@ impl A2aServer {
             let tc = task_context.clone();
             let agent_memory = self.agent_memory.clone();
             tokio::spawn(async move {
+                let mut iterations = 0u64;
                 loop {
+                    iterations += 1;
+                    if iterations > 1_000_000 {
+                        tracing::warn!("Task context updater reached iteration limit, stopping");
+                        break;
+                    }
                     let memory = agent_memory.read().await;
                     let mut ctx = String::new();
 

--- a/crates/arkavo-server/src/server/agent_loop.rs
+++ b/crates/arkavo-server/src/server/agent_loop.rs
@@ -1,8 +1,12 @@
 use std::sync::Arc;
 
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::server::tool_memory::ToolMemory;
+
+/// Absolute safety limit for agent cycles to prevent runaway loops.
+/// At a 5-second minimum tick interval, this allows ~6 days of continuous operation.
+const MAX_AGENT_CYCLES: u64 = 100_000;
 
 /// Configuration for the agent orchestrator loop.
 ///
@@ -158,6 +162,13 @@ pub async fn run_agent_loop(
                 config.inference_active.store(true, std::sync::atomic::Ordering::SeqCst);
                 cycle += 1;
                 config.orchestrator_tick.store(cycle, Relaxed);
+
+                if cycle >= MAX_AGENT_CYCLES {
+                    error!(
+                        "Agent reached absolute cycle limit ({MAX_AGENT_CYCLES}), shutting down loop"
+                    );
+                    break;
+                }
 
                 if config.purpose.is_empty() {
                     continue;


### PR DESCRIPTION
- Fix double-counting bug in LoopDetector::record_failure
- Add absolute cycle limit to server agent loop
- Add iteration caps to A2A background updater loops
- Ignore unmaintained transitive deps in audit.toml
- Bump patch version to 0.74.1