### PR TITLE
Model identity attestation in arkavo-attestation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -518,8 +518,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "arkavo-agent-identity"
+version = "0.77.0"
+dependencies = [
+ "arkavo-attestation",
+ "arkavo-crypto",
+ "arkavo-device-identity",
+ "base64 0.22.1",
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "arkavo-agui"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -565,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -573,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -587,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-device-identity",
  "blake3",
@@ -598,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -617,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -643,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -656,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -673,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -690,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -759,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "chrono",
  "serde",
@@ -771,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-config-bundle",
  "base64 0.22.1",
@@ -788,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -806,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -821,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -845,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -861,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -894,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -910,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -929,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -944,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -960,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -973,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -997,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1018,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "git2",
  "tempfile",
@@ -1027,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1047,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1065,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1088,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1108,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1122,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1132,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -1142,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1181,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1195,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1220,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1244,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1264,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1284,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1313,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1331,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1355,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1386,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1397,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1421,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1442,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1468,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1510,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1520,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1580,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1598,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1612,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1631,7 +1645,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1675,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "lru 0.16.3",
  "serde",
@@ -1688,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1706,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1735,7 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1809,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1844,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1857,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1872,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -1897,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1916,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1938,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1955,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -1979,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1990,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2003,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2015,7 +2029,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2024,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2038,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2057,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2072,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2097,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2107,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -587,9 +587,10 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-device-identity",
+ "blake3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -597,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -616,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -642,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -655,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -672,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -689,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -758,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "chrono",
  "serde",
@@ -770,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-config-bundle",
  "base64 0.22.1",
@@ -787,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -805,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -820,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -844,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -860,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -893,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -909,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -928,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -943,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -959,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -972,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -996,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1017,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "git2",
  "tempfile",
@@ -1026,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1046,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1064,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1087,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1107,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1121,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1131,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -1141,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1180,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1194,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1219,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1243,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1263,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1283,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1312,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1330,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1354,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1385,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1396,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1420,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1441,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1467,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1509,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1519,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1579,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1597,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1611,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1630,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1674,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "lru 0.16.3",
  "serde",
@@ -1687,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1705,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1734,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1808,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1843,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1856,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1871,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -1896,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1915,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1937,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1954,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -1978,7 +1979,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1989,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2002,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2014,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2023,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2037,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2056,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2071,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2096,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2106,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "crates/arkavo-cef",
     "crates/arkavo-device-identity",
     "crates/arkavo-attestation",
+    "crates/arkavo-agent-identity",
     "crates/arkavo-crypto",
     "crates/arkavo-registration",
     "crates/arkavo-agent",
@@ -123,6 +124,7 @@ default-members = [
     "crates/arkavo-orchestrator",
     "crates/arkavo-device-identity",
     "crates/arkavo-attestation",
+    "crates/arkavo-agent-identity",
     "crates/arkavo-crypto",
     "crates/arkavo-registration",
     "crates/arkavo-agent-auth",
@@ -148,7 +150,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.76.0"
+version = "0.77.0"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.75.0"
+version = "0.76.0"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-agent-identity/Cargo.toml
+++ b/crates/arkavo-agent-identity/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "arkavo-agent-identity"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Agent Identity Authority: issues and attests agent identity credentials"
+
+[dependencies]
+arkavo-crypto = { path = "../arkavo-crypto" }
+arkavo-attestation = { path = "../arkavo-attestation" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+chrono = { workspace = true }
+base64 = { workspace = true }
+
+[dev-dependencies]
+arkavo-device-identity = { path = "../arkavo-device-identity" }
+
+[features]
+default = []

--- a/crates/arkavo-agent-identity/README.md
+++ b/crates/arkavo-agent-identity/README.md
@@ -1,0 +1,79 @@
+# arkavo-agent-identity
+
+The Agent Identity Authority (AIA) — a dedicated role whose sole responsibility
+is to issue and attest agent identity.
+
+## Role boundary
+
+The AIA is not an orchestrator and not an access policy decision point.
+
+It **does**: create agent identities, issue credentials, rotate agent keys,
+attest runtime/platform identity, publish a trust chain, and revoke compromised
+agents.
+
+It **does not**: assign work, grant resource access, make ABAC decisions,
+delegate authority, or release TDF keys. Those remain the orchestrator's and
+KAS's responsibilities. Keeping issuance separate from authorization prevents
+the orchestrator from becoming a super-agent that can both mint identities and
+grant access.
+
+```text
+Root Identity Agent (trust anchor)
+   └─ Swarm Identity Agent (issues identities)   ← IdentityAuthority
+        └─ Orchestrator Agent (delegates work)
+             └─ Worker Agents
+```
+
+`Identity Agent ≈ OIDC IdP + SPIFFE CA`, `Orchestrator ≈ STS / capability
+issuer`, `OpenTDF ≈ policy enforcement + key release`.
+
+## OpenTDF attribute origin
+
+`IdentityDocument::tdf_attributes()` emits only attributes that originate from
+identity:
+
+- `agent.identity.type`
+- `agent.identity.trust_level`
+- `agent.identity.runtime`
+- `agent.identity.owner`
+- `agent.identity.organization`
+
+It never emits `ORCHESTRATOR_ISSUED_ATTRIBUTES` — `agent.tool_access`,
+`agent.code_authority`, `agent.resource_scope`, `agent.execution_mode` — which
+describe what an agent may *do* and are issued by the orchestrator.
+
+## Trust, not self-assertion
+
+A credential reaches `TrustLevel::Attested` only when an `IssueRequest` carries
+attestation evidence (`arkavo-attestation` model or trusted-platform evidence).
+Compromised-platform evidence is refused outright. The caller cannot assert a
+trust level.
+
+```rust
+use arkavo_agent_identity::{IdentityAuthority, IssueRequest, Runtime};
+use arkavo_crypto::AgentKeypair;
+use chrono::{Duration, Utc};
+
+let aia = IdentityAuthority::new_root("agent:id-authority");
+let worker = AgentKeypair::generate();
+
+let credential = aia.issue(IssueRequest {
+    subject: "agent:worker-17".into(),
+    agent_type: "coding".into(),
+    agent_public_key: worker.public_key(),
+    runtime: Runtime::Local,
+    capabilities: vec!["a2a".into(), "mcp".into()],
+    owner: None,
+    organization: None,
+    validity: Duration::days(10),
+    attestation: None,
+})?;
+
+// A verifier resolves the issuer key from a trusted trust chain, then verifies.
+let issuer_key = aia.trust_chain().resolve(&aia.verifying_key(), Utc::now())?;
+let document = credential.verify(&issuer_key, Utc::now())?;
+```
+
+Credentials are Ed25519-signed over the canonical document bytes. Verification
+requires an authority key resolved from a `TrustChain` anchored at a trusted
+root — never the credential's own `iss` claim.

--- a/crates/arkavo-agent-identity/src/authority.rs
+++ b/crates/arkavo-agent-identity/src/authority.rs
@@ -1,0 +1,352 @@
+//! The Agent Identity Authority — the role that issues and attests identity.
+
+use crate::credential::IdentityCredential;
+use crate::document::{IdentityDocument, Runtime, TrustLevel, format_rfc3339};
+use crate::revocation::{RevocationClaims, RevocationList, RevokedEntry};
+use crate::trust_chain::{AuthorityEndorsement, EndorsementClaims, TrustChain};
+use crate::{IdentityError, Result, sign_payload};
+use arkavo_attestation::{ModelEvidence, PlatformEvidence, SecurityState};
+use arkavo_crypto::{AgentKeypair, AgentPublicKey};
+use chrono::{Duration, Utc};
+
+/// Runtime and model attestation evidence supplied with an issue request.
+///
+/// Evidence is the *only* way an issued credential reaches
+/// [`TrustLevel::Attested`]: the AIA never accepts a self-asserted trust level.
+#[derive(Debug, Clone, Default)]
+pub struct AttestationEvidence {
+    /// Evidence binding the agent to specific model weights.
+    pub model: Option<ModelEvidence>,
+    /// Evidence describing the platform the agent runs on.
+    pub platform: Option<PlatformEvidence>,
+}
+
+/// A request to issue an identity credential for an agent.
+#[derive(Debug)]
+pub struct IssueRequest {
+    /// Subject agent identifier, e.g. `agent:worker-17`.
+    pub subject: String,
+    /// Free-form agent role/type, e.g. `coding`.
+    pub agent_type: String,
+    /// The agent's own public key.
+    pub agent_public_key: AgentPublicKey,
+    /// Where the agent runs.
+    pub runtime: Runtime,
+    /// Protocols the agent speaks.
+    pub capabilities: Vec<String>,
+    /// Owning principal.
+    pub owner: Option<String>,
+    /// Owning organization.
+    pub organization: Option<String>,
+    /// Credential lifetime.
+    pub validity: Duration,
+    /// Optional runtime/model attestation evidence.
+    pub attestation: Option<AttestationEvidence>,
+}
+
+/// The Agent Identity Authority.
+///
+/// Its sole responsibilities are creating identities, issuing credentials,
+/// rotating keys, attesting runtime identity, publishing a [`TrustChain`], and
+/// revoking agents. It assigns no work, grants no resource access, makes no
+/// ABAC decisions, delegates no authority, and releases no TDF keys.
+pub struct IdentityAuthority {
+    authority_id: String,
+    keypair: AgentKeypair,
+    endorsement: Option<AuthorityEndorsement>,
+    revoked: Vec<RevokedEntry>,
+}
+
+impl IdentityAuthority {
+    /// Create a root AIA — its own trust anchor — with a freshly generated key.
+    pub fn new_root(authority_id: impl Into<String>) -> Self {
+        Self::from_keypair(authority_id, AgentKeypair::generate())
+    }
+
+    /// Create a root AIA from an existing keypair.
+    pub fn from_keypair(authority_id: impl Into<String>, keypair: AgentKeypair) -> Self {
+        Self {
+            authority_id: authority_id.into(),
+            keypair,
+            endorsement: None,
+            revoked: Vec::new(),
+        }
+    }
+
+    /// Create a subordinate AIA that carries a parent's endorsement.
+    pub fn new_subordinate(
+        authority_id: impl Into<String>,
+        keypair: AgentKeypair,
+        endorsement: AuthorityEndorsement,
+    ) -> Self {
+        Self {
+            authority_id: authority_id.into(),
+            keypair,
+            endorsement: Some(endorsement),
+            revoked: Vec::new(),
+        }
+    }
+
+    /// This authority's identifier (the `iss` claim it issues under).
+    pub fn authority_id(&self) -> &str {
+        &self.authority_id
+    }
+
+    /// This authority's public key — the key credentials must be verified with.
+    pub fn verifying_key(&self) -> AgentPublicKey {
+        self.keypair.public_key()
+    }
+
+    /// Issue a signed identity credential for an agent.
+    ///
+    /// The trust level is derived from attestation evidence, never asserted by
+    /// the caller. Compromised-platform evidence is refused outright.
+    pub fn issue(&self, request: IssueRequest) -> Result<IdentityCredential> {
+        let trust_level = evaluate_trust(request.attestation.as_ref())?;
+        let model = request
+            .attestation
+            .as_ref()
+            .and_then(|evidence| evidence.model.as_ref())
+            .map(|model| model.model_id.clone());
+        let (iat, exp) = lifetime(request.validity)?;
+        let document = IdentityDocument {
+            iss: self.authority_id.clone(),
+            sub: request.subject,
+            agent_type: request.agent_type,
+            public_key: request.agent_public_key.to_did_key(),
+            trust_level,
+            runtime: request.runtime,
+            model,
+            owner: request.owner,
+            organization: request.organization,
+            capabilities: request.capabilities,
+            iat,
+            exp,
+        };
+        let signature = sign_payload(&self.keypair, &document)?;
+        Ok(IdentityCredential {
+            document,
+            signature,
+        })
+    }
+
+    /// Re-issue a credential for the same agent under a new key (key rotation).
+    ///
+    /// Every identity claim is preserved except the public key and lifetime.
+    pub fn rotate(
+        &self,
+        current: &IdentityCredential,
+        new_agent_key: &AgentPublicKey,
+        validity: Duration,
+    ) -> Result<IdentityCredential> {
+        let prior = &current.document;
+        let (iat, exp) = lifetime(validity)?;
+        let document = IdentityDocument {
+            iss: self.authority_id.clone(),
+            sub: prior.sub.clone(),
+            agent_type: prior.agent_type.clone(),
+            public_key: new_agent_key.to_did_key(),
+            trust_level: prior.trust_level,
+            runtime: prior.runtime,
+            model: prior.model.clone(),
+            owner: prior.owner.clone(),
+            organization: prior.organization.clone(),
+            capabilities: prior.capabilities.clone(),
+            iat,
+            exp,
+        };
+        let signature = sign_payload(&self.keypair, &document)?;
+        Ok(IdentityCredential {
+            document,
+            signature,
+        })
+    }
+
+    /// Revoke an agent. Idempotent: a re-revoked agent keeps its first entry.
+    pub fn revoke(&mut self, subject: impl Into<String>, reason: Option<String>) {
+        let subject = subject.into();
+        if self.revoked.iter().any(|entry| entry.sub == subject) {
+            return;
+        }
+        self.revoked.push(RevokedEntry {
+            sub: subject,
+            revoked_at: format_rfc3339(Utc::now()),
+            reason,
+        });
+    }
+
+    /// Publish the current revocation list, signed by this authority.
+    pub fn revocation_list(&self) -> Result<RevocationList> {
+        let claims = RevocationClaims {
+            authority_id: self.authority_id.clone(),
+            issued_at: format_rfc3339(Utc::now()),
+            revoked: self.revoked.clone(),
+        };
+        let signature = sign_payload(&self.keypair, &claims)?;
+        Ok(RevocationList { claims, signature })
+    }
+
+    /// Endorse a subordinate AIA, binding its key into this authority's chain.
+    pub fn endorse_subordinate(
+        &self,
+        child_id: impl Into<String>,
+        child_key: &AgentPublicKey,
+        validity: Duration,
+    ) -> Result<AuthorityEndorsement> {
+        let (issued_at, exp) = lifetime(validity)?;
+        let claims = EndorsementClaims {
+            parent_id: self.authority_id.clone(),
+            child_id: child_id.into(),
+            child_key: child_key.to_did_key(),
+            issued_at,
+            exp,
+        };
+        let signature = sign_payload(&self.keypair, &claims)?;
+        Ok(AuthorityEndorsement { claims, signature })
+    }
+
+    /// Publish this authority's trust chain.
+    pub fn trust_chain(&self) -> TrustChain {
+        TrustChain {
+            authority_id: self.authority_id.clone(),
+            authority_key: self.verifying_key().to_did_key(),
+            endorsement: self.endorsement.clone(),
+        }
+    }
+}
+
+/// Compute `(issued_at, expiry)` RFC 3339 strings for a credential lifetime.
+fn lifetime(validity: Duration) -> Result<(String, String)> {
+    let now = Utc::now();
+    let exp = now.checked_add_signed(validity).ok_or_else(|| {
+        IdentityError::Malformed("validity overflows the credential clock".into())
+    })?;
+    Ok((format_rfc3339(now), format_rfc3339(exp)))
+}
+
+/// Derive a trust level from attestation evidence.
+///
+/// Compromised-platform evidence is a hard failure: the AIA will not attest a
+/// runtime it has been told is compromised.
+fn evaluate_trust(attestation: Option<&AttestationEvidence>) -> Result<TrustLevel> {
+    let Some(evidence) = attestation else {
+        return Ok(TrustLevel::Unattested);
+    };
+    if let Some(platform) = &evidence.platform
+        && platform.platform_state == SecurityState::Compromised
+    {
+        return Err(IdentityError::CompromisedRuntime);
+    }
+    let platform_trusted = evidence
+        .platform
+        .as_ref()
+        .is_some_and(|platform| platform.platform_state == SecurityState::Trusted);
+    if evidence.model.is_some() || platform_trusted {
+        Ok(TrustLevel::Attested)
+    } else {
+        Ok(TrustLevel::Unattested)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arkavo_attestation::PlatformEvidence;
+    use arkavo_device_identity::AgentIdentity;
+
+    fn request(agent: &AgentKeypair) -> IssueRequest {
+        IssueRequest {
+            subject: "agent:worker-17".into(),
+            agent_type: "coding".into(),
+            agent_public_key: agent.public_key(),
+            runtime: Runtime::Local,
+            capabilities: vec!["a2a".into(), "mcp".into()],
+            owner: Some("user:paul".into()),
+            organization: Some("arkavo".into()),
+            validity: Duration::days(10),
+            attestation: None,
+        }
+    }
+
+    fn platform_evidence(state: SecurityState) -> PlatformEvidence {
+        let identity = AgentIdentity::new("0.77.0".to_string());
+        let mut evidence = PlatformEvidence::from_agent_identity(identity, "linux-x86_64".into());
+        evidence.platform_state = state;
+        evidence
+    }
+
+    #[test]
+    fn issued_credential_carries_the_requested_identity() {
+        let aia = IdentityAuthority::new_root("agent:id-authority");
+        let agent = AgentKeypair::generate();
+        let credential = aia.issue(request(&agent)).unwrap();
+        let document = &credential.document;
+        assert_eq!(document.iss, "agent:id-authority");
+        assert_eq!(document.sub, "agent:worker-17");
+        assert_eq!(document.public_key, agent.public_key().to_did_key());
+        assert_eq!(document.trust_level, TrustLevel::Unattested);
+        assert_eq!(document.owner.as_deref(), Some("user:paul"));
+    }
+
+    #[test]
+    fn attestation_evidence_drives_the_trust_level() {
+        let aia = IdentityAuthority::new_root("agent:id-authority");
+        let agent = AgentKeypair::generate();
+        let mut req = request(&agent);
+        req.attestation = Some(AttestationEvidence {
+            model: None,
+            platform: Some(platform_evidence(SecurityState::Trusted)),
+        });
+        let credential = aia.issue(req).unwrap();
+        assert_eq!(credential.document.trust_level, TrustLevel::Attested);
+    }
+
+    #[test]
+    fn suspicious_platform_yields_an_unattested_credential() {
+        let aia = IdentityAuthority::new_root("agent:id-authority");
+        let agent = AgentKeypair::generate();
+        let mut req = request(&agent);
+        req.attestation = Some(AttestationEvidence {
+            model: None,
+            platform: Some(platform_evidence(SecurityState::Suspicious)),
+        });
+        let credential = aia.issue(req).unwrap();
+        assert_eq!(credential.document.trust_level, TrustLevel::Unattested);
+    }
+
+    #[test]
+    fn compromised_platform_is_refused() {
+        let aia = IdentityAuthority::new_root("agent:id-authority");
+        let agent = AgentKeypair::generate();
+        let mut req = request(&agent);
+        req.attestation = Some(AttestationEvidence {
+            model: None,
+            platform: Some(platform_evidence(SecurityState::Compromised)),
+        });
+        let err = aia.issue(req).unwrap_err();
+        assert!(matches!(err, IdentityError::CompromisedRuntime));
+    }
+
+    #[test]
+    fn rotation_preserves_identity_but_swaps_the_key() {
+        let aia = IdentityAuthority::new_root("agent:id-authority");
+        let agent = AgentKeypair::generate();
+        let original = aia.issue(request(&agent)).unwrap();
+        let rotated_key = AgentKeypair::generate();
+        let rotated = aia
+            .rotate(&original, &rotated_key.public_key(), Duration::days(10))
+            .unwrap();
+        assert_eq!(rotated.document.sub, original.document.sub);
+        assert_eq!(rotated.document.agent_type, original.document.agent_type);
+        assert_eq!(
+            rotated.document.capabilities,
+            original.document.capabilities
+        );
+        assert_ne!(rotated.document.public_key, original.document.public_key);
+        assert_eq!(
+            rotated.document.public_key,
+            rotated_key.public_key().to_did_key()
+        );
+        assert!(rotated.verify(&aia.verifying_key(), Utc::now()).is_ok());
+    }
+}

--- a/crates/arkavo-agent-identity/src/credential.rs
+++ b/crates/arkavo-agent-identity/src/credential.rs
@@ -1,0 +1,126 @@
+//! The signed identity credential and its verification.
+
+use crate::document::IdentityDocument;
+use crate::{IdentityError, Result, verify_payload};
+use arkavo_crypto::AgentPublicKey;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// An identity document signed by the issuing AIA.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityCredential {
+    /// The signed identity claims.
+    pub document: IdentityDocument,
+    /// Base64 Ed25519 signature over the canonical document bytes.
+    pub signature: String,
+}
+
+impl IdentityCredential {
+    /// Verify the credential against a trusted authority key.
+    ///
+    /// Checks the AIA signature and that the credential has not expired at
+    /// `now`. The caller must obtain `authority_key` from a trusted
+    /// [`TrustChain`] — never from the credential or its `iss` claim alone.
+    ///
+    /// [`TrustChain`]: crate::TrustChain
+    pub fn verify(
+        &self,
+        authority_key: &AgentPublicKey,
+        now: DateTime<Utc>,
+    ) -> Result<&IdentityDocument> {
+        verify_payload(authority_key, &self.document, &self.signature)?;
+        if self.document.is_expired(now)? {
+            return Err(IdentityError::Expired);
+        }
+        Ok(&self.document)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::document::{Runtime, TrustLevel};
+    use crate::{IdentityAuthority, IssueRequest};
+    use arkavo_crypto::AgentKeypair;
+    use chrono::Duration;
+
+    fn issue() -> (IdentityAuthority, IdentityCredential, AgentKeypair) {
+        let aia = IdentityAuthority::new_root("agent:id-authority");
+        let agent = AgentKeypair::generate();
+        let credential = aia
+            .issue(IssueRequest {
+                subject: "agent:worker-17".into(),
+                agent_type: "coding".into(),
+                agent_public_key: agent.public_key(),
+                runtime: Runtime::Local,
+                capabilities: vec!["a2a".into(), "mcp".into()],
+                owner: None,
+                organization: None,
+                validity: Duration::hours(1),
+                attestation: None,
+            })
+            .unwrap();
+        (aia, credential, agent)
+    }
+
+    #[test]
+    fn valid_credential_verifies() {
+        let (aia, credential, _) = issue();
+        let document = credential
+            .verify(&aia.verifying_key(), Utc::now())
+            .expect("verify");
+        assert_eq!(document.sub, "agent:worker-17");
+        assert_eq!(document.trust_level, TrustLevel::Unattested);
+    }
+
+    #[test]
+    fn tampered_document_fails_verification() {
+        let (aia, mut credential, _) = issue();
+        credential.document.agent_type = "exfiltration".into();
+        let err = credential
+            .verify(&aia.verifying_key(), Utc::now())
+            .unwrap_err();
+        assert!(matches!(err, IdentityError::InvalidSignature));
+    }
+
+    #[test]
+    fn wrong_authority_key_fails_verification() {
+        let (_, credential, _) = issue();
+        let impostor = AgentKeypair::generate();
+        let err = credential
+            .verify(&impostor.public_key(), Utc::now())
+            .unwrap_err();
+        assert!(matches!(err, IdentityError::InvalidSignature));
+    }
+
+    #[test]
+    fn expired_credential_is_rejected() {
+        let aia = IdentityAuthority::new_root("agent:id-authority");
+        let agent = AgentKeypair::generate();
+        let credential = aia
+            .issue(IssueRequest {
+                subject: "agent:worker-17".into(),
+                agent_type: "coding".into(),
+                agent_public_key: agent.public_key(),
+                runtime: Runtime::Local,
+                capabilities: vec![],
+                owner: None,
+                organization: None,
+                validity: Duration::seconds(-1),
+                attestation: None,
+            })
+            .unwrap();
+        let err = credential
+            .verify(&aia.verifying_key(), Utc::now())
+            .unwrap_err();
+        assert!(matches!(err, IdentityError::Expired));
+    }
+
+    #[test]
+    fn credential_survives_json_round_trip() {
+        let (aia, credential, _) = issue();
+        let json = serde_json::to_string(&credential).unwrap();
+        let restored: IdentityCredential = serde_json::from_str(&json).unwrap();
+        assert!(restored.verify(&aia.verifying_key(), Utc::now()).is_ok());
+    }
+}

--- a/crates/arkavo-agent-identity/src/document.rs
+++ b/crates/arkavo-agent-identity/src/document.rs
@@ -1,0 +1,228 @@
+//! The agent identity document and its OpenTDF attribute projection.
+
+use crate::{IdentityError, Result};
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+
+/// OpenTDF attributes that the orchestrator issues — never the identity layer.
+///
+/// These describe what an agent may *do*; placing them in an identity document
+/// would let the AIA make authorization decisions, which is not its role.
+pub const ORCHESTRATOR_ISSUED_ATTRIBUTES: [&str; 4] = [
+    "agent.tool_access",
+    "agent.code_authority",
+    "agent.resource_scope",
+    "agent.execution_mode",
+];
+
+/// Confidence the AIA places in an agent's declared identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustLevel {
+    /// Identity issued without corroborating attestation evidence.
+    Unattested,
+    /// Identity backed by verified model or trusted-platform attestation.
+    Attested,
+}
+
+impl TrustLevel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TrustLevel::Unattested => "unattested",
+            TrustLevel::Attested => "attested",
+        }
+    }
+}
+
+/// Where an agent executes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Runtime {
+    Local,
+    Remote,
+}
+
+impl Runtime {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Runtime::Local => "local",
+            Runtime::Remote => "remote",
+        }
+    }
+}
+
+/// A single OpenTDF attribute derived from an identity document.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityAttribute {
+    pub name: String,
+    pub value: String,
+}
+
+/// The claims of an agent identity, as issued and signed by the AIA.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityDocument {
+    /// Issuing authority identifier, e.g. `agent:id-authority`.
+    pub iss: String,
+    /// Subject agent identifier, e.g. `agent:worker-17`.
+    pub sub: String,
+    /// Free-form agent role/type, e.g. `coding`.
+    pub agent_type: String,
+    /// Agent's Ed25519 public key as a `did:key` string.
+    pub public_key: String,
+    /// Confidence in the identity (attested vs unattested).
+    pub trust_level: TrustLevel,
+    /// Where the agent runs.
+    pub runtime: Runtime,
+    /// Attested model identifier, present when model attestation supplied one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Owning principal — source of `agent.identity.owner`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    /// Owning organization — source of `agent.identity.organization`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub organization: Option<String>,
+    /// Protocols the agent speaks, e.g. `a2a`, `mcp`.
+    pub capabilities: Vec<String>,
+    /// Issued-at time (RFC 3339).
+    pub iat: String,
+    /// Expiry time (RFC 3339).
+    pub exp: String,
+}
+
+impl IdentityDocument {
+    /// OpenTDF attributes that originate from this identity.
+    ///
+    /// Only `agent.identity.*` attributes are emitted — facts about *who* the
+    /// agent is. Authorization attributes ([`ORCHESTRATOR_ISSUED_ATTRIBUTES`])
+    /// are never produced here.
+    pub fn tdf_attributes(&self) -> Vec<IdentityAttribute> {
+        let mut attrs = vec![
+            IdentityAttribute {
+                name: "agent.identity.type".into(),
+                value: self.agent_type.clone(),
+            },
+            IdentityAttribute {
+                name: "agent.identity.trust_level".into(),
+                value: self.trust_level.as_str().into(),
+            },
+            IdentityAttribute {
+                name: "agent.identity.runtime".into(),
+                value: self.runtime.as_str().into(),
+            },
+        ];
+        if let Some(owner) = &self.owner {
+            attrs.push(IdentityAttribute {
+                name: "agent.identity.owner".into(),
+                value: owner.clone(),
+            });
+        }
+        if let Some(organization) = &self.organization {
+            attrs.push(IdentityAttribute {
+                name: "agent.identity.organization".into(),
+                value: organization.clone(),
+            });
+        }
+        attrs
+    }
+
+    /// Parse the `exp` claim into a UTC timestamp.
+    pub fn expires_at(&self) -> Result<DateTime<Utc>> {
+        parse_rfc3339(&self.exp)
+    }
+
+    /// Whether the document is expired at `now`.
+    pub fn is_expired(&self, now: DateTime<Utc>) -> Result<bool> {
+        Ok(now >= self.expires_at()?)
+    }
+}
+
+pub(crate) fn parse_rfc3339(s: &str) -> Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| IdentityError::Malformed(format!("invalid RFC 3339 time '{s}': {e}")))
+}
+
+pub(crate) fn format_rfc3339(t: DateTime<Utc>) -> String {
+    t.to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn document() -> IdentityDocument {
+        IdentityDocument {
+            iss: "agent:id-authority".into(),
+            sub: "agent:worker-17".into(),
+            agent_type: "coding".into(),
+            public_key: "did:key:zTest".into(),
+            trust_level: TrustLevel::Attested,
+            runtime: Runtime::Local,
+            model: Some("gemma-4".into()),
+            owner: Some("user:paul".into()),
+            organization: Some("arkavo".into()),
+            capabilities: vec!["a2a".into(), "mcp".into()],
+            iat: "2026-05-22T00:00:00Z".into(),
+            exp: "2026-06-01T00:00:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn tdf_attributes_are_identity_only() {
+        let attrs = document().tdf_attributes();
+        let names: Vec<&str> = attrs.iter().map(|a| a.name.as_str()).collect();
+        assert!(names.contains(&"agent.identity.type"));
+        assert!(names.contains(&"agent.identity.trust_level"));
+        assert!(names.contains(&"agent.identity.runtime"));
+        assert!(names.contains(&"agent.identity.owner"));
+        assert!(names.contains(&"agent.identity.organization"));
+        // The AIA never originates orchestrator-issued authorization attributes.
+        for forbidden in ORCHESTRATOR_ISSUED_ATTRIBUTES {
+            assert!(!names.contains(&forbidden));
+        }
+        for attr in &attrs {
+            assert!(attr.name.starts_with("agent.identity."));
+        }
+    }
+
+    #[test]
+    fn tdf_attributes_omit_absent_optionals() {
+        let mut doc = document();
+        doc.owner = None;
+        doc.organization = None;
+        let names: Vec<String> = doc.tdf_attributes().into_iter().map(|a| a.name).collect();
+        assert_eq!(names.len(), 3);
+        assert!(!names.iter().any(|n| n == "agent.identity.owner"));
+    }
+
+    #[test]
+    fn expiry_is_evaluated_against_now() {
+        let doc = document();
+        let before = parse_rfc3339("2026-05-30T00:00:00Z").unwrap();
+        let after = parse_rfc3339("2026-06-02T00:00:00Z").unwrap();
+        assert!(!doc.is_expired(before).unwrap());
+        assert!(doc.is_expired(after).unwrap());
+    }
+
+    #[test]
+    fn malformed_exp_is_rejected() {
+        let mut doc = document();
+        doc.exp = "not-a-timestamp".into();
+        assert!(doc.expires_at().is_err());
+    }
+
+    #[test]
+    fn rfc3339_round_trip_uses_z_suffix() {
+        let t = parse_rfc3339("2026-06-01T00:00:00Z").unwrap();
+        assert_eq!(format_rfc3339(t), "2026-06-01T00:00:00Z");
+    }
+
+    #[test]
+    fn document_serializes_to_the_expected_shape() {
+        let json = serde_json::to_value(document()).unwrap();
+        assert_eq!(json["trust_level"], "attested");
+        assert_eq!(json["runtime"], "local");
+        assert_eq!(json["capabilities"][0], "a2a");
+    }
+}

--- a/crates/arkavo-agent-identity/src/lib.rs
+++ b/crates/arkavo-agent-identity/src/lib.rs
@@ -1,0 +1,87 @@
+//! Agent Identity Authority (AIA).
+//!
+//! A dedicated role whose sole responsibility is to issue and attest agent
+//! identity. An [`IdentityAuthority`] creates agent identities, issues signed
+//! credentials, rotates agent keys, attests runtime/platform identity,
+//! publishes a [`TrustChain`], and revokes compromised agents.
+//!
+//! The AIA deliberately does *not* assign work, grant resource access, make
+//! ABAC decisions, delegate authority, or release TDF keys — those remain the
+//! orchestrator's and KAS's responsibilities. An identity document yields only
+//! `agent.identity.*` attributes; [`ORCHESTRATOR_ISSUED_ATTRIBUTES`] are the
+//! authorization attributes that must never originate from identity.
+//!
+//! ```text
+//! Root Identity Agent (trust anchor)
+//!    └─ Swarm Identity Agent (issues identities)   ← IdentityAuthority
+//!         └─ Orchestrator Agent (delegates work)   ← not part of this crate
+//!              └─ Worker Agents
+//! ```
+
+mod authority;
+mod credential;
+mod document;
+mod revocation;
+mod trust_chain;
+
+pub use authority::{AttestationEvidence, IdentityAuthority, IssueRequest};
+pub use credential::IdentityCredential;
+pub use document::{
+    IdentityAttribute, IdentityDocument, ORCHESTRATOR_ISSUED_ATTRIBUTES, Runtime, TrustLevel,
+};
+pub use revocation::{RevocationClaims, RevocationList, RevokedEntry};
+pub use trust_chain::{AuthorityEndorsement, EndorsementClaims, TrustChain};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use thiserror::Error;
+
+/// Errors produced while issuing, verifying, or governing agent identity.
+#[derive(Debug, Error)]
+pub enum IdentityError {
+    #[error("signature verification failed")]
+    InvalidSignature,
+    #[error("credential or endorsement has expired")]
+    Expired,
+    #[error("authority '{0}' is not anchored to the trusted root")]
+    UntrustedIssuer(String),
+    #[error("runtime attestation reports a compromised platform")]
+    CompromisedRuntime,
+    #[error("malformed identity data: {0}")]
+    Malformed(String),
+    #[error(transparent)]
+    Crypto(#[from] arkavo_crypto::CryptoError),
+}
+
+pub type Result<T> = std::result::Result<T, IdentityError>;
+
+/// Deterministic bytes used as the signing input for a payload.
+///
+/// `serde_json` serializes structs in declaration order with no incidental
+/// whitespace, so a parsed payload re-serializes to the exact bytes that were
+/// signed.
+fn canonical_bytes<T: serde::Serialize>(value: &T) -> Result<Vec<u8>> {
+    serde_json::to_vec(value).map_err(|e| IdentityError::Malformed(e.to_string()))
+}
+
+/// Sign a payload with an authority keypair, returning a base64 signature.
+fn sign_payload<T: serde::Serialize>(
+    keypair: &arkavo_crypto::AgentKeypair,
+    payload: &T,
+) -> Result<String> {
+    let bytes = canonical_bytes(payload)?;
+    Ok(STANDARD.encode(keypair.sign(&bytes)))
+}
+
+/// Verify a base64 signature over a payload against an authority public key.
+fn verify_payload<T: serde::Serialize>(
+    key: &arkavo_crypto::AgentPublicKey,
+    payload: &T,
+    signature_b64: &str,
+) -> Result<()> {
+    let bytes = canonical_bytes(payload)?;
+    let signature = STANDARD
+        .decode(signature_b64)
+        .map_err(|e| IdentityError::Malformed(format!("signature is not base64: {e}")))?;
+    key.verify(&bytes, &signature)
+        .map_err(|_| IdentityError::InvalidSignature)
+}

--- a/crates/arkavo-agent-identity/src/revocation.rs
+++ b/crates/arkavo-agent-identity/src/revocation.rs
@@ -1,0 +1,96 @@
+//! Signed revocation lists for compromised agents.
+
+use crate::{Result, verify_payload};
+use arkavo_crypto::AgentPublicKey;
+use serde::{Deserialize, Serialize};
+
+/// A revoked agent and the circumstances of its revocation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RevokedEntry {
+    /// Subject identifier of the revoked agent.
+    pub sub: String,
+    /// When the revocation took effect (RFC 3339).
+    pub revoked_at: String,
+    /// Optional human-readable reason.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// The signed claims of a revocation list.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RevocationClaims {
+    /// Issuing authority identifier.
+    pub authority_id: String,
+    /// When the list was published (RFC 3339).
+    pub issued_at: String,
+    /// Every agent the authority has revoked.
+    pub revoked: Vec<RevokedEntry>,
+}
+
+/// A revocation list signed by the issuing AIA.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RevocationList {
+    pub claims: RevocationClaims,
+    /// Base64 Ed25519 signature over the canonical claims bytes.
+    pub signature: String,
+}
+
+impl RevocationList {
+    /// Whether `subject` appears on this list.
+    pub fn is_revoked(&self, subject: &str) -> bool {
+        self.claims.revoked.iter().any(|e| e.sub == subject)
+    }
+
+    /// Verify the list was signed by the given authority key.
+    pub fn verify(&self, authority_key: &AgentPublicKey) -> Result<()> {
+        verify_payload(authority_key, &self.claims, &self.signature)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{IdentityAuthority, IdentityError};
+    use arkavo_crypto::AgentKeypair;
+
+    #[test]
+    fn revocation_list_records_and_verifies() {
+        let mut aia = IdentityAuthority::new_root("agent:id-authority");
+        aia.revoke("agent:worker-17", Some("key compromise".into()));
+        aia.revoke("agent:worker-31", None);
+        let list = aia.revocation_list().unwrap();
+
+        assert!(list.is_revoked("agent:worker-17"));
+        assert!(list.is_revoked("agent:worker-31"));
+        assert!(!list.is_revoked("agent:worker-99"));
+        assert!(list.verify(&aia.verifying_key()).is_ok());
+    }
+
+    #[test]
+    fn revoke_is_idempotent() {
+        let mut aia = IdentityAuthority::new_root("agent:id-authority");
+        aia.revoke("agent:worker-17", Some("first".into()));
+        aia.revoke("agent:worker-17", Some("second".into()));
+        let list = aia.revocation_list().unwrap();
+        assert_eq!(list.claims.revoked.len(), 1);
+        assert_eq!(list.claims.revoked[0].reason.as_deref(), Some("first"));
+    }
+
+    #[test]
+    fn tampered_list_fails_verification() {
+        let mut aia = IdentityAuthority::new_root("agent:id-authority");
+        aia.revoke("agent:worker-17", None);
+        let mut list = aia.revocation_list().unwrap();
+        list.claims.revoked.clear();
+        let err = list.verify(&aia.verifying_key()).unwrap_err();
+        assert!(matches!(err, IdentityError::InvalidSignature));
+    }
+
+    #[test]
+    fn list_signed_by_another_authority_is_rejected() {
+        let mut aia = IdentityAuthority::new_root("agent:id-authority");
+        aia.revoke("agent:worker-17", None);
+        let list = aia.revocation_list().unwrap();
+        let other = AgentKeypair::generate();
+        assert!(list.verify(&other.public_key()).is_err());
+    }
+}

--- a/crates/arkavo-agent-identity/src/trust_chain.rs
+++ b/crates/arkavo-agent-identity/src/trust_chain.rs
@@ -1,0 +1,199 @@
+//! The published trust chain linking a subordinate AIA to a root anchor.
+
+use crate::document::parse_rfc3339;
+use crate::{IdentityError, Result, verify_payload};
+use arkavo_crypto::AgentPublicKey;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// The signed claims of a parent AIA endorsing a subordinate AIA.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EndorsementClaims {
+    /// Endorsing (parent) authority identifier.
+    pub parent_id: String,
+    /// Endorsed (subordinate) authority identifier.
+    pub child_id: String,
+    /// Subordinate AIA's public key as a `did:key` string.
+    pub child_key: String,
+    /// When the endorsement was issued (RFC 3339).
+    pub issued_at: String,
+    /// When the endorsement expires (RFC 3339).
+    pub exp: String,
+}
+
+/// A parent AIA's signed endorsement of a subordinate AIA.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthorityEndorsement {
+    pub claims: EndorsementClaims,
+    /// Base64 Ed25519 signature over the canonical claims bytes.
+    pub signature: String,
+}
+
+impl AuthorityEndorsement {
+    /// Verify the endorsement was signed by `parent_key` and is valid at `now`.
+    pub fn verify(&self, parent_key: &AgentPublicKey, now: DateTime<Utc>) -> Result<()> {
+        verify_payload(parent_key, &self.claims, &self.signature)?;
+        if now >= parse_rfc3339(&self.claims.exp)? {
+            return Err(IdentityError::Expired);
+        }
+        Ok(())
+    }
+}
+
+/// The published trust chain for an AIA.
+///
+/// A root AIA is its own trust anchor (`endorsement` is `None`). A subordinate
+/// AIA carries the endorsement that binds its key to the root.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrustChain {
+    /// This AIA's identifier.
+    pub authority_id: String,
+    /// This AIA's public key as a `did:key` string.
+    pub authority_key: String,
+    /// Endorsement from the root, absent when this AIA is itself the root.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endorsement: Option<AuthorityEndorsement>,
+}
+
+impl TrustChain {
+    /// Resolve and verify this AIA's public key against a trusted root.
+    ///
+    /// For a root AIA the chain is trusted only if its key equals
+    /// `trusted_root`. For a subordinate AIA the endorsement must be signed by
+    /// `trusted_root`, unexpired at `now`, and bound to this AIA's identity.
+    pub fn resolve(
+        &self,
+        trusted_root: &AgentPublicKey,
+        now: DateTime<Utc>,
+    ) -> Result<AgentPublicKey> {
+        let authority_key = AgentPublicKey::from_did_key(&self.authority_key)?;
+        match &self.endorsement {
+            None => {
+                if authority_key.to_bytes() != trusted_root.to_bytes() {
+                    return Err(IdentityError::UntrustedIssuer(self.authority_id.clone()));
+                }
+            }
+            Some(endorsement) => {
+                endorsement.verify(trusted_root, now)?;
+                if endorsement.claims.child_key != self.authority_key {
+                    return Err(IdentityError::Malformed(
+                        "endorsement child_key does not match authority_key".into(),
+                    ));
+                }
+                if endorsement.claims.child_id != self.authority_id {
+                    return Err(IdentityError::Malformed(
+                        "endorsement child_id does not match authority_id".into(),
+                    ));
+                }
+            }
+        }
+        Ok(authority_key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::IdentityAuthority;
+    use arkavo_crypto::AgentKeypair;
+    use chrono::Duration;
+
+    #[test]
+    fn root_chain_resolves_to_its_own_key() {
+        let root = IdentityAuthority::new_root("agent:root-authority");
+        let chain = root.trust_chain();
+        assert!(chain.endorsement.is_none());
+        let resolved = chain.resolve(&root.verifying_key(), Utc::now()).unwrap();
+        assert_eq!(resolved.to_bytes(), root.verifying_key().to_bytes());
+    }
+
+    #[test]
+    fn root_chain_rejects_a_different_anchor() {
+        let root = IdentityAuthority::new_root("agent:root-authority");
+        let chain = root.trust_chain();
+        let other = AgentKeypair::generate();
+        let err = chain.resolve(&other.public_key(), Utc::now()).unwrap_err();
+        assert!(matches!(err, IdentityError::UntrustedIssuer(_)));
+    }
+
+    #[test]
+    fn subordinate_chain_resolves_through_the_root() {
+        let root = IdentityAuthority::new_root("agent:root-authority");
+        let swarm_key = AgentKeypair::generate();
+        let endorsement = root
+            .endorse_subordinate(
+                "agent:swarm-authority",
+                &swarm_key.public_key(),
+                Duration::days(30),
+            )
+            .unwrap();
+        let swarm =
+            IdentityAuthority::new_subordinate("agent:swarm-authority", swarm_key, endorsement);
+        let chain = swarm.trust_chain();
+        let resolved = chain.resolve(&root.verifying_key(), Utc::now()).unwrap();
+        assert_eq!(resolved.to_bytes(), swarm.verifying_key().to_bytes());
+    }
+
+    #[test]
+    fn subordinate_chain_rejects_endorsement_from_an_untrusted_root() {
+        let root = IdentityAuthority::new_root("agent:root-authority");
+        let impostor = IdentityAuthority::new_root("agent:impostor");
+        let swarm_key = AgentKeypair::generate();
+        let endorsement = root
+            .endorse_subordinate(
+                "agent:swarm-authority",
+                &swarm_key.public_key(),
+                Duration::days(30),
+            )
+            .unwrap();
+        let swarm =
+            IdentityAuthority::new_subordinate("agent:swarm-authority", swarm_key, endorsement);
+        let err = swarm
+            .trust_chain()
+            .resolve(&impostor.verifying_key(), Utc::now())
+            .unwrap_err();
+        assert!(matches!(err, IdentityError::InvalidSignature));
+    }
+
+    #[test]
+    fn expired_endorsement_breaks_the_chain() {
+        let root = IdentityAuthority::new_root("agent:root-authority");
+        let swarm_key = AgentKeypair::generate();
+        let endorsement = root
+            .endorse_subordinate(
+                "agent:swarm-authority",
+                &swarm_key.public_key(),
+                Duration::seconds(-1),
+            )
+            .unwrap();
+        let swarm =
+            IdentityAuthority::new_subordinate("agent:swarm-authority", swarm_key, endorsement);
+        let err = swarm
+            .trust_chain()
+            .resolve(&root.verifying_key(), Utc::now())
+            .unwrap_err();
+        assert!(matches!(err, IdentityError::Expired));
+    }
+
+    #[test]
+    fn rebound_endorsement_is_detected() {
+        let root = IdentityAuthority::new_root("agent:root-authority");
+        let swarm_key = AgentKeypair::generate();
+        let endorsement = root
+            .endorse_subordinate(
+                "agent:swarm-authority",
+                &swarm_key.public_key(),
+                Duration::days(30),
+            )
+            .unwrap();
+        // Attacker keeps a valid endorsement but swaps in their own key.
+        let mut chain =
+            IdentityAuthority::new_subordinate("agent:swarm-authority", swarm_key, endorsement)
+                .trust_chain();
+        chain.authority_key = AgentKeypair::generate().public_key().to_did_key();
+        let err = chain
+            .resolve(&root.verifying_key(), Utc::now())
+            .unwrap_err();
+        assert!(matches!(err, IdentityError::Malformed(_)));
+    }
+}

--- a/crates/arkavo-agent-identity/tests/aia_lifecycle_test.rs
+++ b/crates/arkavo-agent-identity/tests/aia_lifecycle_test.rs
@@ -1,0 +1,167 @@
+//! End-to-end Agent Identity Authority lifecycle.
+//!
+//! Walks the ecosystem the AIA role defines: a Root Identity Agent anchors
+//! trust, a Swarm Identity Agent issues worker credentials, a verifier (an
+//! orchestrator) resolves the trust chain and validates a credential, and the
+//! AIA rotates and revokes keys.
+
+use arkavo_agent_identity::{
+    AttestationEvidence, IdentityAuthority, IssueRequest, ORCHESTRATOR_ISSUED_ATTRIBUTES, Runtime,
+    TrustLevel,
+};
+use arkavo_attestation::{ModelEvidence, ModelFormat, ModelRuntime};
+use arkavo_crypto::AgentKeypair;
+use chrono::{Duration, Utc};
+
+fn model_evidence() -> ModelEvidence {
+    ModelEvidence {
+        model_id: "gemma-4".into(),
+        weights_digest: "blake3:0000000000000000000000000000000000000000000000000000000000000000"
+            .into(),
+        weights_size: 4096,
+        format: ModelFormat::Gguf,
+        runtime: ModelRuntime::LlamaCpp,
+        runtime_version: Some("llama.cpp-b4567".into()),
+        architecture: Some("gemma".into()),
+        quantization: Some("Q4_K_M".into()),
+        gguf_version: Some(3),
+        tensor_count: Some(291),
+        timestamp: Utc::now().timestamp(),
+    }
+}
+
+#[test]
+fn test_end_to_end_identity_authority_lifecycle() {
+    println!("\n=== Agent Identity Authority Lifecycle ===\n");
+
+    println!("Step 1: Stand up the Root Identity Agent (trust anchor)");
+    let root = IdentityAuthority::new_root("agent:root-authority");
+    let trusted_root = root.verifying_key();
+    println!("✓ Root anchored: {}", root.authority_id());
+
+    println!("\nStep 2: Root endorses a Swarm Identity Agent");
+    let swarm_keypair = AgentKeypair::generate();
+    let endorsement = root
+        .endorse_subordinate(
+            "agent:swarm-authority",
+            &swarm_keypair.public_key(),
+            Duration::days(30),
+        )
+        .expect("endorsement");
+    let swarm =
+        IdentityAuthority::new_subordinate("agent:swarm-authority", swarm_keypair, endorsement);
+    println!("✓ Swarm AIA endorsed by root");
+
+    println!("\nStep 3: A worker generates its own keypair");
+    let worker = AgentKeypair::generate();
+    println!("✓ Worker holds its private key; only the public key is shared");
+
+    println!("\nStep 4: Swarm AIA issues an attested identity credential");
+    let credential = swarm
+        .issue(IssueRequest {
+            subject: "agent:worker-17".into(),
+            agent_type: "coding".into(),
+            agent_public_key: worker.public_key(),
+            runtime: Runtime::Local,
+            capabilities: vec!["a2a".into(), "mcp".into()],
+            owner: Some("user:paul".into()),
+            organization: Some("arkavo".into()),
+            validity: Duration::days(10),
+            attestation: Some(AttestationEvidence {
+                model: Some(model_evidence()),
+                platform: None,
+            }),
+        })
+        .expect("issue");
+    assert_eq!(credential.document.trust_level, TrustLevel::Attested);
+    assert_eq!(credential.document.model.as_deref(), Some("gemma-4"));
+    println!(
+        "✓ Credential issued: sub={} trust_level={} model={:?}",
+        credential.document.sub,
+        credential.document.trust_level.as_str(),
+        credential.document.model,
+    );
+
+    println!("\nStep 5: An orchestrator resolves the trust chain and verifies");
+    let swarm_key = swarm
+        .trust_chain()
+        .resolve(&trusted_root, Utc::now())
+        .expect("trust chain resolves to the root");
+    let document = credential
+        .verify(&swarm_key, Utc::now())
+        .expect("credential verifies under the resolved key");
+    println!("✓ Trust chain Root -> Swarm -> credential verified");
+
+    println!("\nStep 6: Identity yields only agent.identity.* OpenTDF attributes");
+    let attributes = document.tdf_attributes();
+    for attr in &attributes {
+        println!("  {} = {}", attr.name, attr.value);
+        assert!(attr.name.starts_with("agent.identity."));
+    }
+    for forbidden in ORCHESTRATOR_ISSUED_ATTRIBUTES {
+        assert!(
+            !attributes.iter().any(|a| a.name == forbidden),
+            "AIA must not originate orchestrator-issued attribute {forbidden}"
+        );
+    }
+    println!("✓ Authorization attributes remain orchestrator-issued");
+
+    println!("\nStep 7: Rotate the worker's key");
+    let rotated_key = AgentKeypair::generate();
+    let rotated = swarm
+        .rotate(&credential, &rotated_key.public_key(), Duration::days(10))
+        .expect("rotate");
+    assert_eq!(rotated.document.sub, credential.document.sub);
+    assert_ne!(rotated.document.public_key, credential.document.public_key);
+    rotated
+        .verify(&swarm_key, Utc::now())
+        .expect("rotated credential verifies");
+    println!("✓ Worker re-keyed; identity claims preserved");
+
+    println!("\nStep 8: Revoke the worker and publish the revocation list");
+    let mut swarm = swarm;
+    swarm.revoke("agent:worker-17", Some("key compromise".into()));
+    let revocations = swarm.revocation_list().expect("revocation list");
+    revocations
+        .verify(&swarm_key)
+        .expect("revocation list verifies");
+    assert!(revocations.is_revoked("agent:worker-17"));
+    println!("✓ Revocation list published and signed by the Swarm AIA");
+
+    println!("\n=== Lifecycle Complete ===\n");
+}
+
+#[test]
+fn test_credential_from_an_unendorsed_authority_does_not_chain_to_the_root() {
+    let root = IdentityAuthority::new_root("agent:root-authority");
+    let rogue = IdentityAuthority::new_root("agent:rogue-authority");
+    let worker = AgentKeypair::generate();
+
+    let credential = rogue
+        .issue(IssueRequest {
+            subject: "agent:worker-99".into(),
+            agent_type: "coding".into(),
+            agent_public_key: worker.public_key(),
+            runtime: Runtime::Local,
+            capabilities: vec![],
+            owner: None,
+            organization: None,
+            validity: Duration::days(1),
+            attestation: None,
+        })
+        .expect("issue");
+
+    // The rogue AIA can sign its own credential, but its trust chain is not
+    // anchored to the root the orchestrator trusts.
+    assert!(
+        credential
+            .verify(&rogue.verifying_key(), Utc::now())
+            .is_ok()
+    );
+    assert!(
+        rogue
+            .trust_chain()
+            .resolve(&root.verifying_key(), Utc::now())
+            .is_err()
+    );
+}

--- a/crates/arkavo-attestation/Cargo.toml
+++ b/crates/arkavo-attestation/Cargo.toml
@@ -9,6 +9,7 @@ description = "Platform attestation for arkavo-edge"
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+blake3 = "1.5"
 arkavo-device-identity = { path = "../arkavo-device-identity" }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/arkavo-attestation/README.md
+++ b/crates/arkavo-attestation/README.md
@@ -1,8 +1,8 @@
 # arkavo-attestation
 
-Platform attestation for arkavo-edge agents.
+Platform and model attestation for arkavo-edge agents.
 
-## Features
+## Platform attestation
 
 - **Platform Evidence Collection**: Securely gathers device identity, platform code, and security state.
 - **Security State Detection**: Real-time detection of trusted, suspicious, or compromised system states.
@@ -12,3 +12,33 @@ Platform attestation for arkavo-edge agents.
   - Software-based fingerprinting fallback for legacy or development environments.
 - **Honest Reporting**: Truthful reporting of platform state to the control plane without local policy enforcement.
 - **Cross-platform Support**: Unified attestation interface for macOS, Linux, Windows, and Raspberry Pi.
+
+## Model attestation
+
+Proves *which model* an agent process is running — the missing primitive for
+agent identity. A `ModelAttestor` binds an agent to the weights it loaded and
+the runtime that executes them.
+
+- **Content-addressed weights**: `FileModelAttestor` streams a weights file
+  through BLAKE3, producing a `blake3:<hex>` digest. Identical weights always
+  yield the same digest; a single changed byte changes it.
+- **GGUF metadata**: the GGUF header is parsed (without loading weights) to
+  recover architecture, logical name, quantization, tensor count and container
+  version. `safetensors` files are attested by digest and runtime alone.
+- **Runtime binding**: evidence records the inference runtime (`llama.cpp`,
+  `mlx`, or another) and an optional engine build identifier.
+- **SPIFFE/SPIRE mapping**: `ModelEvidence::spire_selectors()` emits the exact
+  `model:<key>:<value>` selectors a SPIRE workload attestor plugin would
+  publish; `spiffe_id()` derives a `spiffe://…/model/<arch>/<id>/<digest>` ID.
+
+```rust
+use arkavo_attestation::{FileModelAttestor, ModelAttestor, ModelRuntime};
+
+let evidence = FileModelAttestor::new("model.gguf", ModelRuntime::LlamaCpp)
+    .with_runtime_version("llama.cpp-b4567")
+    .attest()?;
+
+for selector in evidence.spire_selectors() {
+    println!("{selector}");
+}
+```

--- a/crates/arkavo-attestation/src/gguf.rs
+++ b/crates/arkavo-attestation/src/gguf.rs
@@ -1,0 +1,320 @@
+//! Minimal GGUF header parser.
+//!
+//! Reads only the metadata block of a GGUF file — magic, version, counts and
+//! key/value pairs — so a model can be identified without loading its weights.
+//! Array values are skipped via `Seek` to keep parsing bounded for files whose
+//! headers embed large tokenizer tables.
+
+use crate::{AttestationError, Result};
+use std::io::{Read, Seek, SeekFrom};
+
+const GGUF_MAGIC: u32 = 0x4655_4747; // "GGUF" little-endian
+
+/// Upper bound on an individual GGUF string. Keys and `general.*` values are
+/// tiny; the cap exists only to reject a malformed length before allocation.
+const MAX_STRING_LEN: u64 = 64 * 1024 * 1024;
+
+/// GGUF metadata value type tags, per the GGUF specification.
+mod value_type {
+    pub const UINT8: u32 = 0;
+    pub const INT8: u32 = 1;
+    pub const UINT16: u32 = 2;
+    pub const INT16: u32 = 3;
+    pub const UINT32: u32 = 4;
+    pub const INT32: u32 = 5;
+    pub const FLOAT32: u32 = 6;
+    pub const BOOL: u32 = 7;
+    pub const STRING: u32 = 8;
+    pub const ARRAY: u32 = 9;
+    pub const UINT64: u32 = 10;
+    pub const INT64: u32 = 11;
+    pub const FLOAT64: u32 = 12;
+}
+
+/// Identifying metadata extracted from a GGUF file header.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GgufMetadata {
+    pub version: u32,
+    pub tensor_count: u64,
+    pub architecture: Option<String>,
+    pub name: Option<String>,
+    pub file_type: Option<u32>,
+}
+
+impl GgufMetadata {
+    /// Human-readable quantization label derived from `general.file_type`.
+    pub fn quantization(&self) -> Option<String> {
+        self.file_type.map(file_type_name)
+    }
+}
+
+/// Parse the metadata block of a GGUF stream positioned at its start.
+pub fn parse<R: Read + Seek>(reader: &mut R) -> Result<GgufMetadata> {
+    if read_u32(reader)? != GGUF_MAGIC {
+        return Err(AttestationError::Model("not a GGUF file".to_string()));
+    }
+    let version = read_u32(reader)?;
+    if !(2..=3).contains(&version) {
+        return Err(AttestationError::Model(format!(
+            "unsupported GGUF version {version}"
+        )));
+    }
+    let tensor_count = read_u64(reader)?;
+    let kv_count = read_u64(reader)?;
+
+    let mut meta = GgufMetadata {
+        version,
+        tensor_count,
+        ..GgufMetadata::default()
+    };
+    for _ in 0..kv_count {
+        let key = read_gguf_string(reader)?;
+        let vt = read_u32(reader)?;
+        match key.as_str() {
+            "general.architecture" => meta.architecture = Some(expect_string(reader, vt, &key)?),
+            "general.name" => meta.name = Some(expect_string(reader, vt, &key)?),
+            "general.file_type" => meta.file_type = Some(expect_u32(reader, vt, &key)?),
+            _ => skip_value(reader, vt)?,
+        }
+    }
+    Ok(meta)
+}
+
+/// Map a `general.file_type` (`llama_ftype`) enum value to a quantization name.
+fn file_type_name(ft: u32) -> String {
+    let name = match ft {
+        0 => "F32",
+        1 => "F16",
+        2 => "Q4_0",
+        3 => "Q4_1",
+        7 => "Q8_0",
+        8 => "Q5_0",
+        9 => "Q5_1",
+        10 => "Q2_K",
+        11 => "Q3_K_S",
+        12 => "Q3_K_M",
+        13 => "Q3_K_L",
+        14 => "Q4_K_S",
+        15 => "Q4_K_M",
+        16 => "Q5_K_S",
+        17 => "Q5_K_M",
+        18 => "Q6_K",
+        19 => "IQ2_XXS",
+        20 => "IQ2_XS",
+        21 => "Q2_K_S",
+        22 => "IQ3_XS",
+        23 => "IQ3_XXS",
+        24 => "IQ1_S",
+        25 => "IQ4_NL",
+        26 => "IQ3_S",
+        27 => "IQ3_M",
+        28 => "IQ2_S",
+        29 => "IQ2_M",
+        30 => "IQ4_XS",
+        31 => "IQ1_M",
+        32 => "BF16",
+        _ => return format!("ftype-{ft}"),
+    };
+    name.to_string()
+}
+
+fn io_err(e: std::io::Error) -> AttestationError {
+    AttestationError::Model(format!("malformed GGUF header: {e}"))
+}
+
+fn read_u32<R: Read>(reader: &mut R) -> Result<u32> {
+    let mut buf = [0u8; 4];
+    reader.read_exact(&mut buf).map_err(io_err)?;
+    Ok(u32::from_le_bytes(buf))
+}
+
+fn read_u64<R: Read>(reader: &mut R) -> Result<u64> {
+    let mut buf = [0u8; 8];
+    reader.read_exact(&mut buf).map_err(io_err)?;
+    Ok(u64::from_le_bytes(buf))
+}
+
+fn read_gguf_string<R: Read>(reader: &mut R) -> Result<String> {
+    let len = read_u64(reader)?;
+    if len > MAX_STRING_LEN {
+        return Err(AttestationError::Model(format!(
+            "GGUF string length {len} exceeds limit"
+        )));
+    }
+    let mut buf = vec![0u8; len as usize];
+    reader.read_exact(&mut buf).map_err(io_err)?;
+    String::from_utf8(buf)
+        .map_err(|e| AttestationError::Model(format!("GGUF string is not UTF-8: {e}")))
+}
+
+fn expect_string<R: Read>(reader: &mut R, vt: u32, key: &str) -> Result<String> {
+    if vt != value_type::STRING {
+        return Err(AttestationError::Model(format!(
+            "GGUF key '{key}' expected string, got value type {vt}"
+        )));
+    }
+    read_gguf_string(reader)
+}
+
+fn expect_u32<R: Read>(reader: &mut R, vt: u32, key: &str) -> Result<u32> {
+    match vt {
+        value_type::UINT32 | value_type::INT32 => read_u32(reader),
+        _ => Err(AttestationError::Model(format!(
+            "GGUF key '{key}' expected uint32, got value type {vt}"
+        ))),
+    }
+}
+
+/// Byte width of a fixed-size scalar value type, or `None` for variable types.
+fn scalar_size(vt: u32) -> Option<u64> {
+    Some(match vt {
+        value_type::UINT8 | value_type::INT8 | value_type::BOOL => 1,
+        value_type::UINT16 | value_type::INT16 => 2,
+        value_type::UINT32 | value_type::INT32 | value_type::FLOAT32 => 4,
+        value_type::UINT64 | value_type::INT64 | value_type::FLOAT64 => 8,
+        _ => return None,
+    })
+}
+
+fn seek_forward<R: Seek>(reader: &mut R, n: u64) -> Result<()> {
+    let offset =
+        i64::try_from(n).map_err(|_| AttestationError::Model("GGUF offset too large".into()))?;
+    reader.seek(SeekFrom::Current(offset)).map_err(io_err)?;
+    Ok(())
+}
+
+/// Advance past a value of `vt` without interpreting it.
+fn skip_value<R: Read + Seek>(reader: &mut R, vt: u32) -> Result<()> {
+    if let Some(sz) = scalar_size(vt) {
+        return seek_forward(reader, sz);
+    }
+    match vt {
+        value_type::STRING => {
+            let len = read_u64(reader)?;
+            seek_forward(reader, len)
+        }
+        value_type::ARRAY => {
+            let elem_type = read_u32(reader)?;
+            let count = read_u64(reader)?;
+            if let Some(sz) = scalar_size(elem_type) {
+                let total = count
+                    .checked_mul(sz)
+                    .ok_or_else(|| AttestationError::Model("GGUF array size overflow".into()))?;
+                seek_forward(reader, total)
+            } else if elem_type == value_type::STRING {
+                for _ in 0..count {
+                    let len = read_u64(reader)?;
+                    seek_forward(reader, len)?;
+                }
+                Ok(())
+            } else {
+                Err(AttestationError::Model(format!(
+                    "unsupported GGUF array element type {elem_type}"
+                )))
+            }
+        }
+        _ => Err(AttestationError::Model(format!(
+            "unknown GGUF value type {vt}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn put_str(buf: &mut Vec<u8>, s: &str) {
+        buf.extend_from_slice(&(s.len() as u64).to_le_bytes());
+        buf.extend_from_slice(s.as_bytes());
+    }
+
+    /// A GGUF v3 header exercising scalar, string, scalar-array and
+    /// string-array value types so the skip path is covered.
+    fn synthetic_gguf() -> Vec<u8> {
+        let mut b = Vec::new();
+        b.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
+        b.extend_from_slice(&3u32.to_le_bytes()); // version
+        b.extend_from_slice(&291u64.to_le_bytes()); // tensor_count
+        b.extend_from_slice(&5u64.to_le_bytes()); // kv_count
+
+        put_str(&mut b, "general.architecture");
+        b.extend_from_slice(&value_type::STRING.to_le_bytes());
+        put_str(&mut b, "llama");
+
+        put_str(&mut b, "general.name");
+        b.extend_from_slice(&value_type::STRING.to_le_bytes());
+        put_str(&mut b, "Test Model");
+
+        put_str(&mut b, "general.file_type");
+        b.extend_from_slice(&value_type::UINT32.to_le_bytes());
+        b.extend_from_slice(&15u32.to_le_bytes());
+
+        put_str(&mut b, "llama.scalar_array");
+        b.extend_from_slice(&value_type::ARRAY.to_le_bytes());
+        b.extend_from_slice(&value_type::UINT32.to_le_bytes());
+        b.extend_from_slice(&3u64.to_le_bytes());
+        b.extend_from_slice(&[0u8; 12]);
+
+        put_str(&mut b, "tokenizer.ggml.tokens");
+        b.extend_from_slice(&value_type::ARRAY.to_le_bytes());
+        b.extend_from_slice(&value_type::STRING.to_le_bytes());
+        b.extend_from_slice(&2u64.to_le_bytes());
+        put_str(&mut b, "a");
+        put_str(&mut b, "bb");
+        b
+    }
+
+    #[test]
+    fn parses_general_metadata() {
+        let meta = parse(&mut Cursor::new(synthetic_gguf())).expect("parse");
+        assert_eq!(meta.version, 3);
+        assert_eq!(meta.tensor_count, 291);
+        assert_eq!(meta.architecture.as_deref(), Some("llama"));
+        assert_eq!(meta.name.as_deref(), Some("Test Model"));
+        assert_eq!(meta.file_type, Some(15));
+        assert_eq!(meta.quantization().as_deref(), Some("Q4_K_M"));
+    }
+
+    #[test]
+    fn rejects_bad_magic() {
+        let err = parse(&mut Cursor::new(b"NOPE____".to_vec())).unwrap_err();
+        assert!(err.to_string().contains("not a GGUF"));
+    }
+
+    #[test]
+    fn rejects_unsupported_version() {
+        let mut b = Vec::new();
+        b.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
+        b.extend_from_slice(&1u32.to_le_bytes());
+        b.extend_from_slice(&[0u8; 16]);
+        let err = parse(&mut Cursor::new(b)).unwrap_err();
+        assert!(err.to_string().contains("unsupported GGUF version 1"));
+    }
+
+    #[test]
+    fn rejects_truncated_header() {
+        let mut b = Vec::new();
+        b.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
+        b.extend_from_slice(&3u32.to_le_bytes());
+        let err = parse(&mut Cursor::new(b)).unwrap_err();
+        assert!(err.to_string().contains("malformed GGUF header"));
+    }
+
+    #[test]
+    fn rejects_oversized_string_length() {
+        let mut b = Vec::new();
+        b.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
+        b.extend_from_slice(&3u32.to_le_bytes());
+        b.extend_from_slice(&0u64.to_le_bytes()); // tensor_count
+        b.extend_from_slice(&1u64.to_le_bytes()); // kv_count
+        b.extend_from_slice(&(MAX_STRING_LEN + 1).to_le_bytes()); // bogus key length
+        let err = parse(&mut Cursor::new(b)).unwrap_err();
+        assert!(err.to_string().contains("exceeds limit"));
+    }
+
+    #[test]
+    fn unknown_file_type_falls_back() {
+        assert_eq!(file_type_name(9999), "ftype-9999");
+    }
+}

--- a/crates/arkavo-attestation/src/lib.rs
+++ b/crates/arkavo-attestation/src/lib.rs
@@ -2,7 +2,11 @@ use arkavo_device_identity::{AgentIdentity, DeviceId};
 use serde::{Deserialize, Serialize};
 
 pub mod evidence;
+pub mod gguf;
+pub mod model;
 pub mod platform;
+
+pub use model::{FileModelAttestor, ModelAttestor, ModelEvidence, ModelFormat, ModelRuntime};
 
 #[derive(Debug, thiserror::Error)]
 pub enum AttestationError {
@@ -12,6 +16,8 @@ pub enum AttestationError {
     EvidenceGeneration(String),
     #[error("Unsupported platform: {0}")]
     UnsupportedPlatform(String),
+    #[error("Model attestation failed: {0}")]
+    Model(String),
 }
 
 pub type Result<T> = std::result::Result<T, AttestationError>;

--- a/crates/arkavo-attestation/src/model.rs
+++ b/crates/arkavo-attestation/src/model.rs
@@ -1,0 +1,475 @@
+//! Model identity attestation.
+//!
+//! Produces verifiable evidence that binds a running agent to the model
+//! weights it loaded — content-addressed by BLAKE3 — together with the runtime
+//! that executes them. The evidence maps directly onto SPIFFE/SPIRE workload
+//! selectors, so a SPIRE workload attestor plugin registered as `model` can
+//! emit exactly the selectors produced here.
+
+use crate::gguf;
+use crate::{AttestationError, Result};
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::{Path, PathBuf};
+
+/// The inference runtime that loads and executes a model's weights.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelRuntime {
+    LlamaCpp,
+    Mlx,
+    Other(String),
+}
+
+impl ModelRuntime {
+    /// Stable lowercase label used in SPIRE selectors and SPIFFE paths.
+    pub fn label(&self) -> &str {
+        match self {
+            ModelRuntime::LlamaCpp => "llama.cpp",
+            ModelRuntime::Mlx => "mlx",
+            ModelRuntime::Other(s) => s,
+        }
+    }
+
+    /// Resolve a runtime from a user-supplied label, accepting common spellings.
+    pub fn from_label(s: &str) -> Self {
+        match s.to_ascii_lowercase().replace(['-', '_'], ".").as_str() {
+            "llama.cpp" | "llamacpp" | "llama" => ModelRuntime::LlamaCpp,
+            "mlx" => ModelRuntime::Mlx,
+            _ => ModelRuntime::Other(s.to_string()),
+        }
+    }
+}
+
+/// On-disk weights container format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelFormat {
+    Gguf,
+    Safetensors,
+    Unknown,
+}
+
+impl ModelFormat {
+    fn label(self) -> &'static str {
+        match self {
+            ModelFormat::Gguf => "gguf",
+            ModelFormat::Safetensors => "safetensors",
+            ModelFormat::Unknown => "unknown",
+        }
+    }
+}
+
+/// Verifiable identity evidence for a model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelEvidence {
+    /// Logical model identifier (GGUF `general.name`, else the file stem).
+    pub model_id: String,
+    /// Content address of the weights file: `blake3:<64 hex chars>`.
+    pub weights_digest: String,
+    /// Size of the weights file in bytes.
+    pub weights_size: u64,
+    /// On-disk weights format.
+    pub format: ModelFormat,
+    /// Runtime that executes the weights.
+    pub runtime: ModelRuntime,
+    /// Runtime build identifier (engine commit or version), when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_version: Option<String>,
+    /// Model architecture from the GGUF `general.architecture` key.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub architecture: Option<String>,
+    /// Quantization scheme derived from the GGUF `general.file_type` key.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quantization: Option<String>,
+    /// GGUF container version, when the file is GGUF.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gguf_version: Option<u32>,
+    /// Tensor count declared in the GGUF header.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tensor_count: Option<u64>,
+    /// Unix timestamp (seconds) when the evidence was produced.
+    pub timestamp: i64,
+}
+
+impl ModelEvidence {
+    /// SPIRE workload selectors derived from this evidence.
+    ///
+    /// Each entry is a `model:<key>:<value>` string — the exact form a SPIRE
+    /// workload attestor plugin registered under the type `model` would emit.
+    pub fn spire_selectors(&self) -> Vec<String> {
+        let mut selectors = vec![
+            format!("model:id:{}", self.model_id),
+            format!("model:weights:{}", self.weights_digest),
+            format!("model:format:{}", self.format.label()),
+            format!("model:runtime:{}", self.runtime.label()),
+        ];
+        if let Some(v) = &self.runtime_version {
+            selectors.push(format!("model:runtime-version:{v}"));
+        }
+        if let Some(a) = &self.architecture {
+            selectors.push(format!("model:arch:{a}"));
+        }
+        if let Some(q) = &self.quantization {
+            selectors.push(format!("model:quant:{q}"));
+        }
+        selectors
+    }
+
+    /// A SPIFFE ID proposal for an agent bound to this model.
+    ///
+    /// Shape: `spiffe://<trust_domain>/model/<arch>/<model-id>/<digest-prefix>`,
+    /// each path segment normalized to a URL-safe form.
+    pub fn spiffe_id(&self, trust_domain: &str) -> String {
+        let arch = self.architecture.as_deref().unwrap_or("unknown");
+        let digest_prefix: String = self
+            .weights_digest
+            .strip_prefix("blake3:")
+            .unwrap_or(&self.weights_digest)
+            .chars()
+            .take(16)
+            .collect();
+        format!(
+            "spiffe://{}/model/{}/{}/{}",
+            trust_domain.trim_matches('/'),
+            path_segment(arch),
+            path_segment(&self.model_id),
+            digest_prefix,
+        )
+    }
+}
+
+/// Attestor that produces [`ModelEvidence`] for a model.
+pub trait ModelAttestor {
+    fn attest(&self) -> Result<ModelEvidence>;
+}
+
+/// Attests a model from its on-disk weights file.
+pub struct FileModelAttestor {
+    weights_path: PathBuf,
+    runtime: ModelRuntime,
+    runtime_version: Option<String>,
+}
+
+impl FileModelAttestor {
+    pub fn new(weights_path: impl Into<PathBuf>, runtime: ModelRuntime) -> Self {
+        Self {
+            weights_path: weights_path.into(),
+            runtime,
+            runtime_version: None,
+        }
+    }
+
+    /// Record the runtime build identifier (engine commit or version string).
+    pub fn with_runtime_version(mut self, version: impl Into<String>) -> Self {
+        self.runtime_version = Some(version.into());
+        self
+    }
+}
+
+impl ModelAttestor for FileModelAttestor {
+    fn attest(&self) -> Result<ModelEvidence> {
+        let path = self.weights_path.as_path();
+        let format = detect_format(path)?;
+        let gguf_meta = if format == ModelFormat::Gguf {
+            let file = File::open(path).map_err(|e| open_err(path, e))?;
+            Some(gguf::parse(&mut BufReader::new(file))?)
+        } else {
+            None
+        };
+        let (weights_digest, weights_size) = digest_file(path)?;
+
+        let model_id = gguf_meta
+            .as_ref()
+            .and_then(|m| m.name.clone())
+            .filter(|n| !n.is_empty())
+            .unwrap_or_else(|| file_stem(path));
+
+        Ok(ModelEvidence {
+            model_id,
+            weights_digest,
+            weights_size,
+            format,
+            runtime: self.runtime.clone(),
+            runtime_version: self.runtime_version.clone(),
+            architecture: gguf_meta.as_ref().and_then(|m| m.architecture.clone()),
+            quantization: gguf_meta
+                .as_ref()
+                .and_then(gguf::GgufMetadata::quantization),
+            gguf_version: gguf_meta.as_ref().map(|m| m.version),
+            tensor_count: gguf_meta.as_ref().map(|m| m.tensor_count),
+            timestamp: now_unix(),
+        })
+    }
+}
+
+fn detect_format(path: &Path) -> Result<ModelFormat> {
+    let mut magic = [0u8; 4];
+    let read = File::open(path)
+        .and_then(|mut f| f.read(&mut magic))
+        .map_err(|e| open_err(path, e))?;
+    if read == 4 && &magic == b"GGUF" {
+        return Ok(ModelFormat::Gguf);
+    }
+    if path.extension().and_then(|e| e.to_str()) == Some("safetensors") {
+        return Ok(ModelFormat::Safetensors);
+    }
+    Ok(ModelFormat::Unknown)
+}
+
+/// Stream the weights file through BLAKE3, returning `(digest, size)`.
+fn digest_file(path: &Path) -> Result<(String, u64)> {
+    let file = File::open(path).map_err(|e| open_err(path, e))?;
+    let size = file.metadata().map_err(|e| open_err(path, e))?.len();
+    let mut reader = BufReader::new(file);
+    let mut hasher = blake3::Hasher::new();
+    let mut buf = [0u8; 65536];
+    loop {
+        let n = reader.read(&mut buf).map_err(|e| open_err(path, e))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok((format!("blake3:{}", hasher.finalize().to_hex()), size))
+}
+
+fn file_stem(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| "model".to_string())
+}
+
+/// Normalize a string into a single URL-safe SPIFFE path segment.
+fn path_segment(s: &str) -> String {
+    let cleaned: String = s
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '-' {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let trimmed = cleaned.trim_matches('-');
+    if trimmed.is_empty() {
+        "unknown".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn open_err(path: &Path, e: std::io::Error) -> AttestationError {
+    AttestationError::Model(format!("{}: {e}", path.display()))
+}
+
+fn now_unix() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn put_str(buf: &mut Vec<u8>, s: &str) {
+        buf.extend_from_slice(&(s.len() as u64).to_le_bytes());
+        buf.extend_from_slice(s.as_bytes());
+    }
+
+    /// A minimal but valid GGUF v3 header for `llama` / `Q4_K_M`.
+    fn synthetic_gguf() -> Vec<u8> {
+        let mut b = Vec::new();
+        b.extend_from_slice(&0x4655_4747u32.to_le_bytes()); // "GGUF"
+        b.extend_from_slice(&3u32.to_le_bytes()); // version
+        b.extend_from_slice(&128u64.to_le_bytes()); // tensor_count
+        b.extend_from_slice(&3u64.to_le_bytes()); // kv_count
+        put_str(&mut b, "general.architecture");
+        b.extend_from_slice(&8u32.to_le_bytes());
+        put_str(&mut b, "llama");
+        put_str(&mut b, "general.name");
+        b.extend_from_slice(&8u32.to_le_bytes());
+        put_str(&mut b, "Ministral 3 8B");
+        put_str(&mut b, "general.file_type");
+        b.extend_from_slice(&4u32.to_le_bytes());
+        b.extend_from_slice(&15u32.to_le_bytes());
+        b
+    }
+
+    struct TempFile(PathBuf);
+
+    impl TempFile {
+        fn new(suffix: &str, bytes: &[u8]) -> Self {
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let mut path = std::env::temp_dir();
+            path.push(format!("arkavo-model-attest-{nanos}-{suffix}"));
+            let mut file = File::create(&path).expect("create temp file");
+            file.write_all(bytes).expect("write temp file");
+            TempFile(path)
+        }
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempFile {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
+    #[test]
+    fn runtime_label_and_parsing() {
+        assert_eq!(ModelRuntime::LlamaCpp.label(), "llama.cpp");
+        assert_eq!(ModelRuntime::Mlx.label(), "mlx");
+        assert_eq!(
+            ModelRuntime::from_label("llama-cpp"),
+            ModelRuntime::LlamaCpp
+        );
+        assert_eq!(ModelRuntime::from_label("MLX"), ModelRuntime::Mlx);
+        assert_eq!(
+            ModelRuntime::from_label("vllm"),
+            ModelRuntime::Other("vllm".to_string())
+        );
+        assert_eq!(ModelRuntime::Other("vllm".to_string()).label(), "vllm");
+    }
+
+    #[test]
+    fn attests_gguf_model() {
+        let tmp = TempFile::new("model.gguf", &synthetic_gguf());
+        let evidence = FileModelAttestor::new(tmp.path(), ModelRuntime::LlamaCpp)
+            .with_runtime_version("b9999")
+            .attest()
+            .expect("attest");
+
+        assert_eq!(evidence.format, ModelFormat::Gguf);
+        assert_eq!(evidence.model_id, "Ministral 3 8B");
+        assert_eq!(evidence.architecture.as_deref(), Some("llama"));
+        assert_eq!(evidence.quantization.as_deref(), Some("Q4_K_M"));
+        assert_eq!(evidence.gguf_version, Some(3));
+        assert_eq!(evidence.tensor_count, Some(128));
+        assert_eq!(evidence.runtime_version.as_deref(), Some("b9999"));
+        assert!(evidence.weights_digest.starts_with("blake3:"));
+        assert_eq!(evidence.weights_digest.len(), "blake3:".len() + 64);
+        assert_eq!(evidence.weights_size, synthetic_gguf().len() as u64);
+    }
+
+    #[test]
+    fn digest_is_deterministic_and_content_addressed() {
+        let tmp = TempFile::new("weights.bin", b"deterministic weights payload");
+        let first = FileModelAttestor::new(tmp.path(), ModelRuntime::Mlx)
+            .attest()
+            .unwrap();
+        let second = FileModelAttestor::new(tmp.path(), ModelRuntime::Mlx)
+            .attest()
+            .unwrap();
+        assert_eq!(first.weights_digest, second.weights_digest);
+
+        let other = TempFile::new("weights.bin", b"different weights payload");
+        let third = FileModelAttestor::new(other.path(), ModelRuntime::Mlx)
+            .attest()
+            .unwrap();
+        assert_ne!(first.weights_digest, third.weights_digest);
+    }
+
+    #[test]
+    fn attests_safetensors_without_gguf_fields() {
+        let tmp = TempFile::new("weights.safetensors", b"\x00\x01safetensors body");
+        let evidence = FileModelAttestor::new(tmp.path(), ModelRuntime::Mlx)
+            .attest()
+            .unwrap();
+        assert_eq!(evidence.format, ModelFormat::Safetensors);
+        assert_eq!(evidence.runtime.label(), "mlx");
+        assert!(evidence.architecture.is_none());
+        assert!(evidence.gguf_version.is_none());
+        // No GGUF name: model_id falls back to the file stem.
+        assert!(evidence.model_id.ends_with("weights"));
+    }
+
+    #[test]
+    fn unknown_format_for_unrecognized_file() {
+        let tmp = TempFile::new("blob.bin", b"not a known model container");
+        let evidence = FileModelAttestor::new(tmp.path(), ModelRuntime::LlamaCpp)
+            .attest()
+            .unwrap();
+        assert_eq!(evidence.format, ModelFormat::Unknown);
+    }
+
+    #[test]
+    fn missing_file_is_an_error() {
+        let result =
+            FileModelAttestor::new("/nonexistent/arkavo/model.gguf", ModelRuntime::LlamaCpp)
+                .attest();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn spire_selectors_cover_all_evidence_fields() {
+        let tmp = TempFile::new("model.gguf", &synthetic_gguf());
+        let evidence = FileModelAttestor::new(tmp.path(), ModelRuntime::LlamaCpp)
+            .with_runtime_version("b9999")
+            .attest()
+            .unwrap();
+        let selectors = evidence.spire_selectors();
+        assert!(selectors.contains(&"model:id:Ministral 3 8B".to_string()));
+        assert!(selectors.contains(&"model:format:gguf".to_string()));
+        assert!(selectors.contains(&"model:runtime:llama.cpp".to_string()));
+        assert!(selectors.contains(&"model:runtime-version:b9999".to_string()));
+        assert!(selectors.contains(&"model:arch:llama".to_string()));
+        assert!(selectors.contains(&"model:quant:Q4_K_M".to_string()));
+        assert!(
+            selectors
+                .iter()
+                .any(|s| s.starts_with("model:weights:blake3:"))
+        );
+    }
+
+    #[test]
+    fn spire_selectors_omit_absent_optional_fields() {
+        let tmp = TempFile::new("weights.bin", b"opaque");
+        let evidence = FileModelAttestor::new(tmp.path(), ModelRuntime::Mlx)
+            .attest()
+            .unwrap();
+        let selectors = evidence.spire_selectors();
+        assert!(!selectors.iter().any(|s| s.starts_with("model:arch:")));
+        assert!(
+            !selectors
+                .iter()
+                .any(|s| s.starts_with("model:runtime-version:"))
+        );
+    }
+
+    #[test]
+    fn spiffe_id_is_url_safe_and_normalized() {
+        let tmp = TempFile::new("model.gguf", &synthetic_gguf());
+        let evidence = FileModelAttestor::new(tmp.path(), ModelRuntime::LlamaCpp)
+            .attest()
+            .unwrap();
+        let id = evidence.spiffe_id("agents.arkavo.com");
+        assert!(id.starts_with("spiffe://agents.arkavo.com/model/llama/ministral-3-8b/"));
+        assert!(!id.contains(' '));
+        // trailing segment is the 16-char digest prefix
+        assert_eq!(id.rsplit('/').next().unwrap().len(), 16);
+    }
+
+    #[test]
+    fn evidence_serde_round_trip() {
+        let tmp = TempFile::new("model.gguf", &synthetic_gguf());
+        let evidence = FileModelAttestor::new(tmp.path(), ModelRuntime::LlamaCpp)
+            .with_runtime_version("b9999")
+            .attest()
+            .unwrap();
+        let json = serde_json::to_string(&evidence).unwrap();
+        let restored: ModelEvidence = serde_json::from_str(&json).unwrap();
+        assert_eq!(evidence, restored);
+    }
+}

--- a/crates/arkavo-attestation/tests/integration_test.rs
+++ b/crates/arkavo-attestation/tests/integration_test.rs
@@ -1,6 +1,4 @@
-use arkavo_attestation::{
-    AttestationType, SecurityState, detect_platform_code, evidence, platform,
-};
+use arkavo_attestation::{SecurityState, detect_platform_code, evidence, platform};
 use arkavo_device_identity::{AgentIdentity, get_or_create_device_id};
 
 const TEST_APP_VERSION: &str = "0.38.2";
@@ -78,7 +76,7 @@ fn test_end_to_end_device_attestation_flow() {
     #[cfg(target_os = "macos")]
     {
         println!("macOS-specific assertions:");
-        if capabilities.attestation_type == AttestationType::SecureEnclave {
+        if capabilities.attestation_type == arkavo_attestation::AttestationType::SecureEnclave {
             println!("✓ Using Secure Enclave attestation");
             assert!(capabilities.supports_freshness);
             assert!(capabilities.supports_hardware_binding);

--- a/crates/arkavo-attestation/tests/model_attestation_test.rs
+++ b/crates/arkavo-attestation/tests/model_attestation_test.rs
@@ -1,0 +1,140 @@
+use arkavo_attestation::{FileModelAttestor, ModelAttestor, ModelFormat, ModelRuntime};
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+/// Build a minimal but well-formed GGUF v3 header for `llama` / `Q4_K_M`.
+fn synthetic_gguf() -> Vec<u8> {
+    fn put_str(buf: &mut Vec<u8>, s: &str) {
+        buf.extend_from_slice(&(s.len() as u64).to_le_bytes());
+        buf.extend_from_slice(s.as_bytes());
+    }
+    let mut b = Vec::new();
+    b.extend_from_slice(&0x4655_4747u32.to_le_bytes()); // "GGUF"
+    b.extend_from_slice(&3u32.to_le_bytes()); // version
+    b.extend_from_slice(&291u64.to_le_bytes()); // tensor_count
+    b.extend_from_slice(&3u64.to_le_bytes()); // kv_count
+    put_str(&mut b, "general.architecture");
+    b.extend_from_slice(&8u32.to_le_bytes());
+    put_str(&mut b, "llama");
+    put_str(&mut b, "general.name");
+    b.extend_from_slice(&8u32.to_le_bytes());
+    put_str(&mut b, "Ministral 3 8B Instruct");
+    put_str(&mut b, "general.file_type");
+    b.extend_from_slice(&4u32.to_le_bytes());
+    b.extend_from_slice(&15u32.to_le_bytes());
+    b
+}
+
+struct TempFile(PathBuf);
+
+impl TempFile {
+    fn new(name: &str, bytes: &[u8]) -> Self {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let mut path = std::env::temp_dir();
+        path.push(format!("arkavo-model-attest-it-{nanos}-{name}"));
+        File::create(&path)
+            .and_then(|mut f| f.write_all(bytes))
+            .expect("write temp model file");
+        TempFile(path)
+    }
+}
+
+impl Drop for TempFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+#[test]
+fn test_end_to_end_model_attestation_to_spire_selectors() {
+    println!("\n=== End-to-End Model Attestation Test ===\n");
+
+    let model = TempFile::new("ministral-3-8b-Q4_K_M.gguf", &synthetic_gguf());
+
+    println!("Step 1: Construct a file-backed model attestor");
+    let attestor = FileModelAttestor::new(&model.0, ModelRuntime::LlamaCpp)
+        .with_runtime_version("llama.cpp-b4567");
+    println!("✓ Attestor bound to {}", model.0.display());
+
+    println!("\nStep 2: Attest the model");
+    let evidence = attestor.attest().expect("attestation failed");
+    println!("✓ Evidence produced");
+    println!("  - model_id:        {}", evidence.model_id);
+    println!("  - weights_digest:  {}", evidence.weights_digest);
+    println!("  - weights_size:    {} bytes", evidence.weights_size);
+    println!("  - runtime:         {}", evidence.runtime.label());
+    println!("  - architecture:    {:?}", evidence.architecture);
+    println!("  - quantization:    {:?}", evidence.quantization);
+
+    assert_eq!(evidence.format, ModelFormat::Gguf);
+    assert_eq!(evidence.model_id, "Ministral 3 8B Instruct");
+    assert_eq!(evidence.architecture.as_deref(), Some("llama"));
+    assert_eq!(evidence.quantization.as_deref(), Some("Q4_K_M"));
+    assert_eq!(evidence.gguf_version, Some(3));
+    assert_eq!(evidence.tensor_count, Some(291));
+    assert!(evidence.weights_digest.starts_with("blake3:"));
+    assert_eq!(evidence.weights_digest.len(), "blake3:".len() + 64);
+
+    println!("\nStep 3: Content-addressing is deterministic");
+    let again = FileModelAttestor::new(&model.0, ModelRuntime::LlamaCpp)
+        .attest()
+        .unwrap();
+    assert_eq!(evidence.weights_digest, again.weights_digest);
+    println!("✓ Re-attestation yields an identical weights digest");
+
+    println!("\nStep 4: Derive SPIRE workload selectors");
+    let selectors = evidence.spire_selectors();
+    for s in &selectors {
+        println!("  {s}");
+    }
+    assert!(selectors.contains(&"model:runtime:llama.cpp".to_string()));
+    assert!(selectors.contains(&"model:arch:llama".to_string()));
+    assert!(selectors.contains(&"model:quant:Q4_K_M".to_string()));
+    assert!(
+        selectors
+            .iter()
+            .any(|s| s.starts_with("model:weights:blake3:"))
+    );
+
+    println!("\nStep 5: Derive a SPIFFE ID");
+    let spiffe_id = evidence.spiffe_id("agents.arkavo.com");
+    println!("✓ {spiffe_id}");
+    assert!(spiffe_id.starts_with("spiffe://agents.arkavo.com/model/llama/"));
+    assert!(!spiffe_id.contains(' '));
+
+    println!("\nStep 6: Evidence serializes to JSON");
+    let json = serde_json::to_string_pretty(&evidence).expect("serialize");
+    assert!(!json.is_empty());
+    println!("{json}");
+
+    println!("\n=== Model Attestation Flow Complete ===\n");
+}
+
+#[test]
+fn test_mlx_safetensors_attestation() {
+    println!("\n=== MLX / safetensors Attestation Test ===\n");
+
+    let model = TempFile::new("model.safetensors", b"\x10\x00mlx safetensors body bytes");
+    let evidence = FileModelAttestor::new(&model.0, ModelRuntime::Mlx)
+        .with_runtime_version("mlx-0.18.0")
+        .attest()
+        .expect("attestation failed");
+
+    assert_eq!(evidence.format, ModelFormat::Safetensors);
+    assert_eq!(evidence.runtime, ModelRuntime::Mlx);
+    // safetensors carries no GGUF key/value header.
+    assert!(evidence.architecture.is_none());
+    assert!(evidence.gguf_version.is_none());
+
+    let selectors = evidence.spire_selectors();
+    assert!(selectors.contains(&"model:runtime:mlx".to_string()));
+    assert!(selectors.contains(&"model:format:safetensors".to_string()));
+    assert!(!selectors.iter().any(|s| s.starts_with("model:arch:")));
+    println!("✓ MLX evidence: {} selectors", selectors.len());
+
+    println!("\n=== MLX Attestation Flow Complete ===\n");
+}

--- a/specs/arkavo-edge/agent-identity.spec.yaml
+++ b/specs/arkavo-edge/agent-identity.spec.yaml
@@ -1,0 +1,146 @@
+# yaml-language-server: $schema=../schema.json
+
+feature: Agent Identity Authority
+module: arkavo_agent_identity
+version: 0.77.0
+
+invariants:
+  - AIA issues and attests identity only; it grants no access and assigns no work
+  - Trust level is derived from attestation evidence, never self-asserted
+  - Credentials are Ed25519-signed over canonical document bytes
+  - Identity yields only agent.identity.* OpenTDF attributes
+  - Authorization attributes remain orchestrator-issued
+  - Credential verification requires a key resolved from a trusted root
+
+scenarios:
+  - id: AIA-001
+    name: Issue an agent identity credential
+    criticality: critical
+    given:
+      - An IdentityAuthority with a signing key
+      - An agent public key and an IssueRequest
+    when: issue called
+    then:
+      - IdentityDocument built with iss, sub, agent_type, public_key
+      - Document signed with the authority's Ed25519 key
+      - iat and exp recorded as RFC 3339 timestamps
+      - Credential bundles the document and its signature
+    refs: [crates/arkavo-agent-identity/src/authority.rs]
+    changed: "2026-05-22"
+    edge_cases:
+      - condition: Validity duration overflows the credential clock
+        expected: Malformed error returned
+
+  - id: AIA-002
+    name: Derive trust level from attestation evidence
+    criticality: critical
+    given:
+      - An IssueRequest carrying model or platform attestation evidence
+    when: issue evaluates the evidence
+    then:
+      - Model evidence or a Trusted platform yields trust_level attested
+      - Suspicious or unknown platform alone yields trust_level unattested
+      - Absent evidence yields trust_level unattested
+      - Attested model id is copied into the document model field
+    refs: [crates/arkavo-agent-identity/src/authority.rs]
+    changed: "2026-05-22"
+
+  - id: AIA-003
+    name: Refuse to attest a compromised runtime
+    criticality: critical
+    given:
+      - An IssueRequest with platform evidence in Compromised state
+    when: issue called
+    then:
+      - Issuance fails with CompromisedRuntime
+      - No credential is produced
+    refs: [crates/arkavo-agent-identity/src/authority.rs]
+    changed: "2026-05-22"
+
+  - id: AIA-004
+    name: Verify a credential against a trusted authority key
+    criticality: critical
+    given:
+      - An IdentityCredential and a trusted authority public key
+    when: verify called
+    then:
+      - Signature checked over the canonical document bytes
+      - Expired credentials rejected
+      - Tampered documents rejected with InvalidSignature
+      - The verified document is returned on success
+    refs: [crates/arkavo-agent-identity/src/credential.rs]
+    changed: "2026-05-22"
+    edge_cases:
+      - condition: Credential verified with a different authority key
+        expected: InvalidSignature returned
+
+  - id: AIA-005
+    name: Rotate an agent key
+    criticality: high
+    given:
+      - An existing credential and a new agent public key
+    when: rotate called
+    then:
+      - A new credential is issued for the same subject
+      - All identity claims preserved except public_key and lifetime
+      - The rotated credential is signed afresh
+    refs: [crates/arkavo-agent-identity/src/authority.rs]
+    changed: "2026-05-22"
+
+  - id: AIA-006
+    name: Revoke an agent and publish a revocation list
+    criticality: critical
+    given:
+      - An IdentityAuthority that has revoked one or more agents
+    when: revocation_list called
+    then:
+      - Each revoked agent recorded with subject and timestamp
+      - Revocation is idempotent per subject
+      - The list is signed by the authority
+      - is_revoked reports membership
+    refs: [crates/arkavo-agent-identity/src/revocation.rs]
+    changed: "2026-05-22"
+
+  - id: AIA-007
+    name: Endorse a subordinate authority and publish a trust chain
+    criticality: high
+    given:
+      - A root IdentityAuthority and a subordinate authority key
+    when: endorse_subordinate and trust_chain called
+    then:
+      - Parent signs an endorsement binding the child id and key
+      - Subordinate trust chain carries the endorsement
+      - Root trust chain carries no endorsement
+    refs: [crates/arkavo-agent-identity/src/trust_chain.rs]
+    changed: "2026-05-22"
+
+  - id: AIA-008
+    name: Resolve a trust chain to a trusted root
+    criticality: critical
+    given:
+      - A published TrustChain and a trusted root public key
+    when: resolve called
+    then:
+      - Root chain trusted only if its key equals the trusted root
+      - Subordinate chain requires a valid root-signed endorsement
+      - The resolved authority key is returned for credential verification
+    refs: [crates/arkavo-agent-identity/src/trust_chain.rs]
+    changed: "2026-05-22"
+    edge_cases:
+      - condition: Endorsement expired
+        expected: Expired error returned
+      - condition: authority_key swapped after endorsement
+        expected: Malformed error returned
+
+  - id: AIA-009
+    name: Project identity to OpenTDF attributes
+    criticality: high
+    given:
+      - An IdentityDocument
+    when: tdf_attributes called
+    then:
+      - Emits agent.identity.type, trust_level, runtime
+      - Emits agent.identity.owner and organization when present
+      - Never emits orchestrator-issued authorization attributes
+    refs: [crates/arkavo-agent-identity/src/document.rs]
+    changed: "2026-05-22"

--- a/specs/arkavo-edge/attestation.spec.yaml
+++ b/specs/arkavo-edge/attestation.spec.yaml
@@ -1,12 +1,15 @@
-feature: Device Attestation and Security State
+feature: Device and Model Attestation
 module: arkavo_attestation
-version: 0.67.6
+version: 0.76.0
 
 invariants:
   - Platform evidence collected via attestor trait
   - "Security state: Trusted, Suspicious, Compromised, Unknown"
   - "Attestation types: TPM Quote, Secure Enclave, Software Fingerprint"
   - Evidence includes timestamp and device ID
+  - Model weights are content-addressed by BLAKE3
+  - Model evidence binds weights digest to runtime identity
+  - Model evidence maps onto SPIFFE/SPIRE workload selectors
 
 scenarios:
   - id: ATT-001
@@ -108,3 +111,94 @@ scenarios:
         expected: Tolerance applied
       - condition: Future timestamp
         expected: Validation error
+
+  - id: ATT-007
+    name: Content-address model weights with BLAKE3
+    criticality: critical
+    given:
+      - Model weights file on disk
+      - FileModelAttestor bound to the file
+    when: attest called
+    then:
+      - Weights streamed through BLAKE3 in bounded chunks
+      - Digest returned as "blake3:<64 hex chars>"
+      - Weights size in bytes recorded
+      - Identical content yields an identical digest
+    refs: [crates/arkavo-attestation/src/model.rs]
+    changed: "2026-05-22"
+    edge_cases:
+      - condition: Weights file missing or unreadable
+        expected: AttestationError::Model returned
+      - condition: Weights content differs by a single byte
+        expected: Distinct digest produced
+
+  - id: ATT-008
+    name: Extract model metadata from GGUF header
+    criticality: high
+    given:
+      - GGUF weights file (version 2 or 3)
+    when: GGUF header parsed
+    then:
+      - Architecture read from general.architecture
+      - Logical name read from general.name
+      - Quantization derived from general.file_type
+      - Tensor count and GGUF version recorded
+      - Array values skipped without loading weights
+    refs: [crates/arkavo-attestation/src/gguf.rs]
+    changed: "2026-05-22"
+    edge_cases:
+      - condition: Magic bytes are not "GGUF"
+        expected: Parse rejected as non-GGUF
+      - condition: Unsupported GGUF version
+        expected: Parse rejected with version error
+      - condition: Declared string length exceeds limit
+        expected: Parse rejected before allocation
+
+  - id: ATT-009
+    name: Attest model identity end-to-end
+    criticality: critical
+    given:
+      - Model weights file and a known runtime
+    when: ModelAttestor::attest called
+    then:
+      - On-disk format detected (GGUF, safetensors, unknown)
+      - ModelEvidence produced with digest, runtime, timestamp
+      - GGUF metadata enriches evidence when present
+      - model_id falls back to file stem without a GGUF name
+    refs: [crates/arkavo-attestation/src/model.rs]
+    changed: "2026-05-22"
+    edge_cases:
+      - condition: safetensors file with no key/value header
+        expected: Evidence omits GGUF-only fields
+      - condition: Runtime build identifier unknown
+        expected: runtime_version left unset, not faked
+
+  - id: ATT-010
+    name: Derive SPIRE workload selectors from model evidence
+    criticality: high
+    given:
+      - ModelEvidence produced by attestation
+    when: spire_selectors called
+    then:
+      - "model:id, model:weights, model:format, model:runtime emitted"
+      - Optional arch, quant, runtime-version emitted when known
+      - Absent optional fields produce no selector
+    refs: [crates/arkavo-attestation/src/model.rs]
+    changed: "2026-05-22"
+
+  - id: ATT-011
+    name: Derive SPIFFE ID from model evidence
+    criticality: high
+    given:
+      - ModelEvidence produced by attestation
+      - A trust domain
+    when: spiffe_id called
+    then:
+      - "ID shaped spiffe://<domain>/model/<arch>/<id>/<digest-prefix>"
+      - Each path segment normalized to a URL-safe form
+      - Digest prefix is the first 16 hex characters
+    refs: [crates/arkavo-attestation/src/model.rs]
+    changed: "2026-05-22"
+    edge_cases:
+      - condition: Architecture unknown
+        expected: arch segment is "unknown"

--- a/specs/arkavo-edge/index.yaml
+++ b/specs/arkavo-edge/index.yaml
@@ -528,13 +528,27 @@ components:
   - name: attestation
     file: attestation.spec.yaml
     module: arkavo_attestation
-    description: Device attestation and security state
+    description: Device and model attestation
     criticality: critical
-    scenario_count: 6
+    scenario_count: 11
     invariants:
       - Platform evidence collected
       - Security state: Trusted/Suspicious/Compromised
       - Timestamp and device ID in evidence
+      - Model weights content-addressed by BLAKE3
+      - Model evidence maps onto SPIFFE/SPIRE selectors
+
+  - name: agent-identity
+    file: agent-identity.spec.yaml
+    module: arkavo_agent_identity
+    description: Agent Identity Authority — issues and attests agent identity
+    criticality: critical
+    scenario_count: 9
+    invariants:
+      - AIA issues and attests identity only; grants no access
+      - Trust level derived from attestation, never self-asserted
+      - Credentials Ed25519-signed over canonical document bytes
+      - Identity yields only agent.identity.* attributes
 
   - name: browser
     file: browser.spec.yaml


### PR DESCRIPTION
Adds a ModelAttestor that proves which model an agent process is
running: FileModelAttestor content-addresses weights with BLAKE3,
parses the GGUF header for architecture, name and quantization, and
binds the result to the inference runtime (llama.cpp, MLX, or other).

ModelEvidence maps directly onto SPIFFE/SPIRE workload selectors via
spire_selectors() and spiffe_id() -- the missing identity primitive
that existing workload attestors, which prove where a process runs
rather than which weights it loaded, do not cover.

https://claude.ai/code/session_016ssNxKJL5WZ885kTQSgKqm