### PR TITLE
Claude Fable support

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -1230,7 +1230,7 @@ jobs:
 
           # Check for env::var calls that require configuration
           # Exclude build.rs files and test files, and allow standard env vars and optional API keys
-          if grep -r 'env::var("[A-Z_]*")\.\(expect\|unwrap\)' crates/ --include="*.rs" --exclude="build.rs" | grep -v test | grep -v "CARGO\|RUST\|PATH\|HOME\|TEMP\|TMP\|USER\|OUT_DIR\|OPENAI_API_KEY\|ANTHROPIC_API_KEY\|MOONSHOT_API_KEY\|DEEPSEEK_API_KEY\|DEEPSEEK_MODEL\|GEMINI_API_KEY\|GEMINI_MODEL\|KIMI_API_KEY\|KIMI_MODEL"; then
+          if grep -r 'env::var("[A-Z_]*")\.\(expect\|unwrap\)' crates/ --include="*.rs" --exclude="build.rs" | grep -v test | grep -v "CARGO\|RUST\|PATH\|HOME\|TEMP\|TMP\|USER\|OUT_DIR\|OPENAI_API_KEY\|ANTHROPIC_API_KEY\|MOONSHOT_API_KEY\|DEEPSEEK_API_KEY\|DEEPSEEK_MODEL\|GEMINI_API_KEY\|GEMINI_MODEL\|KIMI_API_KEY\|KIMI_MODEL\|ANTHROPIC_MODEL"; then
             echo "::error::Found required environment variables"
             exit 1
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "chrono",
  "serde",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-config-bundle",
  "base64 0.22.1",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "git2",
  "tempfile",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1383,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1507,7 +1507,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "lru 0.16.4",
  "serde",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2022,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2036,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.77.1"
+version = "0.78.0"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-cli/src/commands/ui.rs
+++ b/crates/arkavo-cli/src/commands/ui.rs
@@ -995,11 +995,13 @@ async fn create_client_from_routing(
                 Err("Gemini feature not enabled".into())
             }
         }
-        ModelChoice::ClaudeSonnet | ModelChoice::ClaudeOpus => {
+        ModelChoice::ClaudeSonnet | ModelChoice::ClaudeOpus | ModelChoice::ClaudeFable5 => {
             #[cfg(feature = "llm-remote")]
             {
                 use arkavo_llm::providers::AnthropicProvider;
-                let provider = Box::new(AnthropicProvider::from_env()?);
+                let provider = Box::new(AnthropicProvider::from_env_with_model(
+                    decision.recommended_model.name(),
+                )?);
                 Ok(LlmClient::new(provider))
             }
             #[cfg(not(feature = "llm-remote"))]

--- a/crates/arkavo-llm/src/providers/anthropic.rs
+++ b/crates/arkavo-llm/src/providers/anthropic.rs
@@ -57,14 +57,32 @@ impl ThinkingConfig {
     }
 }
 
-/// Claude models on the adaptive-thinking API surface (Fable 5 and Opus 4.7+).
-/// These reject sampling parameters (`temperature`, `top_p`, `top_k`) and
-/// fixed thinking budgets with HTTP 400; requests must omit them and opt into
-/// `thinking: {"type": "adaptive"}` instead.
+/// Claude models on the adaptive-thinking API surface (Fable/Mythos and
+/// Opus 4.7+). These reject sampling parameters (`temperature`, `top_p`,
+/// `top_k`) and fixed thinking budgets with HTTP 400; requests must omit them
+/// and opt into `thinking: {"type": "adaptive"}` instead.
+///
+/// The Opus cutoff is parsed from the version rather than enumerated, so a
+/// future snapshot (4.9, 5.x, ...) pinned in `ModelChoice::name()` — or set
+/// via `ANTHROPIC_MODEL` — is covered without editing this in lockstep. The
+/// model id is the only signal available here; the provider is a lower layer
+/// than the router's `ModelChoice` and also sees raw operator-set ids.
 fn uses_adaptive_thinking(model: &str) -> bool {
-    model.starts_with("claude-fable")
-        || model.starts_with("claude-opus-4-7")
-        || model.starts_with("claude-opus-4-8")
+    // Fable and Mythos are adaptive-thinking-only from their first release.
+    if model.starts_with("claude-fable") || model.starts_with("claude-mythos") {
+        return true;
+    }
+    // Opus removed sampling params + fixed thinking budgets starting at 4.7.
+    if let Some(rest) = model.strip_prefix("claude-opus-") {
+        let mut parts = rest.split('-');
+        if let (Some(Ok(major)), Some(Ok(minor))) = (
+            parts.next().map(str::parse::<u32>),
+            parts.next().map(str::parse::<u32>),
+        ) {
+            return major > 4 || (major == 4 && minor >= 7);
+        }
+    }
+    false
 }
 
 /// Anthropic API request structures
@@ -875,12 +893,28 @@ mod tests {
 
     #[test]
     fn test_adaptive_thinking_surface_detection() {
+        // Current adaptive-surface ids.
         assert!(uses_adaptive_thinking("claude-fable-5"));
+        assert!(uses_adaptive_thinking("claude-mythos-5"));
         assert!(uses_adaptive_thinking("claude-opus-4-7"));
         assert!(uses_adaptive_thinking("claude-opus-4-8"));
-        assert!(!uses_adaptive_thinking("claude-sonnet-4-5-20250929"));
+        // Future snapshots must be covered without editing this function in
+        // lockstep with ModelChoice::name() — a non-adaptive request to one of
+        // these is a hard 400, which the prior hardcoded list would have
+        // missed.
+        assert!(uses_adaptive_thinking("claude-opus-4-9"));
+        assert!(uses_adaptive_thinking("claude-opus-4-12-20270101"));
+        assert!(uses_adaptive_thinking("claude-opus-5-0"));
+        assert!(uses_adaptive_thinking("claude-opus-6-3"));
+        // Pre-adaptive Opus and non-Opus families keep the legacy surface.
+        assert!(!uses_adaptive_thinking("claude-opus-4-6"));
         assert!(!uses_adaptive_thinking("claude-opus-4-5-20251101"));
+        assert!(!uses_adaptive_thinking("claude-sonnet-4-6"));
+        assert!(!uses_adaptive_thinking("claude-sonnet-4-5-20250929"));
         assert!(!uses_adaptive_thinking("kimi-k2.5"));
+        // Malformed / unparseable ids fall back to the legacy surface.
+        assert!(!uses_adaptive_thinking("claude-opus"));
+        assert!(!uses_adaptive_thinking("claude-opus-latest"));
     }
 
     // Regression: Fable 5 / Opus 4.7+ return HTTP 400 if `temperature` or an

--- a/crates/arkavo-llm/src/providers/anthropic.rs
+++ b/crates/arkavo-llm/src/providers/anthropic.rs
@@ -42,6 +42,31 @@ struct ToolDefinition {
     input_schema: Value,
 }
 
+/// `thinking` request parameter. Adaptive-surface models reject an explicit
+/// `{"type": "disabled"}` (Fable 5 returns 400), so the field is omitted
+/// entirely when thinking is off rather than sent as disabled.
+#[derive(Debug, Clone, Serialize)]
+struct ThinkingConfig {
+    #[serde(rename = "type")]
+    mode: &'static str,
+}
+
+impl ThinkingConfig {
+    fn adaptive() -> Self {
+        Self { mode: "adaptive" }
+    }
+}
+
+/// Claude models on the adaptive-thinking API surface (Fable 5 and Opus 4.7+).
+/// These reject sampling parameters (`temperature`, `top_p`, `top_k`) and
+/// fixed thinking budgets with HTTP 400; requests must omit them and opt into
+/// `thinking: {"type": "adaptive"}` instead.
+fn uses_adaptive_thinking(model: &str) -> bool {
+    model.starts_with("claude-fable")
+        || model.starts_with("claude-opus-4-7")
+        || model.starts_with("claude-opus-4-8")
+}
+
 /// Anthropic API request structures
 #[derive(Debug, Clone, Serialize)]
 struct CreateMessageRequest {
@@ -51,6 +76,8 @@ struct CreateMessageRequest {
     max_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking: Option<ThinkingConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     system: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -206,11 +233,19 @@ pub struct AnthropicProvider {
 impl AnthropicProvider {
     /// Create provider from environment variables
     pub fn from_env() -> ProviderResult<Self> {
+        Self::from_env_with_model("claude-sonnet-4-5-20250929")
+    }
+
+    /// Create provider from environment with an explicit model id.
+    ///
+    /// `ANTHROPIC_MODEL` still wins when set so operators can pin a model
+    /// globally; otherwise the routed model id is sent to the API. Without
+    /// this, every routing decision collapses to the env/default model.
+    pub fn from_env_with_model(model: &str) -> ProviderResult<Self> {
         let api_key = env::var("ANTHROPIC_API_KEY")
             .map_err(|_| anyhow::anyhow!("ANTHROPIC_API_KEY environment variable not set"))?;
 
-        let model = env::var("ANTHROPIC_MODEL")
-            .unwrap_or_else(|_| "claude-sonnet-4-5-20250929".to_string());
+        let model = env::var("ANTHROPIC_MODEL").unwrap_or_else(|_| model.to_string());
 
         let config = AnthropicConfig {
             api_key,
@@ -234,7 +269,9 @@ impl AnthropicProvider {
         let http_config = HttpClientConfig {
             base_url: config.base_url.clone(),
             auth_token: None, // Anthropic uses a custom header
-            timeout_secs: 60,
+            // Adaptive-thinking models (Fable 5, Opus 4.7+) can reason for tens
+            // of seconds before a non-streaming response completes.
+            timeout_secs: 120,
             max_retries: 3,
             initial_retry_delay_ms: 1000,
             backoff_factor: 2.0,
@@ -247,6 +284,35 @@ impl AnthropicProvider {
         let client = Arc::new(RetryableHttpClient::new(builder)?);
 
         Ok(Self { config, client })
+    }
+
+    /// Build a request honoring the configured model's API surface.
+    ///
+    /// Adaptive-surface models get `thinking: {"type": "adaptive"}` with no
+    /// sampling parameters (sending them is a 400), plus a larger default
+    /// output ceiling because thinking tokens count toward `max_tokens` and
+    /// would truncate answers at the legacy 4096 cap.
+    fn build_request(
+        &self,
+        messages: Vec<ApiMessage>,
+        system: Option<String>,
+        stream: bool,
+        tools: Option<Vec<ToolDefinition>>,
+        max_tokens: Option<u32>,
+    ) -> CreateMessageRequest {
+        let adaptive = uses_adaptive_thinking(&self.config.model);
+        let default_max_tokens = if adaptive { 16_000 } else { 4_096 };
+
+        CreateMessageRequest {
+            model: self.config.model.clone(),
+            messages,
+            max_tokens: Some(max_tokens.unwrap_or(default_max_tokens)),
+            temperature: if adaptive { None } else { Some(0.7) },
+            thinking: adaptive.then(ThinkingConfig::adaptive),
+            system,
+            stream: Some(stream),
+            tools,
+        }
     }
 
     /// Convert messages to Anthropic's 3-role format
@@ -444,15 +510,7 @@ impl Provider for AnthropicProvider {
     ) -> Result<String, crate::Error> {
         let (system_content, api_messages) = self.convert_messages(messages);
 
-        let request = CreateMessageRequest {
-            model: self.config.model.clone(),
-            messages: api_messages,
-            max_tokens: Some(4096),
-            temperature: Some(0.7),
-            system: system_content,
-            stream: Some(false),
-            tools: None,
-        };
+        let request = self.build_request(api_messages, system_content, false, None, None);
 
         let url = format!("{}/v1/messages", self.config.base_url);
 
@@ -514,15 +572,7 @@ impl Provider for AnthropicProvider {
     > {
         let (system_content, api_messages) = self.convert_messages(messages);
 
-        let request = CreateMessageRequest {
-            model: self.config.model.clone(),
-            messages: api_messages,
-            max_tokens: Some(4096),
-            temperature: Some(0.7),
-            system: system_content,
-            stream: Some(true),
-            tools: None,
-        };
+        let request = self.build_request(api_messages, system_content, true, None, None);
 
         let url = format!("{}/v1/messages", self.config.base_url);
 
@@ -640,15 +690,13 @@ impl Provider for AnthropicProvider {
             .map(Self::convert_tools_to_definitions)
             .transpose()?;
 
-        let request = CreateMessageRequest {
-            model: self.config.model.clone(),
-            messages: api_messages,
-            max_tokens: Some(max_tokens.unwrap_or(4096) as u32),
-            temperature: Some(0.7),
-            system: system_content,
-            stream: Some(false),
-            tools: tool_definitions,
-        };
+        let request = self.build_request(
+            api_messages,
+            system_content,
+            false,
+            tool_definitions,
+            max_tokens.map(|t| t as u32),
+        );
 
         let url = format!("{}/v1/messages", self.config.base_url);
 
@@ -823,6 +871,81 @@ mod tests {
         let config = AnthropicConfig::default();
         let provider = AnthropicProvider::new(config).unwrap();
         assert!(provider.supports_tools());
+    }
+
+    #[test]
+    fn test_adaptive_thinking_surface_detection() {
+        assert!(uses_adaptive_thinking("claude-fable-5"));
+        assert!(uses_adaptive_thinking("claude-opus-4-7"));
+        assert!(uses_adaptive_thinking("claude-opus-4-8"));
+        assert!(!uses_adaptive_thinking("claude-sonnet-4-5-20250929"));
+        assert!(!uses_adaptive_thinking("claude-opus-4-5-20251101"));
+        assert!(!uses_adaptive_thinking("kimi-k2.5"));
+    }
+
+    // Regression: Fable 5 / Opus 4.7+ return HTTP 400 if `temperature` or an
+    // explicit `thinking: {"type": "disabled"}` is sent. Requests for these
+    // models must omit sampling params and opt into adaptive thinking.
+    #[test]
+    fn test_fable_request_omits_sampling_and_uses_adaptive_thinking() {
+        let config = AnthropicConfig {
+            model: "claude-fable-5".to_string(),
+            ..Default::default()
+        };
+        let provider = AnthropicProvider::new(config).unwrap();
+
+        let request = provider.build_request(
+            vec![ApiMessage {
+                role: "user".to_string(),
+                content: "Hello".to_string(),
+            }],
+            None,
+            false,
+            None,
+            None,
+        );
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert!(json.get("temperature").is_none(), "must omit temperature");
+        assert_eq!(json["thinking"]["type"], "adaptive");
+        // Thinking tokens count toward max_tokens; 4096 truncates answers.
+        assert_eq!(json["max_tokens"], 16_000);
+    }
+
+    #[test]
+    fn test_legacy_model_request_keeps_sampling_without_thinking() {
+        let config = AnthropicConfig::default(); // Sonnet 4.5
+        let provider = AnthropicProvider::new(config).unwrap();
+
+        let request = provider.build_request(
+            vec![ApiMessage {
+                role: "user".to_string(),
+                content: "Hello".to_string(),
+            }],
+            None,
+            false,
+            None,
+            None,
+        );
+
+        let json = serde_json::to_value(&request).unwrap();
+        let temperature = json["temperature"].as_f64().expect("temperature present");
+        assert!((temperature - 0.7).abs() < 1e-6);
+        assert!(json.get("thinking").is_none(), "must omit thinking field");
+        assert_eq!(json["max_tokens"], 4096);
+    }
+
+    #[test]
+    fn test_explicit_max_tokens_overrides_default() {
+        let config = AnthropicConfig {
+            model: "claude-fable-5".to_string(),
+            ..Default::default()
+        };
+        let provider = AnthropicProvider::new(config).unwrap();
+
+        let request = provider.build_request(Vec::new(), None, false, None, Some(2048));
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["max_tokens"], 2048);
     }
 
     #[test]

--- a/crates/arkavo-router/src/architect/executor.rs
+++ b/crates/arkavo-router/src/architect/executor.rs
@@ -238,9 +238,9 @@ impl ArchitectExecutor {
 
     async fn get_provider(&self, model: &ModelChoice) -> Result<Box<dyn Provider>> {
         match model {
-            ModelChoice::ClaudeSonnet | ModelChoice::ClaudeOpus => {
+            ModelChoice::ClaudeSonnet | ModelChoice::ClaudeOpus | ModelChoice::ClaudeFable5 => {
                 use arkavo_llm::providers::anthropic::AnthropicProvider;
-                AnthropicProvider::from_env()
+                AnthropicProvider::from_env_with_model(model.name())
                     .map(|p| Box::new(p) as Box<dyn Provider>)
                     .map_err(|e| {
                         Error::ModelExecution(format!("Failed to create Anthropic provider: {e}"))
@@ -299,7 +299,9 @@ impl ArchitectExecutor {
             ModelChoice::Gemini35FlashHigh => ModelChoice::ClaudeSonnet,
             ModelChoice::ClaudeSonnet => ModelChoice::GeminiPro,
             ModelChoice::GeminiPro => ModelChoice::ClaudeOpus,
-            ModelChoice::ClaudeOpus => ModelChoice::ClaudeOpus,
+            // Fable 5 is the most capable tier — the escalation ceiling.
+            ModelChoice::ClaudeOpus => ModelChoice::ClaudeFable5,
+            ModelChoice::ClaudeFable5 => ModelChoice::ClaudeFable5,
             ModelChoice::KimiK2 => ModelChoice::ClaudeSonnet,
         }
     }
@@ -327,7 +329,11 @@ impl ArchitectExecutor {
                 (input_tokens / 1_000_000.0).mul_add(3.00, (output_tokens / 1_000_000.0) * 15.00)
             }
             ModelChoice::ClaudeOpus => {
-                (input_tokens / 1_000_000.0).mul_add(15.00, (output_tokens / 1_000_000.0) * 75.00)
+                // Opus 4.8 pricing ($5/$25); the old $15/$75 was Opus 4.1.
+                (input_tokens / 1_000_000.0).mul_add(5.00, (output_tokens / 1_000_000.0) * 25.00)
+            }
+            ModelChoice::ClaudeFable5 => {
+                (input_tokens / 1_000_000.0).mul_add(10.00, (output_tokens / 1_000_000.0) * 50.00)
             }
             _ => 0.0,
         }
@@ -408,7 +414,12 @@ mod tests {
             );
             assert_eq!(
                 executor.escalate_model(&ModelChoice::ClaudeOpus),
-                ModelChoice::ClaudeOpus
+                ModelChoice::ClaudeFable5
+            );
+            // Fable 5 is the escalation ceiling — it must not escalate past itself.
+            assert_eq!(
+                executor.escalate_model(&ModelChoice::ClaudeFable5),
+                ModelChoice::ClaudeFable5
             );
         }
     }

--- a/crates/arkavo-router/src/architect/planner.rs
+++ b/crates/arkavo-router/src/architect/planner.rs
@@ -269,8 +269,14 @@ Guidelines:
                 input_cost + output_cost
             }
             ModelChoice::ClaudeOpus => {
-                let input_cost = (token_estimate.input as f64 / 1_000_000.0) * 15.00;
-                let output_cost = (token_estimate.output as f64 / 1_000_000.0) * 75.00;
+                // Opus 4.8 pricing ($5/$25); the old $15/$75 was Opus 4.1.
+                let input_cost = (token_estimate.input as f64 / 1_000_000.0) * 5.00;
+                let output_cost = (token_estimate.output as f64 / 1_000_000.0) * 25.00;
+                input_cost + output_cost
+            }
+            ModelChoice::ClaudeFable5 => {
+                let input_cost = (token_estimate.input as f64 / 1_000_000.0) * 10.00;
+                let output_cost = (token_estimate.output as f64 / 1_000_000.0) * 50.00;
                 input_cost + output_cost
             }
             _ => 0.0, // Local models are free
@@ -279,19 +285,19 @@ Guidelines:
 
     fn estimate_costs(&self, plan: &mut ArchitectPlan) {
         // Calculate architect mode total cost
-        let planning_cost = 0.015; // ~200 output tokens from Opus at $75/1M
+        let planning_cost = 0.005; // ~200 output tokens from Opus at $25/1M
         let execution_cost: f64 = plan.subtasks.iter().map(|s| s.estimated_cost_usd).sum();
         plan.architect_estimate_usd = planning_cost + execution_cost;
 
-        // Calculate Opus-only estimate
+        // Calculate Opus-only estimate (Opus 4.8: $5/$25 per MTok)
         let total_output_tokens: u32 = plan
             .subtasks
             .iter()
             .map(|s| s.category.estimated_tokens().output)
             .sum();
         let total_input_tokens = total_output_tokens / 3;
-        let input_cost = (total_input_tokens as f64 / 1_000_000.0) * 15.00;
-        let output_cost = (total_output_tokens as f64 / 1_000_000.0) * 75.00;
+        let input_cost = (total_input_tokens as f64 / 1_000_000.0) * 5.00;
+        let output_cost = (total_output_tokens as f64 / 1_000_000.0) * 25.00;
         plan.opus_only_estimate_usd = input_cost + output_cost;
     }
 }

--- a/crates/arkavo-router/src/decision.rs
+++ b/crates/arkavo-router/src/decision.rs
@@ -36,6 +36,11 @@ pub enum ModelChoice {
     GeminiPro,
     ClaudeSonnet,
     ClaudeOpus,
+    /// Claude Fable 5 - Anthropic's most capable tier, above Opus. 1M context,
+    /// 128K max output, adaptive-thinking-only API surface. At $10/$50 per
+    /// MTok (2x Opus) it is the escalation ceiling and explicit-selection
+    /// premium arm, never a silent default.
+    ClaudeFable5,
     /// Qwen3.5-0.8B - fast DeltaNet, TØRG-compatible (preferred default)
     LocalQwen3,
     /// Ministral-3B - TØRG-compatible, higher quality
@@ -88,7 +93,13 @@ impl ModelChoice {
             Self::Gemini35FlashHigh => "gemini-3.5-flash-high",
             Self::GeminiPro => "gemini-3-pro-preview",
             Self::ClaudeSonnet => "claude-sonnet-4-5-20250929",
-            Self::ClaudeOpus => "claude-opus-4-5-20251101",
+            // Dateless ids are pinned snapshots, not evergreen pointers.
+            // Opus 4.8 is adaptive-thinking-only (same surface as Fable 5);
+            // the provider gates sampling params off via `uses_adaptive_thinking`.
+            Self::ClaudeOpus => "claude-opus-4-8",
+            // Alias, not a dated snapshot — Anthropic serves Fable 5 under
+            // the bare id only.
+            Self::ClaudeFable5 => "claude-fable-5",
             Self::LocalQwen3 => "qwen3.5-0.8b",
             Self::LocalMinistral3B => "ministral-3b",
             Self::LocalMinistral8B => "ministral-8b",
@@ -134,7 +145,7 @@ impl ModelChoice {
             | Self::Gemini35FlashMedium
             | Self::Gemini35FlashHigh
             | Self::GeminiPro => "google",
-            Self::ClaudeSonnet | Self::ClaudeOpus => "anthropic",
+            Self::ClaudeSonnet | Self::ClaudeOpus | Self::ClaudeFable5 => "anthropic",
             Self::KimiK2 => "kimi",
         }
     }
@@ -182,6 +193,7 @@ impl ModelChoice {
             "gemini-3-pro-preview" => Some(Self::GeminiPro),
             _ if name.contains("claude-sonnet") => Some(Self::ClaudeSonnet),
             _ if name.contains("claude-opus") => Some(Self::ClaudeOpus),
+            _ if name.contains("fable") => Some(Self::ClaudeFable5),
             _ => None,
         }
     }
@@ -233,7 +245,10 @@ impl ModelChoice {
     ];
 
     pub fn is_anthropic(&self) -> bool {
-        matches!(self, Self::ClaudeSonnet | Self::ClaudeOpus)
+        matches!(
+            self,
+            Self::ClaudeSonnet | Self::ClaudeOpus | Self::ClaudeFable5
+        )
     }
 
     pub fn is_gemini(&self) -> bool {
@@ -297,7 +312,7 @@ impl ModelChoice {
             | Self::Gemini35FlashMedium
             | Self::Gemini35FlashHigh
             | Self::GeminiPro => "google",
-            Self::ClaudeSonnet | Self::ClaudeOpus => "anthropic",
+            Self::ClaudeSonnet | Self::ClaudeOpus | Self::ClaudeFable5 => "anthropic",
             Self::LocalQwen3
             | Self::LocalQwen35_9B
             | Self::LocalQwen35_27B
@@ -347,6 +362,7 @@ impl ModelChoice {
             | Self::GeminiPro
             | Self::ClaudeSonnet
             | Self::ClaudeOpus
+            | Self::ClaudeFable5
             | Self::DeepSeekV32
             | Self::DeepSeekV32Speciale
             | Self::KimiK2 => PlannerTier::Large,
@@ -545,6 +561,7 @@ impl ModelChoice {
             Self::GeminiPro => "Gemini Pro",
             Self::ClaudeSonnet => "Claude Sonnet",
             Self::ClaudeOpus => "Claude Opus",
+            Self::ClaudeFable5 => "Claude Fable 5",
             Self::DeepSeekV32 => "DeepSeek V3.2",
             Self::DeepSeekV32Speciale => "DeepSeek V3.2 Speciale",
             Self::KimiK2 => "Kimi K2.5",
@@ -666,6 +683,13 @@ impl RoutingDecision {
                     ModelChoice::LocalMinistral8B,
                 ]
             }
+            (ModelChoice::ClaudeFable5, _) => {
+                vec![
+                    ModelChoice::ClaudeOpus,
+                    ModelChoice::GeminiPro,
+                    ModelChoice::LocalMinistral8B,
+                ]
+            }
             // Qwen3 -> Ministral-3B -> Ministral-8B -> GLM-4.7-Flash
             (ModelChoice::LocalQwen3, _) => {
                 vec![ModelChoice::LocalMinistral3B, ModelChoice::GeminiFlash]
@@ -757,9 +781,19 @@ impl RoutingDecision {
                 input_cost + output_cost
             }
             ModelChoice::ClaudeOpus => {
-                // Claude Opus 4.5: $15/1M input, $75/1M output
-                let input_cost = (token_estimate.input as f64 / 1_000_000.0) * 15.00;
-                let output_cost = (token_estimate.output as f64 / 1_000_000.0) * 75.00;
+                // Claude Opus 4.8: $5/1M input, $25/1M output. The old
+                // $15/$75 figure here was Opus 4.1 pricing and overstated
+                // Opus cost 3x in every routing comparison.
+                let input_cost = (token_estimate.input as f64 / 1_000_000.0) * 5.00;
+                let output_cost = (token_estimate.output as f64 / 1_000_000.0) * 25.00;
+                input_cost + output_cost
+            }
+            ModelChoice::ClaudeFable5 => {
+                // Claude Fable 5: $10/1M input, $50/1M output — 2x Opus.
+                // Premium capability tier; cost-justified only on escalation
+                // or explicit selection.
+                let input_cost = (token_estimate.input as f64 / 1_000_000.0) * 10.00;
+                let output_cost = (token_estimate.output as f64 / 1_000_000.0) * 50.00;
                 input_cost + output_cost
             }
             ModelChoice::DeepSeekV32 | ModelChoice::DeepSeekV32Speciale => {
@@ -806,7 +840,10 @@ impl RoutingDecision {
             ModelChoice::Gemini35FlashHigh => Duration::from_secs(20),
             ModelChoice::GeminiPro => Duration::from_secs(10),
             ModelChoice::ClaudeSonnet => Duration::from_secs(5),
-            ModelChoice::ClaudeOpus => Duration::from_secs(15),
+            // Opus 4.8 and Fable 5 both reason via adaptive thinking, which
+            // spends extra wall-clock on hard tasks.
+            ModelChoice::ClaudeOpus => Duration::from_secs(18),
+            ModelChoice::ClaudeFable5 => Duration::from_secs(20),
             ModelChoice::LocalQwen3 => Duration::from_millis(500),
             ModelChoice::LocalMinistral3B => Duration::from_secs(2),
             ModelChoice::LocalMinistral8B => Duration::from_secs(4),
@@ -846,6 +883,92 @@ mod tests {
         assert_eq!(ModelChoice::GeminiFlash.name(), "gemini-flash-latest");
         assert_eq!(ModelChoice::Gemini35Flash.name(), "gemini-3.5-flash");
         assert_eq!(ModelChoice::LocalGemma270M.name(), "gemma-3-270m-it");
+    }
+
+    // Regression: ClaudeOpus must pin the current dateless Opus snapshot.
+    // The provider routes `claude-opus-4-8` onto the adaptive-thinking surface
+    // (no sampling params), so a stale dated id here would also send the wrong
+    // request shape.
+    #[test]
+    fn test_claude_opus_pins_opus_4_8() {
+        assert_eq!(ModelChoice::ClaudeOpus.name(), "claude-opus-4-8");
+        assert_eq!(
+            ModelChoice::from_name("claude-opus-4-8"),
+            Some(ModelChoice::ClaudeOpus)
+        );
+    }
+
+    #[test]
+    fn test_claude_fable_5_properties() {
+        let model = ModelChoice::ClaudeFable5;
+        assert_eq!(model.name(), "claude-fable-5");
+        assert_eq!(model.provider(), "anthropic");
+        assert_eq!(model.family(), "anthropic");
+        assert_eq!(model.display_name(), "Claude Fable 5");
+        assert!(model.is_anthropic());
+        assert!(model.is_cloud());
+        assert!(!model.is_local());
+        assert_eq!(model.capability(), PlannerTier::Large);
+    }
+
+    #[test]
+    fn test_claude_fable_5_name_resolution() {
+        for alias in ["claude-fable-5", "claude-fable", "fable"] {
+            assert_eq!(
+                ModelChoice::from_name(alias),
+                Some(ModelChoice::ClaudeFable5),
+                "alias {alias} should resolve to ClaudeFable5"
+            );
+        }
+        assert_eq!(
+            ModelChoice::from_name(ModelChoice::ClaudeFable5.name()),
+            Some(ModelChoice::ClaudeFable5),
+            "round-trip via primary name"
+        );
+    }
+
+    #[test]
+    fn test_claude_fable_5_costs_double_opus() {
+        // Fable 5 is $10/$50 vs Opus 4.8 at $5/$25 — the premium tier must
+        // estimate at exactly 2x Opus so budget policies see the real spread.
+        let fable = RoutingDecision::estimate_cost(
+            &ModelChoice::ClaudeFable5,
+            TaskCategory::CodeGeneration,
+        );
+        let opus =
+            RoutingDecision::estimate_cost(&ModelChoice::ClaudeOpus, TaskCategory::CodeGeneration);
+        assert!(fable > 0.0);
+        assert!(
+            (fable - opus * 2.0).abs() < 1e-9,
+            "fable={fable} opus={opus}"
+        );
+    }
+
+    // Regression: ClaudeOpus pins claude-opus-4-8, which is $5/$25 per MTok.
+    // The previous $15/$75 figure (Opus 4.1 pricing) overstated cost 3x.
+    #[test]
+    fn test_claude_opus_cost_uses_opus_4_8_pricing() {
+        let opus =
+            RoutingDecision::estimate_cost(&ModelChoice::ClaudeOpus, TaskCategory::CodeGeneration);
+        let tokens = TaskCategory::CodeGeneration.estimated_tokens();
+        let expected = (f64::from(tokens.input) / 1_000_000.0) * 5.00
+            + (f64::from(tokens.output) / 1_000_000.0) * 25.00;
+        assert!((opus - expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_claude_fable_5_fallback_chain_steps_down_to_opus() {
+        let decision = RoutingDecision::new(
+            ModelChoice::ClaudeFable5,
+            TaskCategory::CodeGeneration,
+            0.9,
+            "Test".to_string(),
+        );
+        assert_eq!(
+            decision.fallback_chain.first(),
+            Some(&ModelChoice::ClaudeOpus)
+        );
+        assert!(decision.fallback_chain.iter().any(ModelChoice::is_local));
     }
 
     #[test]

--- a/crates/arkavo-router/src/provider.rs
+++ b/crates/arkavo-router/src/provider.rs
@@ -83,7 +83,9 @@ impl super::Router {
 
     pub(crate) fn is_model_available(&self, model: &ModelChoice) -> bool {
         match model {
-            ModelChoice::ClaudeSonnet | ModelChoice::ClaudeOpus => self.is_anthropic_available(),
+            ModelChoice::ClaudeSonnet | ModelChoice::ClaudeOpus | ModelChoice::ClaudeFable5 => {
+                self.is_anthropic_available()
+            }
             ModelChoice::GeminiFlash
             | ModelChoice::Gemini35Flash
             | ModelChoice::Gemini35FlashMinimal
@@ -262,9 +264,11 @@ impl super::Router {
     ) -> Result<Box<dyn Provider>> {
         tracing::debug!(model = %model.name(), use_spec_decoding, "Instantiating provider");
         match model {
-            ModelChoice::ClaudeSonnet | ModelChoice::ClaudeOpus => {
+            ModelChoice::ClaudeSonnet | ModelChoice::ClaudeOpus | ModelChoice::ClaudeFable5 => {
                 use arkavo_llm::providers::anthropic::AnthropicProvider;
-                if let Ok(provider) = AnthropicProvider::from_env() {
+                // Pass the routed model id so distinct arms reach distinct
+                // API models instead of collapsing to the env/default model.
+                if let Ok(provider) = AnthropicProvider::from_env_with_model(model.name()) {
                     Ok(Box::new(provider))
                 } else {
                     #[cfg(feature = "gemini")]

--- a/crates/arkavo-router/src/selector.rs
+++ b/crates/arkavo-router/src/selector.rs
@@ -371,6 +371,12 @@ impl ModelSelector {
         if self.availability.anthropic {
             models.push(ModelChoice::ClaudeSonnet);
             models.push(ModelChoice::ClaudeOpus);
+            // Fable 5 is 2x Opus pricing; exposed as a Thompson Sampling arm
+            // so the learning module can converge on the task categories
+            // where the capability gain justifies the premium. It is never a
+            // category default — it's reached via learning, escalation, or an
+            // explicit AGENTS.md `model:` hint.
+            models.push(ModelChoice::ClaudeFable5);
         }
         if self.availability.deepseek {
             models.push(ModelChoice::DeepSeekV32);

--- a/crates/arkavo-router/src/selector_quality.rs
+++ b/crates/arkavo-router/src/selector_quality.rs
@@ -11,12 +11,13 @@ impl ModelSelector {
         classification: &Classification,
     ) -> String {
         let category_reason = match (classification.category, model) {
-            (TaskCategory::FrontendUI, ModelChoice::ClaudeSonnet | ModelChoice::ClaudeOpus) => {
-                "Frontend task: Claude Sonnet excellent for UI development"
-            }
+            (
+                TaskCategory::FrontendUI,
+                ModelChoice::ClaudeSonnet | ModelChoice::ClaudeOpus | ModelChoice::ClaudeFable5,
+            ) => "Frontend task: Claude excellent for UI development",
             (TaskCategory::FrontendUI, _) => "Frontend task: Gemini Flash ranks #1 on WebDev Arena",
-            (TaskCategory::BackendAPI, ModelChoice::ClaudeOpus) => {
-                "Backend API: Claude Opus for highest quality code"
+            (TaskCategory::BackendAPI, ModelChoice::ClaudeOpus | ModelChoice::ClaudeFable5) => {
+                "Backend API: top-tier Claude for highest quality code"
             }
             (TaskCategory::BackendAPI, ModelChoice::ClaudeSonnet) => {
                 "Backend API: Claude Sonnet for fast, high-quality code"
@@ -25,16 +26,17 @@ impl ModelSelector {
             (TaskCategory::CodeSearch, _) => "Code search: Local Gemma 4B is fast and free",
             (TaskCategory::SecurityScan, _) => "Security scan: Local Gemma 4B for privacy",
             (TaskCategory::CodeReview, _) => "Code review: Capable model for thorough analysis",
-            (TaskCategory::TestGeneration, ModelChoice::ClaudeOpus) => {
-                "Test generation: Claude Opus for comprehensive tests"
+            (TaskCategory::TestGeneration, ModelChoice::ClaudeOpus | ModelChoice::ClaudeFable5) => {
+                "Test generation: top-tier Claude for comprehensive tests"
             }
             (TaskCategory::TestGeneration, _) => {
                 "Test generation: Gemini Pro for comprehensive tests"
             }
             (TaskCategory::Documentation, _) => "Documentation: Local Gemma 4B sufficient",
-            (TaskCategory::Refactoring, ModelChoice::ClaudeSonnet | ModelChoice::ClaudeOpus) => {
-                "Refactoring: Claude for excellent code transformations"
-            }
+            (
+                TaskCategory::Refactoring,
+                ModelChoice::ClaudeSonnet | ModelChoice::ClaudeOpus | ModelChoice::ClaudeFable5,
+            ) => "Refactoring: Claude for excellent code transformations",
             (TaskCategory::Refactoring, _) => "Refactoring: Gemini Flash for quick iterations",
             (TaskCategory::CodeGeneration, ModelChoice::DeepSeekV32) => {
                 "Code generation: DeepSeek V3.2 with tool support for code generation"
@@ -70,7 +72,10 @@ impl ModelSelector {
             }
             ModelChoice::GeminiPro => "Highest quality, comprehensive output ($0.009)",
             ModelChoice::ClaudeSonnet => "Fast (5s), excellent quality ($0.018-0.045)",
-            ModelChoice::ClaudeOpus => "Premium quality, complex reasoning ($0.090-0.225)",
+            ModelChoice::ClaudeOpus => "Premium quality, complex reasoning ($0.030-0.075)",
+            ModelChoice::ClaudeFable5 => {
+                "Most capable tier, adaptive deep reasoning ($0.060-0.150)"
+            }
             ModelChoice::LocalQwen3 => "Ultra-fast (<1s), zero cost, TØRG-compatible",
             ModelChoice::LocalMinistral3B => "Fast (2s), zero cost, TØRG-compatible",
             ModelChoice::LocalMinistral8B => "High quality (4s), zero cost, TØRG-compatible",
@@ -469,6 +474,13 @@ fn static_model_priors(model: &ModelChoice) -> Vec<(&'static str, f64, f64)> {
         ModelChoice::ClaudeOpus => {
             vec![("test_generation", 5.0, 2.0), ("backend_api", 5.0, 2.0)]
         }
+        // Seeded below Opus so the cheaper tier wins ties; real feedback must
+        // earn Fable 5 its premium slot per category.
+        ModelChoice::ClaudeFable5 => vec![
+            ("test_generation", 4.0, 2.0),
+            ("backend_api", 4.0, 2.0),
+            ("code_review", 4.0, 2.0),
+        ],
         ModelChoice::GeminiFlash => vec![("frontend_ui", 5.0, 2.0)],
         // Gemini 3.5 Flash: pro-tier reasoning + agentic; warm-start for code & agent tasks.
         ModelChoice::Gemini35Flash => vec![

--- a/crates/arkavo-router/src/tool_extraction.rs
+++ b/crates/arkavo-router/src/tool_extraction.rs
@@ -51,6 +51,7 @@ pub(crate) fn detail_level_for_model(
         | ModelChoice::GeminiPro
         | ModelChoice::ClaudeSonnet
         | ModelChoice::ClaudeOpus
+        | ModelChoice::ClaudeFable5
         | ModelChoice::DeepSeekV32
         | ModelChoice::DeepSeekV32Speciale
         | ModelChoice::KimiK2 => arkavo_mcp_tools::DetailLevel::FullSchema,

--- a/crates/arkavo-ui-core/src/llm_integration.rs
+++ b/crates/arkavo-ui-core/src/llm_integration.rs
@@ -55,9 +55,11 @@ impl LlmIntegration {
                     anyhow::bail!("Gemini feature not enabled")
                 }
             }
-            ModelChoice::ClaudeSonnet | ModelChoice::ClaudeOpus => {
+            ModelChoice::ClaudeSonnet | ModelChoice::ClaudeOpus | ModelChoice::ClaudeFable5 => {
                 use arkavo_llm::providers::anthropic::AnthropicProvider;
-                if let Ok(provider) = AnthropicProvider::from_env() {
+                if let Ok(provider) =
+                    AnthropicProvider::from_env_with_model(decision.recommended_model.name())
+                {
                     Ok(LlmClient::new(Box::new(provider)))
                 } else {
                     anyhow::bail!("ANTHROPIC_API_KEY not set")


### PR DESCRIPTION
## Summary
Adds Anthropic's Claude Fable 5 as a routed model, fixes the Anthropic provider to send the correct request shape for adaptive-thinking models, and corrects stale Opus pricing/model-id that predated this change.

## Fable 5
- New `ClaudeFable5` variant (`claude-fable-5`): **$10 / $50 per MTok**, 1M context, 128K output, adaptive-thinking-only — verified against the live Anthropic models docs.
- Wired through name/family/provider/capability/display/`from_name` (aliases `fable`, `claude-fable`), cost, latency, and fallback chain (Fable → Opus → Gemini Pro → local).
- **Placement:** it is 2× Opus pricing, so it's the architect escalation ceiling and a Thompson Sampling arm seeded *below* Opus — never a silent default. Reachable via learning, escalation, or an AGENTS.md `model:` hint.

## Provider — latest API surface
- Fable 5 / Opus 4.7+ return HTTP 400 if sent `temperature`/`top_p`/`top_k` or a fixed thinking budget, and Fable also 400s on explicit `thinking: disabled`. New `build_request` gates on the model: adaptive-surface models get `thinking: {"type": "adaptive"}`, no sampling params, and a 16K `max_tokens` default (thinking tokens count toward the cap; 4096 truncates). Legacy models are unchanged.
- Fixed a latent bug: `from_env()` ignored the routed model, collapsing every Anthropic decision to `ANTHROPIC_MODEL`/Sonnet. New `from_env_with_model()` is used at all four instantiation sites (`ANTHROPIC_MODEL` still overrides).
- HTTP timeout 60s → 120s for thinking headroom.

## Opus correctness fixes
- `ClaudeOpus` repointed from the dated `claude-opus-4-5-20251101` to `claude-opus-4-8` (same $5/$25, also adaptive-surface — now handled by the provider).
- Corrected Opus cost from the stale **$15/$75** (Opus 4.1 pricing) to **$5/$25** across `decision.rs`, `architect/executor.rs`, and `architect/planner.rs`, including the architect-vs-Opus savings estimate that was inflated 3×.

## Testing
- `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check` all clean.
- New regression tests: adaptive request shape (omits sampling, uses adaptive thinking, 16K cap), legacy shape preserved, Fable = 2× Opus cost, corrected Opus pricing, Opus pins `claude-opus-4-8`, name round-trips, fallback chain, escalation ceiling. 359 router + 239 llm tests pass.

> Note: the suite has one **pre-existing** flaky failure, `selector_quality::tests::test_select_adaptive_uses_thompson_sampling` — a probabilistic Thompson Sampling test using `gemini_only()`. Verified it also fails on the unmodified baseline; it does not touch any path changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)