### PR TITLE
Fix rate limiter eviction deadlock breaking nightly fuzz

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -27,7 +27,7 @@ jobs:
           - fuzz_tdf_policy
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -50,7 +50,7 @@ jobs:
         run: cargo install cargo-fuzz --locked
 
       - name: Cache corpus
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: crates/arkavo-protocol/fuzz/corpus/${{ matrix.target }}
           key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fuzz-crash-${{ matrix.target }}
           path: crates/arkavo-protocol/fuzz/artifacts/${{ matrix.target }}/
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "chrono",
  "serde",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-config-bundle",
  "base64 0.22.1",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "git2",
  "tempfile",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "bindgen",
  "cc",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "lru 0.16.4",
  "serde",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "libc",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -1979,7 +1979,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.76.1"
+version = "0.76.2"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.76.1"
+version = "0.76.2"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-protocol/src/rate_limit.rs
+++ b/crates/arkavo-protocol/src/rate_limit.rs
@@ -268,37 +268,47 @@ impl IpRateLimiter {
         let mut attempts = 0;
         let max_attempts = self.config.max_ip_entries * 2; // Safety limit
 
-        // Process entries from the queue until we reach target size
+        // Process entries from the queue until we reach target size. The queue
+        // may be empty before we reach the target, or it may be full of stale
+        // entries that exhaust the attempt budget; both cases fall through to the
+        // deterministic sweep below so the map is always brought under capacity.
         while self.limiters.len() > target_size && attempts < max_attempts {
             attempts += 1;
 
-            if let Some((ip, accessed_at)) = self.access_queue.pop() {
-                // Check if this IP is still in the map
-                if let Some(entry) = self.limiters.get(&ip) {
-                    // If it's the same access time or expired, remove it
-                    if entry.last_accessed == accessed_at
+            let Some((ip, accessed_at)) = self.access_queue.pop() else {
+                break;
+            };
+
+            // Decide whether to evict while only holding a read guard, then drop
+            // it before removing. Holding a dashmap `Ref` across `remove` on the
+            // same key deadlocks the shard against itself.
+            let should_remove = match self.limiters.get(&ip) {
+                Some(entry) => {
+                    entry.last_accessed == accessed_at
                         || (self.config.ip_entry_ttl_seconds > 0
                             && now.duration_since(accessed_at) > ttl)
-                    {
-                        self.limiters.remove(&ip);
-                    }
-                    // Otherwise, this is a stale queue entry, skip it
                 }
-            } else {
-                // Queue is empty but map is still too large
-                // Fall back to removing oldest entries directly
-                let mut oldest_entries: Vec<_> = self
-                    .limiters
-                    .iter()
-                    .map(|entry| (*entry.key(), entry.value().last_accessed))
-                    .collect();
-                oldest_entries.sort_by_key(|&(_, accessed)| accessed);
+                None => false,
+            };
+            if should_remove {
+                self.limiters.remove(&ip);
+            }
+            // Otherwise, this is a stale queue entry, skip it.
+        }
 
-                let to_remove = self.limiters.len() - target_size;
-                for (ip, _) in oldest_entries.into_iter().take(to_remove) {
-                    self.limiters.remove(&ip);
-                }
-                break;
+        // If the queue drained or the attempt budget was exhausted before we hit
+        // the target, remove the oldest entries directly so capacity is enforced.
+        if self.limiters.len() > target_size {
+            let mut oldest_entries: Vec<_> = self
+                .limiters
+                .iter()
+                .map(|entry| (*entry.key(), entry.value().last_accessed))
+                .collect();
+            oldest_entries.sort_by_key(|&(_, accessed)| accessed);
+
+            let to_remove = self.limiters.len().saturating_sub(target_size);
+            for (ip, _) in oldest_entries.into_iter().take(to_remove) {
+                self.limiters.remove(&ip);
             }
         }
     }

--- a/crates/arkavo-protocol/tests/rate_limit_integration.rs
+++ b/crates/arkavo-protocol/tests/rate_limit_integration.rs
@@ -42,6 +42,53 @@ async fn test_rate_limit_eviction_with_background_task() {
     cleanup_handle.abort();
 }
 
+/// Regression test for the eviction path in `evict_lru_entries`.
+///
+/// Inserting far more distinct IPs than `max_ip_entries` forces repeated
+/// eviction where the popped queue entry's IP is still live with a matching
+/// access time. Previously this held a dashmap read `Ref` across a `remove` on
+/// the same key, which self-deadlocked the shard and hung the nightly fuzzer.
+/// It also exhausted the attempt budget on stale entries without the fallback
+/// sweep, letting the map grow past capacity. This test would hang (or trip the
+/// capacity assertion) before the fix and must finish quickly after it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_eviction_stays_under_capacity_under_churn() {
+    let max_ip_entries = 100;
+    let config = RateLimitConfig {
+        max_requests_per_second: 1000,
+        burst_size: 100,
+        enabled: true,
+        max_ip_entries,
+        ip_entry_ttl_seconds: 3600, // long TTL: eviction is driven by capacity, not expiry
+    };
+
+    let result = time::timeout(Duration::from_secs(30), async move {
+        let limiter = IpRateLimiter::new(config);
+
+        // Insert many more distinct IPs than capacity, checking the invariant
+        // throughout. The /16 spread guarantees ~5000 unique addresses.
+        for i in 0..5000u32 {
+            let ip: IpAddr = format!("10.0.{}.{}", (i / 256) % 256, i % 256)
+                .parse()
+                .unwrap();
+            let _ = limiter.check_rate_limit(ip);
+
+            assert!(
+                limiter.entry_count() <= max_ip_entries,
+                "entry count {} exceeded max {} during churn",
+                limiter.entry_count(),
+                max_ip_entries
+            );
+        }
+
+        limiter.cleanup_old_entries();
+        assert!(limiter.entry_count() <= max_ip_entries);
+    })
+    .await;
+
+    assert!(result.is_ok(), "eviction churn deadlocked or timed out");
+}
+
 #[tokio::test]
 async fn test_rate_limit_headers() {
     let config = RateLimitConfig {


### PR DESCRIPTION
## Summary

The nightly fuzz job was failing because `IpRateLimiter::evict_lru_entries` deadlocked under heavy eviction load.

- **Self-deadlock:** the eviction loop held a dashmap read `Ref` on an IP key and then called `remove()` on that same key while the guard was still alive. dashmap's sharded locks make this a self-deadlock, hanging `fuzz_rate_limit` / `fuzz_rate_limit_concurrent` until libfuzzer reported a timeout and failed the job.
- **Capacity escape:** when the attempt budget was exhausted on stale queue entries, the loop exited without running the deterministic fallback sweep (which only ran when the queue was empty), so the map could exceed `max_ip_entries` and trip the fuzzer's capacity invariant.

## Changes

- `crates/arkavo-protocol/src/rate_limit.rs`: compute the eviction decision while only holding the read guard, drop it before `remove()`, and always run the fallback sweep when still above target so capacity is enforced regardless of queue state.
- `crates/arkavo-protocol/tests/rate_limit_integration.rs`: regression test (`test_eviction_stays_under_capacity_under_churn`) that drives heavy eviction churn under a 30s timeout and asserts the entry count never exceeds capacity. Would hang/over-fill before the fix.
- Bump workspace version `0.76.1` → `0.76.2` (+ `Cargo.lock`).
- `.github/workflows/nightly.yaml`: upgrade Node 20 actions to the current Node 24 majors — `actions/checkout` v4→v6, `actions/cache` v4→v5, `actions/upload-artifact` v4→v7.

## Verification

`cargo test -p arkavo-protocol --test rate_limit_integration` — all 4 tests pass (new regression test completes in ~3s rather than hanging). `cargo fmt` clean; no new clippy warnings.

https://claude.ai/code/session_01SmNCgVtqA6RsWm4RDqz3Ts

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmNCgVtqA6RsWm4RDqz3Ts)_