### PR TITLE
Add standalone shadow-consolidation job for Fable

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -1230,7 +1230,7 @@ jobs:
 
           # Check for env::var calls that require configuration
           # Exclude build.rs files and test files, and allow standard env vars and optional API keys
-          if grep -r 'env::var("[A-Z_]*")\.\(expect\|unwrap\)' crates/ --include="*.rs" --exclude="build.rs" | grep -v test | grep -v "CARGO\|RUST\|PATH\|HOME\|TEMP\|TMP\|USER\|OUT_DIR\|OPENAI_API_KEY\|ANTHROPIC_API_KEY\|MOONSHOT_API_KEY\|DEEPSEEK_API_KEY\|DEEPSEEK_MODEL\|GEMINI_API_KEY\|GEMINI_MODEL\|KIMI_API_KEY\|KIMI_MODEL\|ANTHROPIC_MODEL"; then
+          if grep -r 'env::var("[A-Z_]*")\.\(expect\|unwrap\)' crates/ --include="*.rs" --exclude="build.rs" | grep -v test | grep -v "CARGO\|RUST\|PATH\|HOME\|TEMP\|TMP\|USER\|OUT_DIR\|OPENAI_API_KEY\|ANTHROPIC_API_KEY\|MOONSHOT_API_KEY\|DEEPSEEK_API_KEY\|DEEPSEEK_MODEL\|GEMINI_API_KEY\|GEMINI_MODEL\|KIMI_API_KEY\|KIMI_MODEL\|ANTHROPIC_MODEL\|ANTHROPIC_BASE_URL"; then
             echo "::error::Found required environment variables"
             exit 1
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,6 +1907,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "ureq 2.12.1",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,6 +1773,7 @@ dependencies = [
  "clap",
  "crossbeam-queue",
  "dashmap",
+ "ed25519-dalek 2.2.0",
  "futures",
  "governor",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,6 +580,7 @@ dependencies = [
  "arkavo-arp",
  "arkavo-observability",
  "arkavo-policy-cache",
+ "chrono",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "chrono",
  "serde",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-config-bundle",
  "base64 0.22.1",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "git2",
  "tempfile",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1383,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1507,7 +1507,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "lru 0.16.4",
  "serde",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1841,8 +1841,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "arkavo-shadow-consolidation"
+version = "0.79.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tempfile",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "arkavo-snpe"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1855,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1870,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -1895,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1914,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1936,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1953,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -1977,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1988,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2001,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2013,7 +2029,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2022,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2036,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2055,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2070,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2095,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2105,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,7 @@ dependencies = [
 name = "arkavo-arp"
 version = "0.80.0"
 dependencies = [
+ "arkavo-test-macros",
  "serde",
  "serde_json",
 ]
@@ -580,6 +581,7 @@ dependencies = [
  "arkavo-arp",
  "arkavo-observability",
  "arkavo-policy-cache",
+ "arkavo-test-macros",
  "chrono",
  "serde",
  "serde_json",
@@ -1115,6 +1117,10 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
 ]
+
+[[package]]
+name = "arkavo-lesson-synthesis"
+version = "0.80.0"
 
 [[package]]
 name = "arkavo-llama-cpp"
@@ -1749,6 +1755,7 @@ dependencies = [
  "arkavo-evofabric",
  "arkavo-gossip",
  "arkavo-hrm",
+ "arkavo-lesson-synthesis",
  "arkavo-llama-cpp",
  "arkavo-llm",
  "arkavo-mcp",
@@ -1848,6 +1855,8 @@ name = "arkavo-shadow-consolidation"
 version = "0.80.0"
 dependencies = [
  "anyhow",
+ "arkavo-lesson-synthesis",
+ "arkavo-test-macros",
  "chrono",
  "clap",
  "reqwest 0.12.28",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,6 +1737,7 @@ version = "0.79.0"
 dependencies = [
  "anyhow",
  "arkavo-agent",
+ "arkavo-arp",
  "arkavo-arp-runtime",
  "arkavo-autolearn",
  "arkavo-budget",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "chrono",
  "serde",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-config-bundle",
  "base64 0.22.1",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "git2",
  "tempfile",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1596,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "lru 0.16.4",
  "serde",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1733,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-shadow-consolidation"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1889,7 +1889,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2008,7 +2008,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2075,7 +2075,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.79.0"
+version = "0.80.0"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ members = [
     "crates/arkavo-swarmkit",
     "crates/arkavo-swarmkit-runtime",
     "crates/arkavo-mcp-identity",
+    "crates/arkavo-shadow-consolidation",
     "tests/golden_dataset",
     ".cargo/xtask",
 ]
@@ -141,6 +142,7 @@ default-members = [
     "crates/arkavo-swarmkit",
     "crates/arkavo-swarmkit-runtime",
     "crates/arkavo-mcp-identity",
+    "crates/arkavo-shadow-consolidation",
     ".cargo/xtask",
 ]
 exclude = ["crates/arkavo-protocol/fuzz", "examples"]
@@ -148,7 +150,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.78.0"
+version = "0.79.0"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ members = [
     "crates/arkavo-swarmkit-runtime",
     "crates/arkavo-mcp-identity",
     "crates/arkavo-shadow-consolidation",
+    "crates/arkavo-lesson-synthesis",
     "tests/golden_dataset",
     ".cargo/xtask",
 ]

--- a/crates/arkavo-adaptation/src/lib.rs
+++ b/crates/arkavo-adaptation/src/lib.rs
@@ -27,9 +27,20 @@ pub struct Outcome {
 }
 
 /// The adaptation engine selects entities using configured method (§6).
+///
+/// When `prior_management.provenance_tracking` is enabled, live (runtime)
+/// and distilled (teacher-provided) evidence are tracked separately and the
+/// engine samples the *effective* prior: live mass plus distilled mass
+/// decayed by accumulating live observations. This prevents synthetic warm
+/// starts from masking real-world divergence.
 pub struct AdaptationEngine {
     config: Adaptation,
+    /// Live prior mass: runtime outcomes plus the configured initial prior.
     priors: HashMap<String, BetaPrior>,
+    /// Distilled prior mass, seeded by consolidation warm starts.
+    distilled: HashMap<String, BetaPrior>,
+    /// Live outcome updates per entity — drives distilled displacement.
+    live_update_counts: HashMap<String, u32>,
     observation_counts: HashMap<String, u32>,
     version_hashes: HashMap<String, String>,
     total_selections: u64,
@@ -41,6 +52,8 @@ impl AdaptationEngine {
         Self {
             config,
             priors: HashMap::new(),
+            distilled: HashMap::new(),
+            live_update_counts: HashMap::new(),
             observation_counts: HashMap::new(),
             version_hashes: HashMap::new(),
             total_selections: 0,
@@ -73,7 +86,13 @@ impl AdaptationEngine {
     }
 
     /// Update the prior for an entity based on observed outcome.
+    /// Live evidence: always lands in the live prior and advances the
+    /// distilled displacement counter.
     pub fn update(&mut self, entity_id: &str, outcome: Outcome) {
+        *self
+            .live_update_counts
+            .entry(entity_id.to_string())
+            .or_insert(0) += 1;
         let prior = self.prior_for(entity_id);
         if outcome.success {
             prior.alpha += outcome.quality_score;
@@ -82,12 +101,80 @@ impl AdaptationEngine {
         }
     }
 
-    /// Get the current prior for an entity.
+    /// Seed distilled (teacher-provided) prior mass for an entity.
+    ///
+    /// With provenance tracking enabled the mass is tracked separately and
+    /// decays as live evidence accumulates. Without it (the default) the
+    /// mass merges into the live prior — exactly the pre-provenance
+    /// behavior, so warm starts remain possible either way.
+    pub fn seed_distilled(&mut self, entity_id: &str, mass: BetaPrior) {
+        let mass = mass.sanitize();
+        if self.provenance_enabled() {
+            let entry = self
+                .distilled
+                .entry(entity_id.to_string())
+                .or_insert(BetaPrior {
+                    alpha: 0.0,
+                    beta: 0.0,
+                });
+            entry.alpha += mass.alpha;
+            entry.beta += mass.beta;
+        } else {
+            let prior = self.prior_for(entity_id);
+            prior.alpha += mass.alpha;
+            prior.beta += mass.beta;
+        }
+    }
+
+    /// The effective prior the engine samples: live mass plus distilled mass
+    /// scaled by the displacement weight.
     pub fn get_prior(&self, entity_id: &str) -> BetaPrior {
+        let live = self.live_prior(entity_id);
+        match self.distilled.get(entity_id) {
+            Some(d) => {
+                let w = self.distilled_weight(entity_id);
+                BetaPrior::new(live.alpha + w * d.alpha, live.beta + w * d.beta)
+            }
+            None => live,
+        }
+    }
+
+    /// The live component of an entity's prior (runtime evidence + initial).
+    pub fn live_prior(&self, entity_id: &str) -> BetaPrior {
         self.priors
             .get(entity_id)
             .copied()
             .unwrap_or_else(|| self.initial_prior())
+    }
+
+    /// The undecayed distilled component, if any was seeded.
+    pub fn distilled_prior(&self, entity_id: &str) -> Option<BetaPrior> {
+        self.distilled.get(entity_id).copied()
+    }
+
+    /// Current weight applied to distilled mass:
+    /// `max(floor, 1 - displacement_factor * live_updates)`.
+    pub fn distilled_weight(&self, entity_id: &str) -> f64 {
+        let decay = self
+            .config
+            .prior_management
+            .as_ref()
+            .and_then(|pm| pm.distilled_decay.as_ref());
+        let factor = decay
+            .and_then(|d| d.displacement_factor)
+            .unwrap_or(0.05)
+            .clamp(f64::EPSILON, 1.0);
+        let floor = decay.and_then(|d| d.floor).unwrap_or(0.0).clamp(0.0, 1.0);
+        let live = f64::from(self.live_update_counts.get(entity_id).copied().unwrap_or(0));
+        (1.0 - factor * live).max(floor)
+    }
+
+    fn provenance_enabled(&self) -> bool {
+        self.config
+            .prior_management
+            .as_ref()
+            .and_then(|pm| pm.provenance_tracking)
+            .unwrap_or(false)
     }
 
     /// Get observation count for an entity.
@@ -106,18 +193,26 @@ impl AdaptationEngine {
         self.observations(entity_id) < warmup_period
     }
 
-    /// Reset the prior for a specific entity to initial state.
+    /// Reset the prior for a specific entity to initial state. Distilled
+    /// mass is cleared too: it was distilled for the old entity version.
     pub fn reset_prior(&mut self, entity_id: &str) {
         let initial = self.reset_state();
         self.priors.insert(entity_id.to_string(), initial);
+        self.distilled.remove(entity_id);
+        self.live_update_counts.remove(entity_id);
         self.observation_counts.insert(entity_id.to_string(), 0);
     }
 
     /// Snapshot of all known entity priors plus their observation counts.
-    /// Used by UIs and audit tooling to inspect engine state.
+    /// Used by UIs and audit tooling to inspect engine state. `alpha`/`beta`
+    /// are the effective prior the engine samples; the live/distilled split
+    /// is exposed alongside for provenance-aware views.
     pub fn snapshot(&self) -> Vec<EntityPriorSnapshot> {
         let mut ids: std::collections::HashSet<&str> = std::collections::HashSet::new();
         for k in self.priors.keys() {
+            ids.insert(k.as_str());
+        }
+        for k in self.distilled.keys() {
             ids.insert(k.as_str());
         }
         for k in self.observation_counts.keys() {
@@ -133,6 +228,8 @@ impl AdaptationEngine {
             .into_iter()
             .map(|id| {
                 let prior = self.get_prior(id);
+                let live = self.live_prior(id);
+                let distilled = self.distilled_prior(id);
                 let observations = self.observations(id);
                 let mean = prior.alpha / (prior.alpha + prior.beta).max(f64::EPSILON);
                 EntityPriorSnapshot {
@@ -142,6 +239,11 @@ impl AdaptationEngine {
                     mean,
                     observations,
                     in_warmup: observations < warmup_period,
+                    live_alpha: live.alpha,
+                    live_beta: live.beta,
+                    distilled_alpha: distilled.map(|d| d.alpha),
+                    distilled_beta: distilled.map(|d| d.beta),
+                    distilled_weight: distilled.map(|_| self.distilled_weight(id)),
                 }
             })
             .collect();
@@ -300,6 +402,8 @@ impl AdaptationEngine {
 }
 
 /// Read-only snapshot of an entity's prior plus observation count.
+/// `alpha`/`beta` are the effective prior; the live/distilled split is
+/// `None` for distilled fields when no distilled mass was seeded.
 #[derive(Debug, Clone)]
 pub struct EntityPriorSnapshot {
     pub id: String,
@@ -308,6 +412,12 @@ pub struct EntityPriorSnapshot {
     pub mean: f64,
     pub observations: u32,
     pub in_warmup: bool,
+    pub live_alpha: f64,
+    pub live_beta: f64,
+    pub distilled_alpha: Option<f64>,
+    pub distilled_beta: Option<f64>,
+    /// Current displacement weight applied to distilled mass.
+    pub distilled_weight: Option<f64>,
 }
 
 #[cfg(test)]
@@ -362,6 +472,8 @@ mod tests {
                     alpha: 2.0,
                     beta: 1.0,
                 }),
+                provenance_tracking: None,
+                distilled_decay: None,
             }),
             signal_separation: None,
         }
@@ -569,6 +681,153 @@ mod tests {
         let mut engine = AdaptationEngine::new(config);
         let result = engine.select(&entities());
         assert_eq!(result, Some("model_a".into()));
+    }
+
+    fn provenance_config(displacement_factor: f64, floor: f64) -> Adaptation {
+        use arkavo_arp::adaptation::{DistilledDecay, DistilledDecayStrategy};
+        let mut config = thompson_config();
+        let pm = config.prior_management.as_mut().unwrap();
+        pm.provenance_tracking = Some(true);
+        pm.distilled_decay = Some(DistilledDecay {
+            strategy: DistilledDecayStrategy::LiveDisplacement,
+            displacement_factor: Some(displacement_factor),
+            floor: Some(floor),
+        });
+        config
+    }
+
+    #[test]
+    fn distilled_mass_contributes_when_tracking_on() {
+        let mut engine = AdaptationEngine::new(provenance_config(0.1, 0.0));
+        let live_before = engine.get_prior("model_a");
+        engine.seed_distilled(
+            "model_a",
+            BetaPrior {
+                alpha: 10.0,
+                beta: 2.0,
+            },
+        );
+        let effective = engine.get_prior("model_a");
+        // No live updates yet: full distilled weight.
+        assert!((effective.alpha - (live_before.alpha + 10.0)).abs() < 1e-9);
+        assert!((effective.beta - (live_before.beta + 2.0)).abs() < 1e-9);
+        // Live component unchanged by seeding.
+        let live = engine.live_prior("model_a");
+        assert_eq!(live.alpha, live_before.alpha);
+    }
+
+    #[test]
+    fn live_evidence_displaces_distilled_mass() {
+        // The motivating scenario: a teacher distills an optimistic prior,
+        // but the real world disagrees. Synthetic mass must not mask the
+        // divergence.
+        let mut engine = AdaptationEngine::new(provenance_config(0.1, 0.0));
+        engine.seed_distilled(
+            "model_a",
+            BetaPrior {
+                alpha: 50.0,
+                beta: 1.0,
+            },
+        );
+        let optimistic = engine.get_prior("model_a");
+        let optimistic_mean = optimistic.alpha / (optimistic.alpha + optimistic.beta);
+        assert!(optimistic_mean > 0.9);
+
+        // Ten live failures fully displace the distilled mass (0.1 * 10 = 1).
+        for _ in 0..10 {
+            engine.update(
+                "model_a",
+                Outcome {
+                    success: false,
+                    quality_score: 0.0,
+                },
+            );
+        }
+        assert!((engine.distilled_weight("model_a")).abs() < f64::EPSILON);
+        let effective = engine.get_prior("model_a");
+        let live = engine.live_prior("model_a");
+        // Effective prior has converged to live evidence only.
+        assert!((effective.alpha - live.alpha).abs() < 1e-9);
+        let effective_mean = effective.alpha / (effective.alpha + effective.beta);
+        assert!(
+            effective_mean < 0.3,
+            "live failures must dominate: mean {effective_mean}"
+        );
+    }
+
+    #[test]
+    fn floor_preserves_distilled_mass() {
+        let mut engine = AdaptationEngine::new(provenance_config(0.1, 0.25));
+        engine.seed_distilled(
+            "model_a",
+            BetaPrior {
+                alpha: 8.0,
+                beta: 4.0,
+            },
+        );
+        for _ in 0..100 {
+            engine.update(
+                "model_a",
+                Outcome {
+                    success: true,
+                    quality_score: 0.5,
+                },
+            );
+        }
+        assert!((engine.distilled_weight("model_a") - 0.25).abs() < 1e-9);
+        let effective = engine.get_prior("model_a");
+        let live = engine.live_prior("model_a");
+        assert!((effective.alpha - (live.alpha + 0.25 * 8.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn seed_merges_into_live_when_tracking_off() {
+        // Default (provenance_tracking unset): pre-provenance behavior.
+        let mut engine = AdaptationEngine::new(thompson_config());
+        let before = engine.get_prior("model_a");
+        engine.seed_distilled(
+            "model_a",
+            BetaPrior {
+                alpha: 5.0,
+                beta: 3.0,
+            },
+        );
+        let live = engine.live_prior("model_a");
+        assert!((live.alpha - (before.alpha + 5.0)).abs() < 1e-9);
+        assert!(engine.distilled_prior("model_a").is_none());
+    }
+
+    #[test]
+    fn snapshot_exposes_live_distilled_split() {
+        let mut engine = AdaptationEngine::new(provenance_config(0.1, 0.0));
+        engine.seed_distilled(
+            "model_a",
+            BetaPrior {
+                alpha: 6.0,
+                beta: 2.0,
+            },
+        );
+        let snap = engine.snapshot();
+        let a = snap.iter().find(|s| s.id == "model_a").unwrap();
+        assert_eq!(a.distilled_alpha, Some(6.0));
+        assert_eq!(a.distilled_beta, Some(2.0));
+        assert_eq!(a.distilled_weight, Some(1.0));
+        assert!(a.alpha > a.live_alpha);
+    }
+
+    #[test]
+    fn version_reset_clears_distilled_mass() {
+        let mut engine = AdaptationEngine::new(provenance_config(0.1, 0.0));
+        engine.seed_distilled(
+            "model_a",
+            BetaPrior {
+                alpha: 9.0,
+                beta: 1.0,
+            },
+        );
+        engine.reset_prior("model_a");
+        assert!(engine.distilled_prior("model_a").is_none());
+        assert!((engine.distilled_weight("model_a") - 1.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/arkavo-agui/src/arp_handler.rs
+++ b/crates/arkavo-agui/src/arp_handler.rs
@@ -25,7 +25,8 @@ use tokio::sync::RwLock;
 use crate::types::{
     AgentArpStatus, ArpAdaptationEntity, ArpAdaptationSnapshot, ArpBudgetSummary,
     ArpDecisionTraceEntry, ArpDocumentSummary, ArpPolicyCacheConfigSummary, ArpPolicyCacheEntry,
-    ArpPolicyCacheSnapshot, ArpQualityGateSummary, ArpStatusSnapshot, FlightContext,
+    ArpPolicyCacheSnapshot, ArpProposalSnapshot, ArpQualityGateSummary, ArpStatusSnapshot,
+    ArpTraceRef, FlightContext,
 };
 
 const DEFAULT_DOC_FILENAME: &str = "arkavo.arp.json";
@@ -136,6 +137,33 @@ impl ArpHandler {
             },
         };
         self.install_loaded(agent_id, loaded).await;
+    }
+
+    /// Apply a findings-inbox HITL decision to one agent's proposal queue.
+    /// Returns the resulting state label, or an error when the agent has no
+    /// runtime or the proposal is not awaiting review.
+    pub async fn review_proposal(
+        &self,
+        agent_id: &str,
+        proposal_id: &str,
+        approve: bool,
+        reviewer: &str,
+    ) -> Result<String, String> {
+        let runtime = {
+            let guard = self.agents.read().await;
+            guard
+                .get(agent_id)
+                .and_then(|e| e.runtime.clone())
+                .ok_or_else(|| format!("agent {agent_id} has no ARP runtime"))?
+        };
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let queue = runtime.proposal_queue();
+        let mut guard = queue.lock().await;
+        let state = guard.review(proposal_id, approve, reviewer, now)?;
+        Ok(format!("{state:?}").to_lowercase())
     }
 
     /// Stash a parsed/erroneous document and, when valid, instantiate the
@@ -358,11 +386,29 @@ async fn build_agent_status(agent_id: &str, entry: &AgentEntry) -> AgentArpStatu
                         mean: p.mean,
                         observations: p.observations,
                         in_warmup: p.in_warmup,
+                        live_alpha: p.live_alpha,
+                        live_beta: p.live_beta,
+                        distilled_alpha: p.distilled_alpha,
+                        distilled_beta: p.distilled_beta,
+                        distilled_weight: p.distilled_weight,
                     })
                     .collect(),
             })
         }
         None => None,
+    };
+
+    let proposals = match entry.runtime.as_ref() {
+        Some(rt) => {
+            let queue = rt.proposal_queue();
+            let guard = queue.lock().await;
+            guard
+                .proposals()
+                .into_iter()
+                .map(convert_proposal)
+                .collect()
+        }
+        None => Vec::new(),
     };
 
     // Prefer an explicitly attached trace; otherwise pull from the
@@ -396,8 +442,73 @@ async fn build_agent_status(agent_id: &str, entry: &AgentEntry) -> AgentArpStatu
         document: summary,
         policy_cache,
         adaptation,
+        proposals,
         decision_traces,
         flight_context: entry.flight_context.clone(),
+    }
+}
+
+/// Render a TighteningProposal as a findings-inbox card payload.
+fn convert_proposal(p: arkavo_arp::proposal::TighteningProposal) -> ArpProposalSnapshot {
+    use arkavo_arp::proposal::TighteningEffect;
+    let (effect_kind, effect_summary) = match &p.effect {
+        TighteningEffect::LowerTaskCeiling { new_ceiling_usd } => (
+            "lower_task_ceiling",
+            format!("lower task ceiling to ${new_ceiling_usd}"),
+        ),
+        TighteningEffect::LowerLayerBudget {
+            layer,
+            new_limit_usd,
+        } => (
+            "lower_layer_budget",
+            format!("lower {layer:?} layer budget to ${new_limit_usd}"),
+        ),
+        TighteningEffect::RaiseQualityGateThreshold { new_threshold } => (
+            "raise_quality_gate_threshold",
+            format!("raise quality gate to {new_threshold}"),
+        ),
+        TighteningEffect::AddQuarantine { scope, entity } => {
+            ("add_quarantine", format!("quarantine {entity} ({scope:?})"))
+        }
+        TighteningEffect::DenyTool { tool } => ("deny_tool", format!("deny tool {tool}")),
+        TighteningEffect::DenyEgress { host } => ("deny_egress", format!("deny egress to {host}")),
+        TighteningEffect::LowerRateLimit {
+            new_requests_per_second,
+        } => (
+            "lower_rate_limit",
+            format!("lower rate limit to {new_requests_per_second}/s"),
+        ),
+    };
+    ArpProposalSnapshot {
+        id: p.id,
+        origin: format!("{:?}", p.origin).to_lowercase(),
+        state: format!("{:?}", p.state).to_lowercase(),
+        effect_kind: effect_kind.to_string(),
+        effect_summary,
+        rationale: p.rationale,
+        blast_radius: blast_radius_label(p.blast_radius).to_string(),
+        evidence: p
+            .evidence
+            .into_iter()
+            .map(|t| ArpTraceRef {
+                trace_id: t.trace_id,
+                episode_ids: t.episode_ids,
+            })
+            .collect(),
+        created_at: p.created_at,
+        applied_at: p.applied_at,
+        reviewed_by: p.reviewed_by,
+        disposition_reason: p.disposition_reason,
+    }
+}
+
+fn blast_radius_label(r: arkavo_arp::proposal::BlastRadius) -> &'static str {
+    use arkavo_arp::proposal::BlastRadius;
+    match r {
+        BlastRadius::SingleEntity => "single_entity",
+        BlastRadius::SingleAgent => "single_agent",
+        BlastRadius::Flight => "flight",
+        BlastRadius::Mesh => "mesh",
     }
 }
 
@@ -866,5 +977,139 @@ mod tests {
         assert_eq!(entry.layer, "execution");
         assert_eq!(entry.chosen_entity.as_deref(), Some("filesystem_tools"));
         assert_eq!(entry.success, Some(true));
+    }
+}
+
+#[cfg(test)]
+mod proposal_tests {
+    // #[tokio::test] expands to Runtime::block_on; harmless in tests.
+    #![allow(clippy::disallowed_methods)]
+
+    use super::*;
+    use arkavo_arp::proposal::{
+        BlastRadius, ProposalOrigin, ProposalState, TighteningEffect, TighteningProposal, TraceRef,
+    };
+
+    const DOC_WITH_POLICY: &str = r#"{
+        "arp_spec": "0.1.0",
+        "adl_ref": {"uri": "https://example.com/adl.json"},
+        "adaptation": {"method": "thompson_sampling"},
+        "feedback_loops": {
+            "immediate": {
+                "quality_gate": {
+                    "threshold_default": 0.7,
+                    "metric": "cosine_similarity",
+                    "on_failure": "update_prior_and_log"
+                }
+            },
+            "short_term": {
+                "policy_cache": {
+                    "default_ttl_sec": 3600,
+                    "decay_strategy": "linear"
+                }
+            }
+        },
+        "budget": {
+            "task_ceiling_usd": 2.5,
+            "on_exhaustion": "halt_and_report",
+            "velocity": {"max_spend_per_minute_usd": 0.5}
+        },
+        "proposal_policy": {
+            "accepted_origins": ["consolidation", "human"],
+            "auto_apply_max_blast_radius": "single_entity",
+            "observation_window_sec": 600
+        }
+    }"#;
+
+    fn proposal(id: &str, radius: BlastRadius) -> TighteningProposal {
+        TighteningProposal {
+            id: id.into(),
+            origin: ProposalOrigin::Consolidation,
+            state: ProposalState::Proposed,
+            effect: TighteningEffect::DenyTool {
+                tool: "game-rl:reset".into(),
+            },
+            rationale: "reset correlated with colony loss".into(),
+            blast_radius: radius,
+            evidence: vec![TraceRef {
+                trace_id: "t-1".into(),
+                episode_ids: vec!["ep-1".into()],
+            }],
+            created_at: "2026-06-10T00:00:00Z".into(),
+            applied_at: None,
+            reviewed_by: None,
+            disposition_reason: None,
+        }
+    }
+
+    async fn ingest_into(handler: &ArpHandler, agent_id: &str, p: TighteningProposal) {
+        let runtime = {
+            let guard = handler.agents.read().await;
+            guard.get(agent_id).and_then(|e| e.runtime.clone()).unwrap()
+        };
+        let queue = runtime.proposal_queue();
+        queue.lock().await.ingest(p, 1_000);
+    }
+
+    #[tokio::test]
+    async fn proposals_surface_in_snapshot_as_inbox_cards() {
+        let handler = ArpHandler::new();
+        handler.set_agent_arp("rover-alpha", DOC_WITH_POLICY).await;
+        ingest_into(
+            &handler,
+            "rover-alpha",
+            proposal("p1", BlastRadius::SingleEntity),
+        )
+        .await;
+
+        let snapshot = handler.snapshot().await;
+        let agent = snapshot
+            .agents
+            .iter()
+            .find(|a| a.agent_id == "rover-alpha")
+            .unwrap();
+        assert_eq!(agent.proposals.len(), 1);
+        let card = &agent.proposals[0];
+        assert_eq!(card.effect_kind, "deny_tool");
+        // Within the auto-apply radius: applied and observing.
+        assert_eq!(card.state, "observed");
+        assert_eq!(card.evidence[0].episode_ids, vec!["ep-1".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn review_proposal_approves_held_proposal() {
+        let handler = ArpHandler::new();
+        handler.set_agent_arp("rover-alpha", DOC_WITH_POLICY).await;
+        // single_agent radius exceeds the single_entity auto-apply ceiling.
+        ingest_into(
+            &handler,
+            "rover-alpha",
+            proposal("p2", BlastRadius::SingleAgent),
+        )
+        .await;
+
+        let state = handler
+            .review_proposal("rover-alpha", "p2", true, "operator")
+            .await
+            .unwrap();
+        assert_eq!(state, "observed");
+
+        let snapshot = handler.snapshot().await;
+        let agent = snapshot
+            .agents
+            .iter()
+            .find(|a| a.agent_id == "rover-alpha")
+            .unwrap();
+        assert_eq!(agent.proposals[0].reviewed_by.as_deref(), Some("operator"));
+    }
+
+    #[tokio::test]
+    async fn review_proposal_errors_for_unknown_agent() {
+        let handler = ArpHandler::new();
+        let err = handler
+            .review_proposal("ghost", "p1", true, "operator")
+            .await
+            .unwrap_err();
+        assert!(err.contains("no ARP runtime"));
     }
 }

--- a/crates/arkavo-agui/src/arp_handler.rs
+++ b/crates/arkavo-agui/src/arp_handler.rs
@@ -530,6 +530,7 @@ fn trace_event_label(event: TraceEventType) -> &'static str {
         TraceEventType::BudgetEvent => "budget_event",
         TraceEventType::Quarantine => "quarantine",
         TraceEventType::HitlAction => "hitl_action",
+        TraceEventType::ProposalLifecycle => "proposal_lifecycle",
     }
 }
 

--- a/crates/arkavo-agui/src/arp_handler.rs
+++ b/crates/arkavo-agui/src/arp_handler.rs
@@ -989,6 +989,7 @@ mod proposal_tests {
     use arkavo_arp::proposal::{
         BlastRadius, ProposalOrigin, ProposalState, TighteningEffect, TighteningProposal, TraceRef,
     };
+    use arkavo_test_macros::spec;
 
     const DOC_WITH_POLICY: &str = r#"{
         "arp_spec": "0.1.0",
@@ -1051,6 +1052,7 @@ mod proposal_tests {
         queue.lock().await.ingest(p, 1_000);
     }
 
+    #[spec("AGUI-013")]
     #[tokio::test]
     async fn proposals_surface_in_snapshot_as_inbox_cards() {
         let handler = ArpHandler::new();
@@ -1076,6 +1078,7 @@ mod proposal_tests {
         assert_eq!(card.evidence[0].episode_ids, vec!["ep-1".to_string()]);
     }
 
+    #[spec("AGUI-014")]
     #[tokio::test]
     async fn review_proposal_approves_held_proposal() {
         let handler = ArpHandler::new();

--- a/crates/arkavo-agui/src/gateway.rs
+++ b/crates/arkavo-agui/src/gateway.rs
@@ -431,6 +431,13 @@ impl AgUiGateway {
             HealthRegistry::global().register(reporter).await;
         }
 
+        // Per-agent A2A ARP polling: mesh agents report their own effective
+        // documents instead of everything keying off the synthetic "(local)".
+        crate::gateway_monitors::spawn_arp_poller(
+            state.agent_connections.clone(),
+            state.arp_handler.clone(),
+        );
+
         // Sync agent-internal HRM tasks into the UI dashboard
         crate::gateway_task_sync::spawn_agent_task_sync(
             state.connections.clone(),

--- a/crates/arkavo-agui/src/gateway_monitors.rs
+++ b/crates/arkavo-agui/src/gateway_monitors.rs
@@ -1,8 +1,71 @@
+use crate::agent_connection::AgentConnection;
+use crate::arp_handler::ArpHandler;
 use crate::gateway::ConnectionInfo;
 use crate::types::*;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+
+/// Poll interval for per-agent ARP documents. ARPs change on proposal
+/// application or operator edits — far slower than task state.
+const ARP_POLL_INTERVAL_SECS: u64 = 30;
+
+/// Apply one agent's `arp/get` response to the ARP handler. Returns true
+/// when a document was installed. Extracted from the poll loop for
+/// testability.
+pub(crate) async fn apply_arp_response(
+    arp_handler: &ArpHandler,
+    agent_id: &str,
+    response: &serde_json::Value,
+) -> bool {
+    match response.get("document") {
+        Some(doc) if !doc.is_null() => {
+            arp_handler.set_agent_arp(agent_id, &doc.to_string()).await;
+            true
+        }
+        _ => false,
+    }
+}
+
+/// Per-agent A2A ARP polling: every interval, ask each connected agent for
+/// its effective ARP document and install it under that agent's id. This is
+/// what retires the synthetic `(local)` placeholder as the only key — the
+/// gateway's own document keeps that id; mesh agents report their own.
+pub fn spawn_arp_poller(
+    agent_connections: Arc<RwLock<HashMap<String, Arc<AgentConnection>>>>,
+    arp_handler: Arc<ArpHandler>,
+) {
+    tokio::spawn(async move {
+        let mut interval =
+            tokio::time::interval(tokio::time::Duration::from_secs(ARP_POLL_INTERVAL_SECS));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            interval.tick().await;
+            let conns: Vec<(String, Arc<AgentConnection>)> = {
+                let guard = agent_connections.read().await;
+                guard
+                    .iter()
+                    .map(|(id, conn)| (id.clone(), conn.clone()))
+                    .collect()
+            };
+            for (agent_id, conn) in conns {
+                match conn
+                    .send_request("arp/get", serde_json::json!({}), "arp-poll")
+                    .await
+                {
+                    Ok(response) => {
+                        apply_arp_response(&arp_handler, &agent_id, &response).await;
+                    }
+                    Err(e) => {
+                        // Older agents don't expose arp/get; absence is not
+                        // an error worth surfacing per poll.
+                        tracing::debug!(agent_id = %agent_id, error = %e, "arp/get poll failed");
+                    }
+                }
+            }
+        }
+    });
+}
 
 pub fn spawn_status_broadcaster(connections: Arc<RwLock<HashMap<String, ConnectionInfo>>>) {
     tokio::spawn(async move {
@@ -144,4 +207,62 @@ pub fn spawn_agent_monitor(
             previous = current;
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    // #[tokio::test] expands to Runtime::block_on; harmless in tests.
+    #![allow(clippy::disallowed_methods)]
+
+    use super::*;
+
+    const MIN_DOC: &str = r#"{
+        "arp_spec": "0.1.0",
+        "adl_ref": {"uri": "https://example.com/adl.json"},
+        "adaptation": {"method": "thompson_sampling"},
+        "feedback_loops": {
+            "immediate": {
+                "quality_gate": {
+                    "threshold_default": 0.7,
+                    "metric": "cosine_similarity",
+                    "on_failure": "update_prior_and_log"
+                }
+            },
+            "short_term": {
+                "policy_cache": {
+                    "default_ttl_sec": 3600,
+                    "decay_strategy": "linear"
+                }
+            }
+        },
+        "budget": {
+            "task_ceiling_usd": 2.5,
+            "on_exhaustion": "halt_and_report",
+            "velocity": {"max_spend_per_minute_usd": 0.5}
+        }
+    }"#;
+
+    #[tokio::test]
+    async fn apply_arp_response_installs_document_under_agent_id() {
+        let handler = ArpHandler::new();
+        let doc: serde_json::Value = serde_json::from_str(MIN_DOC).unwrap();
+        let response = serde_json::json!({ "document": doc });
+
+        assert!(apply_arp_response(&handler, "rover-alpha", &response).await);
+        let snapshot = handler.snapshot().await;
+        let agent = snapshot
+            .agents
+            .iter()
+            .find(|a| a.agent_id == "rover-alpha")
+            .expect("polled agent appears in the mesh snapshot");
+        assert!(agent.document.is_some());
+    }
+
+    #[tokio::test]
+    async fn apply_arp_response_ignores_null_or_missing_document() {
+        let handler = ArpHandler::new();
+        assert!(!apply_arp_response(&handler, "a", &serde_json::json!({ "document": null })).await);
+        assert!(!apply_arp_response(&handler, "a", &serde_json::json!({})).await);
+        assert!(handler.snapshot().await.agents.is_empty());
+    }
 }

--- a/crates/arkavo-agui/src/gateway_ws.rs
+++ b/crates/arkavo-agui/src/gateway_ws.rs
@@ -425,6 +425,40 @@ async fn dispatch_event(
         AgUiEvent::FlightStopped { .. } => {
             // Server-emitted event; ignore if it ever round-trips back.
         }
+        AgUiEvent::RequestArpProposalAction {
+            agent_id,
+            proposal_id,
+            action,
+        } => {
+            let approve = action == "approve";
+            let error = if approve || action == "reject" {
+                arp_handler
+                    .review_proposal(&agent_id, &proposal_id, approve, "agui-operator")
+                    .await
+                    .err()
+            } else {
+                Some(format!("unknown action {action:?}"))
+            };
+            tx.send(AgUiEvent::ArpProposalActionResult {
+                agent_id,
+                proposal_id,
+                error,
+            })
+            .await?;
+
+            // Push a fresh snapshot so the card re-renders in its new
+            // state on the same cycle instead of the next 5s poll.
+            let mut snapshot = arp_handler.snapshot().await;
+            snapshot.swarmkit_launch_errors = swarm_flights.launch_errors_snapshot().await;
+            tx.send(AgUiEvent::ArpStatusUpdate {
+                snapshot,
+                event_id: uuid::Uuid::new_v4().to_string(),
+            })
+            .await?;
+        }
+        AgUiEvent::ArpProposalActionResult { .. } => {
+            // Server-emitted event; ignore if it ever round-trips back.
+        }
         AgUiEvent::RequestLearningStatus => {
             let lesson_count = lesson_store.read().await.len();
             gateway_routing::handle_request_learning_status(

--- a/crates/arkavo-agui/src/types.rs
+++ b/crates/arkavo-agui/src/types.rs
@@ -547,6 +547,24 @@ pub enum AgUiEvent {
         #[serde(rename = "eventId")]
         event_id: String,
     },
+    /// Findings-inbox HITL decision on a tightening proposal.
+    RequestArpProposalAction {
+        #[serde(rename = "agentId")]
+        agent_id: String,
+        #[serde(rename = "proposalId")]
+        proposal_id: String,
+        /// "approve" or "reject".
+        action: String,
+    },
+    ArpProposalActionResult {
+        #[serde(rename = "agentId")]
+        agent_id: String,
+        #[serde(rename = "proposalId")]
+        proposal_id: String,
+        /// `None` on success; the rejection reason otherwise.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
 
     // MCP-T Published Trust panel — read-only view of what the agent
     // publishes externally via `trust/query` and `trust/history`.
@@ -1212,6 +1230,9 @@ pub struct AgentArpStatus {
     /// Adaptation engine state (None if engine not instantiated).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub adaptation: Option<ArpAdaptationSnapshot>,
+    /// Tightening proposals (findings inbox).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub proposals: Vec<ArpProposalSnapshot>,
     /// Most recent decision-trace entries from arkavo-observability.
     #[serde(
         rename = "decisionTraces",
@@ -1358,6 +1379,53 @@ pub struct ArpAdaptationEntity {
     pub observations: u32,
     #[serde(rename = "inWarmup")]
     pub in_warmup: bool,
+    /// Live component of the effective prior (prior provenance).
+    #[serde(rename = "liveAlpha")]
+    pub live_alpha: f64,
+    #[serde(rename = "liveBeta")]
+    pub live_beta: f64,
+    /// Distilled (teacher-provided) mass; absent when none was seeded.
+    #[serde(rename = "distilledAlpha", skip_serializing_if = "Option::is_none")]
+    pub distilled_alpha: Option<f64>,
+    #[serde(rename = "distilledBeta", skip_serializing_if = "Option::is_none")]
+    pub distilled_beta: Option<f64>,
+    /// Current displacement weight applied to distilled mass.
+    #[serde(rename = "distilledWeight", skip_serializing_if = "Option::is_none")]
+    pub distilled_weight: Option<f64>,
+}
+
+/// One tightening proposal rendered as a findings-inbox card.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArpProposalSnapshot {
+    pub id: String,
+    pub origin: String,
+    pub state: String,
+    #[serde(rename = "effectKind")]
+    pub effect_kind: String,
+    #[serde(rename = "effectSummary")]
+    pub effect_summary: String,
+    pub rationale: String,
+    #[serde(rename = "blastRadius")]
+    pub blast_radius: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence: Vec<ArpTraceRef>,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "appliedAt", skip_serializing_if = "Option::is_none")]
+    pub applied_at: Option<String>,
+    #[serde(rename = "reviewedBy", skip_serializing_if = "Option::is_none")]
+    pub reviewed_by: Option<String>,
+    #[serde(rename = "dispositionReason", skip_serializing_if = "Option::is_none")]
+    pub disposition_reason: Option<String>,
+}
+
+/// Evidence back-link on a proposal card.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArpTraceRef {
+    #[serde(rename = "traceId")]
+    pub trace_id: String,
+    #[serde(rename = "episodeIds", default, skip_serializing_if = "Vec::is_empty")]
+    pub episode_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/arkavo-agui/static/js/app.js
+++ b/crates/arkavo-agui/static/js/app.js
@@ -95,6 +95,12 @@ function routeEvent(event) {
         case 'arpStatusUpdate':
             handleArpStatusUpdate(event);
             break;
+        case 'arpProposalActionResult':
+            if (event.error) {
+                console.warn('ARP proposal action failed:', event.proposalId, event.error);
+            }
+            // State change arrives via the paired arpStatusUpdate.
+            break;
         case 'publishedTrustUpdate':
             handlePublishedTrustUpdate(event);
             break;

--- a/crates/arkavo-agui/static/js/panels/arp.js
+++ b/crates/arkavo-agui/static/js/panels/arp.js
@@ -89,6 +89,7 @@ function renderArp() {
     }
 
     html += renderArpDocumentSection(selected);
+    html += renderArpProposalsSection(selected);
     html += renderArpViolationsSection(selected.decisionTraces);
     html += renderArpPolicyCacheSection(selected.policyCache);
     html += renderArpAdaptationSection(selected.adaptation);
@@ -114,6 +115,28 @@ function renderArp() {
             if (!id) return;
             AppState.arpSelectedAgent = id;
             renderArp();
+        });
+    });
+
+    // Findings-inbox approve/reject buttons. The gateway applies the
+    // decision through the proposal queue and answers with a fresh
+    // ArpStatusUpdate, so the card re-renders in its new state.
+    var proposalBtns = document.querySelectorAll('.arp-proposal-action');
+    Array.prototype.forEach.call(proposalBtns, function(btn) {
+        btn.addEventListener('click', function(e) {
+            e.stopPropagation();
+            var pid = btn.getAttribute('data-proposal-id');
+            var agentId = btn.getAttribute('data-agent-id');
+            var action = btn.getAttribute('data-action');
+            if (!pid || !agentId || !action) return;
+            btn.disabled = true;
+            btn.textContent = action === 'approve' ? 'Approving…' : 'Rejecting…';
+            wsSend({
+                type: 'requestArpProposalAction',
+                agentId: agentId,
+                proposalId: pid,
+                action: action
+            });
         });
     });
 
@@ -342,6 +365,65 @@ function renderArpDocumentSection(snap) {
     return html;
 }
 
+var PROPOSAL_STATE_CLASS = {
+    proposed: 'status-warn',
+    reviewed: 'status-warn',
+    applied: 'status-ok',
+    observed: 'status-ok',
+    confirmed: 'status-ok',
+    reverted: 'status-warn',
+    rejected: 'status-warn'
+};
+
+function renderArpProposalsSection(snap) {
+    var proposals = snap.proposals || [];
+    var pending = proposals.filter(function(p) { return p.state === 'proposed'; }).length;
+    var html = '<div class="section-title">Findings Inbox' +
+        (pending > 0 ? ' <span class="status-warn">(' + pending + ' awaiting review)</span>' : '') +
+        '</div>';
+    if (proposals.length === 0) {
+        html += '<div class="empty-state"><p>No tightening proposals. ' +
+            'Audit-plane findings (consolidation teacher, critic, historian) land here for review.</p></div>';
+        return html;
+    }
+
+    html += '<div class="arp-proposal-cards">';
+    proposals.slice().reverse().forEach(function(p) {
+        var stateClass = PROPOSAL_STATE_CLASS[p.state] || '';
+        html += '<div class="cost-table arp-proposal-card"><table><tbody>';
+        html += '<tr><td>Effect</td><td><code>' + escapeHtml(p.effectKind || '') + '</code> ' +
+            escapeHtml(p.effectSummary || '') + '</td></tr>';
+        html += '<tr><td>Rationale</td><td>' + escapeHtml(p.rationale || '') + '</td></tr>';
+        html += '<tr><td>State</td><td><span class="' + stateClass + '">' + escapeHtml(p.state) + '</span>' +
+            (p.dispositionReason ? ' — ' + escapeHtml(p.dispositionReason) : '') + '</td></tr>';
+        html += '<tr><td>Origin / Radius</td><td><code>' + escapeHtml(p.origin) + '</code> / <code>' +
+            escapeHtml(p.blastRadius) + '</code></td></tr>';
+        var ev = (p.evidence || []).map(function(t) {
+            var eps = (t.episodeIds && t.episodeIds.length) ? ' (' + t.episodeIds.length + ' episodes)' : '';
+            return '<code>' + escapeHtml(t.traceId) + '</code>' + eps;
+        }).join(', ');
+        html += '<tr><td>Evidence</td><td>' + (ev || '--') + '</td></tr>';
+        if (p.state === 'proposed') {
+            html += '<tr><td>Review</td><td>' +
+                '<button type="button" class="arp-proposal-action"' +
+                ' data-action="approve" data-proposal-id="' + escapeHtml(p.id) + '"' +
+                ' data-agent-id="' + escapeHtml(snap.agentId) + '">Approve</button> ' +
+                '<button type="button" class="arp-proposal-action"' +
+                ' data-action="reject" data-proposal-id="' + escapeHtml(p.id) + '"' +
+                ' data-agent-id="' + escapeHtml(snap.agentId) + '">Reject</button>' +
+                '</td></tr>';
+        } else if (p.state === 'observed') {
+            html += '<tr><td>Review</td><td><span class="status-ok">auto-applied</span> — ' +
+                'in observation window; reverts automatically on quality-gate regression</td></tr>';
+        } else if (p.reviewedBy) {
+            html += '<tr><td>Reviewed by</td><td>' + escapeHtml(p.reviewedBy) + '</td></tr>';
+        }
+        html += '</tbody></table></div>';
+    });
+    html += '</div>';
+    return html;
+}
+
 function renderArpViolationsSection(traces) {
     var violations = (traces || []).filter(isViolation);
     var html = '<div class="section-title">Violations <span class="status-warn">(' + violations.length + ')</span></div>';
@@ -410,15 +492,19 @@ function renderArpAdaptationSection(adaptation) {
     html += '</tbody></table></div>';
 
     if (adaptation.entities && adaptation.entities.length) {
-        html += '<table class="cost-table"><thead><tr><th>Entity</th><th>alpha</th><th>beta</th><th>Mean</th><th>Obs</th><th>Warmup</th></tr></thead><tbody>';
+        html += '<table class="cost-table"><thead><tr>' +
+            '<th>Entity</th><th>Beta(α, β)</th><th>Distribution</th><th>Mean</th>' +
+            '<th>Evidence</th><th>Obs</th><th>Health</th>' +
+            '</tr></thead><tbody>';
         adaptation.entities.forEach(function(e) {
             html += '<tr>' +
                 '<td><code>' + escapeHtml(e.id) + '</code></td>' +
-                '<td>' + e.alpha.toFixed(2) + '</td>' +
-                '<td>' + e.beta.toFixed(2) + '</td>' +
+                '<td>' + e.alpha.toFixed(2) + ' / ' + e.beta.toFixed(2) + '</td>' +
+                '<td>' + betaCurveSvg(e.alpha, e.beta) + '</td>' +
                 '<td>' + e.mean.toFixed(3) + '</td>' +
+                '<td>' + evidenceSplitCell(e) + '</td>' +
                 '<td>' + e.observations + '</td>' +
-                '<td>' + (e.inWarmup ? 'yes' : 'no') + '</td>' +
+                '<td>' + banditHealthCell(e) + '</td>' +
                 '</tr>';
         });
         html += '</tbody></table>';
@@ -452,4 +538,59 @@ function renderArpTracesSection(traces) {
     });
     html += '</tbody></table>';
     return html;
+}
+
+// Unnormalized Beta(a,b) density rendered as an inline SVG sparkline.
+// Normalization is irrelevant for shape comparison, so the gamma function
+// is unnecessary: scale the peak to the viewbox height instead.
+function betaCurveSvg(alpha, beta) {
+    var W = 90, H = 24, N = 40;
+    var pts = [];
+    var maxY = 0;
+    for (var i = 0; i <= N; i++) {
+        var x = (i + 0.5) / (N + 1);
+        var y = Math.pow(x, alpha - 1) * Math.pow(1 - x, beta - 1);
+        if (!isFinite(y)) y = 0;
+        pts.push(y);
+        if (y > maxY) maxY = y;
+    }
+    if (maxY <= 0) maxY = 1;
+    var path = '';
+    for (var j = 0; j <= N; j++) {
+        var px = (j / N) * W;
+        var py = H - 2 - (pts[j] / maxY) * (H - 4);
+        path += (j === 0 ? 'M' : 'L') + px.toFixed(1) + ',' + py.toFixed(1);
+    }
+    return '<svg class="arp-beta-curve" width="' + W + '" height="' + H + '"' +
+        ' viewBox="0 0 ' + W + ' ' + H + '" aria-label="Beta(' +
+        alpha.toFixed(2) + ', ' + beta.toFixed(2) + ')">' +
+        '<path d="' + path + '" fill="none" stroke="currentColor" stroke-width="1.5"/>' +
+        '</svg>';
+}
+
+// Live vs distilled evidence split (prior provenance). Entities without
+// distilled mass — or gateways predating provenance — render as all-live.
+function evidenceSplitCell(e) {
+    if (e.distilledAlpha == null) {
+        return '<span title="all evidence is live">live</span>';
+    }
+    var w = e.distilledWeight != null ? e.distilledWeight : 1.0;
+    return 'live ' + e.liveAlpha.toFixed(1) + '/' + e.liveBeta.toFixed(1) +
+        ' · <span title="distilled mass × current displacement weight">distilled ' +
+        e.distilledAlpha.toFixed(1) + '/' + e.distilledBeta.toFixed(1) +
+        ' @ ' + (w * 100).toFixed(0) + '%</span>';
+}
+
+// High-variance arms are curiosity targets: the posterior is too wide to
+// trust, so the engine (and the operator) should want more samples there.
+function banditHealthCell(e) {
+    if (e.inWarmup) return '<span class="status-warn">warmup</span>';
+    var a = e.alpha, b = e.beta;
+    var variance = (a * b) / ((a + b) * (a + b) * (a + b + 1));
+    var sd = Math.sqrt(variance);
+    if (sd > 0.15) {
+        return '<span class="status-warn" title="posterior sd ' + sd.toFixed(3) +
+            ' — wide credible interval">curiosity target</span>';
+    }
+    return '<span class="status-ok" title="posterior sd ' + sd.toFixed(3) + '">converged</span>';
 }

--- a/crates/arkavo-arp-runtime/Cargo.toml
+++ b/crates/arkavo-arp-runtime/Cargo.toml
@@ -13,6 +13,7 @@ arkavo-arp = { path = "../arkavo-arp" }
 arkavo-policy-cache = { path = "../arkavo-policy-cache" }
 arkavo-adaptation = { path = "../arkavo-adaptation" }
 arkavo-observability = { path = "../arkavo-observability" }
+chrono = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }

--- a/crates/arkavo-arp-runtime/Cargo.toml
+++ b/crates/arkavo-arp-runtime/Cargo.toml
@@ -20,4 +20,5 @@ tokio = { workspace = true, features = ["sync"] }
 uuid = { workspace = true }
 
 [dev-dependencies]
+arkavo-test-macros = { path = "../arkavo-test-macros" }
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/arkavo-arp-runtime/src/lib.rs
+++ b/crates/arkavo-arp-runtime/src/lib.rs
@@ -17,6 +17,8 @@
 //! tool-loop call site. The CLI installs an instance once at startup; the
 //! standalone AG-UI gateway constructs its own when no agent is running.
 
+pub mod proposal_queue;
+
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 
@@ -28,6 +30,7 @@ use arkavo_arp::observability::{
 };
 use arkavo_observability::decision_trace::DecisionTrace;
 use arkavo_policy_cache::{PolicyCache, PolicySource};
+pub use proposal_queue::ProposalQueue;
 use serde_json::json;
 use tokio::sync::Mutex;
 
@@ -79,6 +82,10 @@ pub struct ArpRuntime {
     adaptation: Arc<Mutex<AdaptationEngine>>,
     decision_trace: Arc<DecisionTrace>,
     quality_threshold: f64,
+    /// Tightening-proposal queue. Owns the canonical post-apply document;
+    /// an applied RaiseQualityGateThreshold takes effect on the next
+    /// outcome recorded through this runtime.
+    proposals: Arc<Mutex<ProposalQueue>>,
     /// Monotonic counter so each cache key is unique. Required because the
     /// PolicyCache hash chain doesn't tolerate same-key overwrites.
     outcome_seq: AtomicU64,
@@ -106,14 +113,25 @@ impl ArpRuntime {
                 cryptographic_signing: None,
             });
         let decision_trace = Arc::new(DecisionTrace::new(trace_cfg));
+        let proposals = Arc::new(Mutex::new(ProposalQueue::new(
+            doc.clone(),
+            decision_trace.clone(),
+            DEFAULT_AGENT_ID.to_string(),
+        )));
 
         Self {
             cache,
             adaptation,
             decision_trace,
             quality_threshold,
+            proposals,
             outcome_seq: AtomicU64::new(0),
         }
+    }
+
+    /// The tightening-proposal queue for this runtime.
+    pub fn proposal_queue(&self) -> Arc<Mutex<ProposalQueue>> {
+        self.proposals.clone()
     }
 
     pub fn cache(&self) -> Arc<PolicyCache> {
@@ -157,7 +175,21 @@ impl ArpRuntime {
         ctx: &ToolOutcomeContext,
     ) {
         let q = quality.clamp(0.0, 1.0);
-        let above_gate = q >= self.quality_threshold;
+        // The proposal queue owns the post-apply document: an applied
+        // RaiseQualityGateThreshold takes effect here. The queue also tallies
+        // gate outcomes to evaluate observation windows.
+        let above_gate = {
+            let mut queue = self.proposals.lock().await;
+            let threshold = queue
+                .document()
+                .feedback_loops
+                .immediate
+                .quality_gate
+                .threshold_default;
+            let above = q >= threshold;
+            queue.record_quality_gate(above);
+            above
+        };
         let effective_success = success && above_gate;
 
         // Update the prior, capturing before/after for the trace entry.
@@ -250,8 +282,47 @@ pub fn current() -> Option<Arc<ArpRuntime>> {
     GLOBAL.get().cloned()
 }
 
+// Test helpers — short string forms of the trace enums for assertion-readability.
+#[cfg(test)]
+trait EnumStringRepr {
+    fn to_string_repr(&self) -> &'static str;
+}
+
+#[cfg(test)]
+impl EnumStringRepr for TraceLayer {
+    fn to_string_repr(&self) -> &'static str {
+        match self {
+            TraceLayer::Cognitive => "cognitive",
+            TraceLayer::Execution => "execution",
+            TraceLayer::DataSovereignty => "data_sovereignty",
+            TraceLayer::Network => "network",
+        }
+    }
+}
+
+#[cfg(test)]
+impl EnumStringRepr for TraceEventType {
+    fn to_string_repr(&self) -> &'static str {
+        match self {
+            TraceEventType::RoutingDecision => "routing_decision",
+            TraceEventType::QualityGate => "quality_gate",
+            TraceEventType::ToolInvocation => "tool_invocation",
+            TraceEventType::DataAccess => "data_access",
+            TraceEventType::Delegation => "delegation",
+            TraceEventType::Escalation => "escalation",
+            TraceEventType::BudgetEvent => "budget_event",
+            TraceEventType::Quarantine => "quarantine",
+            TraceEventType::HitlAction => "hitl_action",
+            TraceEventType::ProposalLifecycle => "proposal_lifecycle",
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    // #[tokio::test] expands to Runtime::block_on; harmless in tests.
+    #![allow(clippy::disallowed_methods)]
+
     use super::*;
 
     const MIN_DOC: &str = r#"{
@@ -389,6 +460,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn applied_threshold_raise_bites_on_next_outcome() {
+        // An auto-applied RaiseQualityGateThreshold must take effect on the
+        // very next recorded outcome — the queue owns the live document.
+        use arkavo_arp::proposal::{
+            BlastRadius, ProposalOrigin, ProposalState, TighteningEffect, TighteningProposal,
+            TraceRef,
+        };
+        let mut doc = arkavo_arp::parse(MIN_DOC).unwrap();
+        doc.proposal_policy = Some(arkavo_arp::proposal::ProposalPolicy {
+            accepted_origins: vec![ProposalOrigin::Consolidation],
+            auto_apply_max_blast_radius: BlastRadius::SingleEntity,
+            review: None,
+            observation_window_sec: Some(600),
+        });
+        let rt = ArpRuntime::from_document(&doc);
+
+        // Quality 0.75 passes the original 0.7 gate.
+        rt.record_tool_outcome("tool_x", true, 0.75).await;
+        let entries = rt.decision_trace().snapshot();
+        assert_eq!(entries.last().unwrap().outcome.success, Some(true));
+
+        let state = rt.proposal_queue().lock().await.ingest(
+            TighteningProposal {
+                id: "raise-gate".into(),
+                origin: ProposalOrigin::Consolidation,
+                state: ProposalState::Proposed,
+                effect: TighteningEffect::RaiseQualityGateThreshold { new_threshold: 0.8 },
+                rationale: "0.7 admitted low-quality outcomes".into(),
+                blast_radius: BlastRadius::SingleEntity,
+                evidence: vec![TraceRef {
+                    trace_id: "t-1".into(),
+                    episode_ids: vec![],
+                }],
+                created_at: "2026-06-10T00:00:00Z".into(),
+                applied_at: None,
+                reviewed_by: None,
+                disposition_reason: None,
+            },
+            1_000,
+        );
+        assert_eq!(state, ProposalState::Observed);
+
+        // The same 0.75 quality now fails the raised 0.8 gate.
+        rt.record_tool_outcome("tool_x", true, 0.75).await;
+        let entries = rt.decision_trace().snapshot();
+        let last = entries
+            .iter()
+            .rfind(|e| e.decision.chosen.as_deref() == Some("tool_x"))
+            .unwrap();
+        assert_eq!(last.outcome.success, Some(false));
+        assert_eq!(
+            last.outcome.error_type.as_deref(),
+            Some("below_quality_gate")
+        );
+    }
+
+    #[tokio::test]
     async fn explicit_error_type_overrides_default() {
         let rt = make_runtime();
         let ctx = ToolOutcomeContext::new().with_error_type("connection_refused");
@@ -400,40 +528,5 @@ mod tests {
             entries[0].outcome.error_type.as_deref(),
             Some("connection_refused")
         );
-    }
-}
-
-// Test helpers — short string forms of the trace enums for assertion-readability.
-#[cfg(test)]
-trait EnumStringRepr {
-    fn to_string_repr(&self) -> &'static str;
-}
-
-#[cfg(test)]
-impl EnumStringRepr for TraceLayer {
-    fn to_string_repr(&self) -> &'static str {
-        match self {
-            TraceLayer::Cognitive => "cognitive",
-            TraceLayer::Execution => "execution",
-            TraceLayer::DataSovereignty => "data_sovereignty",
-            TraceLayer::Network => "network",
-        }
-    }
-}
-
-#[cfg(test)]
-impl EnumStringRepr for TraceEventType {
-    fn to_string_repr(&self) -> &'static str {
-        match self {
-            TraceEventType::RoutingDecision => "routing_decision",
-            TraceEventType::QualityGate => "quality_gate",
-            TraceEventType::ToolInvocation => "tool_invocation",
-            TraceEventType::DataAccess => "data_access",
-            TraceEventType::Delegation => "delegation",
-            TraceEventType::Escalation => "escalation",
-            TraceEventType::BudgetEvent => "budget_event",
-            TraceEventType::Quarantine => "quarantine",
-            TraceEventType::HitlAction => "hitl_action",
-        }
     }
 }

--- a/crates/arkavo-arp-runtime/src/proposal_queue.rs
+++ b/crates/arkavo-arp-runtime/src/proposal_queue.rs
@@ -124,6 +124,15 @@ impl ProposalQueue {
         if let Err(reason) = self.direction_violation(&proposal.effect) {
             return self.reject(proposal, &reason);
         }
+        // A replayed id is refused without recording: pushing a second entry
+        // under the same id would corrupt every id-keyed lookup, and the id
+        // is already on the books.
+        if self.duplicate_id(&proposal.id) {
+            return ProposalState::Rejected;
+        }
+        if let Err(reason) = self.overlap_violation(&proposal.effect) {
+            return self.reject(proposal, &reason);
+        }
 
         proposal.state = ProposalState::Proposed;
         if proposal.blast_radius <= policy.auto_apply_max_blast_radius {
@@ -143,6 +152,13 @@ impl ProposalQueue {
             return Err("document has no proposal_policy".to_string());
         };
         validate_proposal(proposal, policy).map_err(|e| e.to_string())?;
+        if self.duplicate_id(&proposal.id) {
+            return Err(format!(
+                "proposal id {} already exists in this queue; retry with a fresh id",
+                proposal.id
+            ));
+        }
+        self.overlap_violation(&proposal.effect)?;
         self.direction_violation(&proposal.effect)
     }
 
@@ -239,8 +255,12 @@ impl ProposalQueue {
         proposal.reviewed_by = Some(reviewer.to_string());
         proposal.state = ProposalState::Reviewed;
         if approve {
-            // Re-check direction: current values may have moved since ingest.
-            if let Err(reason) = self.direction_violation(&proposal.effect) {
+            // Re-check direction and overlap: current values and active
+            // observations may have moved since ingest.
+            let recheck = self
+                .direction_violation(&proposal.effect)
+                .and_then(|()| self.overlap_violation(&proposal.effect));
+            if let Err(reason) = recheck {
                 proposal.state = ProposalState::Rejected;
                 proposal.disposition_reason = Some(reason);
             } else {
@@ -318,6 +338,35 @@ impl ProposalQueue {
         proposal.disposition_reason = Some(reason.to_string());
         self.proposals.push(proposal);
         ProposalState::Rejected
+    }
+
+    fn duplicate_id(&self, id: &str) -> bool {
+        self.proposals.iter().any(|p| p.id == id)
+    }
+
+    /// Refuse a scalar proposal while another proposal on the same document
+    /// field is still under observation. A revert restores a point-in-time
+    /// displaced value, so two live observations on one field would let an
+    /// automatic revert of the earlier proposal silently overwrite the later,
+    /// still-active tightening — a machine-initiated loosening. Set-based
+    /// effects revert by removal and are already deduplicated by the
+    /// direction check.
+    fn overlap_violation(&self, effect: &TighteningEffect) -> Result<(), String> {
+        let Some(key) = scalar_field_key(effect) else {
+            return Ok(());
+        };
+        let owner = self.proposals.iter().find(|p| {
+            self.observations.contains_key(&p.id)
+                && scalar_field_key(&p.effect).as_deref() == Some(key.as_str())
+        });
+        match owner {
+            Some(p) => Err(format!(
+                "field {key} is still under observation by proposal {}; \
+                 wait for it to confirm or revert",
+                p.id
+            )),
+            None => Ok(()),
+        }
     }
 
     /// Direction check against *current* values: the typed effect already
@@ -593,6 +642,25 @@ impl ProposalQueue {
             decision,
             outcome,
         );
+    }
+}
+
+/// The document field a scalar effect tightens; `None` for set-based effects.
+fn scalar_field_key(effect: &TighteningEffect) -> Option<String> {
+    match effect {
+        TighteningEffect::LowerTaskCeiling { .. } => Some("budget.task_ceiling_usd".to_string()),
+        TighteningEffect::LowerLayerBudget { layer, .. } => {
+            Some(format!("budget.per_layer.{layer:?}"))
+        }
+        TighteningEffect::RaiseQualityGateThreshold { .. } => {
+            Some("quality_gate.threshold_default".to_string())
+        }
+        TighteningEffect::LowerRateLimit { .. } => {
+            Some("rate_limiting.global.requests_per_second".to_string())
+        }
+        TighteningEffect::AddQuarantine { .. }
+        | TighteningEffect::DenyTool { .. }
+        | TighteningEffect::DenyEgress { .. } => None,
     }
 }
 
@@ -914,6 +982,156 @@ mod tests {
         );
         // Auto-applied — no longer awaiting review.
         assert!(q.review("p1", true, "op", 0).is_err());
+    }
+
+    #[test]
+    fn duplicate_id_is_refused_everywhere_and_does_not_corrupt_state() {
+        let mut q = queue();
+        q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::DenyTool { tool: "a".into() },
+                BlastRadius::SingleEntity,
+            ),
+            1_000,
+        );
+        // A replayed id must be refused outright — a second entry under the
+        // same id would corrupt every id-keyed lookup (state, review, revert)
+        // and overwrite the observation's displaced value.
+        let state = q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::DenyTool { tool: "b".into() },
+                BlastRadius::SingleEntity,
+            ),
+            1_001,
+        );
+        assert_eq!(state, ProposalState::Rejected);
+        assert_eq!(q.proposals().len(), 1);
+        assert!(q.is_tool_denied("a"));
+        assert!(!q.is_tool_denied("b"));
+
+        // The flight precheck and the reviewed path refuse the same id too.
+        let dup = proposal(
+            "p1",
+            TighteningEffect::DenyTool { tool: "c".into() },
+            BlastRadius::SingleEntity,
+        );
+        assert!(q.check(&dup).is_err());
+        assert!(q.ingest_reviewed(dup, "op", 1_002).is_err());
+        assert_eq!(q.proposals().len(), 1);
+    }
+
+    #[test]
+    fn scalar_field_under_observation_refuses_overlapping_proposal() {
+        let mut q = queue();
+        let s1 = q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::LowerTaskCeiling {
+                    new_ceiling_usd: 1.0,
+                },
+                BlastRadius::SingleEntity,
+            ),
+            1_000,
+        );
+        assert_eq!(s1, ProposalState::Observed);
+
+        // p2 tightens further, but the field's displaced value is still owned
+        // by p1's observation — reverting p1 later would write 2.5 over p2's
+        // active 0.5, a machine-initiated loosening. Refuse the overlap.
+        let s2 = q.ingest(
+            proposal(
+                "p2",
+                TighteningEffect::LowerTaskCeiling {
+                    new_ceiling_usd: 0.5,
+                },
+                BlastRadius::SingleEntity,
+            ),
+            1_010,
+        );
+        assert_eq!(s2, ProposalState::Rejected);
+        assert!((q.document().budget.task_ceiling_usd - 1.0).abs() < 1e-9);
+
+        // Reverting p1 restores the pre-p1 value with no later tightening to
+        // clobber — the loosening path is closed.
+        q.force_revert("p1", "operator rollback").unwrap();
+        assert!((q.document().budget.task_ceiling_usd - 2.5).abs() < 1e-9);
+
+        // The field is free again once no observation owns it.
+        let s3 = q.ingest(
+            proposal(
+                "p3",
+                TighteningEffect::LowerTaskCeiling {
+                    new_ceiling_usd: 0.5,
+                },
+                BlastRadius::SingleEntity,
+            ),
+            1_020,
+        );
+        assert_eq!(s3, ProposalState::Observed);
+        assert!((q.document().budget.task_ceiling_usd - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn scalar_field_frees_after_confirmation() {
+        let mut q = queue();
+        q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::LowerTaskCeiling {
+                    new_ceiling_usd: 1.0,
+                },
+                BlastRadius::SingleEntity,
+            ),
+            1_000,
+        );
+        // Window (600s) elapses without regression: p1 confirms and releases
+        // the field.
+        q.evaluate_observations(1_700);
+        assert_eq!(q.proposal_state("p1"), Some(ProposalState::Confirmed));
+        let state = q.ingest(
+            proposal(
+                "p2",
+                TighteningEffect::LowerTaskCeiling {
+                    new_ceiling_usd: 0.5,
+                },
+                BlastRadius::SingleEntity,
+            ),
+            1_710,
+        );
+        assert_eq!(state, ProposalState::Observed);
+    }
+
+    #[test]
+    fn review_approval_rechecks_field_overlap() {
+        let mut q = queue();
+        // Held for review: wider than the auto-apply radius.
+        q.ingest(
+            proposal(
+                "held",
+                TighteningEffect::LowerTaskCeiling {
+                    new_ceiling_usd: 0.8,
+                },
+                BlastRadius::SingleAgent,
+            ),
+            1_000,
+        );
+        // Meanwhile an auto-applied proposal takes the field.
+        q.ingest(
+            proposal(
+                "auto",
+                TighteningEffect::LowerTaskCeiling {
+                    new_ceiling_usd: 1.0,
+                },
+                BlastRadius::SingleEntity,
+            ),
+            1_001,
+        );
+        // Approval must refuse: the field is under observation by "auto".
+        let state = q.review("held", true, "op", 1_010).unwrap();
+        assert_eq!(state, ProposalState::Rejected);
+        assert!((q.document().budget.task_ceiling_usd - 1.0).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/arkavo-arp-runtime/src/proposal_queue.rs
+++ b/crates/arkavo-arp-runtime/src/proposal_queue.rs
@@ -59,6 +59,11 @@ pub struct ProposalQueue {
     doc: ArpDocument,
     proposals: Vec<TighteningProposal>,
     observations: HashMap<String, Observation>,
+    /// Displaced values for proposals that survived their observation window
+    /// and were confirmed. The observation record is gone, but the prior value
+    /// is retained so an out-of-band [`ProposalQueue::force_revert`] — the
+    /// flight-convergence path — can still undo a confirmed tightening.
+    confirmed_displaced: HashMap<String, DisplacedValue>,
     denied_tools: HashSet<String>,
     denied_hosts: HashSet<String>,
     /// `"{scope:?}:{entity}"` keys for applied quarantines.
@@ -78,6 +83,7 @@ impl ProposalQueue {
             doc,
             proposals: Vec::new(),
             observations: HashMap::new(),
+            confirmed_displaced: HashMap::new(),
             denied_tools: HashSet::new(),
             denied_hosts: HashSet::new(),
             quarantined: HashSet::new(),
@@ -117,18 +123,19 @@ impl ProposalQueue {
         let Some(policy) = self.policy.clone() else {
             return self.reject(proposal, "document has no proposal_policy");
         };
+        // A replayed id is refused without recording, and this must come first:
+        // `reject()` records the proposal, so any reject (validation, direction,
+        // overlap) on a known id would push a second entry under that id and
+        // corrupt every id-keyed lookup. The id is already on the books.
+        if self.duplicate_id(&proposal.id) {
+            return ProposalState::Rejected;
+        }
         if let Err(e) = validate_proposal(&proposal, &policy) {
             let reason = e.to_string();
             return self.reject(proposal, &reason);
         }
         if let Err(reason) = self.direction_violation(&proposal.effect) {
             return self.reject(proposal, &reason);
-        }
-        // A replayed id is refused without recording: pushing a second entry
-        // under the same id would corrupt every id-keyed lookup, and the id
-        // is already on the books.
-        if self.duplicate_id(&proposal.id) {
-            return ProposalState::Rejected;
         }
         if let Err(reason) = self.overlap_violation(&proposal.effect) {
             return self.reject(proposal, &reason);
@@ -205,17 +212,25 @@ impl ProposalQueue {
             .position(|p| p.id == proposal_id)
             .ok_or_else(|| format!("unknown proposal {proposal_id}"))?;
         let state = self.proposals[idx].state;
-        if !matches!(state, ProposalState::Applied | ProposalState::Observed) {
+        if !matches!(
+            state,
+            ProposalState::Applied | ProposalState::Observed | ProposalState::Confirmed
+        ) {
             return Err(format!(
-                "proposal {proposal_id} is {state:?}; only applied/observed proposals revert"
+                "proposal {proposal_id} is {state:?}; only applied/observed/confirmed proposals revert"
             ));
         }
-        let obs = self
+        // Applied/observed proposals carry a live observation record; a
+        // confirmed one's record was consumed at confirmation but its displaced
+        // value is retained separately. Either way the prior value is required.
+        let displaced = self
             .observations
             .remove(proposal_id)
-            .ok_or_else(|| format!("proposal {proposal_id} has no observation record"))?;
+            .map(|obs| obs.displaced)
+            .or_else(|| self.confirmed_displaced.remove(proposal_id))
+            .ok_or_else(|| format!("proposal {proposal_id} has no displaced-value record"))?;
         let effect = self.proposals[idx].effect.clone();
-        self.restore(&effect, &obs.displaced);
+        self.restore(&effect, &displaced);
         self.proposals[idx].state = ProposalState::Reverted;
         self.proposals[idx].disposition_reason = Some(reason.to_string());
         self.emit_trace(
@@ -326,6 +341,9 @@ impl ProposalQueue {
                 transitions.push((id, ProposalState::Reverted));
             } else {
                 self.proposals[idx].state = ProposalState::Confirmed;
+                // Retain the displaced value so flight reconcile can still
+                // force-revert this confirmed proposal to converge a flight.
+                self.confirmed_displaced.insert(id.clone(), obs.displaced);
                 self.emit_trace(&self.proposals[idx].clone(), "confirmed", None);
                 transitions.push((id, ProposalState::Confirmed));
             }
@@ -871,6 +889,43 @@ mod tests {
 
     #[spec("ARP-003")]
     #[test]
+    fn force_revert_undoes_a_confirmed_proposal() {
+        // Regression (#609): flight reconcile treats a Confirmed proposal as
+        // present and force-reverts it to converge a divergent flight. The
+        // confirm path drops the observation record, so force_revert must
+        // recover the displaced value from the confirmed store rather than
+        // failing — otherwise a confirmed role stays permanently tightened
+        // while its missing peers do not.
+        let mut q = queue();
+        q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::DenyTool {
+                    tool: "game-rl:reset".into(),
+                },
+                BlastRadius::SingleEntity,
+            ),
+            1_000,
+        );
+        for _ in 0..10 {
+            q.record_quality_gate(true);
+        }
+        let transitions = q.evaluate_observations(1_700);
+        assert_eq!(transitions, vec![("p1".into(), ProposalState::Confirmed)]);
+        assert!(q.is_tool_denied("game-rl:reset"));
+
+        // Confirmed, yet still revertible out of band for flight convergence.
+        q.force_revert("p1", "flight reconcile").unwrap();
+        assert_eq!(q.proposal_state("p1"), Some(ProposalState::Reverted));
+        assert!(!q.is_tool_denied("game-rl:reset"));
+        let p = q.proposals().into_iter().find(|p| p.id == "p1").unwrap();
+        assert!(p.disposition_reason.unwrap().contains("reconcile"));
+        // A second revert is a no-op error: the displaced value is consumed.
+        assert!(q.force_revert("p1", "again").is_err());
+    }
+
+    #[spec("ARP-003")]
+    #[test]
     fn regression_reverts_and_restores_prior_value() {
         let mut q = queue();
         // Establish a clean baseline before the proposal.
@@ -1018,6 +1073,39 @@ mod tests {
         assert_eq!(q.proposals().len(), 1);
         assert!(q.is_tool_denied("a"));
         assert!(!q.is_tool_denied("b"));
+    }
+
+    #[spec("ARP-004")]
+    #[test]
+    fn replayed_id_failing_direction_check_does_not_record_a_duplicate() {
+        // Regression: a replayed id whose effect ALSO fails an earlier check
+        // (here the direction check — re-denying an already-denied tool) must
+        // still be refused without recording a second entry. The duplicate-id
+        // guard has to run before validate/direction, or `reject()` pushes a
+        // phantom entry under the same id and corrupts every id-keyed lookup.
+        let mut q = queue();
+        q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::DenyTool { tool: "a".into() },
+                BlastRadius::SingleEntity,
+            ),
+            1_000,
+        );
+        let state = q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::DenyTool { tool: "a".into() },
+                BlastRadius::SingleEntity,
+            ),
+            1_001,
+        );
+        assert_eq!(state, ProposalState::Rejected);
+        assert_eq!(q.proposals().len(), 1);
+        // The single surviving entry is the original applied proposal (now
+        // under observation), so id-keyed lookups still resolve to it.
+        assert_eq!(q.proposal_state("p1"), Some(ProposalState::Observed));
+        assert!(q.is_tool_denied("a"));
     }
 
     #[spec("ARP-004")]

--- a/crates/arkavo-arp-runtime/src/proposal_queue.rs
+++ b/crates/arkavo-arp-runtime/src/proposal_queue.rs
@@ -135,6 +135,81 @@ impl ProposalQueue {
         state
     }
 
+    /// Side-effect-free admission check: would this proposal pass validation
+    /// and the direction check right now? The flight controller uses this as
+    /// phase one of check-then-apply across all role queues.
+    pub fn check(&self, proposal: &TighteningProposal) -> Result<(), String> {
+        let Some(policy) = self.policy.as_ref() else {
+            return Err("document has no proposal_policy".to_string());
+        };
+        validate_proposal(proposal, policy).map_err(|e| e.to_string())?;
+        self.direction_violation(&proposal.effect)
+    }
+
+    /// Ingest a proposal whose review already happened upstream (kit-level
+    /// flight approval): check, then apply immediately regardless of this
+    /// document's auto-apply radius. Used by the flight controller after the
+    /// kit's flight_approval mechanism approved a flight-radius proposal.
+    pub fn ingest_reviewed(
+        &mut self,
+        mut proposal: TighteningProposal,
+        reviewer: &str,
+        now_epoch_sec: u64,
+    ) -> Result<ProposalState, String> {
+        self.check(&proposal)?;
+        let window = self
+            .policy
+            .as_ref()
+            .and_then(|p| p.observation_window_sec)
+            .unwrap_or(3600);
+        proposal.reviewed_by = Some(reviewer.to_string());
+        proposal.state = ProposalState::Reviewed;
+        self.apply(&mut proposal, now_epoch_sec, window);
+        let state = proposal.state;
+        self.proposals.push(proposal);
+        Ok(state)
+    }
+
+    /// Current state of a proposal, if known to this queue.
+    pub fn proposal_state(&self, proposal_id: &str) -> Option<ProposalState> {
+        self.proposals
+            .iter()
+            .find(|p| p.id == proposal_id)
+            .map(|p| p.state)
+    }
+
+    /// Revert an applied/observed proposal out of band — the convergence
+    /// path when a flight-wide apply partially failed. Restores the
+    /// displaced value and emits the auditable revert trace entry exactly
+    /// like an observation-window revert.
+    pub fn force_revert(&mut self, proposal_id: &str, reason: &str) -> Result<(), String> {
+        let idx = self
+            .proposals
+            .iter()
+            .position(|p| p.id == proposal_id)
+            .ok_or_else(|| format!("unknown proposal {proposal_id}"))?;
+        let state = self.proposals[idx].state;
+        if !matches!(state, ProposalState::Applied | ProposalState::Observed) {
+            return Err(format!(
+                "proposal {proposal_id} is {state:?}; only applied/observed proposals revert"
+            ));
+        }
+        let obs = self
+            .observations
+            .remove(proposal_id)
+            .ok_or_else(|| format!("proposal {proposal_id} has no observation record"))?;
+        let effect = self.proposals[idx].effect.clone();
+        self.restore(&effect, &obs.displaced);
+        self.proposals[idx].state = ProposalState::Reverted;
+        self.proposals[idx].disposition_reason = Some(reason.to_string());
+        self.emit_trace(
+            &self.proposals[idx].clone(),
+            "reverted",
+            Some(reason.to_string()),
+        );
+        Ok(())
+    }
+
     /// HITL review of a held proposal: approve applies it, deny rejects it.
     pub fn review(
         &mut self,

--- a/crates/arkavo-arp-runtime/src/proposal_queue.rs
+++ b/crates/arkavo-arp-runtime/src/proposal_queue.rs
@@ -1,0 +1,870 @@
+//! Tightening-proposal queue and lifecycle state machine (§18).
+//!
+//! States: `proposed → reviewed → applied → observed → confirmed | reverted`,
+//! with `rejected` reachable at ingest or review. Auto-apply happens when the
+//! proposal's blast radius is within the document's
+//! `proposal_policy.auto_apply_max_blast_radius`; everything wider waits for
+//! HITL review. Applying an effect records the prior value; a revert restores
+//! it AND emits a `proposal_lifecycle` DecisionTrace entry — reverts are
+//! auditable, never erased.
+//!
+//! Observation semantics (v1): while a proposal is `observed`, quality-gate
+//! outcomes are tallied; at window end the in-window failure rate is compared
+//! against the pre-apply baseline. A regression beyond
+//! [`REGRESSION_MARGIN`] reverts the proposal, otherwise it is confirmed.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use arkavo_arp::ArpDocument;
+use arkavo_arp::constraints::{LayerBudget, PerLayerBudget};
+use arkavo_arp::observability::{TraceDecision, TraceEventType, TraceLayer, TraceOutcome};
+use arkavo_arp::proposal::{
+    BudgetLayerName, ProposalPolicy, ProposalState, TighteningEffect, TighteningProposal,
+};
+use arkavo_arp::validate::validate_proposal;
+use arkavo_observability::decision_trace::DecisionTrace;
+
+/// In-window failure rate may exceed the pre-apply baseline by this margin
+/// before the change is considered a regression.
+pub const REGRESSION_MARGIN: f64 = 0.05;
+
+/// Value displaced by an applied effect, kept so a revert can restore it.
+#[derive(Debug, Clone, PartialEq)]
+enum DisplacedValue {
+    TaskCeiling(f64),
+    LayerBudget(BudgetLayerName, Option<f64>),
+    QualityThreshold(f64),
+    /// Set-insertion effects (quarantine/deny): revert removes the key.
+    SetInsertion,
+    RateLimit(Option<f64>),
+}
+
+/// Per-applied-proposal observation bookkeeping.
+#[derive(Debug, Clone)]
+struct Observation {
+    started_at_epoch_sec: u64,
+    window_sec: u64,
+    baseline_failure_rate: f64,
+    checks: u64,
+    failures: u64,
+    displaced: DisplacedValue,
+}
+
+/// Queue of tightening proposals plus the live policy document their effects
+/// apply to. The queue owns the canonical post-apply document; accessors
+/// expose the effective values and deny sets to the conductor.
+pub struct ProposalQueue {
+    policy: Option<ProposalPolicy>,
+    doc: ArpDocument,
+    proposals: Vec<TighteningProposal>,
+    observations: HashMap<String, Observation>,
+    denied_tools: HashSet<String>,
+    denied_hosts: HashSet<String>,
+    /// `"{scope:?}:{entity}"` keys for applied quarantines.
+    quarantined: HashSet<String>,
+    gate_checks: u64,
+    gate_failures: u64,
+    trace: Arc<DecisionTrace>,
+    agent_id: String,
+}
+
+impl ProposalQueue {
+    /// Build a queue around a document. The policy comes from
+    /// `doc.proposal_policy`; without one, every ingest is rejected.
+    pub fn new(doc: ArpDocument, trace: Arc<DecisionTrace>, agent_id: String) -> Self {
+        Self {
+            policy: doc.proposal_policy.clone(),
+            doc,
+            proposals: Vec::new(),
+            observations: HashMap::new(),
+            denied_tools: HashSet::new(),
+            denied_hosts: HashSet::new(),
+            quarantined: HashSet::new(),
+            gate_checks: 0,
+            gate_failures: 0,
+            trace,
+            agent_id,
+        }
+    }
+
+    /// The current effective document (post-applied effects).
+    pub fn document(&self) -> &ArpDocument {
+        &self.doc
+    }
+
+    /// Snapshot of all proposals and their states.
+    pub fn proposals(&self) -> Vec<TighteningProposal> {
+        self.proposals.clone()
+    }
+
+    pub fn is_tool_denied(&self, tool: &str) -> bool {
+        self.denied_tools.contains(tool)
+    }
+
+    pub fn is_host_denied(&self, host: &str) -> bool {
+        self.denied_hosts.contains(host)
+    }
+
+    /// Ingest a proposal: validate, direction-check against current values,
+    /// then either auto-apply (within policy radius) or hold for review.
+    /// Returns the resulting state; rejects are recorded, not dropped.
+    pub fn ingest(
+        &mut self,
+        mut proposal: TighteningProposal,
+        now_epoch_sec: u64,
+    ) -> ProposalState {
+        let Some(policy) = self.policy.clone() else {
+            return self.reject(proposal, "document has no proposal_policy");
+        };
+        if let Err(e) = validate_proposal(&proposal, &policy) {
+            let reason = e.to_string();
+            return self.reject(proposal, &reason);
+        }
+        if let Err(reason) = self.direction_violation(&proposal.effect) {
+            return self.reject(proposal, &reason);
+        }
+
+        proposal.state = ProposalState::Proposed;
+        if proposal.blast_radius <= policy.auto_apply_max_blast_radius {
+            let window = policy.observation_window_sec.unwrap_or(3600);
+            self.apply(&mut proposal, now_epoch_sec, window);
+        }
+        let state = proposal.state;
+        self.proposals.push(proposal);
+        state
+    }
+
+    /// HITL review of a held proposal: approve applies it, deny rejects it.
+    pub fn review(
+        &mut self,
+        proposal_id: &str,
+        approve: bool,
+        reviewer: &str,
+        now_epoch_sec: u64,
+    ) -> Result<ProposalState, String> {
+        let window = self
+            .policy
+            .as_ref()
+            .and_then(|p| p.observation_window_sec)
+            .unwrap_or(3600);
+        let idx = self
+            .proposals
+            .iter()
+            .position(|p| p.id == proposal_id)
+            .ok_or_else(|| format!("unknown proposal {proposal_id}"))?;
+        if self.proposals[idx].state != ProposalState::Proposed {
+            return Err(format!(
+                "proposal {proposal_id} is {:?}, not awaiting review",
+                self.proposals[idx].state
+            ));
+        }
+
+        let mut proposal = self.proposals[idx].clone();
+        proposal.reviewed_by = Some(reviewer.to_string());
+        proposal.state = ProposalState::Reviewed;
+        if approve {
+            // Re-check direction: current values may have moved since ingest.
+            if let Err(reason) = self.direction_violation(&proposal.effect) {
+                proposal.state = ProposalState::Rejected;
+                proposal.disposition_reason = Some(reason);
+            } else {
+                self.apply(&mut proposal, now_epoch_sec, window);
+            }
+        } else {
+            proposal.state = ProposalState::Rejected;
+            proposal.disposition_reason = Some(format!("rejected by reviewer {reviewer}"));
+        }
+        let state = proposal.state;
+        self.proposals[idx] = proposal;
+        Ok(state)
+    }
+
+    /// Feed a quality-gate outcome into the baseline and all active windows.
+    pub fn record_quality_gate(&mut self, passed: bool) {
+        self.gate_checks += 1;
+        if !passed {
+            self.gate_failures += 1;
+        }
+        for obs in self.observations.values_mut() {
+            obs.checks += 1;
+            if !passed {
+                obs.failures += 1;
+            }
+        }
+    }
+
+    /// Evaluate all observation windows: confirm proposals whose window
+    /// elapsed without regression, revert those that regressed. Returns the
+    /// transitions made.
+    pub fn evaluate_observations(&mut self, now_epoch_sec: u64) -> Vec<(String, ProposalState)> {
+        let due: Vec<String> = self
+            .observations
+            .iter()
+            .filter(|(_, obs)| now_epoch_sec >= obs.started_at_epoch_sec + obs.window_sec)
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        let mut transitions = Vec::new();
+        for id in due {
+            let obs = self.observations.remove(&id).expect("due id exists");
+            let window_rate = if obs.checks == 0 {
+                0.0
+            } else {
+                obs.failures as f64 / obs.checks as f64
+            };
+            let regressed = window_rate > obs.baseline_failure_rate + REGRESSION_MARGIN;
+
+            let idx = self.proposals.iter().position(|p| p.id == id);
+            let Some(idx) = idx else { continue };
+            if regressed {
+                let reason = format!(
+                    "quality-gate regression during observation: window failure rate {:.3} \
+                     vs baseline {:.3}",
+                    window_rate, obs.baseline_failure_rate
+                );
+                let effect = self.proposals[idx].effect.clone();
+                self.restore(&effect, &obs.displaced);
+                self.proposals[idx].state = ProposalState::Reverted;
+                self.proposals[idx].disposition_reason = Some(reason.clone());
+                self.emit_trace(&self.proposals[idx].clone(), "reverted", Some(reason));
+                transitions.push((id, ProposalState::Reverted));
+            } else {
+                self.proposals[idx].state = ProposalState::Confirmed;
+                self.emit_trace(&self.proposals[idx].clone(), "confirmed", None);
+                transitions.push((id, ProposalState::Confirmed));
+            }
+        }
+        transitions
+    }
+
+    fn reject(&mut self, mut proposal: TighteningProposal, reason: &str) -> ProposalState {
+        proposal.state = ProposalState::Rejected;
+        proposal.disposition_reason = Some(reason.to_string());
+        self.proposals.push(proposal);
+        ProposalState::Rejected
+    }
+
+    /// Direction check against *current* values: the typed effect already
+    /// guarantees the tighten direction by construction; this verifies the
+    /// new value is actually stricter than what is in force right now.
+    fn direction_violation(&self, effect: &TighteningEffect) -> Result<(), String> {
+        match effect {
+            TighteningEffect::LowerTaskCeiling { new_ceiling_usd } => {
+                let current = self.doc.budget.task_ceiling_usd;
+                if *new_ceiling_usd >= current {
+                    return Err(format!(
+                        "new ceiling {new_ceiling_usd} does not tighten current {current}"
+                    ));
+                }
+            }
+            TighteningEffect::LowerLayerBudget {
+                layer,
+                new_limit_usd,
+            } => {
+                if *layer == BudgetLayerName::Consolidation {
+                    return Err(
+                        "consolidation layer budget is not wired into per_layer yet".to_string()
+                    );
+                }
+                if let Some(current) = self.layer_limit(*layer)
+                    && *new_limit_usd >= current
+                {
+                    return Err(format!(
+                        "new layer limit {new_limit_usd} does not tighten current {current}"
+                    ));
+                }
+                // No current limit: introducing one is a tightening.
+            }
+            TighteningEffect::RaiseQualityGateThreshold { new_threshold } => {
+                let current = self
+                    .doc
+                    .feedback_loops
+                    .immediate
+                    .quality_gate
+                    .threshold_default;
+                if *new_threshold <= current {
+                    return Err(format!(
+                        "new threshold {new_threshold} does not tighten current {current}"
+                    ));
+                }
+            }
+            TighteningEffect::AddQuarantine { scope, entity } => {
+                if self.quarantined.contains(&format!("{scope:?}:{entity}")) {
+                    return Err(format!("{entity} is already quarantined"));
+                }
+            }
+            TighteningEffect::DenyTool { tool } => {
+                if self.denied_tools.contains(tool) {
+                    return Err(format!("tool {tool} is already denied"));
+                }
+            }
+            TighteningEffect::DenyEgress { host } => {
+                if self.denied_hosts.contains(host) {
+                    return Err(format!("host {host} is already denied"));
+                }
+            }
+            TighteningEffect::LowerRateLimit {
+                new_requests_per_second,
+            } => {
+                let current = self
+                    .doc
+                    .budget
+                    .rate_limiting
+                    .as_ref()
+                    .and_then(|r| r.global.as_ref())
+                    .and_then(|g| g.requests_per_second);
+                if let Some(current) = current
+                    && *new_requests_per_second >= current
+                {
+                    return Err(format!(
+                        "new rate {new_requests_per_second} does not tighten current {current}"
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn layer_limit(&self, layer: BudgetLayerName) -> Option<f64> {
+        let per = self.doc.budget.per_layer.as_ref()?;
+        let lb = match layer {
+            BudgetLayerName::Cognitive => per.cognitive,
+            BudgetLayerName::Execution => per.execution,
+            BudgetLayerName::Data => per.data,
+            BudgetLayerName::Network => per.network,
+            BudgetLayerName::Consolidation => None,
+        };
+        lb.and_then(|l| l.limit_usd)
+    }
+
+    /// Apply an effect to the live document/deny sets, recording the
+    /// displaced value, and move the proposal to `observed`.
+    fn apply(&mut self, proposal: &mut TighteningProposal, now_epoch_sec: u64, window_sec: u64) {
+        let displaced = match &proposal.effect {
+            TighteningEffect::LowerTaskCeiling { new_ceiling_usd } => {
+                let old = self.doc.budget.task_ceiling_usd;
+                self.doc.budget.task_ceiling_usd = *new_ceiling_usd;
+                DisplacedValue::TaskCeiling(old)
+            }
+            TighteningEffect::LowerLayerBudget {
+                layer,
+                new_limit_usd,
+            } => {
+                let old = self.layer_limit(*layer);
+                self.set_layer_limit(*layer, *new_limit_usd);
+                DisplacedValue::LayerBudget(*layer, old)
+            }
+            TighteningEffect::RaiseQualityGateThreshold { new_threshold } => {
+                let gate = &mut self.doc.feedback_loops.immediate.quality_gate;
+                let old = gate.threshold_default;
+                gate.threshold_default = *new_threshold;
+                DisplacedValue::QualityThreshold(old)
+            }
+            TighteningEffect::AddQuarantine { scope, entity } => {
+                self.quarantined.insert(format!("{scope:?}:{entity}"));
+                DisplacedValue::SetInsertion
+            }
+            TighteningEffect::DenyTool { tool } => {
+                self.denied_tools.insert(tool.clone());
+                DisplacedValue::SetInsertion
+            }
+            TighteningEffect::DenyEgress { host } => {
+                self.denied_hosts.insert(host.clone());
+                DisplacedValue::SetInsertion
+            }
+            TighteningEffect::LowerRateLimit {
+                new_requests_per_second,
+            } => {
+                let old = self
+                    .doc
+                    .budget
+                    .rate_limiting
+                    .as_ref()
+                    .and_then(|r| r.global.as_ref())
+                    .and_then(|g| g.requests_per_second);
+                self.set_rate_limit(*new_requests_per_second);
+                DisplacedValue::RateLimit(old)
+            }
+        };
+
+        let baseline = if self.gate_checks == 0 {
+            0.0
+        } else {
+            self.gate_failures as f64 / self.gate_checks as f64
+        };
+        self.observations.insert(
+            proposal.id.clone(),
+            Observation {
+                started_at_epoch_sec: now_epoch_sec,
+                window_sec,
+                baseline_failure_rate: baseline,
+                checks: 0,
+                failures: 0,
+                displaced,
+            },
+        );
+        proposal.state = ProposalState::Observed;
+        proposal.applied_at = Some(format_epoch(now_epoch_sec));
+        self.emit_trace(proposal, "applied", None);
+    }
+
+    /// Restore a displaced value — the revert path.
+    fn restore(&mut self, effect: &TighteningEffect, displaced: &DisplacedValue) {
+        match (effect, displaced) {
+            (_, DisplacedValue::TaskCeiling(old)) => {
+                self.doc.budget.task_ceiling_usd = *old;
+            }
+            (_, DisplacedValue::LayerBudget(layer, old)) => match old {
+                Some(v) => self.set_layer_limit(*layer, *v),
+                None => self.clear_layer_limit(*layer),
+            },
+            (_, DisplacedValue::QualityThreshold(old)) => {
+                self.doc
+                    .feedback_loops
+                    .immediate
+                    .quality_gate
+                    .threshold_default = *old;
+            }
+            (TighteningEffect::AddQuarantine { scope, entity }, DisplacedValue::SetInsertion) => {
+                self.quarantined.remove(&format!("{scope:?}:{entity}"));
+            }
+            (TighteningEffect::DenyTool { tool }, DisplacedValue::SetInsertion) => {
+                self.denied_tools.remove(tool);
+            }
+            (TighteningEffect::DenyEgress { host }, DisplacedValue::SetInsertion) => {
+                self.denied_hosts.remove(host);
+            }
+            (_, DisplacedValue::RateLimit(old)) => match old {
+                Some(v) => self.set_rate_limit(*v),
+                None => {
+                    if let Some(r) = self.doc.budget.rate_limiting.as_mut()
+                        && let Some(g) = r.global.as_mut()
+                    {
+                        g.requests_per_second = None;
+                    }
+                }
+            },
+            // Effect/displaced mismatch cannot be constructed by apply().
+            (_, DisplacedValue::SetInsertion) => {}
+        }
+    }
+
+    fn set_layer_limit(&mut self, layer: BudgetLayerName, limit: f64) {
+        let per = self.doc.budget.per_layer.get_or_insert(PerLayerBudget {
+            cognitive: None,
+            execution: None,
+            data: None,
+            network: None,
+        });
+        let slot = match layer {
+            BudgetLayerName::Cognitive => &mut per.cognitive,
+            BudgetLayerName::Execution => &mut per.execution,
+            BudgetLayerName::Data => &mut per.data,
+            BudgetLayerName::Network => &mut per.network,
+            BudgetLayerName::Consolidation => return,
+        };
+        *slot = Some(LayerBudget {
+            limit_usd: Some(limit),
+        });
+    }
+
+    fn clear_layer_limit(&mut self, layer: BudgetLayerName) {
+        if let Some(per) = self.doc.budget.per_layer.as_mut() {
+            let slot = match layer {
+                BudgetLayerName::Cognitive => &mut per.cognitive,
+                BudgetLayerName::Execution => &mut per.execution,
+                BudgetLayerName::Data => &mut per.data,
+                BudgetLayerName::Network => &mut per.network,
+                BudgetLayerName::Consolidation => return,
+            };
+            *slot = None;
+        }
+    }
+
+    fn set_rate_limit(&mut self, rps: f64) {
+        use arkavo_arp::constraints::{RateLimit, RateLimiting};
+        let limiting = self.doc.budget.rate_limiting.get_or_insert(RateLimiting {
+            global: None,
+            per_endpoint: None,
+            per_tool: None,
+            max_tracking_entries: None,
+            tracking_entry_ttl_sec: None,
+            cleanup_interval_sec: None,
+        });
+        let global = limiting.global.get_or_insert(RateLimit {
+            requests_per_second: None,
+            burst_size: None,
+        });
+        global.requests_per_second = Some(rps);
+    }
+
+    fn emit_trace(&self, proposal: &TighteningProposal, transition: &str, reason: Option<String>) {
+        let decision = TraceDecision {
+            chosen: Some(format!("proposal {} {}", proposal.id, transition)),
+            alternatives_considered: None,
+            selection_method: None,
+            prior_state: None,
+            posterior_state: None,
+        };
+        let outcome = TraceOutcome {
+            success: Some(transition != "reverted"),
+            quality_score: None,
+            latency_ms: None,
+            cost_usd: None,
+            error_type: reason,
+        };
+        self.trace.record(
+            TraceLayer::Execution,
+            TraceEventType::ProposalLifecycle,
+            uuid::Uuid::nil(),
+            &self.agent_id,
+            decision,
+            outcome,
+        );
+    }
+}
+
+fn format_epoch(epoch_sec: u64) -> String {
+    chrono::DateTime::from_timestamp(epoch_sec as i64, 0)
+        .map(|dt| dt.to_rfc3339())
+        .unwrap_or_else(|| format!("epoch:{epoch_sec}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arkavo_arp::constraints::QuarantineScope;
+    use arkavo_arp::observability::DecisionTraceConfig;
+    use arkavo_arp::proposal::{BlastRadius, ProposalOrigin, TraceRef};
+
+    const DOC: &str = r#"{
+        "arp_spec": "0.1.0",
+        "adl_ref": {"uri": "https://example.com/adl.json"},
+        "adaptation": {"method": "thompson_sampling"},
+        "feedback_loops": {
+            "immediate": {
+                "quality_gate": {
+                    "threshold_default": 0.7,
+                    "metric": "cosine_similarity",
+                    "on_failure": "update_prior_and_log"
+                }
+            },
+            "short_term": {
+                "policy_cache": {
+                    "default_ttl_sec": 3600,
+                    "decay_strategy": "linear"
+                }
+            }
+        },
+        "budget": {
+            "task_ceiling_usd": 2.5,
+            "on_exhaustion": "halt_and_report",
+            "velocity": {"max_spend_per_minute_usd": 0.5}
+        },
+        "proposal_policy": {
+            "accepted_origins": ["consolidation", "human"],
+            "auto_apply_max_blast_radius": "single_entity",
+            "observation_window_sec": 600
+        }
+    }"#;
+
+    fn queue() -> ProposalQueue {
+        let doc = arkavo_arp::parse(DOC).unwrap();
+        let trace = Arc::new(DecisionTrace::new(DecisionTraceConfig {
+            enabled: Some(true),
+            storage: Some("append_only".into()),
+            retention_days: None,
+            cryptographic_signing: None,
+        }));
+        ProposalQueue::new(doc, trace, "test-agent".into())
+    }
+
+    fn proposal(id: &str, effect: TighteningEffect, radius: BlastRadius) -> TighteningProposal {
+        TighteningProposal {
+            id: id.into(),
+            origin: ProposalOrigin::Consolidation,
+            state: ProposalState::Proposed,
+            effect,
+            rationale: "evidence-backed".into(),
+            blast_radius: radius,
+            evidence: vec![TraceRef {
+                trace_id: "t-1".into(),
+                episode_ids: vec!["ep-1".into()],
+            }],
+            created_at: "2026-06-10T00:00:00Z".into(),
+            applied_at: None,
+            reviewed_by: None,
+            disposition_reason: None,
+        }
+    }
+
+    #[test]
+    fn auto_apply_within_radius_goes_to_observed() {
+        let mut q = queue();
+        let state = q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::DenyTool {
+                    tool: "game-rl:reset".into(),
+                },
+                BlastRadius::SingleEntity,
+            ),
+            1_000,
+        );
+        assert_eq!(state, ProposalState::Observed);
+        assert!(q.is_tool_denied("game-rl:reset"));
+        // Apply emitted a proposal_lifecycle trace entry.
+        assert_eq!(q.trace.len(), 1);
+    }
+
+    #[test]
+    fn wider_radius_waits_for_review_then_applies() {
+        let mut q = queue();
+        let state = q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::LowerTaskCeiling {
+                    new_ceiling_usd: 1.0,
+                },
+                BlastRadius::SingleAgent,
+            ),
+            1_000,
+        );
+        assert_eq!(state, ProposalState::Proposed);
+        assert!((q.document().budget.task_ceiling_usd - 2.5).abs() < 1e-9);
+
+        let state = q.review("p1", true, "operator", 1_100).unwrap();
+        assert_eq!(state, ProposalState::Observed);
+        assert!((q.document().budget.task_ceiling_usd - 1.0).abs() < 1e-9);
+        let p = &q.proposals()[0];
+        assert_eq!(p.reviewed_by.as_deref(), Some("operator"));
+    }
+
+    #[test]
+    fn reviewer_denial_rejects() {
+        let mut q = queue();
+        q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::LowerTaskCeiling {
+                    new_ceiling_usd: 1.0,
+                },
+                BlastRadius::SingleAgent,
+            ),
+            1_000,
+        );
+        let state = q.review("p1", false, "operator", 1_100).unwrap();
+        assert_eq!(state, ProposalState::Rejected);
+        assert!((q.document().budget.task_ceiling_usd - 2.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn ingest_rejects_empty_evidence_bad_origin_and_non_tightening() {
+        let mut q = queue();
+        // Empty evidence.
+        let mut p = proposal(
+            "p1",
+            TighteningEffect::DenyTool { tool: "x".into() },
+            BlastRadius::SingleEntity,
+        );
+        p.evidence.clear();
+        assert_eq!(q.ingest(p, 0), ProposalState::Rejected);
+
+        // Unaccepted origin.
+        let mut p = proposal(
+            "p2",
+            TighteningEffect::DenyTool { tool: "x".into() },
+            BlastRadius::SingleEntity,
+        );
+        p.origin = ProposalOrigin::Critic;
+        assert_eq!(q.ingest(p, 0), ProposalState::Rejected);
+
+        // Direction violation: "lower" ceiling above the current one.
+        let p = proposal(
+            "p3",
+            TighteningEffect::LowerTaskCeiling {
+                new_ceiling_usd: 99.0,
+            },
+            BlastRadius::SingleEntity,
+        );
+        assert_eq!(q.ingest(p, 0), ProposalState::Rejected);
+        // Every reject is recorded with a reason, never dropped.
+        assert_eq!(q.proposals().len(), 3);
+        assert!(q.proposals().iter().all(|p| p.disposition_reason.is_some()));
+    }
+
+    #[test]
+    fn clean_window_confirms() {
+        let mut q = queue();
+        q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::RaiseQualityGateThreshold { new_threshold: 0.8 },
+                BlastRadius::SingleEntity,
+            ),
+            1_000,
+        );
+        for _ in 0..10 {
+            q.record_quality_gate(true);
+        }
+        // Window (600s) not yet elapsed: no transition.
+        assert!(q.evaluate_observations(1_300).is_empty());
+        let transitions = q.evaluate_observations(1_700);
+        assert_eq!(transitions, vec![("p1".into(), ProposalState::Confirmed)]);
+        // Effect stays in force.
+        assert!(
+            (q.document()
+                .feedback_loops
+                .immediate
+                .quality_gate
+                .threshold_default
+                - 0.8)
+                .abs()
+                < 1e-9
+        );
+    }
+
+    #[test]
+    fn regression_reverts_and_restores_prior_value() {
+        let mut q = queue();
+        // Establish a clean baseline before the proposal.
+        for _ in 0..10 {
+            q.record_quality_gate(true);
+        }
+        q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::RaiseQualityGateThreshold { new_threshold: 0.9 },
+                BlastRadius::SingleEntity,
+            ),
+            1_000,
+        );
+        // In-window failures: clear regression vs the 0.0 baseline.
+        for _ in 0..10 {
+            q.record_quality_gate(false);
+        }
+        let transitions = q.evaluate_observations(2_000);
+        assert_eq!(transitions, vec![("p1".into(), ProposalState::Reverted)]);
+        // Prior value restored...
+        assert!(
+            (q.document()
+                .feedback_loops
+                .immediate
+                .quality_gate
+                .threshold_default
+                - 0.7)
+                .abs()
+                < 1e-9
+        );
+        // ...and the revert is auditable: apply + revert trace entries.
+        assert_eq!(q.trace.len(), 2);
+        let p = q.proposals().into_iter().find(|p| p.id == "p1").unwrap();
+        assert!(p.disposition_reason.unwrap().contains("regression"));
+    }
+
+    #[test]
+    fn revert_removes_set_insertions() {
+        let mut q = queue();
+        q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::AddQuarantine {
+                    scope: QuarantineScope::Tool,
+                    entity: "game-rl:reset".into(),
+                },
+                BlastRadius::SingleEntity,
+            ),
+            1_000,
+        );
+        assert!(q.quarantined.contains("Tool:game-rl:reset"));
+        for _ in 0..5 {
+            q.record_quality_gate(false);
+        }
+        q.evaluate_observations(2_000);
+        assert!(!q.quarantined.contains("Tool:game-rl:reset"));
+    }
+
+    #[test]
+    fn duplicate_deny_is_rejected_as_no_op() {
+        let mut q = queue();
+        q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::DenyTool { tool: "x".into() },
+                BlastRadius::SingleEntity,
+            ),
+            0,
+        );
+        let state = q.ingest(
+            proposal(
+                "p2",
+                TighteningEffect::DenyTool { tool: "x".into() },
+                BlastRadius::SingleEntity,
+            ),
+            0,
+        );
+        assert_eq!(state, ProposalState::Rejected);
+    }
+
+    #[test]
+    fn no_policy_rejects_everything() {
+        let mut doc = arkavo_arp::parse(DOC).unwrap();
+        doc.proposal_policy = None;
+        let trace = Arc::new(DecisionTrace::new(DecisionTraceConfig {
+            enabled: Some(true),
+            storage: Some("append_only".into()),
+            retention_days: None,
+            cryptographic_signing: None,
+        }));
+        let mut q = ProposalQueue::new(doc, trace, "test".into());
+        let state = q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::DenyTool { tool: "x".into() },
+                BlastRadius::SingleEntity,
+            ),
+            0,
+        );
+        assert_eq!(state, ProposalState::Rejected);
+    }
+
+    #[test]
+    fn review_unknown_or_already_decided_errors() {
+        let mut q = queue();
+        assert!(q.review("missing", true, "op", 0).is_err());
+        q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::DenyTool { tool: "x".into() },
+                BlastRadius::SingleEntity,
+            ),
+            0,
+        );
+        // Auto-applied — no longer awaiting review.
+        assert!(q.review("p1", true, "op", 0).is_err());
+    }
+
+    #[test]
+    fn layer_budget_introduction_and_revert_clears_it() {
+        let mut q = queue();
+        q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::LowerLayerBudget {
+                    layer: BudgetLayerName::Execution,
+                    new_limit_usd: 0.5,
+                },
+                BlastRadius::SingleEntity,
+            ),
+            1_000,
+        );
+        assert_eq!(q.layer_limit(BudgetLayerName::Execution), Some(0.5));
+        for _ in 0..5 {
+            q.record_quality_gate(false);
+        }
+        q.evaluate_observations(2_000);
+        // No limit existed before; revert clears it.
+        assert_eq!(q.layer_limit(BudgetLayerName::Execution), None);
+    }
+}

--- a/crates/arkavo-arp-runtime/src/proposal_queue.rs
+++ b/crates/arkavo-arp-runtime/src/proposal_queue.rs
@@ -337,11 +337,6 @@ impl ProposalQueue {
                 layer,
                 new_limit_usd,
             } => {
-                if *layer == BudgetLayerName::Consolidation {
-                    return Err(
-                        "consolidation layer budget is not wired into per_layer yet".to_string()
-                    );
-                }
                 if let Some(current) = self.layer_limit(*layer)
                     && *new_limit_usd >= current
                 {
@@ -408,7 +403,7 @@ impl ProposalQueue {
             BudgetLayerName::Execution => per.execution,
             BudgetLayerName::Data => per.data,
             BudgetLayerName::Network => per.network,
-            BudgetLayerName::Consolidation => None,
+            BudgetLayerName::Consolidation => per.consolidation,
         };
         lb.and_then(|l| l.limit_usd)
     }
@@ -531,13 +526,14 @@ impl ProposalQueue {
             execution: None,
             data: None,
             network: None,
+            consolidation: None,
         });
         let slot = match layer {
             BudgetLayerName::Cognitive => &mut per.cognitive,
             BudgetLayerName::Execution => &mut per.execution,
             BudgetLayerName::Data => &mut per.data,
             BudgetLayerName::Network => &mut per.network,
-            BudgetLayerName::Consolidation => return,
+            BudgetLayerName::Consolidation => &mut per.consolidation,
         };
         *slot = Some(LayerBudget {
             limit_usd: Some(limit),
@@ -551,7 +547,7 @@ impl ProposalQueue {
                 BudgetLayerName::Execution => &mut per.execution,
                 BudgetLayerName::Data => &mut per.data,
                 BudgetLayerName::Network => &mut per.network,
-                BudgetLayerName::Consolidation => return,
+                BudgetLayerName::Consolidation => &mut per.consolidation,
             };
             *slot = None;
         }

--- a/crates/arkavo-arp-runtime/src/proposal_queue.rs
+++ b/crates/arkavo-arp-runtime/src/proposal_queue.rs
@@ -676,6 +676,7 @@ mod tests {
     use arkavo_arp::constraints::QuarantineScope;
     use arkavo_arp::observability::DecisionTraceConfig;
     use arkavo_arp::proposal::{BlastRadius, ProposalOrigin, TraceRef};
+    use arkavo_test_macros::spec;
 
     const DOC: &str = r#"{
         "arp_spec": "0.1.0",
@@ -738,6 +739,7 @@ mod tests {
         }
     }
 
+    #[spec("ARP-001")]
     #[test]
     fn auto_apply_within_radius_goes_to_observed() {
         let mut q = queue();
@@ -757,6 +759,7 @@ mod tests {
         assert_eq!(q.trace.len(), 1);
     }
 
+    #[spec("ARP-002")]
     #[test]
     fn wider_radius_waits_for_review_then_applies() {
         let mut q = queue();
@@ -780,6 +783,7 @@ mod tests {
         assert_eq!(p.reviewed_by.as_deref(), Some("operator"));
     }
 
+    #[spec("ARP-002")]
     #[test]
     fn reviewer_denial_rejects() {
         let mut q = queue();
@@ -833,6 +837,7 @@ mod tests {
         assert!(q.proposals().iter().all(|p| p.disposition_reason.is_some()));
     }
 
+    #[spec("ARP-001")]
     #[test]
     fn clean_window_confirms() {
         let mut q = queue();
@@ -864,6 +869,7 @@ mod tests {
         );
     }
 
+    #[spec("ARP-003")]
     #[test]
     fn regression_reverts_and_restores_prior_value() {
         let mut q = queue();
@@ -902,6 +908,7 @@ mod tests {
         assert!(p.disposition_reason.unwrap().contains("regression"));
     }
 
+    #[spec("ARP-003")]
     #[test]
     fn revert_removes_set_insertions() {
         let mut q = queue();
@@ -984,8 +991,9 @@ mod tests {
         assert!(q.review("p1", true, "op", 0).is_err());
     }
 
+    #[spec("ARP-004")]
     #[test]
-    fn duplicate_id_is_refused_everywhere_and_does_not_corrupt_state() {
+    fn duplicate_id_ingest_is_refused_and_does_not_corrupt_state() {
         let mut q = queue();
         q.ingest(
             proposal(
@@ -1010,8 +1018,21 @@ mod tests {
         assert_eq!(q.proposals().len(), 1);
         assert!(q.is_tool_denied("a"));
         assert!(!q.is_tool_denied("b"));
+    }
 
-        // The flight precheck and the reviewed path refuse the same id too.
+    #[spec("ARP-004")]
+    #[test]
+    fn duplicate_id_is_refused_by_check_and_reviewed_path() {
+        let mut q = queue();
+        q.ingest(
+            proposal(
+                "p1",
+                TighteningEffect::DenyTool { tool: "a".into() },
+                BlastRadius::SingleEntity,
+            ),
+            1_000,
+        );
+        // The flight precheck and the kit-approved path refuse a known id.
         let dup = proposal(
             "p1",
             TighteningEffect::DenyTool { tool: "c".into() },
@@ -1020,8 +1041,10 @@ mod tests {
         assert!(q.check(&dup).is_err());
         assert!(q.ingest_reviewed(dup, "op", 1_002).is_err());
         assert_eq!(q.proposals().len(), 1);
+        assert!(!q.is_tool_denied("c"));
     }
 
+    #[spec("ARP-005")]
     #[test]
     fn scalar_field_under_observation_refuses_overlapping_proposal() {
         let mut q = queue();
@@ -1073,6 +1096,7 @@ mod tests {
         assert!((q.document().budget.task_ceiling_usd - 0.5).abs() < 1e-9);
     }
 
+    #[spec("ARP-005")]
     #[test]
     fn scalar_field_frees_after_confirmation() {
         let mut q = queue();
@@ -1103,6 +1127,8 @@ mod tests {
         assert_eq!(state, ProposalState::Observed);
     }
 
+    #[spec("ARP-002")]
+    #[spec("ARP-005")]
     #[test]
     fn review_approval_rechecks_field_overlap() {
         let mut q = queue();
@@ -1134,6 +1160,7 @@ mod tests {
         assert!((q.document().budget.task_ceiling_usd - 1.0).abs() < 1e-9);
     }
 
+    #[spec("ARP-003")]
     #[test]
     fn layer_budget_introduction_and_revert_clears_it() {
         let mut q = queue();

--- a/crates/arkavo-arp/Cargo.toml
+++ b/crates/arkavo-arp/Cargo.toml
@@ -13,3 +13,4 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 [dev-dependencies]
+arkavo-test-macros = { path = "../arkavo-test-macros" }

--- a/crates/arkavo-arp/src/adaptation.rs
+++ b/crates/arkavo-arp/src/adaptation.rs
@@ -82,6 +82,41 @@ pub struct PriorManagement {
     pub reset_on_version_change: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reset_state: Option<BetaPrior>,
+    /// Track per-observation provenance (live vs distilled). Default false:
+    /// distilled mass merges into the live prior, exactly as before.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provenance_tracking: Option<bool>,
+    /// How distilled (teacher-provided) mass decays as live evidence
+    /// accumulates. Only meaningful when `provenance_tracking` is true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub distilled_decay: Option<DistilledDecay>,
+}
+
+/// Decay of distilled prior mass under accumulating live evidence (§6.5).
+///
+/// The `BetaPrior` wire format is unchanged: provenance exists only in
+/// engine state and snapshots; the effective prior sampled by the engine is
+/// `live + decayed distilled` mass.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct DistilledDecay {
+    pub strategy: DistilledDecayStrategy,
+    /// Per-live-observation reduction of the distilled weight. The weight is
+    /// `max(floor, 1 - displacement_factor * live_observations)`. Must be in
+    /// (0, 1]. Default 0.05.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub displacement_factor: Option<f64>,
+    /// Minimum distilled weight that always survives. Must be in [0, 1].
+    /// Default 0.0 (live evidence can fully displace distilled mass).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub floor: Option<f64>,
+}
+
+/// Distilled-decay strategy (§6.5).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DistilledDecayStrategy {
+    /// Live observations linearly displace distilled mass.
+    LiveDisplacement,
 }
 
 /// How priors are bound to entity versions (§6.3).

--- a/crates/arkavo-arp/src/capability.rs
+++ b/crates/arkavo-arp/src/capability.rs
@@ -8,6 +8,12 @@
 //! There is deliberately no auto-apply field on this type at all.
 //!
 //! Two channels, asymmetric friction: tightenings flow, capabilities crawl.
+//!
+//! These types are declarative only: nothing in this crate (or any runtime
+//! crate) constructs or enforces a capability proposal. The gates name
+//! checks (conformance suite, canary) whose runners do not exist yet —
+//! [`CapabilityProposal::is_approvable`] is the admission predicate a future
+//! enforcement point must call, never a guarantee that it was called.
 
 use serde::{Deserialize, Serialize};
 
@@ -151,6 +157,7 @@ impl CapabilityProposal {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
     fn proposal(gates: CapabilityGates) -> CapabilityProposal {
         CapabilityProposal {
@@ -192,6 +199,7 @@ mod tests {
         assert_eq!(p.gates.remaining().len(), 6);
     }
 
+    #[spec("ARP-008")]
     #[test]
     fn every_gate_plus_named_human_is_approvable() {
         let p = proposal(all_gates());
@@ -199,6 +207,7 @@ mod tests {
         assert!(p.gates.remaining().is_empty());
     }
 
+    #[spec("ARP-008")]
     #[test]
     fn any_single_missing_gate_blocks() {
         for missing in 0..6 {
@@ -217,6 +226,7 @@ mod tests {
         }
     }
 
+    #[spec("ARP-008")]
     #[test]
     fn human_approval_is_an_identity_not_a_boolean() {
         let p = proposal(all_gates());
@@ -238,6 +248,7 @@ mod tests {
         assert!(p.intake_violation().unwrap().contains("component_digest"));
     }
 
+    #[spec("ARP-007")]
     #[test]
     fn capability_addition_cannot_ride_the_tightening_channel() {
         // The structural exclusion: there is no TighteningEffect variant

--- a/crates/arkavo-arp/src/capability.rs
+++ b/crates/arkavo-arp/src/capability.rs
@@ -1,0 +1,250 @@
+//! Capability proposals (§19, ARP v0.2): requests to **add** capability.
+//!
+//! A new capability is not a tightening and cannot ride the proposal
+//! channel — [`crate::proposal::TighteningEffect`] is a closed enum with no
+//! capability-addition variant, so the exclusion is structural, not policy.
+//! This second class carries mandatory gates instead: every gate must pass
+//! and a human must approve before a capability proposal is admissible.
+//! There is deliberately no auto-apply field on this type at all.
+//!
+//! Two channels, asymmetric friction: tightenings flow, capabilities crawl.
+
+use serde::{Deserialize, Serialize};
+
+use crate::proposal::{ProposalOrigin, TraceRef};
+
+/// What the proposed capability is: a WASM component behind a WIT contract,
+/// gated by a torg-verified circuit.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CapabilityRef {
+    /// Capability name (becomes the tool/import name).
+    pub name: String,
+    /// WIT world the component implements (WASI 0.2 pinned for v1).
+    pub wit_world: String,
+    /// Content digest of the component binary (e.g. `blake3:<hex>`).
+    pub component_digest: String,
+    /// Digest of the torg gating circuit that decides whether/when the
+    /// capability may run. The component decides only how.
+    pub gating_circuit_digest: String,
+}
+
+/// The mandatory gate checklist. All gates must pass; none is optional and
+/// none can be waived by configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CapabilityGates {
+    /// sbe+sat verifier pass on the gating circuit: SAT boundary probing
+    /// found no violation and the SBE invariant layer holds.
+    pub verifier_pass: bool,
+    /// The component conforms to its declared WIT world.
+    pub wit_conformance: bool,
+    /// SwarmKit conformance suite passed with the capability enabled.
+    pub swarmkit_conformance: bool,
+    /// Canary completed under an ARP Quarantine scope without incident.
+    pub canary_completed: bool,
+    /// Identity of the human approver. `None` means not approved — human
+    /// approval is a recorded identity, never a boolean.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub human_approval: Option<String>,
+    /// The kit was re-signed with the component as a member. Components
+    /// execute only as members of a signed, TDF-wrapped kit.
+    pub kit_resigned: bool,
+}
+
+impl CapabilityGates {
+    /// Names of the gates still unpassed, in checklist order.
+    #[must_use]
+    pub fn remaining(&self) -> Vec<&'static str> {
+        let mut out = Vec::new();
+        if !self.verifier_pass {
+            out.push("verifier_pass (sbe+sat)");
+        }
+        if !self.wit_conformance {
+            out.push("wit_conformance");
+        }
+        if !self.swarmkit_conformance {
+            out.push("swarmkit_conformance");
+        }
+        if !self.canary_completed {
+            out.push("canary_completed (quarantine scope)");
+        }
+        if self.human_approval.is_none() {
+            out.push("human_approval");
+        }
+        if !self.kit_resigned {
+            out.push("kit_resigned");
+        }
+        out
+    }
+
+    /// True only when every gate passed and a human approved.
+    #[must_use]
+    pub fn all_passed(&self) -> bool {
+        self.remaining().is_empty()
+    }
+}
+
+/// Lifecycle of a capability proposal. There is no auto-apply transition:
+/// `Active` is reachable only through [`CapabilityGates::all_passed`].
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityState {
+    Proposed,
+    /// Gates in progress.
+    Gated,
+    /// Every gate passed, human approved — eligible for kit inclusion.
+    Approved,
+    /// Shipped as a member of a re-signed kit.
+    Active,
+    Withdrawn,
+}
+
+/// A request to add capability, carrying its gate checklist.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CapabilityProposal {
+    pub id: String,
+    pub origin: ProposalOrigin,
+    pub state: CapabilityState,
+    pub capability: CapabilityRef,
+    pub rationale: String,
+    /// Must be non-empty, like every proposal in the system.
+    pub evidence: Vec<TraceRef>,
+    pub gates: CapabilityGates,
+    /// RFC 3339 creation timestamp.
+    pub created_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disposition_reason: Option<String>,
+}
+
+impl CapabilityProposal {
+    /// Validation at ingest: evidence and capability identifiers must be
+    /// present. Returns the violation, or `None` when admissible for gating.
+    #[must_use]
+    pub fn intake_violation(&self) -> Option<String> {
+        if self.evidence.is_empty() {
+            return Some(format!("capability proposal {} has no evidence", self.id));
+        }
+        for (field, value) in [
+            ("name", &self.capability.name),
+            ("wit_world", &self.capability.wit_world),
+            ("component_digest", &self.capability.component_digest),
+            (
+                "gating_circuit_digest",
+                &self.capability.gating_circuit_digest,
+            ),
+        ] {
+            if value.trim().is_empty() {
+                return Some(format!("capability.{field} must be non-empty"));
+            }
+        }
+        None
+    }
+
+    /// Whether the proposal may transition to [`CapabilityState::Approved`].
+    /// The only road to activation runs through every gate plus a named
+    /// human approver.
+    #[must_use]
+    pub fn is_approvable(&self) -> bool {
+        self.intake_violation().is_none() && self.gates.all_passed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn proposal(gates: CapabilityGates) -> CapabilityProposal {
+        CapabilityProposal {
+            id: "cap-1".into(),
+            origin: ProposalOrigin::Consolidation,
+            state: CapabilityState::Gated,
+            capability: CapabilityRef {
+                name: "summarize_table".into(),
+                wit_world: "arkavo:capability/tool@0.2.0".into(),
+                component_digest: "blake3:abc123".into(),
+                gating_circuit_digest: "blake3:def456".into(),
+            },
+            rationale: "repeated manual table summarization in episodes".into(),
+            evidence: vec![TraceRef {
+                trace_id: "t-1".into(),
+                episode_ids: vec!["ep-1".into()],
+            }],
+            gates,
+            created_at: "2026-06-10T00:00:00Z".into(),
+            disposition_reason: None,
+        }
+    }
+
+    fn all_gates() -> CapabilityGates {
+        CapabilityGates {
+            verifier_pass: true,
+            wit_conformance: true,
+            swarmkit_conformance: true,
+            canary_completed: true,
+            human_approval: Some("did:web:operator.example.com".into()),
+            kit_resigned: true,
+        }
+    }
+
+    #[test]
+    fn default_gates_block_approval_with_full_checklist() {
+        let p = proposal(CapabilityGates::default());
+        assert!(!p.is_approvable());
+        assert_eq!(p.gates.remaining().len(), 6);
+    }
+
+    #[test]
+    fn every_gate_plus_named_human_is_approvable() {
+        let p = proposal(all_gates());
+        assert!(p.is_approvable());
+        assert!(p.gates.remaining().is_empty());
+    }
+
+    #[test]
+    fn any_single_missing_gate_blocks() {
+        for missing in 0..6 {
+            let mut gates = all_gates();
+            match missing {
+                0 => gates.verifier_pass = false,
+                1 => gates.wit_conformance = false,
+                2 => gates.swarmkit_conformance = false,
+                3 => gates.canary_completed = false,
+                4 => gates.human_approval = None,
+                _ => gates.kit_resigned = false,
+            }
+            let p = proposal(gates);
+            assert!(!p.is_approvable(), "gate {missing} must block approval");
+            assert_eq!(p.gates.remaining().len(), 1);
+        }
+    }
+
+    #[test]
+    fn human_approval_is_an_identity_not_a_boolean() {
+        let p = proposal(all_gates());
+        let json = serde_json::to_value(&p).unwrap();
+        assert_eq!(
+            json["gates"]["human_approval"],
+            "did:web:operator.example.com"
+        );
+    }
+
+    #[test]
+    fn intake_requires_evidence_and_identifiers() {
+        let mut p = proposal(all_gates());
+        p.evidence.clear();
+        assert!(p.intake_violation().unwrap().contains("no evidence"));
+
+        let mut p = proposal(all_gates());
+        p.capability.component_digest = "  ".into();
+        assert!(p.intake_violation().unwrap().contains("component_digest"));
+    }
+
+    #[test]
+    fn capability_addition_cannot_ride_the_tightening_channel() {
+        // The structural exclusion: there is no TighteningEffect variant
+        // that adds capability, so a capability "effect" fails to parse.
+        let json = r#"{"kind": "add_capability", "name": "summarize_table"}"#;
+        assert!(serde_json::from_str::<crate::proposal::TighteningEffect>(json).is_err());
+        let json = r#"{"kind": "allow_tool", "tool": "summarize_table"}"#;
+        assert!(serde_json::from_str::<crate::proposal::TighteningEffect>(json).is_err());
+    }
+}

--- a/crates/arkavo-arp/src/constraints.rs
+++ b/crates/arkavo-arp/src/constraints.rs
@@ -54,6 +54,11 @@ pub struct PerLayerBudget {
     pub data: Option<LayerBudget>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network: Option<LayerBudget>,
+    /// Offline learning spend (§7.4). Required when the consolidation
+    /// teacher is non-local; exhaustion yields partial output plus a
+    /// budget_exhausted trace, never borrowing from runtime budgets.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub consolidation: Option<LayerBudget>,
 }
 
 /// Budget limit for a single layer.

--- a/crates/arkavo-arp/src/lib.rs
+++ b/crates/arkavo-arp/src/lib.rs
@@ -5,6 +5,7 @@
 //! and parser only — no policy engine or business logic.
 
 pub mod adaptation;
+pub mod capability;
 pub mod constraints;
 pub mod feedback;
 pub mod layers;
@@ -13,6 +14,7 @@ pub mod observability;
 pub mod proposal;
 pub mod validate;
 
+pub use capability::{CapabilityGates, CapabilityProposal, CapabilityRef, CapabilityState};
 pub use model::ArpDocument;
 pub use proposal::{
     BlastRadius, ProposalOrigin, ProposalPolicy, ProposalState, TighteningEffect,

--- a/crates/arkavo-arp/src/lib.rs
+++ b/crates/arkavo-arp/src/lib.rs
@@ -10,9 +10,14 @@ pub mod feedback;
 pub mod layers;
 pub mod model;
 pub mod observability;
+pub mod proposal;
 pub mod validate;
 
 pub use model::ArpDocument;
+pub use proposal::{
+    BlastRadius, ProposalOrigin, ProposalPolicy, ProposalState, TighteningEffect,
+    TighteningProposal, TraceRef,
+};
 
 /// Parse an ARP document from a JSON string.
 pub fn parse(json: &str) -> Result<ArpDocument, ParseError> {

--- a/crates/arkavo-arp/src/model.rs
+++ b/crates/arkavo-arp/src/model.rs
@@ -7,6 +7,7 @@ use crate::constraints::{Budget, Escalation, Hitl, Quarantine, Session};
 use crate::feedback::FeedbackLoops;
 use crate::layers::{Cognitive, DataSovereignty, Execution, Network};
 use crate::observability::{Observability, StateStorage};
+use crate::proposal::ProposalPolicy;
 
 /// Top-level ARP document per §4.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -40,6 +41,9 @@ pub struct ArpDocument {
     pub state_storage: Option<StateStorage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub observability: Option<Observability>,
+    /// Governs which tightening proposals this agent ingests (§18.2).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proposal_policy: Option<ProposalPolicy>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
 }

--- a/crates/arkavo-arp/src/observability.rs
+++ b/crates/arkavo-arp/src/observability.rs
@@ -190,6 +190,8 @@ pub enum TraceEventType {
     BudgetEvent,
     Quarantine,
     HitlAction,
+    /// Tightening-proposal lifecycle transition (apply/revert/confirm).
+    ProposalLifecycle,
 }
 
 /// Decision details: who chose what and why.

--- a/crates/arkavo-arp/src/proposal.rs
+++ b/crates/arkavo-arp/src/proposal.rs
@@ -1,0 +1,288 @@
+//! Tightening proposals (§18, ARP v0.2): typed, evidence-backed requests to
+//! make a policy stricter, produced by audit-plane components and reviewed
+//! before application.
+//!
+//! The direction guarantee is structural: [`TighteningEffect`] is a closed
+//! enum whose every variant restricts behavior — there are no loosen variants
+//! to construct. Relaxation stays on the existing HITL relaxation path
+//! (§15.1) and cannot ride this channel.
+
+use serde::{Deserialize, Serialize};
+
+use crate::constraints::{ApprovalMechanism, QuarantineScope};
+
+/// How widely a proposal's effect propagates once applied. Ordering is the
+/// declaration order and is load-bearing: auto-apply eligibility is
+/// `blast_radius <= policy.auto_apply_max_blast_radius`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum BlastRadius {
+    /// One adaptation entity (a single tool/model arm) on one agent.
+    SingleEntity,
+    /// One agent's whole ARP.
+    SingleAgent,
+    /// Every role ARP in one flight.
+    Flight,
+    /// Every agent in the mesh. Never auto-applied.
+    Mesh,
+}
+
+/// Audit-plane component that produced a proposal.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProposalOrigin {
+    /// Offline consolidation teacher (§7.4).
+    Consolidation,
+    /// Runtime critic.
+    Critic,
+    /// Historian / episode-audit role.
+    Historian,
+    /// Human operator.
+    Human,
+}
+
+/// Lifecycle state. Transitions are owned by the runtime queue:
+/// `proposed → reviewed → applied → observed → confirmed | reverted`,
+/// with `rejected` reachable from `proposed`/`reviewed`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProposalState {
+    Proposed,
+    Reviewed,
+    Applied,
+    Observed,
+    Confirmed,
+    Reverted,
+    Rejected,
+}
+
+/// Reference to the evidence behind a proposal: a DecisionTrace entry and,
+/// when the evidence came from episodic memory, the episode store row ids.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TraceRef {
+    pub trace_id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub episode_ids: Vec<String>,
+}
+
+/// Budget layer a [`TighteningEffect::LowerLayerBudget`] targets (§13.3).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BudgetLayerName {
+    Cognitive,
+    Execution,
+    Data,
+    Network,
+    /// Offline learning spend (§7.4); wired by the consolidation teacher.
+    Consolidation,
+}
+
+/// The typed effect of a tightening. Closed by construction: every variant
+/// restricts behavior. Whether a value actually tightens *relative to the
+/// current policy* (e.g. the new ceiling is below the present one) is checked
+/// at ingest by the runtime, which knows the current values.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TighteningEffect {
+    /// Lower `budget.task_ceiling_usd`.
+    LowerTaskCeiling { new_ceiling_usd: f64 },
+    /// Lower one layer's limit in `budget.per_layer`.
+    LowerLayerBudget {
+        layer: BudgetLayerName,
+        new_limit_usd: f64,
+    },
+    /// Raise `feedback_loops.immediate.quality_gate.threshold_default`.
+    RaiseQualityGateThreshold { new_threshold: f64 },
+    /// Quarantine a specific entity (§14.2).
+    AddQuarantine {
+        scope: QuarantineScope,
+        entity: String,
+    },
+    /// Deny a tool outright.
+    DenyTool { tool: String },
+    /// Deny network egress to a host.
+    DenyEgress { host: String },
+    /// Lower a global rate limit (§13.4).
+    LowerRateLimit { new_requests_per_second: f64 },
+}
+
+impl TighteningEffect {
+    /// Value-sanity check for the effect, independent of current policy
+    /// state. Returns the violation, or `None` when sane.
+    #[must_use]
+    pub fn value_violation(&self) -> Option<String> {
+        match self {
+            Self::LowerTaskCeiling { new_ceiling_usd } if *new_ceiling_usd <= 0.0 => Some(format!(
+                "new_ceiling_usd must be positive, got {new_ceiling_usd}"
+            )),
+            Self::LowerLayerBudget { new_limit_usd, .. } if *new_limit_usd <= 0.0 => Some(format!(
+                "new_limit_usd must be positive, got {new_limit_usd}"
+            )),
+            Self::RaiseQualityGateThreshold { new_threshold }
+                if !(*new_threshold > 0.0 && *new_threshold <= 1.0) =>
+            {
+                Some(format!(
+                    "new_threshold must be in (0, 1], got {new_threshold}"
+                ))
+            }
+            Self::AddQuarantine { entity, .. } if entity.trim().is_empty() => {
+                Some("quarantine entity must be non-empty".to_string())
+            }
+            Self::DenyTool { tool } if tool.trim().is_empty() => {
+                Some("denied tool must be non-empty".to_string())
+            }
+            Self::DenyEgress { host } if host.trim().is_empty() => {
+                Some("denied host must be non-empty".to_string())
+            }
+            Self::LowerRateLimit {
+                new_requests_per_second,
+            } if *new_requests_per_second <= 0.0 => Some(format!(
+                "new_requests_per_second must be positive, got {new_requests_per_second}"
+            )),
+            _ => None,
+        }
+    }
+}
+
+/// An evidence-backed request to tighten policy.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TighteningProposal {
+    /// Unique proposal id (producer-assigned, typically a UUID string).
+    pub id: String,
+    pub origin: ProposalOrigin,
+    pub state: ProposalState,
+    pub effect: TighteningEffect,
+    /// Plain-language rationale grounded in the evidence.
+    pub rationale: String,
+    pub blast_radius: BlastRadius,
+    /// Must be non-empty: a proposal without evidence is rejected at ingest.
+    pub evidence: Vec<TraceRef>,
+    /// RFC 3339 creation timestamp.
+    pub created_at: String,
+    /// RFC 3339 timestamp set when the effect was applied.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub applied_at: Option<String>,
+    /// Identity that reviewed/approved (HITL path).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reviewed_by: Option<String>,
+    /// Why the proposal was reverted or rejected, when it was.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disposition_reason: Option<String>,
+}
+
+/// Per-document policy governing which proposals may be ingested and how far
+/// they may auto-apply (§18.2). Lives at `ArpDocument.proposal_policy`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ProposalPolicy {
+    /// Origins this agent accepts proposals from. Must be non-empty.
+    pub accepted_origins: Vec<ProposalOrigin>,
+    /// Largest radius that may apply without human review.
+    /// [`BlastRadius::Mesh`] is never auto-applied regardless of this value;
+    /// validation rejects it here.
+    pub auto_apply_max_blast_radius: BlastRadius,
+    /// Review mechanism for proposals above the auto-apply radius (§15.1).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review: Option<ApprovalMechanism>,
+    /// How long an applied proposal stays in `observed` before it can be
+    /// confirmed (no quality-gate regression attributable to the change).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observation_window_sec: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blast_radius_ordering_is_load_bearing() {
+        assert!(BlastRadius::SingleEntity < BlastRadius::SingleAgent);
+        assert!(BlastRadius::SingleAgent < BlastRadius::Flight);
+        assert!(BlastRadius::Flight < BlastRadius::Mesh);
+    }
+
+    #[test]
+    fn blast_radius_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&BlastRadius::SingleEntity).unwrap(),
+            "\"single_entity\""
+        );
+        assert_eq!(
+            serde_json::to_string(&BlastRadius::Mesh).unwrap(),
+            "\"mesh\""
+        );
+    }
+
+    #[test]
+    fn effect_is_internally_tagged() {
+        let effect = TighteningEffect::LowerTaskCeiling {
+            new_ceiling_usd: 1.5,
+        };
+        let json = serde_json::to_value(&effect).unwrap();
+        assert_eq!(json["kind"], "lower_task_ceiling");
+        assert_eq!(json["new_ceiling_usd"], 1.5);
+
+        let parsed: TighteningEffect = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, effect);
+    }
+
+    #[test]
+    fn effect_value_sanity() {
+        assert!(
+            TighteningEffect::LowerTaskCeiling {
+                new_ceiling_usd: -1.0
+            }
+            .value_violation()
+            .is_some()
+        );
+        assert!(
+            TighteningEffect::RaiseQualityGateThreshold { new_threshold: 1.2 }
+                .value_violation()
+                .is_some()
+        );
+        assert!(
+            TighteningEffect::DenyTool { tool: "  ".into() }
+                .value_violation()
+                .is_some()
+        );
+        assert!(
+            TighteningEffect::AddQuarantine {
+                scope: QuarantineScope::Tool,
+                entity: "game-rl:reset".into()
+            }
+            .value_violation()
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn proposal_round_trips() {
+        let json = r#"{
+            "id": "prop-1",
+            "origin": "consolidation",
+            "state": "proposed",
+            "effect": {"kind": "deny_tool", "tool": "game-rl:reset"},
+            "rationale": "reset correlated with colony loss in 4/4 failures",
+            "blast_radius": "single_agent",
+            "evidence": [{"trace_id": "t-1", "episode_ids": ["ep-1", "ep-2"]}],
+            "created_at": "2026-06-10T00:00:00Z"
+        }"#;
+        let p: TighteningProposal = serde_json::from_str(json).unwrap();
+        assert_eq!(p.origin, ProposalOrigin::Consolidation);
+        assert_eq!(p.state, ProposalState::Proposed);
+        assert_eq!(p.blast_radius, BlastRadius::SingleAgent);
+        assert!(matches!(p.effect, TighteningEffect::DenyTool { .. }));
+        let back = serde_json::to_string(&p).unwrap();
+        let p2: TighteningProposal = serde_json::from_str(&back).unwrap();
+        assert_eq!(p, p2);
+    }
+
+    #[test]
+    fn there_is_no_loosen_variant() {
+        // The closed-enum guarantee: deserializing a loosening "effect"
+        // fails at the type level, not at a validation layer.
+        let json = r#"{"kind": "raise_task_ceiling", "new_ceiling_usd": 100.0}"#;
+        assert!(serde_json::from_str::<TighteningEffect>(json).is_err());
+        let json = r#"{"kind": "allow_tool", "tool": "anything"}"#;
+        assert!(serde_json::from_str::<TighteningEffect>(json).is_err());
+    }
+}

--- a/crates/arkavo-arp/src/proposal.rs
+++ b/crates/arkavo-arp/src/proposal.rs
@@ -111,13 +111,24 @@ impl TighteningEffect {
     /// state. Returns the violation, or `None` when sane.
     #[must_use]
     pub fn value_violation(&self) -> Option<String> {
+        // Scalar guards are written as negated conjunctions so NaN (every
+        // comparison false) and ±infinity fail closed instead of slipping
+        // through a `<= 0.0` check.
         match self {
-            Self::LowerTaskCeiling { new_ceiling_usd } if *new_ceiling_usd <= 0.0 => Some(format!(
-                "new_ceiling_usd must be positive, got {new_ceiling_usd}"
-            )),
-            Self::LowerLayerBudget { new_limit_usd, .. } if *new_limit_usd <= 0.0 => Some(format!(
-                "new_limit_usd must be positive, got {new_limit_usd}"
-            )),
+            Self::LowerTaskCeiling { new_ceiling_usd }
+                if !(new_ceiling_usd.is_finite() && *new_ceiling_usd > 0.0) =>
+            {
+                Some(format!(
+                    "new_ceiling_usd must be finite and positive, got {new_ceiling_usd}"
+                ))
+            }
+            Self::LowerLayerBudget { new_limit_usd, .. }
+                if !(new_limit_usd.is_finite() && *new_limit_usd > 0.0) =>
+            {
+                Some(format!(
+                    "new_limit_usd must be finite and positive, got {new_limit_usd}"
+                ))
+            }
             Self::RaiseQualityGateThreshold { new_threshold }
                 if !(*new_threshold > 0.0 && *new_threshold <= 1.0) =>
             {
@@ -136,9 +147,12 @@ impl TighteningEffect {
             }
             Self::LowerRateLimit {
                 new_requests_per_second,
-            } if *new_requests_per_second <= 0.0 => Some(format!(
-                "new_requests_per_second must be positive, got {new_requests_per_second}"
-            )),
+            } if !(new_requests_per_second.is_finite() && *new_requests_per_second > 0.0) => {
+                Some(format!(
+                    "new_requests_per_second must be finite and positive, got \
+                     {new_requests_per_second}"
+                ))
+            }
             _ => None,
         }
     }
@@ -253,6 +267,47 @@ mod tests {
             .value_violation()
             .is_none()
         );
+    }
+
+    #[test]
+    fn effect_value_sanity_rejects_nan_and_infinity() {
+        // Comparisons against NaN are false, so a `<= 0.0` guard silently
+        // admits NaN; +inf passes any positivity check. Every scalar arm
+        // must reject both — serde_json blocks them on the wire, but
+        // programmatically built proposals reach value_violation directly.
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(
+                TighteningEffect::LowerTaskCeiling {
+                    new_ceiling_usd: bad
+                }
+                .value_violation()
+                .is_some(),
+                "ceiling {bad} must be rejected"
+            );
+            assert!(
+                TighteningEffect::LowerLayerBudget {
+                    layer: BudgetLayerName::Consolidation,
+                    new_limit_usd: bad
+                }
+                .value_violation()
+                .is_some(),
+                "layer limit {bad} must be rejected"
+            );
+            assert!(
+                TighteningEffect::LowerRateLimit {
+                    new_requests_per_second: bad
+                }
+                .value_violation()
+                .is_some(),
+                "rate {bad} must be rejected"
+            );
+            assert!(
+                TighteningEffect::RaiseQualityGateThreshold { new_threshold: bad }
+                    .value_violation()
+                    .is_some(),
+                "threshold {bad} must be rejected"
+            );
+        }
     }
 
     #[test]

--- a/crates/arkavo-arp/src/proposal.rs
+++ b/crates/arkavo-arp/src/proposal.rs
@@ -192,6 +192,7 @@ pub struct ProposalPolicy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
     #[test]
     fn blast_radius_ordering_is_load_bearing() {
@@ -276,6 +277,7 @@ mod tests {
         assert_eq!(p, p2);
     }
 
+    #[spec("ARP-007")]
     #[test]
     fn there_is_no_loosen_variant() {
         // The closed-enum guarantee: deserializing a loosening "effect"

--- a/crates/arkavo-arp/src/validate.rs
+++ b/crates/arkavo-arp/src/validate.rs
@@ -14,6 +14,31 @@ pub fn validate(doc: &ArpDocument) -> Result<(), ValidationError> {
     validate_quarantine_invariants(doc)?;
     validate_quality_gate_threshold(doc)?;
     validate_proposal_policy(doc)?;
+    validate_distilled_decay(doc)?;
+    Ok(())
+}
+
+fn validate_distilled_decay(doc: &ArpDocument) -> Result<(), ValidationError> {
+    if let Some(pm) = &doc.adaptation.prior_management
+        && let Some(decay) = &pm.distilled_decay
+    {
+        if let Some(factor) = decay.displacement_factor
+            && !(factor > 0.0 && factor <= 1.0)
+        {
+            return Err(ValidationError {
+                field: "adaptation.prior_management.distilled_decay.displacement_factor".into(),
+                message: format!("displacement_factor must be in (0, 1], got {factor}"),
+            });
+        }
+        if let Some(floor) = decay.floor
+            && !(0.0..=1.0).contains(&floor)
+        {
+            return Err(ValidationError {
+                field: "adaptation.prior_management.distilled_decay.floor".into(),
+                message: format!("floor must be in [0, 1], got {floor}"),
+            });
+        }
+    }
     Ok(())
 }
 
@@ -301,6 +326,40 @@ mod tests {
         }
     }
 
+    fn doc_with_decay(factor: Option<f64>, floor: Option<f64>) -> ArpDocument {
+        use crate::adaptation::{DistilledDecay, DistilledDecayStrategy, PriorManagement};
+        let mut doc = minimal_doc();
+        doc.adaptation.prior_management = Some(PriorManagement {
+            version_binding: None,
+            reset_on_version_change: None,
+            reset_state: None,
+            provenance_tracking: Some(true),
+            distilled_decay: Some(DistilledDecay {
+                strategy: DistilledDecayStrategy::LiveDisplacement,
+                displacement_factor: factor,
+                floor,
+            }),
+        });
+        doc
+    }
+
+    #[test]
+    fn accept_valid_distilled_decay() {
+        assert!(validate(&doc_with_decay(Some(0.05), Some(0.1))).is_ok());
+        // Both fields optional — defaults apply.
+        assert!(validate(&doc_with_decay(None, None)).is_ok());
+    }
+
+    #[test]
+    fn reject_distilled_decay_out_of_range() {
+        let err = validate(&doc_with_decay(Some(0.0), None)).unwrap_err();
+        assert!(err.field.contains("displacement_factor"));
+        let err = validate(&doc_with_decay(Some(1.5), None)).unwrap_err();
+        assert!(err.field.contains("displacement_factor"));
+        let err = validate(&doc_with_decay(Some(0.05), Some(1.5))).unwrap_err();
+        assert!(err.field.contains("floor"));
+    }
+
     #[test]
     fn valid_minimal_document() {
         let doc = minimal_doc();
@@ -483,6 +542,8 @@ mod tests {
                     alpha: 1.0,
                     beta: -0.5,
                 }),
+                provenance_tracking: None,
+                distilled_decay: None,
             }),
             signal_separation: None,
         };

--- a/crates/arkavo-arp/src/validate.rs
+++ b/crates/arkavo-arp/src/validate.rs
@@ -231,6 +231,7 @@ mod tests {
     };
     use crate::model::{AdlRef, BetaPrior};
     use crate::proposal::{ProposalOrigin, TraceRef};
+    use arkavo_test_macros::spec;
 
     fn minimal_doc() -> ArpDocument {
         ArpDocument {
@@ -384,6 +385,7 @@ mod tests {
         assert!(err.field.contains("accepted_origins"));
     }
 
+    #[spec("ARP-006")]
     #[test]
     fn reject_mesh_auto_apply_ceiling() {
         let mut doc = minimal_doc();

--- a/crates/arkavo-arp/src/validate.rs
+++ b/crates/arkavo-arp/src/validate.rs
@@ -2,6 +2,7 @@
 
 use crate::feedback::DecayStrategy;
 use crate::model::{ArpDocument, SignedContent};
+use crate::proposal::{BlastRadius, ProposalPolicy, TighteningProposal};
 
 /// Validate semantic constraints that cannot be expressed in JSON Schema alone.
 pub fn validate(doc: &ArpDocument) -> Result<(), ValidationError> {
@@ -12,6 +13,7 @@ pub fn validate(doc: &ArpDocument) -> Result<(), ValidationError> {
     validate_escalation_invariants(doc)?;
     validate_quarantine_invariants(doc)?;
     validate_quality_gate_threshold(doc)?;
+    validate_proposal_policy(doc)?;
     Ok(())
 }
 
@@ -126,6 +128,58 @@ fn validate_quality_gate_threshold(doc: &ArpDocument) -> Result<(), ValidationEr
     Ok(())
 }
 
+fn validate_proposal_policy(doc: &ArpDocument) -> Result<(), ValidationError> {
+    if let Some(policy) = &doc.proposal_policy {
+        if policy.accepted_origins.is_empty() {
+            return Err(ValidationError {
+                field: "proposal_policy.accepted_origins".into(),
+                message: "accepted_origins must be non-empty when proposal_policy is present"
+                    .into(),
+            });
+        }
+        if policy.auto_apply_max_blast_radius >= BlastRadius::Mesh {
+            return Err(ValidationError {
+                field: "proposal_policy.auto_apply_max_blast_radius".into(),
+                message: "mesh-radius proposals are never auto-applied; the ceiling must be \
+                          below 'mesh'"
+                    .into(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Ingest-side validation of a single proposal against a policy: non-empty
+/// evidence, accepted origin, and per-effect value sanity. The runtime layers
+/// the current-value direction comparison on top of this.
+pub fn validate_proposal(
+    proposal: &TighteningProposal,
+    policy: &ProposalPolicy,
+) -> Result<(), ValidationError> {
+    if proposal.evidence.is_empty() {
+        return Err(ValidationError {
+            field: "proposal.evidence".into(),
+            message: format!("proposal {} has no evidence", proposal.id),
+        });
+    }
+    if !policy.accepted_origins.contains(&proposal.origin) {
+        return Err(ValidationError {
+            field: "proposal.origin".into(),
+            message: format!(
+                "origin {:?} is not in this document's accepted_origins",
+                proposal.origin
+            ),
+        });
+    }
+    if let Some(violation) = proposal.effect.value_violation() {
+        return Err(ValidationError {
+            field: "proposal.effect".into(),
+            message: violation,
+        });
+    }
+    Ok(())
+}
+
 /// A semantic validation error.
 #[derive(Debug)]
 pub struct ValidationError {
@@ -151,6 +205,7 @@ mod tests {
         QualityMetric, ShortTermFeedback,
     };
     use crate::model::{AdlRef, BetaPrior};
+    use crate::proposal::{ProposalOrigin, TraceRef};
 
     fn minimal_doc() -> ArpDocument {
         ArpDocument {
@@ -214,7 +269,35 @@ mod tests {
             session: None,
             state_storage: None,
             observability: None,
+            proposal_policy: None,
             metadata: None,
+        }
+    }
+
+    fn proposal(origin: ProposalOrigin, evidence: Vec<TraceRef>) -> TighteningProposal {
+        TighteningProposal {
+            id: "prop-1".into(),
+            origin,
+            state: crate::proposal::ProposalState::Proposed,
+            effect: crate::proposal::TighteningEffect::DenyTool {
+                tool: "game-rl:reset".into(),
+            },
+            rationale: "reset correlated with colony loss".into(),
+            blast_radius: BlastRadius::SingleAgent,
+            evidence,
+            created_at: "2026-06-10T00:00:00Z".into(),
+            applied_at: None,
+            reviewed_by: None,
+            disposition_reason: None,
+        }
+    }
+
+    fn policy() -> ProposalPolicy {
+        ProposalPolicy {
+            accepted_origins: vec![ProposalOrigin::Consolidation, ProposalOrigin::Human],
+            auto_apply_max_blast_radius: BlastRadius::SingleEntity,
+            review: None,
+            observation_window_sec: Some(3600),
         }
     }
 
@@ -222,6 +305,82 @@ mod tests {
     fn valid_minimal_document() {
         let doc = minimal_doc();
         assert!(validate(&doc).is_ok());
+    }
+
+    #[test]
+    fn accept_document_with_proposal_policy() {
+        let mut doc = minimal_doc();
+        doc.proposal_policy = Some(policy());
+        assert!(validate(&doc).is_ok());
+    }
+
+    #[test]
+    fn reject_proposal_policy_with_empty_origins() {
+        let mut doc = minimal_doc();
+        doc.proposal_policy = Some(ProposalPolicy {
+            accepted_origins: vec![],
+            ..policy()
+        });
+        let err = validate(&doc).unwrap_err();
+        assert!(err.field.contains("accepted_origins"));
+    }
+
+    #[test]
+    fn reject_mesh_auto_apply_ceiling() {
+        let mut doc = minimal_doc();
+        doc.proposal_policy = Some(ProposalPolicy {
+            auto_apply_max_blast_radius: BlastRadius::Mesh,
+            ..policy()
+        });
+        let err = validate(&doc).unwrap_err();
+        assert!(err.field.contains("auto_apply_max_blast_radius"));
+    }
+
+    #[test]
+    fn reject_proposal_without_evidence() {
+        let p = proposal(ProposalOrigin::Consolidation, vec![]);
+        let err = validate_proposal(&p, &policy()).unwrap_err();
+        assert_eq!(err.field, "proposal.evidence");
+    }
+
+    #[test]
+    fn reject_proposal_from_unaccepted_origin() {
+        let p = proposal(
+            ProposalOrigin::Critic,
+            vec![TraceRef {
+                trace_id: "t-1".into(),
+                episode_ids: vec![],
+            }],
+        );
+        let err = validate_proposal(&p, &policy()).unwrap_err();
+        assert_eq!(err.field, "proposal.origin");
+    }
+
+    #[test]
+    fn reject_proposal_with_insane_effect_value() {
+        let mut p = proposal(
+            ProposalOrigin::Consolidation,
+            vec![TraceRef {
+                trace_id: "t-1".into(),
+                episode_ids: vec![],
+            }],
+        );
+        p.effect =
+            crate::proposal::TighteningEffect::RaiseQualityGateThreshold { new_threshold: 7.0 };
+        let err = validate_proposal(&p, &policy()).unwrap_err();
+        assert_eq!(err.field, "proposal.effect");
+    }
+
+    #[test]
+    fn accept_conformant_proposal() {
+        let p = proposal(
+            ProposalOrigin::Consolidation,
+            vec![TraceRef {
+                trace_id: "t-1".into(),
+                episode_ids: vec!["ep-1".into()],
+            }],
+        );
+        assert!(validate_proposal(&p, &policy()).is_ok());
     }
 
     #[test]

--- a/crates/arkavo-lesson-synthesis/Cargo.toml
+++ b/crates/arkavo-lesson-synthesis/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "arkavo-lesson-synthesis"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "The lesson-synthesis rules shared by the runtime consolidation teacher and the audit-plane shadow job."
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/crates/arkavo-lesson-synthesis/src/lib.rs
+++ b/crates/arkavo-lesson-synthesis/src/lib.rs
@@ -1,0 +1,69 @@
+//! The lesson-synthesis rules shared by every consolidation surface.
+//!
+//! A lesson must reason about which *actions* produce good outcomes, not
+//! about tool-calling mechanics, so read-only observe/list/hash/summary
+//! calls are stripped from evidence before synthesis. This crate is the
+//! single definition of that rule — the runtime consolidation teacher and
+//! the audit-plane shadow job both consume it, so the two planes cannot
+//! drift apart on what counts as an action.
+//!
+//! Pure functions over std only: depending on this crate creates no
+//! runtime contact.
+
+/// A tool is an *action* tool only when its name does not mark it as a
+/// read-only observe/list/hash/summary call.
+#[must_use]
+pub fn is_action_tool(tool: &str) -> bool {
+    let lower = tool.to_lowercase();
+    !lower.contains("observe")
+        && !lower.contains("list")
+        && !lower.contains("hash")
+        && !lower.contains("summary")
+}
+
+/// Apply [`is_action_tool`] to a tool list — the evidence-stripping step.
+#[must_use]
+pub fn strip_observe(tools: &[String]) -> Vec<String> {
+    tools
+        .iter()
+        .filter(|t| is_action_tool(t))
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_only_names_are_not_actions() {
+        for tool in [
+            "game-rl:observe",
+            "Observe",
+            "list_files",
+            "tools/list",
+            "content_hash",
+            "summary_report",
+        ] {
+            assert!(!is_action_tool(tool), "{tool} must be read-only");
+        }
+    }
+
+    #[test]
+    fn action_names_pass() {
+        for tool in ["set_priority", "PlaceOrder", "game-rl:act", "deploy"] {
+            assert!(is_action_tool(tool), "{tool} must be an action");
+        }
+    }
+
+    #[test]
+    fn strip_observe_keeps_only_actions_in_order() {
+        let tools = vec![
+            "observe".to_string(),
+            "set_priority".to_string(),
+            "list_files".to_string(),
+            "deploy".to_string(),
+        ];
+        assert_eq!(strip_observe(&tools), vec!["set_priority", "deploy"]);
+    }
+}

--- a/crates/arkavo-llm/src/providers/anthropic.rs
+++ b/crates/arkavo-llm/src/providers/anthropic.rs
@@ -138,6 +138,13 @@ enum ResponseContentBlock {
     Other,
 }
 
+/// Token usage reported by a completion, for caller-side cost accounting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CompletionUsage {
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+}
+
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 struct Usage {
@@ -516,6 +523,69 @@ impl AnthropicProvider {
                 _ => ProviderError::Other(anyhow::anyhow!("Anthropic API error: {status}")),
             }
         }
+    }
+
+    /// Non-streaming completion that also returns the API-reported token
+    /// usage, for callers that do their own cost accounting (e.g. the
+    /// consolidation teacher's per-layer budget ledger).
+    pub async fn complete_with_usage(
+        &self,
+        messages: Vec<Message>,
+    ) -> Result<(String, CompletionUsage), crate::Error> {
+        let (system_content, api_messages) = self.convert_messages(messages);
+        let request = self.build_request(api_messages, system_content, false, None, None);
+        let url = format!("{}/v1/messages", self.config.base_url);
+
+        let result = self
+            .client
+            .execute_with_retry(|client| {
+                let config = self.config.clone();
+                let url = url.clone();
+                let request = request.clone();
+                Box::pin(async move {
+                    let response = client
+                        .post(&url)
+                        .header("x-api-key", &config.api_key)
+                        .header("anthropic-version", &config.api_version)
+                        .header("content-type", "application/json")
+                        .json(&request)
+                        .send()
+                        .await?;
+
+                    if response.status().is_success() {
+                        let message: MessageResponse = response.json().await?;
+                        let content = message
+                            .content
+                            .iter()
+                            .filter_map(|block| match block {
+                                ResponseContentBlock::Text { text } => Some(text.clone()),
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        Ok((
+                            content,
+                            CompletionUsage {
+                                input_tokens: message.usage.input_tokens,
+                                output_tokens: message.usage.output_tokens,
+                            },
+                        ))
+                    } else {
+                        let status = response.status();
+                        let error_text = response
+                            .text()
+                            .await
+                            .unwrap_or_else(|_| "Failed to read error response".to_string());
+                        Err(anyhow::anyhow!(
+                            "Anthropic API error {status}: {error_text}"
+                        ))
+                    }
+                })
+            })
+            .await
+            .map_err(|e| crate::Error::Provider(e.to_string()))?;
+
+        Ok(result)
     }
 }
 

--- a/crates/arkavo-observability/src/decision_trace.rs
+++ b/crates/arkavo-observability/src/decision_trace.rs
@@ -369,6 +369,7 @@ mod tests {
             TraceEventType::BudgetEvent,
             TraceEventType::Quarantine,
             TraceEventType::HitlAction,
+            TraceEventType::ProposalLifecycle,
         ];
 
         for event_type in event_types {

--- a/crates/arkavo-observability/src/decision_trace.rs
+++ b/crates/arkavo-observability/src/decision_trace.rs
@@ -372,6 +372,7 @@ mod tests {
             TraceEventType::ProposalLifecycle,
         ];
 
+        let expected = event_types.len();
         for event_type in event_types {
             trace.record(
                 TraceLayer::Execution,
@@ -383,7 +384,7 @@ mod tests {
             );
         }
 
-        assert_eq!(trace.len(), 9);
+        assert_eq!(trace.len(), expected);
     }
 
     #[test]

--- a/crates/arkavo-protocol/src/agent_specialization.rs
+++ b/crates/arkavo-protocol/src/agent_specialization.rs
@@ -408,6 +408,7 @@ mod tests {
             session: None,
             state_storage: None,
             observability: None,
+            proposal_policy: None,
             metadata: None,
         }
     }

--- a/crates/arkavo-server/Cargo.toml
+++ b/crates/arkavo-server/Cargo.toml
@@ -84,6 +84,7 @@ arkavo-tasks = { path = "../arkavo-tasks" }
 arkavo-mcp = { path = "../arkavo-mcp" }
 arkavo-mcp-tools = { path = "../arkavo-mcp-tools" }
 arkavo-memory = { path = "../arkavo-memory" }
+arkavo-lesson-synthesis = { path = "../arkavo-lesson-synthesis" }
 arkavo-llm = { path = "../arkavo-llm", default-features = false, features = ["kimi"] }
 # Direct llama.cpp handle for LlamaTokenEstimator (real tokenizer); only under llama-cpp.
 arkavo-llama-cpp = { path = "../arkavo-llama-cpp", optional = true }

--- a/crates/arkavo-server/Cargo.toml
+++ b/crates/arkavo-server/Cargo.toml
@@ -102,7 +102,9 @@ arkavo-ucp = { path = "../arkavo-ucp" }
 arkavo-critic = { path = "../arkavo-critic" }
 arkavo-trust = { path = "../arkavo-trust" }
 arkavo-device-identity = { path = "../arkavo-device-identity" }
+arkavo-arp = { path = "../arkavo-arp" }
 arkavo-arp-runtime = { path = "../arkavo-arp-runtime" }
+ed25519-dalek = { workspace = true }
 arkavo-tdf = { path = "../arkavo-tdf", features = ["a2a"], optional = true }
 arkavo-tdf-iroh = { path = "../arkavo-tdf-iroh", optional = true }
 
@@ -124,7 +126,6 @@ llama-cpp = ["arkavo-llm/llama-cpp", "dep:arkavo-llama-cpp"]
 claude-agent = ["dep:arkavo-mcp-claude"]
 
 [dev-dependencies]
-arkavo-arp = { path = "../arkavo-arp" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/arkavo-server/Cargo.toml
+++ b/crates/arkavo-server/Cargo.toml
@@ -124,6 +124,7 @@ llama-cpp = ["arkavo-llm/llama-cpp", "dep:arkavo-llama-cpp"]
 claude-agent = ["dep:arkavo-mcp-claude"]
 
 [dev-dependencies]
+arkavo-arp = { path = "../arkavo-arp" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/arkavo-server/src/server/consolidation_teacher.rs
+++ b/crates/arkavo-server/src/server/consolidation_teacher.rs
@@ -1,0 +1,701 @@
+//! Consolidation teacher block (§7.4, #611): the first consumer of the ARP
+//! `feedback_loops.consolidation` config.
+//!
+//! The teacher is the offline model that distills episodes into action-named
+//! lessons and typed tightening proposals. Its contract is enforced post-hoc
+//! regardless of the producing model: a lesson must name an action present in
+//! the batch evidence; a tightening must deserialize into the closed
+//! `TighteningEffect` enum and pass value sanity. Violations are recorded as
+//! rejects, never silently dropped — the accept/reject split is the
+//! contract-conformance rate.
+//!
+//! Budget discipline: `budget.per_layer.consolidation.limit_usd` is the hard
+//! ceiling for one run. It is required when the teacher is non-local;
+//! exhaustion stops between batches with partial output and a
+//! `budget_exhausted` BudgetEvent trace. The teacher never borrows from
+//! runtime budgets.
+//!
+//! Attribution: accepted lessons are signed by the **consolidation runner's
+//! identity** (ed25519 over the canonical lesson JSON), not attributed to the
+//! remote model — the teacher informs, the runner vouches.
+
+use arkavo_arp::observability::{TraceDecision, TraceEventType, TraceLayer, TraceOutcome};
+use arkavo_arp::proposal::{
+    BlastRadius, ProposalOrigin, ProposalState, TighteningEffect, TighteningProposal, TraceRef,
+};
+use arkavo_observability::decision_trace::DecisionTrace;
+use arkavo_router::learning::{Episode, Lesson, LessonPattern};
+use async_trait::async_trait;
+use base64::Engine;
+use ed25519_dalek::{Signer, SigningKey};
+use serde_json::{Value, json};
+
+use super::synthesis::is_action_tool;
+
+/// Fable 5 list price, USD per million tokens.
+const FABLE_INPUT_USD_PER_MTOK: f64 = 10.0;
+const FABLE_OUTPUT_USD_PER_MTOK: f64 = 50.0;
+
+/// One teacher completion: text plus the cost it incurred.
+#[derive(Debug, Clone)]
+pub struct TeacherReply {
+    pub text: String,
+    pub cost_usd: f64,
+}
+
+/// A consolidation teacher model. Implementations: Fable via the Anthropic
+/// provider (non-local — per-layer budget required), the local router path
+/// (offline-safe fallback), and mocks in tests.
+#[async_trait]
+pub trait TeacherModel: Send + Sync {
+    async fn complete(&self, system: &str, user: &str) -> Result<TeacherReply, String>;
+    /// Model identity, recorded for audit (never used as the signer).
+    fn identity(&self) -> String;
+    /// Non-local teachers require a consolidation layer budget.
+    fn is_local(&self) -> bool;
+}
+
+/// Fable teacher over the arkavo-llm Anthropic provider.
+pub struct FableTeacher {
+    provider: arkavo_llm::providers::anthropic::AnthropicProvider,
+    model: String,
+}
+
+impl FableTeacher {
+    /// Construct from the environment (`ANTHROPIC_API_KEY`), honoring the
+    /// config's `model_preference`.
+    pub fn from_env(model_preference: &str) -> Result<Self, String> {
+        let provider = arkavo_llm::providers::anthropic::AnthropicProvider::from_env_with_model(
+            model_preference,
+        )
+        .map_err(|e| format!("Fable teacher unavailable: {e}"))?;
+        Ok(Self {
+            provider,
+            model: model_preference.to_string(),
+        })
+    }
+}
+
+#[async_trait]
+impl TeacherModel for FableTeacher {
+    async fn complete(&self, system: &str, user: &str) -> Result<TeacherReply, String> {
+        let messages = vec![
+            arkavo_llm::Message::system(system),
+            arkavo_llm::Message::user(user),
+        ];
+        let (text, usage) = self
+            .provider
+            .complete_with_usage(messages)
+            .await
+            .map_err(|e| e.to_string())?;
+        let cost_usd = f64::from(usage.input_tokens) / 1e6 * FABLE_INPUT_USD_PER_MTOK
+            + f64::from(usage.output_tokens) / 1e6 * FABLE_OUTPUT_USD_PER_MTOK;
+        Ok(TeacherReply { text, cost_usd })
+    }
+
+    fn identity(&self) -> String {
+        self.model.clone()
+    }
+
+    fn is_local(&self) -> bool {
+        false
+    }
+}
+
+/// A lesson accepted by the contract, signed by the runner identity.
+#[derive(Debug, Clone)]
+pub struct SignedLesson {
+    pub lesson: Lesson,
+    /// Base64url(ed25519 signature over the canonical lesson-pattern JSON).
+    pub signature_b64: String,
+    /// The consolidation runner's identity — never the teacher model.
+    pub signed_by: String,
+}
+
+/// A contract violation, recorded with its reason.
+#[derive(Debug, Clone)]
+pub struct TeacherReject {
+    pub category: String,
+    pub reason: String,
+    pub payload: Value,
+}
+
+/// Outcome of one teacher run.
+#[derive(Debug, Default)]
+pub struct TeacherRun {
+    pub lessons: Vec<SignedLesson>,
+    pub proposals: Vec<TighteningProposal>,
+    pub rejects: Vec<TeacherReject>,
+    pub total_cost_usd: f64,
+    /// True when the per-layer ceiling stopped the run early; output is
+    /// partial by design.
+    pub budget_exhausted: bool,
+    pub categories_consolidated: u32,
+    pub categories_budget_stopped: u32,
+}
+
+/// Runner identity: the signing key plus the attribution string.
+pub struct RunnerIdentity {
+    pub signing_key: SigningKey,
+    pub runner_did: String,
+}
+
+const SYSTEM_PROMPT: &str = "\
+You are the offline consolidation teacher for an agent swarm. You receive \
+action->outcome evidence from episodes in one task category, with read-only \
+observe/list calls already removed. Reason about WHICH ACTION produces good \
+outcomes under WHICH CONDITION. Do not discuss observe, list, or tool \
+sequencing.\n\n\
+Return ONLY a JSON object:\n\
+{\n\
+  \"lesson\": {\"condition\": \"...\", \"action\": \"tool named in evidence\", \
+\"expected_outcome\": \"...\", \"confidence\": 0.0} | null,\n\
+  \"tightenings\": [\n\
+    {\"effect\": {\"kind\": \"deny_tool\", \"tool\": \"...\"} | \
+{\"kind\": \"raise_quality_gate_threshold\", \"new_threshold\": 0.0} | \
+{\"kind\": \"lower_task_ceiling\", \"new_ceiling_usd\": 0.0} | \
+{\"kind\": \"deny_egress\", \"host\": \"...\"},\n\
+     \"rationale\": \"grounded in the outcomes above\",\n\
+     \"blast_radius\": \"single_entity\" | \"single_agent\"}\n\
+  ]\n\
+}\n\
+Every effect must RESTRICT behavior. A lesson MUST name an action from the \
+evidence; use null when no pattern is clear.";
+
+/// Run the teacher over per-category episode batches under the given budget
+/// ceiling. `limit_usd` is `budget.per_layer.consolidation.limit_usd`; it is
+/// mandatory for non-local teachers.
+pub async fn run_teacher(
+    teacher: &dyn TeacherModel,
+    batches: &[(String, Vec<Episode>)],
+    limit_usd: Option<f64>,
+    identity: &RunnerIdentity,
+    agent_id: &str,
+    swarm_id: &str,
+    trace: Option<&DecisionTrace>,
+) -> Result<TeacherRun, String> {
+    let limit = match limit_usd {
+        Some(l) => l,
+        None if teacher.is_local() => f64::INFINITY,
+        None => {
+            return Err(
+                "budget.per_layer.consolidation.limit_usd is required for a non-local teacher"
+                    .to_string(),
+            );
+        }
+    };
+
+    let mut run = TeacherRun::default();
+    for (idx, (category, episodes)) in batches.iter().enumerate() {
+        if run.total_cost_usd >= limit {
+            run.budget_exhausted = true;
+            run.categories_budget_stopped = (batches.len() - idx) as u32;
+            emit_budget_exhausted_trace(trace, agent_id, run.total_cost_usd, limit);
+            break;
+        }
+        let user = build_user_prompt(category, episodes);
+        let reply = teacher.complete(SYSTEM_PROMPT, &user).await?;
+        run.total_cost_usd += reply.cost_usd;
+        run.categories_consolidated += 1;
+
+        let evidence_actions = evidence_action_set(episodes);
+        let episode_ids: Vec<String> = episodes.iter().map(|e| e.id.to_string()).collect();
+        parse_and_enforce(
+            category,
+            &reply.text,
+            &evidence_actions,
+            &episode_ids,
+            episodes.len() as u32,
+            identity,
+            agent_id,
+            swarm_id,
+            &mut run,
+        );
+    }
+    Ok(run)
+}
+
+/// Action-name set from the batch, observe calls stripped per the
+/// lesson-synthesis rule (single in-crate definition in `synthesis`).
+fn evidence_action_set(episodes: &[Episode]) -> Vec<String> {
+    let mut out: Vec<String> = episodes
+        .iter()
+        .flat_map(|e| e.observation.tools_used.iter())
+        .filter(|t| is_action_tool(t))
+        .map(|t| t.to_lowercase())
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+fn build_user_prompt(category: &str, episodes: &[Episode]) -> String {
+    let outcomes: Vec<Value> = episodes
+        .iter()
+        .map(|e| {
+            let actions: Vec<&String> = e
+                .observation
+                .tools_used
+                .iter()
+                .filter(|t| is_action_tool(t))
+                .collect();
+            json!({
+                "actions": actions,
+                "success": e.outcome.success,
+                "quality": e.outcome.quality_metrics.correctness,
+            })
+        })
+        .collect();
+    let success = episodes.iter().filter(|e| e.outcome.success).count();
+    format!(
+        "Category: {}\n\nAction->outcome pairs ({} successes, {} failures):\n{}",
+        category,
+        success,
+        episodes.len() - success,
+        serde_json::to_string_pretty(&outcomes).unwrap_or_default()
+    )
+}
+
+/// True when the lesson's leading action token names an evidence action
+/// (namespace-tolerant in both directions).
+fn names_evidence_action(action: &str, evidence: &[String]) -> bool {
+    let token = action
+        .trim()
+        .split(|c: char| c.is_whitespace() || c == '(')
+        .next()
+        .unwrap_or("")
+        .trim_end_matches([':', ',', '.'])
+        .to_lowercase();
+    if token.is_empty() {
+        return false;
+    }
+    evidence.iter().any(|e| {
+        e == &token || e.ends_with(&format!(":{token}")) || token.ends_with(&format!(":{e}"))
+    })
+}
+
+#[allow(clippy::too_many_arguments)] // internal plumbing fn, not API surface
+fn parse_and_enforce(
+    category: &str,
+    reply: &str,
+    evidence: &[String],
+    episode_ids: &[String],
+    episode_count: u32,
+    identity: &RunnerIdentity,
+    agent_id: &str,
+    swarm_id: &str,
+    run: &mut TeacherRun,
+) {
+    let parsed = extract_json(reply).and_then(|s| serde_json::from_str::<Value>(&s).ok());
+    let Some(root) = parsed else {
+        run.rejects.push(TeacherReject {
+            category: category.to_string(),
+            reason: "reply does not contain a parseable JSON object".into(),
+            payload: Value::String(reply.chars().take(2000).collect()),
+        });
+        return;
+    };
+
+    // Lesson: action-named, regardless of producing model.
+    match root.get("lesson") {
+        None | Some(Value::Null) => {}
+        Some(lesson_val) => {
+            let condition = lesson_val.get("condition").and_then(Value::as_str);
+            let action = lesson_val.get("action").and_then(Value::as_str);
+            match (condition, action) {
+                (Some(c), Some(a)) if !c.trim().is_empty() && !a.trim().is_empty() => {
+                    if names_evidence_action(a, evidence) {
+                        let expected = lesson_val
+                            .get("expected_outcome")
+                            .and_then(Value::as_str)
+                            .unwrap_or("improved_outcome");
+                        let confidence = lesson_val
+                            .get("confidence")
+                            .and_then(Value::as_f64)
+                            .unwrap_or(0.5)
+                            .clamp(0.0, 1.0);
+                        let lesson = Lesson::new(
+                            agent_id.to_string(),
+                            swarm_id.to_string(),
+                            category.to_string(),
+                            LessonPattern::new(c.to_string(), a.to_string(), expected.to_string()),
+                            confidence,
+                            episode_count,
+                        );
+                        run.lessons.push(sign_lesson(lesson, identity));
+                    } else {
+                        run.rejects.push(TeacherReject {
+                            category: category.to_string(),
+                            reason: format!("lesson action {a:?} does not name an evidence action"),
+                            payload: lesson_val.clone(),
+                        });
+                    }
+                }
+                _ => run.rejects.push(TeacherReject {
+                    category: category.to_string(),
+                    reason: "lesson missing condition or action".into(),
+                    payload: lesson_val.clone(),
+                }),
+            }
+        }
+    }
+
+    // Tightenings: must deserialize into the closed effect enum.
+    if let Some(arr) = root.get("tightenings").and_then(Value::as_array) {
+        for item in arr {
+            let effect: Result<TighteningEffect, _> =
+                serde_json::from_value(item.get("effect").cloned().unwrap_or(Value::Null));
+            let effect = match effect {
+                Ok(e) => e,
+                Err(e) => {
+                    run.rejects.push(TeacherReject {
+                        category: category.to_string(),
+                        reason: format!("effect is not a valid tightening: {e}"),
+                        payload: item.clone(),
+                    });
+                    continue;
+                }
+            };
+            if let Some(violation) = effect.value_violation() {
+                run.rejects.push(TeacherReject {
+                    category: category.to_string(),
+                    reason: violation,
+                    payload: item.clone(),
+                });
+                continue;
+            }
+            let radius = item
+                .get("blast_radius")
+                .cloned()
+                .and_then(|v| serde_json::from_value::<BlastRadius>(v).ok())
+                .unwrap_or(BlastRadius::SingleEntity);
+            run.proposals.push(TighteningProposal {
+                id: uuid::Uuid::new_v4().to_string(),
+                origin: ProposalOrigin::Consolidation,
+                state: ProposalState::Proposed,
+                effect,
+                rationale: item
+                    .get("rationale")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string(),
+                blast_radius: radius,
+                evidence: vec![TraceRef {
+                    trace_id: format!("consolidation:{category}"),
+                    episode_ids: episode_ids.to_vec(),
+                }],
+                created_at: chrono::Utc::now().to_rfc3339(),
+                applied_at: None,
+                reviewed_by: None,
+                disposition_reason: None,
+            });
+        }
+    }
+}
+
+/// Sign the lesson pattern with the runner identity. Attribution is the
+/// runner, never the remote model.
+fn sign_lesson(mut lesson: Lesson, identity: &RunnerIdentity) -> SignedLesson {
+    let canonical = serde_json::to_vec(&lesson.pattern).unwrap_or_default();
+    let signature = identity.signing_key.sign(&canonical);
+    lesson.signature = signature.to_bytes().to_vec();
+    SignedLesson {
+        lesson,
+        signature_b64: base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(signature.to_bytes()),
+        signed_by: identity.runner_did.clone(),
+    }
+}
+
+fn extract_json(content: &str) -> Option<String> {
+    let start = content.find('{')?;
+    let end = content.rfind('}')?;
+    if end < start {
+        return None;
+    }
+    Some(
+        content[start..=end]
+            .chars()
+            .map(|c| if c.is_control() { ' ' } else { c })
+            .collect(),
+    )
+}
+
+fn emit_budget_exhausted_trace(
+    trace: Option<&DecisionTrace>,
+    agent_id: &str,
+    spent: f64,
+    limit: f64,
+) {
+    if let Some(trace) = trace {
+        trace.record(
+            TraceLayer::Cognitive,
+            TraceEventType::BudgetEvent,
+            uuid::Uuid::nil(),
+            agent_id,
+            TraceDecision {
+                chosen: Some("consolidation budget_exhausted".to_string()),
+                alternatives_considered: None,
+                selection_method: None,
+                prior_state: None,
+                posterior_state: None,
+            },
+            TraceOutcome {
+                success: Some(false),
+                quality_score: None,
+                latency_ms: None,
+                cost_usd: Some(spent),
+                error_type: Some(format!(
+                    "consolidation layer budget exhausted: spent {spent:.4} of {limit:.4}"
+                )),
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // #[tokio::test] expands to Runtime::block_on; harmless in tests.
+    #![allow(clippy::disallowed_methods)]
+
+    use super::*;
+    use arkavo_router::learning::{EpisodeOutcome, Observation, QualityMetrics};
+    use std::sync::Mutex;
+
+    struct MockTeacher {
+        replies: Mutex<Vec<Result<TeacherReply, String>>>,
+        local: bool,
+    }
+
+    impl MockTeacher {
+        fn scripted(replies: Vec<(&str, f64)>, local: bool) -> Self {
+            Self {
+                replies: Mutex::new(
+                    replies
+                        .into_iter()
+                        .rev()
+                        .map(|(text, cost)| {
+                            Ok(TeacherReply {
+                                text: text.to_string(),
+                                cost_usd: cost,
+                            })
+                        })
+                        .collect(),
+                ),
+                local,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl TeacherModel for MockTeacher {
+        async fn complete(&self, _system: &str, _user: &str) -> Result<TeacherReply, String> {
+            self.replies
+                .lock()
+                .unwrap()
+                .pop()
+                .unwrap_or_else(|| Err("mock exhausted".into()))
+        }
+        fn identity(&self) -> String {
+            "mock-teacher".into()
+        }
+        fn is_local(&self) -> bool {
+            self.local
+        }
+    }
+
+    fn identity() -> RunnerIdentity {
+        RunnerIdentity {
+            signing_key: SigningKey::from_bytes(&[7u8; 32]),
+            runner_did: "did:web:runner.example.com".into(),
+        }
+    }
+
+    fn episode(tools: &[&str], success: bool) -> Episode {
+        Episode::new(
+            "agent".into(),
+            "swarm".into(),
+            uuid::Uuid::new_v4(),
+            "colony".into(),
+            Observation::new(
+                json!({}),
+                "acts".into(),
+                json!({}),
+                tools.iter().map(|t| t.to_string()).collect(),
+            ),
+            if success {
+                EpisodeOutcome::new(true, QualityMetrics::new(0.9, 0.9, 1.0), 100, 0.0)
+            } else {
+                EpisodeOutcome::new(false, QualityMetrics::new(0.1, 0.1, 1.0), 100, 0.0)
+            },
+        )
+    }
+
+    fn batch() -> Vec<(String, Vec<Episode>)> {
+        vec![(
+            "colony".to_string(),
+            vec![
+                episode(&["observe", "set_priority"], true),
+                episode(&["game-rl:reset"], false),
+                episode(&["set_priority"], true),
+            ],
+        )]
+    }
+
+    const GOOD_REPLY: &str = r#"{
+        "lesson": {"condition": "food low", "action": "set_priority(Growing)",
+                   "expected_outcome": "food recovers", "confidence": 0.85},
+        "tightenings": [
+            {"effect": {"kind": "deny_tool", "tool": "game-rl:reset"},
+             "rationale": "reset correlated with failures",
+             "blast_radius": "single_agent"}
+        ]
+    }"#;
+
+    #[tokio::test]
+    async fn conformant_reply_yields_signed_lesson_and_typed_proposal() {
+        let teacher = MockTeacher::scripted(vec![(GOOD_REPLY, 0.05)], false);
+        let run = run_teacher(
+            &teacher,
+            &batch(),
+            Some(1.0),
+            &identity(),
+            "agent",
+            "swarm",
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(run.lessons.len(), 1);
+        let signed = &run.lessons[0];
+        // Attribution: runner identity, never the model.
+        assert_eq!(signed.signed_by, "did:web:runner.example.com");
+        assert_ne!(signed.signed_by, teacher.identity());
+        // Signature verifies over the canonical pattern bytes.
+        use ed25519_dalek::Verifier;
+        let canonical = serde_json::to_vec(&signed.lesson.pattern).unwrap();
+        let sig = ed25519_dalek::Signature::from_slice(&signed.lesson.signature).unwrap();
+        assert!(
+            identity()
+                .signing_key
+                .verifying_key()
+                .verify(&canonical, &sig)
+                .is_ok()
+        );
+
+        assert_eq!(run.proposals.len(), 1);
+        let p = &run.proposals[0];
+        assert!(matches!(p.effect, TighteningEffect::DenyTool { .. }));
+        assert_eq!(p.origin, ProposalOrigin::Consolidation);
+        assert_eq!(p.evidence[0].episode_ids.len(), 3);
+        assert!(run.rejects.is_empty());
+        assert!((run.total_cost_usd - 0.05).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn lesson_not_naming_evidence_action_is_rejected_regardless_of_model() {
+        let reply = r#"{"lesson": {"condition": "x", "action": "teleport home",
+                        "confidence": 0.9}, "tightenings": []}"#;
+        let teacher = MockTeacher::scripted(vec![(reply, 0.01)], false);
+        let run = run_teacher(
+            &teacher,
+            &batch(),
+            Some(1.0),
+            &identity(),
+            "agent",
+            "swarm",
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(run.lessons.is_empty());
+        assert_eq!(run.rejects.len(), 1);
+        assert!(run.rejects[0].reason.contains("evidence action"));
+    }
+
+    #[tokio::test]
+    async fn loosening_effect_fails_the_closed_enum() {
+        let reply = r#"{"lesson": null, "tightenings": [
+            {"effect": {"kind": "raise_task_ceiling", "new_ceiling_usd": 99.0},
+             "rationale": "more budget"}]}"#;
+        let teacher = MockTeacher::scripted(vec![(reply, 0.01)], false);
+        let run = run_teacher(
+            &teacher,
+            &batch(),
+            Some(1.0),
+            &identity(),
+            "agent",
+            "swarm",
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(run.proposals.is_empty());
+        assert_eq!(run.rejects.len(), 1);
+        assert!(run.rejects[0].reason.contains("not a valid tightening"));
+    }
+
+    #[tokio::test]
+    async fn non_local_teacher_without_layer_budget_is_refused() {
+        let teacher = MockTeacher::scripted(vec![(GOOD_REPLY, 0.05)], false);
+        let err = run_teacher(&teacher, &batch(), None, &identity(), "a", "s", None)
+            .await
+            .unwrap_err();
+        assert!(err.contains("per_layer.consolidation"));
+    }
+
+    #[tokio::test]
+    async fn local_teacher_runs_without_layer_budget() {
+        let teacher = MockTeacher::scripted(vec![(GOOD_REPLY, 0.0)], true);
+        let run = run_teacher(&teacher, &batch(), None, &identity(), "a", "s", None)
+            .await
+            .unwrap();
+        assert_eq!(run.categories_consolidated, 1);
+    }
+
+    #[tokio::test]
+    async fn budget_exhaustion_stops_between_batches_with_trace() {
+        use arkavo_arp::observability::DecisionTraceConfig;
+        let mut batches = batch();
+        batches.push(("nav".to_string(), vec![episode(&["move"], true); 3]));
+        batches.push(("mine".to_string(), vec![episode(&["dig"], true); 3]));
+
+        // First reply costs 0.06 — over the 0.05 ceiling before batch 2.
+        let teacher = MockTeacher::scripted(vec![(GOOD_REPLY, 0.06)], false);
+        let trace = DecisionTrace::new(DecisionTraceConfig {
+            enabled: Some(true),
+            storage: Some("append_only".into()),
+            retention_days: None,
+            cryptographic_signing: None,
+        });
+        let run = run_teacher(
+            &teacher,
+            &batches,
+            Some(0.05),
+            &identity(),
+            "agent",
+            "swarm",
+            Some(&trace),
+        )
+        .await
+        .unwrap();
+
+        assert!(run.budget_exhausted);
+        assert_eq!(run.categories_consolidated, 1);
+        assert_eq!(run.categories_budget_stopped, 2);
+        // Partial output is real output.
+        assert_eq!(run.lessons.len(), 1);
+        // budget_exhausted is traced, never silent.
+        let entries = trace.snapshot();
+        assert_eq!(entries.len(), 1);
+        assert!(
+            entries[0]
+                .outcome
+                .error_type
+                .as_deref()
+                .unwrap()
+                .contains("budget exhausted")
+        );
+    }
+}

--- a/crates/arkavo-server/src/server/consolidation_teacher.rs
+++ b/crates/arkavo-server/src/server/consolidation_teacher.rs
@@ -88,8 +88,10 @@ impl TeacherModel for FableTeacher {
             .complete_with_usage(messages)
             .await
             .map_err(|e| e.to_string())?;
-        let cost_usd = f64::from(usage.input_tokens) / 1e6 * FABLE_INPUT_USD_PER_MTOK
-            + f64::from(usage.output_tokens) / 1e6 * FABLE_OUTPUT_USD_PER_MTOK;
+        let cost_usd = (f64::from(usage.input_tokens) / 1e6).mul_add(
+            FABLE_INPUT_USD_PER_MTOK,
+            f64::from(usage.output_tokens) / 1e6 * FABLE_OUTPUT_USD_PER_MTOK,
+        );
         Ok(TeacherReply { text, cost_usd })
     }
 

--- a/crates/arkavo-server/src/server/consolidation_teacher.rs
+++ b/crates/arkavo-server/src/server/consolidation_teacher.rs
@@ -462,6 +462,7 @@ mod tests {
 
     use super::*;
     use arkavo_router::learning::{EpisodeOutcome, Observation, QualityMetrics};
+    use arkavo_test_macros::spec;
     use std::sync::Mutex;
 
     struct MockTeacher {
@@ -638,6 +639,7 @@ mod tests {
         assert!(run.rejects[0].reason.contains("not a valid tightening"));
     }
 
+    #[spec("SRV-011")]
     #[tokio::test]
     async fn non_local_teacher_without_layer_budget_is_refused() {
         let teacher = MockTeacher::scripted(vec![(GOOD_REPLY, 0.05)], false);
@@ -647,6 +649,7 @@ mod tests {
         assert!(err.contains("per_layer.consolidation"));
     }
 
+    #[spec("SRV-011")]
     #[tokio::test]
     async fn local_teacher_runs_without_layer_budget() {
         let teacher = MockTeacher::scripted(vec![(GOOD_REPLY, 0.0)], true);
@@ -656,6 +659,7 @@ mod tests {
         assert_eq!(run.categories_consolidated, 1);
     }
 
+    #[spec("SRV-012")]
     #[tokio::test]
     async fn budget_exhaustion_stops_between_batches_with_trace() {
         use arkavo_arp::observability::DecisionTraceConfig;

--- a/crates/arkavo-server/src/server/handlers/arp.rs
+++ b/crates/arkavo-server/src/server/handlers/arp.rs
@@ -1,0 +1,81 @@
+//! `arp/get` — expose this agent's effective ARP document over A2A.
+//!
+//! Each agent in the mesh owns its own ARP. The gateway polls this method
+//! per agent so the AG-UI audit views can show real per-agent documents
+//! instead of the synthetic `(local)` placeholder. The document returned is
+//! the proposal queue's post-apply document, so applied tightenings are
+//! visible to mesh-wide audit.
+
+use std::sync::Arc;
+
+use arkavo_arp_runtime::ArpRuntime;
+use jsonrpsee::core::RpcResult;
+use serde_json::{Value, json};
+
+/// Build the `arp/get` payload from an optional runtime. `document` is null
+/// when no ARP runtime is installed in this process.
+pub(in crate::server) async fn arp_get_payload(runtime: Option<Arc<ArpRuntime>>) -> Value {
+    let document = match runtime {
+        Some(rt) => {
+            let queue = rt.proposal_queue();
+            let guard = queue.lock().await;
+            serde_json::to_value(guard.document()).unwrap_or(Value::Null)
+        }
+        None => Value::Null,
+    };
+    json!({
+        "document": document,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    })
+}
+
+/// Handle the `arp/get` A2A method.
+pub(in crate::server) async fn handle_arp_get() -> RpcResult<Value> {
+    Ok(arp_get_payload(arkavo_arp_runtime::current()).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn no_runtime_yields_null_document() {
+        let payload = arp_get_payload(None).await;
+        assert!(payload["document"].is_null());
+        assert!(payload["timestamp"].is_string());
+    }
+
+    #[tokio::test]
+    async fn runtime_yields_post_apply_document() {
+        const DOC: &str = r#"{
+            "arp_spec": "0.1.0",
+            "adl_ref": {"uri": "https://example.com/adl.json"},
+            "adaptation": {"method": "thompson_sampling"},
+            "feedback_loops": {
+                "immediate": {
+                    "quality_gate": {
+                        "threshold_default": 0.7,
+                        "metric": "cosine_similarity",
+                        "on_failure": "update_prior_and_log"
+                    }
+                },
+                "short_term": {
+                    "policy_cache": {
+                        "default_ttl_sec": 3600,
+                        "decay_strategy": "linear"
+                    }
+                }
+            },
+            "budget": {
+                "task_ceiling_usd": 2.5,
+                "on_exhaustion": "halt_and_report",
+                "velocity": {"max_spend_per_minute_usd": 0.5}
+            }
+        }"#;
+        let doc = arkavo_arp::parse(DOC).unwrap();
+        let rt = Arc::new(ArpRuntime::from_document(&doc));
+        let payload = arp_get_payload(Some(rt)).await;
+        assert_eq!(payload["document"]["arp_spec"], "0.1.0");
+        assert_eq!(payload["document"]["budget"]["task_ceiling_usd"], 2.5);
+    }
+}

--- a/crates/arkavo-server/src/server/handlers/mod.rs
+++ b/crates/arkavo-server/src/server/handlers/mod.rs
@@ -1,6 +1,7 @@
 #![allow(unreachable_pub)]
 #![allow(clippy::significant_drop_tightening)]
 
+pub(super) mod arp;
 pub(super) mod chat;
 pub(super) mod config;
 pub(super) mod discovery;

--- a/crates/arkavo-server/src/server/mod.rs
+++ b/crates/arkavo-server/src/server/mod.rs
@@ -11,6 +11,7 @@ mod conductor_planner;
 mod conductor_tool_loop;
 pub mod config_helpers;
 mod consolidation;
+pub mod consolidation_teacher;
 mod contract_negotiation;
 mod conversation_window;
 mod curiosity;

--- a/crates/arkavo-server/src/server/mod.rs
+++ b/crates/arkavo-server/src/server/mod.rs
@@ -139,6 +139,11 @@ pub trait A2aRpc {
     #[method(name = "rpc.discover")]
     async fn rpc_discover(&self) -> RpcResult<serde_json::Value>;
 
+    /// This agent's effective ARP document (post-applied tightenings), for
+    /// per-agent mesh audit polling.
+    #[method(name = "arp/get")]
+    async fn arp_get(&self) -> RpcResult<serde_json::Value>;
+
     // A2A Protocol Methods
 
     /// Send a message synchronously
@@ -541,6 +546,10 @@ impl A2aRpcServer for A2aRpcImpl {
 
     async fn rpc_discover(&self) -> RpcResult<serde_json::Value> {
         handlers::discovery::handle_rpc_discover(&self.metrics).await
+    }
+
+    async fn arp_get(&self) -> RpcResult<serde_json::Value> {
+        handlers::arp::handle_arp_get().await
     }
 
     // A2A Protocol Method Implementations

--- a/crates/arkavo-server/src/server/synthesis.rs
+++ b/crates/arkavo-server/src/server/synthesis.rs
@@ -13,18 +13,10 @@ use uuid::Uuid;
 
 use super::episode_buffer::ToolObservation;
 
-/// The lesson-synthesis rule: a tool is an *action* tool only when it is not
-/// a read-only observe/list/hash/summary call. Lessons must reason about
-/// which actions produce good outcomes, not tool-calling mechanics. This is
-/// the single in-crate definition — the consolidation teacher consumes it
-/// too; do not re-inline it elsewhere.
-pub(super) fn is_action_tool(tool: &str) -> bool {
-    let lower = tool.to_lowercase();
-    !lower.contains("observe")
-        && !lower.contains("list")
-        && !lower.contains("hash")
-        && !lower.contains("summary")
-}
+// The lesson-synthesis rule lives in arkavo-lesson-synthesis, shared with
+// the audit-plane shadow job so the two planes cannot drift; the
+// consolidation teacher consumes it through this re-export.
+pub(super) use arkavo_lesson_synthesis::is_action_tool;
 
 /// Truncate a result string to fit within a character budget.
 fn truncate_result(result: &str, max_chars: usize) -> String {

--- a/crates/arkavo-server/src/server/synthesis.rs
+++ b/crates/arkavo-server/src/server/synthesis.rs
@@ -13,6 +13,19 @@ use uuid::Uuid;
 
 use super::episode_buffer::ToolObservation;
 
+/// The lesson-synthesis rule: a tool is an *action* tool only when it is not
+/// a read-only observe/list/hash/summary call. Lessons must reason about
+/// which actions produce good outcomes, not tool-calling mechanics. This is
+/// the single in-crate definition — the consolidation teacher consumes it
+/// too; do not re-inline it elsewhere.
+pub(super) fn is_action_tool(tool: &str) -> bool {
+    let lower = tool.to_lowercase();
+    !lower.contains("observe")
+        && !lower.contains("list")
+        && !lower.contains("hash")
+        && !lower.contains("summary")
+}
+
 /// Truncate a result string to fit within a character budget.
 fn truncate_result(result: &str, max_chars: usize) -> String {
     if result.len() <= max_chars {
@@ -149,13 +162,7 @@ pub(super) async fn synthesize_lesson(
                 .observation
                 .tools_used
                 .iter()
-                .filter(|t| {
-                    let lower = t.to_lowercase();
-                    !lower.contains("observe")
-                        && !lower.contains("list")
-                        && !lower.contains("hash")
-                        && !lower.contains("summary")
-                })
+                .filter(|t| is_action_tool(t))
                 .cloned()
                 .collect();
             serde_json::json!({

--- a/crates/arkavo-shadow-consolidation/Cargo.toml
+++ b/crates/arkavo-shadow-consolidation/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+arkavo-lesson-synthesis = { path = "../arkavo-lesson-synthesis" }
 chrono = { workspace = true }
 clap = { workspace = true }
 reqwest = { workspace = true }
@@ -27,5 +28,6 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 uuid = { workspace = true }
 
 [dev-dependencies]
+arkavo-test-macros = { path = "../arkavo-test-macros" }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "io-util"] }

--- a/crates/arkavo-shadow-consolidation/Cargo.toml
+++ b/crates/arkavo-shadow-consolidation/Cargo.toml
@@ -23,8 +23,9 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 uuid = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "io-util"] }

--- a/crates/arkavo-shadow-consolidation/Cargo.toml
+++ b/crates/arkavo-shadow-consolidation/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "arkavo-shadow-consolidation"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Standalone overnight shadow-consolidation: batches stripped episode traces to Fable and emits action-named lessons, candidate tightenings, and a cost ledger with zero runtime contact."
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "arkavo-shadow-consolidation"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+uuid = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/arkavo-shadow-consolidation/src/episodes.rs
+++ b/crates/arkavo-shadow-consolidation/src/episodes.rs
@@ -66,28 +66,11 @@ pub struct LoadResult {
     pub categories_skipped: u64,
 }
 
-/// The lesson-synthesis rule: keep only *action* tools.
-///
-/// A tool is read-only (and dropped) when its name contains observe/list/hash/
-/// summary. Lessons must reason about which actions produce good outcomes, not
-/// about tool-calling mechanics.
-#[must_use]
-pub fn is_action_tool(tool: &str) -> bool {
-    let lower = tool.to_lowercase();
-    !lower.contains("observe")
-        && !lower.contains("list")
-        && !lower.contains("hash")
-        && !lower.contains("summary")
-}
-
-/// Apply [`is_action_tool`] to a tool list.
-fn strip_observe(tools: &[String]) -> Vec<String> {
-    tools
-        .iter()
-        .filter(|t| is_action_tool(t))
-        .cloned()
-        .collect()
-}
+// The lesson-synthesis rule lives in arkavo-lesson-synthesis (a pure
+// std-only leaf crate, so the zero-runtime-contact property holds), shared
+// with the runtime consolidation teacher so the two planes cannot drift.
+pub use arkavo_lesson_synthesis::is_action_tool;
+use arkavo_lesson_synthesis::strip_observe;
 
 /// Group raw `(id, category, observation_json, outcome_json)` rows into
 /// batches, stripping observe calls and dropping categories below

--- a/crates/arkavo-shadow-consolidation/src/episodes.rs
+++ b/crates/arkavo-shadow-consolidation/src/episodes.rs
@@ -49,6 +49,9 @@ pub struct ActionOutcome {
 #[derive(Debug, Clone, PartialEq)]
 pub struct CategoryBatch {
     pub category: String,
+    /// Store row ids of the episodes in this batch, preserved so tonight's
+    /// proposals can be back-linked to their evidence later.
+    pub episode_ids: Vec<String>,
     pub outcomes: Vec<ActionOutcome>,
 }
 
@@ -86,28 +89,28 @@ fn strip_observe(tools: &[String]) -> Vec<String> {
         .collect()
 }
 
-/// Group raw `(category, observation_json, outcome_json)` rows into batches,
-/// stripping observe calls and dropping categories below `min_episodes`.
-fn group_rows(rows: Vec<(String, String, String)>, min_episodes: usize) -> LoadResult {
+/// Group raw `(id, category, observation_json, outcome_json)` rows into
+/// batches, stripping observe calls and dropping categories below
+/// `min_episodes`.
+fn group_rows(rows: Vec<(String, String, String, String)>, min_episodes: usize) -> LoadResult {
     let episodes_total = rows.len() as u64;
     // BTreeMap keeps category order stable for reproducible output.
-    let mut by_category: BTreeMap<String, Vec<ActionOutcome>> = BTreeMap::new();
+    let mut by_category: BTreeMap<String, (Vec<String>, Vec<ActionOutcome>)> = BTreeMap::new();
 
-    for (category, obs_json, outcome_json) in rows {
+    for (id, category, obs_json, outcome_json) in rows {
         let actions = serde_json::from_str::<RawObservation>(&obs_json)
             .map(|o| strip_observe(&o.tools_used))
             .unwrap_or_default();
         let (success, quality) = serde_json::from_str::<RawOutcome>(&outcome_json)
             .map(|o| (o.success, o.quality_metrics.correctness.clamp(0.0, 1.0)))
             .unwrap_or((false, 0.0));
-        by_category
-            .entry(category)
-            .or_default()
-            .push(ActionOutcome {
-                actions,
-                success,
-                quality,
-            });
+        let (ids, outcomes) = by_category.entry(category).or_default();
+        ids.push(id);
+        outcomes.push(ActionOutcome {
+            actions,
+            success,
+            quality,
+        });
     }
 
     let categories_total = by_category.len() as u64;
@@ -115,10 +118,14 @@ fn group_rows(rows: Vec<(String, String, String)>, min_episodes: usize) -> LoadR
     let mut categories_skipped = 0_u64;
     let mut episodes_consolidated = 0_u64;
 
-    for (category, outcomes) in by_category {
+    for (category, (episode_ids, outcomes)) in by_category {
         if outcomes.len() >= min_episodes {
             episodes_consolidated += outcomes.len() as u64;
-            batches.push(CategoryBatch { category, outcomes });
+            batches.push(CategoryBatch {
+                category,
+                episode_ids,
+                outcomes,
+            });
         } else {
             categories_skipped += 1;
         }
@@ -163,15 +170,16 @@ impl EpisodeReader {
     /// Load and group all episodes into per-category batches.
     pub async fn load_batches(&self, min_episodes: usize) -> anyhow::Result<LoadResult> {
         let rows =
-            sqlx::query("SELECT task_category, observation_json, outcome_json FROM episodes")
+            sqlx::query("SELECT id, task_category, observation_json, outcome_json FROM episodes")
                 .fetch_all(&self.pool)
                 .await
                 .context("querying episodes table")?;
 
-        let raw: Vec<(String, String, String)> = rows
+        let raw: Vec<(String, String, String, String)> = rows
             .into_iter()
             .map(|row| {
                 Ok::<_, sqlx::Error>((
+                    row.try_get::<String, _>("id")?,
                     row.try_get::<String, _>("task_category")?,
                     row.try_get::<String, _>("observation_json")?,
                     row.try_get::<String, _>("outcome_json")?,
@@ -221,21 +229,25 @@ mod tests {
     fn grouping_drops_below_threshold() {
         let rows = vec![
             (
+                "ep-1".to_string(),
                 "a".to_string(),
                 r#"{"tools_used":["observe","step"]}"#.to_string(),
                 r#"{"success":true,"quality_metrics":{"correctness":0.9}}"#.to_string(),
             ),
             (
+                "ep-2".to_string(),
                 "a".to_string(),
                 r#"{"tools_used":["step"]}"#.to_string(),
                 r#"{"success":false,"quality_metrics":{"correctness":0.2}}"#.to_string(),
             ),
             (
+                "ep-3".to_string(),
                 "a".to_string(),
                 r#"{"tools_used":["reset"]}"#.to_string(),
                 r#"{"success":true,"quality_metrics":{"correctness":0.5}}"#.to_string(),
             ),
             (
+                "ep-4".to_string(),
                 "b".to_string(),
                 r#"{"tools_used":["step"]}"#.to_string(),
                 r#"{"success":true,"quality_metrics":{"correctness":1.0}}"#.to_string(),
@@ -248,6 +260,11 @@ mod tests {
         assert_eq!(result.batches[0].category, "a");
         assert_eq!(result.episodes_consolidated, 3);
         assert_eq!(result.categories_skipped, 1);
+        // Episode ids preserved so proposals can be back-linked to evidence.
+        assert_eq!(
+            result.batches[0].episode_ids,
+            vec!["ep-1".to_string(), "ep-2".to_string(), "ep-3".to_string()]
+        );
         // observe stripped from the first episode.
         assert_eq!(
             result.batches[0].outcomes[0].actions,
@@ -259,12 +276,19 @@ mod tests {
     fn malformed_json_yields_empty_action_failed_outcome() {
         let rows = vec![
             (
+                "ep-1".to_string(),
                 "a".to_string(),
                 "not json".to_string(),
                 "not json".to_string(),
             ),
-            ("a".to_string(), "{}".to_string(), "{}".to_string()),
             (
+                "ep-2".to_string(),
+                "a".to_string(),
+                "{}".to_string(),
+                "{}".to_string(),
+            ),
+            (
+                "ep-3".to_string(),
                 "a".to_string(),
                 r#"{"tools_used":["step"]}"#.to_string(),
                 r#"{"success":true,"quality_metrics":{"correctness":0.7}}"#.to_string(),
@@ -319,6 +343,8 @@ mod tests {
         assert_eq!(result.episodes_total, 3);
         assert_eq!(result.batches.len(), 1);
         assert_eq!(result.batches[0].category, "colony");
+        assert_eq!(result.batches[0].episode_ids.len(), 3);
+        assert!(result.batches[0].episode_ids.contains(&"id-0".to_string()));
         assert_eq!(
             result.batches[0].outcomes[0].actions,
             vec!["set_priority".to_string()]

--- a/crates/arkavo-shadow-consolidation/src/episodes.rs
+++ b/crates/arkavo-shadow-consolidation/src/episodes.rs
@@ -1,0 +1,335 @@
+//! Read existing episode traces from the learning store, strip observe calls
+//! per the lesson-synthesis rule, and group them into per-category batches.
+//!
+//! The store is opened **read-only** and never created — the job touches the
+//! on-disk traces only as data, never as a live runtime.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::Context;
+use serde::Deserialize;
+use sqlx::Row;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+
+/// The subset of the on-disk `Observation` JSON the consolidation job needs.
+/// Matches the runtime `Observation` serialization (extra fields are ignored).
+#[derive(Debug, Deserialize)]
+struct RawObservation {
+    #[serde(default)]
+    tools_used: Vec<String>,
+}
+
+/// The subset of the on-disk `EpisodeOutcome` JSON the job needs.
+#[derive(Debug, Deserialize)]
+struct RawOutcome {
+    #[serde(default)]
+    success: bool,
+    #[serde(default)]
+    quality_metrics: RawQuality,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawQuality {
+    #[serde(default)]
+    correctness: f64,
+}
+
+/// One action→outcome pair, with read-only/observe tools already stripped.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ActionOutcome {
+    /// Action tools used (observe/list/hash/summary removed).
+    pub actions: Vec<String>,
+    pub success: bool,
+    /// Correctness quality metric in `[0, 1]`.
+    pub quality: f64,
+}
+
+/// All action→outcome evidence for a single task category.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CategoryBatch {
+    pub category: String,
+    pub outcomes: Vec<ActionOutcome>,
+}
+
+/// Outcome of loading + grouping episodes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LoadResult {
+    /// Categories that met the minimum-episode threshold, ready to consolidate.
+    pub batches: Vec<CategoryBatch>,
+    pub episodes_total: u64,
+    pub episodes_consolidated: u64,
+    pub categories_total: u64,
+    pub categories_skipped: u64,
+}
+
+/// The lesson-synthesis rule: keep only *action* tools.
+///
+/// A tool is read-only (and dropped) when its name contains observe/list/hash/
+/// summary. Lessons must reason about which actions produce good outcomes, not
+/// about tool-calling mechanics.
+#[must_use]
+pub fn is_action_tool(tool: &str) -> bool {
+    let lower = tool.to_lowercase();
+    !lower.contains("observe")
+        && !lower.contains("list")
+        && !lower.contains("hash")
+        && !lower.contains("summary")
+}
+
+/// Apply [`is_action_tool`] to a tool list.
+fn strip_observe(tools: &[String]) -> Vec<String> {
+    tools
+        .iter()
+        .filter(|t| is_action_tool(t))
+        .cloned()
+        .collect()
+}
+
+/// Group raw `(category, observation_json, outcome_json)` rows into batches,
+/// stripping observe calls and dropping categories below `min_episodes`.
+fn group_rows(rows: Vec<(String, String, String)>, min_episodes: usize) -> LoadResult {
+    let episodes_total = rows.len() as u64;
+    // BTreeMap keeps category order stable for reproducible output.
+    let mut by_category: BTreeMap<String, Vec<ActionOutcome>> = BTreeMap::new();
+
+    for (category, obs_json, outcome_json) in rows {
+        let actions = serde_json::from_str::<RawObservation>(&obs_json)
+            .map(|o| strip_observe(&o.tools_used))
+            .unwrap_or_default();
+        let (success, quality) = serde_json::from_str::<RawOutcome>(&outcome_json)
+            .map(|o| (o.success, o.quality_metrics.correctness.clamp(0.0, 1.0)))
+            .unwrap_or((false, 0.0));
+        by_category
+            .entry(category)
+            .or_default()
+            .push(ActionOutcome {
+                actions,
+                success,
+                quality,
+            });
+    }
+
+    let categories_total = by_category.len() as u64;
+    let mut batches = Vec::new();
+    let mut categories_skipped = 0_u64;
+    let mut episodes_consolidated = 0_u64;
+
+    for (category, outcomes) in by_category {
+        if outcomes.len() >= min_episodes {
+            episodes_consolidated += outcomes.len() as u64;
+            batches.push(CategoryBatch { category, outcomes });
+        } else {
+            categories_skipped += 1;
+        }
+    }
+
+    LoadResult {
+        batches,
+        episodes_total,
+        episodes_consolidated,
+        categories_total,
+        categories_skipped,
+    }
+}
+
+/// Read-only reader over the episode SQLite store.
+#[derive(Debug)]
+pub struct EpisodeReader {
+    pool: sqlx::SqlitePool,
+}
+
+impl EpisodeReader {
+    /// Open the learning store read-only. Errors if the file does not exist —
+    /// the job never creates or migrates the store.
+    pub async fn open(db_path: &Path) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            db_path.exists(),
+            "episode store does not exist: {}",
+            db_path.display()
+        );
+        let opts = SqliteConnectOptions::new()
+            .filename(db_path)
+            .read_only(true)
+            .create_if_missing(false);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(opts)
+            .await
+            .with_context(|| format!("opening episode store {}", db_path.display()))?;
+        Ok(Self { pool })
+    }
+
+    /// Load and group all episodes into per-category batches.
+    pub async fn load_batches(&self, min_episodes: usize) -> anyhow::Result<LoadResult> {
+        let rows =
+            sqlx::query("SELECT task_category, observation_json, outcome_json FROM episodes")
+                .fetch_all(&self.pool)
+                .await
+                .context("querying episodes table")?;
+
+        let raw: Vec<(String, String, String)> = rows
+            .into_iter()
+            .map(|row| {
+                Ok::<_, sqlx::Error>((
+                    row.try_get::<String, _>("task_category")?,
+                    row.try_get::<String, _>("observation_json")?,
+                    row.try_get::<String, _>("outcome_json")?,
+                ))
+            })
+            .collect::<Result<_, _>>()
+            .context("decoding episode rows")?;
+
+        Ok(group_rows(raw, min_episodes))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // #[tokio::test] expands to Runtime::block_on; harmless in tests.
+    #![allow(clippy::disallowed_methods)]
+
+    use super::*;
+
+    #[test]
+    fn strips_read_only_tools() {
+        let tools = vec![
+            "observe".to_string(),
+            "list_tools".to_string(),
+            "stateHash".to_string(),
+            "episodeSummary".to_string(),
+            "game-rl:step".to_string(),
+            "set_priority".to_string(),
+        ];
+        assert_eq!(
+            strip_observe(&tools),
+            vec!["game-rl:step".to_string(), "set_priority".to_string()]
+        );
+    }
+
+    #[test]
+    fn action_tool_rule_matches_runtime() {
+        assert!(!is_action_tool("Observe"));
+        assert!(!is_action_tool("list_resources"));
+        assert!(!is_action_tool("stateHash"));
+        assert!(!is_action_tool("episodeSummary"));
+        assert!(is_action_tool("game-rl:reset"));
+        assert!(is_action_tool("set_priority"));
+    }
+
+    #[test]
+    fn grouping_drops_below_threshold() {
+        let rows = vec![
+            (
+                "a".to_string(),
+                r#"{"tools_used":["observe","step"]}"#.to_string(),
+                r#"{"success":true,"quality_metrics":{"correctness":0.9}}"#.to_string(),
+            ),
+            (
+                "a".to_string(),
+                r#"{"tools_used":["step"]}"#.to_string(),
+                r#"{"success":false,"quality_metrics":{"correctness":0.2}}"#.to_string(),
+            ),
+            (
+                "a".to_string(),
+                r#"{"tools_used":["reset"]}"#.to_string(),
+                r#"{"success":true,"quality_metrics":{"correctness":0.5}}"#.to_string(),
+            ),
+            (
+                "b".to_string(),
+                r#"{"tools_used":["step"]}"#.to_string(),
+                r#"{"success":true,"quality_metrics":{"correctness":1.0}}"#.to_string(),
+            ),
+        ];
+        let result = group_rows(rows, 3);
+        assert_eq!(result.episodes_total, 4);
+        assert_eq!(result.categories_total, 2);
+        assert_eq!(result.batches.len(), 1);
+        assert_eq!(result.batches[0].category, "a");
+        assert_eq!(result.episodes_consolidated, 3);
+        assert_eq!(result.categories_skipped, 1);
+        // observe stripped from the first episode.
+        assert_eq!(
+            result.batches[0].outcomes[0].actions,
+            vec!["step".to_string()]
+        );
+    }
+
+    #[test]
+    fn malformed_json_yields_empty_action_failed_outcome() {
+        let rows = vec![
+            (
+                "a".to_string(),
+                "not json".to_string(),
+                "not json".to_string(),
+            ),
+            ("a".to_string(), "{}".to_string(), "{}".to_string()),
+            (
+                "a".to_string(),
+                r#"{"tools_used":["step"]}"#.to_string(),
+                r#"{"success":true,"quality_metrics":{"correctness":0.7}}"#.to_string(),
+            ),
+        ];
+        let result = group_rows(rows, 1);
+        assert_eq!(result.batches.len(), 1);
+        let outcomes = &result.batches[0].outcomes;
+        assert!(outcomes[0].actions.is_empty());
+        assert!(!outcomes[0].success);
+        assert!((outcomes[0].quality).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn reads_episodes_from_sqlite() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        // Seed a store with the runtime episodes schema.
+        let opts = SqliteConnectOptions::new()
+            .filename(&path)
+            .create_if_missing(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(opts)
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE episodes (id TEXT PRIMARY KEY, agent_id TEXT, swarm_id TEXT, \
+             task_id TEXT, task_category TEXT NOT NULL, observation_json TEXT NOT NULL, \
+             outcome_json TEXT NOT NULL, timestamp TEXT, context_hash BLOB)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        for i in 0..3 {
+            sqlx::query(
+                "INSERT INTO episodes (id, task_category, observation_json, outcome_json) \
+                 VALUES (?, ?, ?, ?)",
+            )
+            .bind(format!("id-{i}"))
+            .bind("colony")
+            .bind(r#"{"tools_used":["observe","set_priority"]}"#)
+            .bind(r#"{"success":true,"quality_metrics":{"correctness":0.8}}"#)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+        pool.close().await;
+
+        let reader = EpisodeReader::open(&path).await.unwrap();
+        let result = reader.load_batches(3).await.unwrap();
+        assert_eq!(result.episodes_total, 3);
+        assert_eq!(result.batches.len(), 1);
+        assert_eq!(result.batches[0].category, "colony");
+        assert_eq!(
+            result.batches[0].outcomes[0].actions,
+            vec!["set_priority".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn open_missing_store_errors() {
+        let err = EpisodeReader::open(Path::new("/nonexistent/does-not-exist.db"))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("does not exist"));
+    }
+}

--- a/crates/arkavo-shadow-consolidation/src/episodes.rs
+++ b/crates/arkavo-shadow-consolidation/src/episodes.rs
@@ -55,6 +55,14 @@ pub struct CategoryBatch {
     pub outcomes: Vec<ActionOutcome>,
 }
 
+/// Per-category episode cap.
+///
+/// One prompt carries a whole category, so an unbounded category can blow
+/// the model's input context (aborting the batch) and skew the budget
+/// recommendation upward. The most recent episodes are kept — they reflect
+/// current behavior.
+pub const MAX_EPISODES_PER_CATEGORY: usize = 200;
+
 /// Outcome of loading + grouping episodes.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LoadResult {
@@ -62,6 +70,9 @@ pub struct LoadResult {
     pub batches: Vec<CategoryBatch>,
     pub episodes_total: u64,
     pub episodes_consolidated: u64,
+    /// Episodes dropped by the per-category sampling cap — recorded so the
+    /// ledger never reads as "consolidated everything" when it sampled.
+    pub episodes_sampled_out: u64,
     pub categories_total: u64,
     pub categories_skipped: u64,
 }
@@ -73,9 +84,14 @@ pub use arkavo_lesson_synthesis::is_action_tool;
 use arkavo_lesson_synthesis::strip_observe;
 
 /// Group raw `(id, category, observation_json, outcome_json)` rows into
-/// batches, stripping observe calls and dropping categories below
-/// `min_episodes`.
-fn group_rows(rows: Vec<(String, String, String, String)>, min_episodes: usize) -> LoadResult {
+/// batches, stripping observe calls, dropping categories below
+/// `min_episodes`, and keeping at most `max_per_category` of the most
+/// recent episodes per category (rows arrive in insertion order).
+fn group_rows(
+    rows: Vec<(String, String, String, String)>,
+    min_episodes: usize,
+    max_per_category: usize,
+) -> LoadResult {
     let episodes_total = rows.len() as u64;
     // BTreeMap keeps category order stable for reproducible output.
     let mut by_category: BTreeMap<String, (Vec<String>, Vec<ActionOutcome>)> = BTreeMap::new();
@@ -100,24 +116,34 @@ fn group_rows(rows: Vec<(String, String, String, String)>, min_episodes: usize) 
     let mut batches = Vec::new();
     let mut categories_skipped = 0_u64;
     let mut episodes_consolidated = 0_u64;
+    let mut episodes_sampled_out = 0_u64;
 
-    for (category, (episode_ids, outcomes)) in by_category {
-        if outcomes.len() >= min_episodes {
-            episodes_consolidated += outcomes.len() as u64;
-            batches.push(CategoryBatch {
-                category,
-                episode_ids,
-                outcomes,
-            });
-        } else {
+    for (category, (mut episode_ids, mut outcomes)) in by_category {
+        if outcomes.len() < min_episodes {
             categories_skipped += 1;
+            continue;
         }
+        // Rows arrive in insertion order, so the tail is the most recent
+        // evidence; keep it and account for what was sampled out.
+        if outcomes.len() > max_per_category {
+            let dropped = outcomes.len() - max_per_category;
+            episodes_sampled_out += dropped as u64;
+            episode_ids.drain(..dropped);
+            outcomes.drain(..dropped);
+        }
+        episodes_consolidated += outcomes.len() as u64;
+        batches.push(CategoryBatch {
+            category,
+            episode_ids,
+            outcomes,
+        });
     }
 
     LoadResult {
         batches,
         episodes_total,
         episodes_consolidated,
+        episodes_sampled_out,
         categories_total,
         categories_skipped,
     }
@@ -152,11 +178,13 @@ impl EpisodeReader {
 
     /// Load and group all episodes into per-category batches.
     pub async fn load_batches(&self, min_episodes: usize) -> anyhow::Result<LoadResult> {
-        let rows =
-            sqlx::query("SELECT id, task_category, observation_json, outcome_json FROM episodes")
-                .fetch_all(&self.pool)
-                .await
-                .context("querying episodes table")?;
+        let rows = sqlx::query(
+            "SELECT id, task_category, observation_json, outcome_json FROM episodes \
+             ORDER BY rowid",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .context("querying episodes table")?;
 
         let raw: Vec<(String, String, String, String)> = rows
             .into_iter()
@@ -171,7 +199,7 @@ impl EpisodeReader {
             .collect::<Result<_, _>>()
             .context("decoding episode rows")?;
 
-        Ok(group_rows(raw, min_episodes))
+        Ok(group_rows(raw, min_episodes, MAX_EPISODES_PER_CATEGORY))
     }
 }
 
@@ -181,6 +209,54 @@ mod tests {
     #![allow(clippy::disallowed_methods)]
 
     use super::*;
+    use arkavo_test_macros::spec;
+
+    #[spec("SC-006")]
+    #[test]
+    fn oversized_category_samples_most_recent_and_records_dropped() {
+        // 8 episodes in insertion order, cap 5: the prompt must carry the
+        // most recent 5 and the ledger must see 3 sampled out.
+        let rows: Vec<_> = (0..8)
+            .map(|i| {
+                (
+                    format!("ep-{i}"),
+                    "colony".to_string(),
+                    r#"{"tools_used":["set_priority"]}"#.to_string(),
+                    r#"{"success":true,"quality_metrics":{"correctness":0.8}}"#.to_string(),
+                )
+            })
+            .collect();
+        let result = group_rows(rows, 3, 5);
+        assert_eq!(result.batches.len(), 1);
+        let batch = &result.batches[0];
+        assert_eq!(batch.outcomes.len(), 5);
+        assert_eq!(
+            batch.episode_ids,
+            vec!["ep-3", "ep-4", "ep-5", "ep-6", "ep-7"]
+        );
+        assert_eq!(result.episodes_total, 8);
+        assert_eq!(result.episodes_consolidated, 5);
+        assert_eq!(result.episodes_sampled_out, 3);
+    }
+
+    #[spec("SC-006")]
+    #[test]
+    fn category_within_cap_is_untouched() {
+        let rows: Vec<_> = (0..5)
+            .map(|i| {
+                (
+                    format!("ep-{i}"),
+                    "colony".to_string(),
+                    r#"{"tools_used":["set_priority"]}"#.to_string(),
+                    r#"{"success":true,"quality_metrics":{"correctness":0.8}}"#.to_string(),
+                )
+            })
+            .collect();
+        let result = group_rows(rows, 3, 5);
+        assert_eq!(result.batches[0].outcomes.len(), 5);
+        assert_eq!(result.episodes_sampled_out, 0);
+        assert_eq!(result.episodes_consolidated, 5);
+    }
 
     #[test]
     fn strips_read_only_tools() {
@@ -236,7 +312,7 @@ mod tests {
                 r#"{"success":true,"quality_metrics":{"correctness":1.0}}"#.to_string(),
             ),
         ];
-        let result = group_rows(rows, 3);
+        let result = group_rows(rows, 3, MAX_EPISODES_PER_CATEGORY);
         assert_eq!(result.episodes_total, 4);
         assert_eq!(result.categories_total, 2);
         assert_eq!(result.batches.len(), 1);
@@ -277,7 +353,7 @@ mod tests {
                 r#"{"success":true,"quality_metrics":{"correctness":0.7}}"#.to_string(),
             ),
         ];
-        let result = group_rows(rows, 1);
+        let result = group_rows(rows, 1, MAX_EPISODES_PER_CATEGORY);
         assert_eq!(result.batches.len(), 1);
         let outcomes = &result.batches[0].outcomes;
         assert!(outcomes[0].actions.is_empty());

--- a/crates/arkavo-shadow-consolidation/src/fable.rs
+++ b/crates/arkavo-shadow-consolidation/src/fable.rs
@@ -1,0 +1,237 @@
+//! Minimal Fable client over raw rustls HTTP.
+//!
+//! This is deliberately not the runtime LLM provider: the audit-plane job
+//! talks to Fable directly so it fully controls the request shape (adaptive
+//! thinking, no sampling params) and reads the exact `usage` block it needs to
+//! build a real cost ledger. No arkavo runtime crate is involved.
+
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, bail};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+/// Fable 5 list price, USD per million tokens (input).
+pub const FABLE_INPUT_USD_PER_MTOK: f64 = 10.0;
+/// Fable 5 list price, USD per million tokens (output, thinking billed here).
+pub const FABLE_OUTPUT_USD_PER_MTOK: f64 = 50.0;
+
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
+/// Generous ceiling — adaptive thinking at high effort can take a while, and
+/// this is an overnight job, not an interactive request.
+const REQUEST_TIMEOUT_SECS: u64 = 600;
+
+/// Token usage from a Fable completion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+pub struct Usage {
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+}
+
+impl Usage {
+    /// Cost of this completion at Fable list price (thinking is billed as
+    /// output tokens by the API, so it is already included here).
+    #[must_use]
+    pub fn cost_usd(&self) -> f64 {
+        let output_cost = (self.output_tokens as f64 / 1_000_000.0) * FABLE_OUTPUT_USD_PER_MTOK;
+        (self.input_tokens as f64 / 1_000_000.0).mul_add(FABLE_INPUT_USD_PER_MTOK, output_cost)
+    }
+}
+
+/// A completed Fable call.
+#[derive(Debug, Clone)]
+pub struct FableCompletion {
+    /// Concatenated text blocks (thinking blocks are excluded).
+    pub text: String,
+    pub usage: Usage,
+    pub latency_ms: u64,
+}
+
+/// Client configuration.
+#[derive(Debug, Clone)]
+pub struct FableConfig {
+    pub api_key: String,
+    pub base_url: String,
+    pub model: String,
+    pub max_tokens: u32,
+    pub effort: String,
+}
+
+impl FableConfig {
+    /// Build configuration from the environment. Requires `ANTHROPIC_API_KEY`;
+    /// honors `ANTHROPIC_BASE_URL` for proxies / gateways.
+    pub fn from_env(model: String, max_tokens: u32, effort: String) -> anyhow::Result<Self> {
+        let api_key = std::env::var("ANTHROPIC_API_KEY")
+            .context("ANTHROPIC_API_KEY must be set to call Fable (use --dry-run to skip)")?;
+        anyhow::ensure!(!api_key.trim().is_empty(), "ANTHROPIC_API_KEY is empty");
+        let base_url =
+            std::env::var("ANTHROPIC_BASE_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
+        Ok(Self {
+            api_key,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            model,
+            max_tokens,
+            effort,
+        })
+    }
+}
+
+/// Build the `/v1/messages` request body for a Fable consolidation call.
+///
+/// Fable 5 requires adaptive thinking and rejects sampling parameters, so the
+/// body carries `thinking: {type: adaptive}` and no `temperature` / `top_p`.
+#[must_use]
+pub fn build_request_body(cfg: &FableConfig, system: &str, user: &str) -> Value {
+    json!({
+        "model": cfg.model,
+        "max_tokens": cfg.max_tokens,
+        "system": system,
+        "messages": [{ "role": "user", "content": user }],
+        "thinking": { "type": "adaptive" },
+        "output_config": { "effort": cfg.effort }
+    })
+}
+
+/// Extract and concatenate `text` blocks from an Anthropic `content` array.
+fn extract_text(content: &[Value]) -> String {
+    content
+        .iter()
+        .filter(|block| block.get("type").and_then(Value::as_str) == Some("text"))
+        .filter_map(|block| block.get("text").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiResponse {
+    #[serde(default)]
+    content: Vec<Value>,
+    usage: Usage,
+}
+
+/// Fable client.
+pub struct FableClient {
+    http: reqwest::Client,
+    cfg: FableConfig,
+}
+
+impl FableClient {
+    pub fn new(cfg: FableConfig) -> anyhow::Result<Self> {
+        let http = reqwest::Client::builder()
+            .use_rustls_tls()
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .build()
+            .context("building HTTP client")?;
+        Ok(Self { http, cfg })
+    }
+
+    /// The model id this client calls.
+    #[must_use]
+    pub fn model(&self) -> &str {
+        &self.cfg.model
+    }
+
+    /// Run one consolidation completion.
+    pub async fn complete(&self, system: &str, user: &str) -> anyhow::Result<FableCompletion> {
+        let body = build_request_body(&self.cfg, system, user);
+        let url = format!("{}/v1/messages", self.cfg.base_url);
+
+        let started = Instant::now();
+        let resp = self
+            .http
+            .post(&url)
+            .header("x-api-key", &self.cfg.api_key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .context("sending Fable request")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let detail = resp.text().await.unwrap_or_default();
+            bail!("Fable API error {status}: {detail}");
+        }
+
+        let parsed: ApiResponse = resp.json().await.context("decoding Fable response")?;
+        let latency_ms = started.elapsed().as_millis() as u64;
+
+        Ok(FableCompletion {
+            text: extract_text(&parsed.content),
+            usage: parsed.usage,
+            latency_ms,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> FableConfig {
+        FableConfig {
+            api_key: "k".into(),
+            base_url: "https://api.anthropic.com".into(),
+            model: "claude-fable-5".into(),
+            max_tokens: 8192,
+            effort: "high".into(),
+        }
+    }
+
+    #[test]
+    fn request_body_uses_adaptive_thinking_and_no_sampling() {
+        let body = build_request_body(&cfg(), "sys", "usr");
+        assert_eq!(body["model"], "claude-fable-5");
+        assert_eq!(body["thinking"]["type"], "adaptive");
+        assert_eq!(body["output_config"]["effort"], "high");
+        assert_eq!(body["system"], "sys");
+        assert_eq!(body["messages"][0]["role"], "user");
+        assert_eq!(body["messages"][0]["content"], "usr");
+        // Fable rejects sampling params — they must be absent.
+        assert!(body.get("temperature").is_none());
+        assert!(body.get("top_p").is_none());
+    }
+
+    #[test]
+    fn cost_matches_fable_list_price() {
+        let usage = Usage {
+            input_tokens: 1_000_000,
+            output_tokens: 1_000_000,
+        };
+        // $10 input + $50 output per MTok.
+        assert!((usage.cost_usd() - 60.0).abs() < 1e-9);
+
+        let small = Usage {
+            input_tokens: 2000,
+            output_tokens: 800,
+        };
+        let input_cost = 2000.0 / 1e6 * 10.0;
+        let output_cost = 800.0 / 1e6 * 50.0;
+        let expected = input_cost + output_cost;
+        assert!((small.cost_usd() - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn extracts_only_text_blocks() {
+        let content = vec![
+            json!({"type": "thinking", "thinking": "reasoning"}),
+            json!({"type": "text", "text": "hello"}),
+            json!({"type": "text", "text": "world"}),
+        ];
+        assert_eq!(extract_text(&content), "hello\nworld");
+    }
+
+    #[test]
+    fn from_env_requires_key() {
+        // SAFETY: single-threaded test; restore afterwards.
+        unsafe {
+            std::env::remove_var("ANTHROPIC_API_KEY");
+        }
+        let err = FableConfig::from_env("claude-fable-5".into(), 8192, "high".into()).unwrap_err();
+        assert!(err.to_string().contains("ANTHROPIC_API_KEY"));
+    }
+}

--- a/crates/arkavo-shadow-consolidation/src/fable.rs
+++ b/crates/arkavo-shadow-consolidation/src/fable.rs
@@ -50,6 +50,12 @@ pub struct FableCompletion {
     pub latency_ms: u64,
 }
 
+/// Attempts per call on transient failures; an unattended overnight run must
+/// outlive a 3 a.m. overload spike, not die on it.
+const DEFAULT_RETRY_ATTEMPTS: u32 = 3;
+/// First backoff; doubles per retry.
+const DEFAULT_RETRY_BACKOFF_MS: u64 = 2_000;
+
 /// Client configuration.
 #[derive(Debug, Clone)]
 pub struct FableConfig {
@@ -58,6 +64,8 @@ pub struct FableConfig {
     pub model: String,
     pub max_tokens: u32,
     pub effort: String,
+    pub retry_attempts: u32,
+    pub retry_backoff_ms: u64,
 }
 
 impl FableConfig {
@@ -75,6 +83,8 @@ impl FableConfig {
             model,
             max_tokens,
             effort,
+            retry_attempts: DEFAULT_RETRY_ATTEMPTS,
+            retry_backoff_ms: DEFAULT_RETRY_BACKOFF_MS,
         })
     }
 }
@@ -134,43 +144,74 @@ impl FableClient {
         &self.cfg.model
     }
 
-    /// Run one consolidation completion.
+    /// Run one consolidation completion, retrying transient failures with
+    /// exponential backoff. A decode failure after a successful status is
+    /// never retried: the call was already billed, and re-sending would bill
+    /// it again.
     pub async fn complete(&self, system: &str, user: &str) -> anyhow::Result<FableCompletion> {
         let body = build_request_body(&self.cfg, system, user);
         let url = format!("{}/v1/messages", self.cfg.base_url);
 
-        let started = Instant::now();
-        let resp = self
-            .http
-            .post(&url)
-            .header("x-api-key", &self.cfg.api_key)
-            .header("anthropic-version", ANTHROPIC_VERSION)
-            .header("content-type", "application/json")
-            .json(&body)
-            .send()
-            .await
-            .context("sending Fable request")?;
+        let mut attempt = 0u32;
+        loop {
+            attempt += 1;
+            let started = Instant::now();
+            let result = self
+                .http
+                .post(&url)
+                .header("x-api-key", &self.cfg.api_key)
+                .header("anthropic-version", ANTHROPIC_VERSION)
+                .header("content-type", "application/json")
+                .json(&body)
+                .send()
+                .await;
 
-        let status = resp.status();
-        if !status.is_success() {
-            let detail = resp.text().await.unwrap_or_default();
-            bail!("Fable API error {status}: {detail}");
+            let err = match result {
+                Ok(resp) => {
+                    let status = resp.status();
+                    if status.is_success() {
+                        let parsed: ApiResponse =
+                            resp.json().await.context("decoding Fable response")?;
+                        let latency_ms = started.elapsed().as_millis() as u64;
+                        return Ok(FableCompletion {
+                            text: extract_text(&parsed.content),
+                            usage: parsed.usage,
+                            latency_ms,
+                        });
+                    }
+                    let detail = resp.text().await.unwrap_or_default();
+                    if !retryable(status) {
+                        bail!("Fable API error {status}: {detail}");
+                    }
+                    anyhow::anyhow!("Fable API error {status}: {detail}")
+                }
+                Err(e) => anyhow::Error::new(e).context("sending Fable request"),
+            };
+
+            if attempt >= self.cfg.retry_attempts.max(1) {
+                return Err(err.context(format!("giving up after {attempt} attempts")));
+            }
+            let backoff = Duration::from_millis(self.cfg.retry_backoff_ms << (attempt - 1));
+            tokio::time::sleep(backoff).await;
         }
-
-        let parsed: ApiResponse = resp.json().await.context("decoding Fable response")?;
-        let latency_ms = started.elapsed().as_millis() as u64;
-
-        Ok(FableCompletion {
-            text: extract_text(&parsed.content),
-            usage: parsed.usage,
-            latency_ms,
-        })
     }
+}
+
+/// Transient statuses worth another attempt on an unattended run: rate
+/// limiting (429) and server-side errors including Anthropic overload (529).
+fn retryable(status: reqwest::StatusCode) -> bool {
+    status.as_u16() == 429 || status.is_server_error()
 }
 
 #[cfg(test)]
 mod tests {
+    // #[tokio::test] expands to Runtime::block_on; harmless in tests.
+    #![allow(clippy::disallowed_methods)]
+
     use super::*;
+    use std::net::SocketAddr;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
 
     fn cfg() -> FableConfig {
         FableConfig {
@@ -179,7 +220,102 @@ mod tests {
             model: "claude-fable-5".into(),
             max_tokens: 8192,
             effort: "high".into(),
+            retry_attempts: 3,
+            retry_backoff_ms: 1,
         }
+    }
+
+    const SUCCESS_BODY: &str = r#"{"content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":10,"output_tokens":5}}"#;
+
+    /// Serve the given (status, body) responses, one connection each, then
+    /// stop listening. Plain HTTP/1.1 over a loopback socket — enough to
+    /// exercise the client's status handling without any TLS or HTTP dep.
+    async fn serve(responses: Vec<(u16, &'static str)>) -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            for (status, body) in responses {
+                let (mut sock, _) = listener.accept().await.unwrap();
+                read_request(&mut sock).await;
+                let resp = format!(
+                    "HTTP/1.1 {status} STATUS\r\ncontent-type: application/json\r\n\
+                     content-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                sock.write_all(resp.as_bytes()).await.unwrap();
+            }
+        });
+        addr
+    }
+
+    /// Read headers plus the content-length body so the client never sees a
+    /// reset mid-request.
+    async fn read_request(sock: &mut tokio::net::TcpStream) {
+        let mut data = Vec::new();
+        let mut buf = [0u8; 4096];
+        loop {
+            let n = sock.read(&mut buf).await.unwrap();
+            if n == 0 {
+                return;
+            }
+            data.extend_from_slice(&buf[..n]);
+            if let Some(pos) = data.windows(4).position(|w| w == b"\r\n\r\n") {
+                let headers = String::from_utf8_lossy(&data[..pos]).to_lowercase();
+                let len = headers
+                    .lines()
+                    .find_map(|l| l.strip_prefix("content-length:"))
+                    .and_then(|v| v.trim().parse::<usize>().ok())
+                    .unwrap_or(0);
+                if data.len() >= pos + 4 + len {
+                    return;
+                }
+            }
+        }
+    }
+
+    fn local_cfg(addr: SocketAddr) -> FableConfig {
+        FableConfig {
+            base_url: format!("http://{addr}"),
+            ..cfg()
+        }
+    }
+
+    #[tokio::test]
+    async fn retries_transient_overload_then_succeeds() {
+        let addr = serve(vec![
+            (529, "overloaded"),
+            (429, "rate limited"),
+            (200, SUCCESS_BODY),
+        ])
+        .await;
+        let client = FableClient::new(local_cfg(addr)).unwrap();
+        let completion = client.complete("sys", "usr").await.unwrap();
+        assert_eq!(completion.text, "ok");
+        assert_eq!(completion.usage.input_tokens, 10);
+        assert_eq!(completion.usage.output_tokens, 5);
+    }
+
+    #[tokio::test]
+    async fn non_retryable_status_fails_without_retry() {
+        // One served response only: a retry would hit a closed listener and
+        // surface a connect error instead of the 400 detail asserted here.
+        let addr = serve(vec![(400, "bad request")]).await;
+        let client = FableClient::new(local_cfg(addr)).unwrap();
+        let err = client.complete("sys", "usr").await.unwrap_err();
+        assert!(
+            format!("{err:#}").contains("400"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn exhausts_retries_and_reports_last_error() {
+        let addr = serve(vec![(500, "boom"), (500, "boom"), (500, "boom")]).await;
+        let client = FableClient::new(local_cfg(addr)).unwrap();
+        let err = client.complete("sys", "usr").await.unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("500"), "unexpected error: {msg}");
+        assert!(msg.contains("attempts"), "unexpected error: {msg}");
     }
 
     #[test]

--- a/crates/arkavo-shadow-consolidation/src/fable.rs
+++ b/crates/arkavo-shadow-consolidation/src/fable.rs
@@ -209,6 +209,7 @@ mod tests {
     #![allow(clippy::disallowed_methods)]
 
     use super::*;
+    use arkavo_test_macros::spec;
     use std::net::SocketAddr;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
@@ -280,6 +281,7 @@ mod tests {
         }
     }
 
+    #[spec("SC-004")]
     #[tokio::test]
     async fn retries_transient_overload_then_succeeds() {
         let addr = serve(vec![
@@ -295,6 +297,7 @@ mod tests {
         assert_eq!(completion.usage.output_tokens, 5);
     }
 
+    #[spec("SC-004")]
     #[tokio::test]
     async fn non_retryable_status_fails_without_retry() {
         // One served response only: a retry would hit a closed listener and
@@ -308,6 +311,7 @@ mod tests {
         );
     }
 
+    #[spec("SC-004")]
     #[tokio::test]
     async fn exhausts_retries_and_reports_last_error() {
         let addr = serve(vec![(500, "boom"), (500, "boom"), (500, "boom")]).await;

--- a/crates/arkavo-shadow-consolidation/src/lib.rs
+++ b/crates/arkavo-shadow-consolidation/src/lib.rs
@@ -1,0 +1,25 @@
+//! Shadow consolidation with Fable — outside the runtime.
+//!
+//! A standalone, audit-plane job that takes existing episode traces (with
+//! observe calls stripped, per the lesson-synthesis rule), batches them to
+//! Fable, and writes three artifacts to disk:
+//!
+//! - `lessons.json` — action-named lessons ([`proposal::ActionLesson`]).
+//! - `proposals.json` — candidate tightenings, the draft `proposal.rs` JSON shape ([`proposal::Proposal`]).
+//! - `cost_ledger.json` — real token/dollar accounting plus a recommended value for `budget.per_layer["consolidation"]` ([`proposal::CostLedger`]).
+//!
+//! It also emits `findings.json` — [`proposal::FindingCard`] seed cards
+//! projected from the genuine lessons and proposals, so the findings-inbox UI
+//! can be populated from real output instead of invented fixtures.
+//!
+//! The job has **zero runtime contact**: it depends on no arkavo runtime
+//! crate, opens the episode store read-only, and reaches only Fable over the
+//! network.
+
+pub mod episodes;
+pub mod fable;
+pub mod proposal;
+pub mod run;
+pub mod synthesis;
+
+pub use run::{Config, RunSummary, execute};

--- a/crates/arkavo-shadow-consolidation/src/lib.rs
+++ b/crates/arkavo-shadow-consolidation/src/lib.rs
@@ -10,16 +10,23 @@
 //!
 //! It also emits `findings.json` — [`proposal::FindingCard`] seed cards
 //! projected from the genuine lessons and proposals, so the findings-inbox UI
-//! can be populated from real output instead of invented fixtures.
+//! can be populated from real output instead of invented fixtures — plus
+//! `rejects.json` ([`validate::Reject`]) recording every contract violation
+//! with a reason (the source of the ledger's contract-conformance rate), and
+//! a `raw/` archive of each verbatim Fable reply for contract-evolution
+//! regression.
 //!
 //! The job has **zero runtime contact**: it depends on no arkavo runtime
 //! crate, opens the episode store read-only, and reaches only Fable over the
-//! network.
+//! network — under a hard run-level cost ceiling (`--max-run-cost-usd`) that
+//! stops the run between batches, keeps partial outputs, and marks the ledger
+//! budget-exhausted.
 
 pub mod episodes;
 pub mod fable;
 pub mod proposal;
 pub mod run;
 pub mod synthesis;
+pub mod validate;
 
 pub use run::{Config, RunSummary, execute};

--- a/crates/arkavo-shadow-consolidation/src/lib.rs
+++ b/crates/arkavo-shadow-consolidation/src/lib.rs
@@ -17,10 +17,17 @@
 //! regression.
 //!
 //! The job has **zero runtime contact**: it depends on no arkavo runtime
-//! crate, opens the episode store read-only, and reaches only Fable over the
-//! network — under a hard run-level cost ceiling (`--max-run-cost-usd`) that
-//! stops the run between batches, keeps partial outputs, and marks the ledger
-//! budget-exhausted.
+//! crate (its only arkavo dependency is the std-only lesson-synthesis rules
+//! crate shared with the consolidation teacher), opens the episode store
+//! read-only, and reaches only Fable over the network — under a hard
+//! run-level cost ceiling (`--max-run-cost-usd`) that stops the run between
+//! batches, keeps partial outputs, and marks the ledger budget-exhausted.
+//!
+//! This crate is transitional: it exists to validate the consolidation
+//! contract before the runtime teacher takes over, and it folds into the
+//! runtime as a shadow mode once that validation holds. The artifacts are
+//! the durable contract — build consumers against the JSON shapes, not
+//! against this binary.
 
 pub mod episodes;
 pub mod fable;

--- a/crates/arkavo-shadow-consolidation/src/main.rs
+++ b/crates/arkavo-shadow-consolidation/src/main.rs
@@ -1,0 +1,83 @@
+//! Binary entry point for the shadow-consolidation overnight job.
+
+use std::path::PathBuf;
+
+use anyhow::Context;
+use arkavo_shadow_consolidation::{Config, execute};
+use clap::Parser;
+
+/// Batch existing episode traces to Fable and emit action-named lessons,
+/// candidate tightenings, and a cost ledger. Zero runtime contact.
+#[derive(Debug, Parser)]
+#[command(name = "arkavo-shadow-consolidation", version, about)]
+struct Args {
+    /// Path to the episode SQLite store (opened read-only).
+    #[arg(long, env = "ARKAVO_LEARNING_DB")]
+    db: PathBuf,
+
+    /// Directory the four artifacts are written to (created if absent).
+    #[arg(
+        long,
+        env = "ARKAVO_SHADOW_OUT",
+        default_value = "shadow-consolidation-out"
+    )]
+    out: PathBuf,
+
+    /// Fable model id.
+    #[arg(long, default_value = "claude-fable-5")]
+    model: String,
+
+    /// Minimum episodes a category needs before it is consolidated.
+    #[arg(long, default_value_t = 3)]
+    min_episodes: usize,
+
+    /// `max_tokens` for each Fable completion (thinking is billed within this).
+    #[arg(long, default_value_t = 8192)]
+    max_tokens: u32,
+
+    /// Reasoning effort for Fable: low | medium | high | max.
+    #[arg(long, default_value = "high")]
+    effort: String,
+
+    /// Build batches and write prompts without calling Fable (no spend).
+    #[arg(long)]
+    dry_run: bool,
+}
+
+#[tokio::main]
+#[allow(clippy::disallowed_methods)] // #[tokio::main] expands to Runtime::block_on
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let cfg = Config {
+        db_path: args.db,
+        out_dir: args.out,
+        model: args.model,
+        min_episodes: args.min_episodes,
+        max_tokens: args.max_tokens,
+        effort: args.effort,
+        dry_run: args.dry_run,
+    };
+
+    let summary = execute(cfg).await.context("shadow consolidation failed")?;
+
+    let mode = if summary.total_cost_usd == 0.0 && summary.lessons == 0 && summary.proposals == 0 {
+        "(dry-run / no output)"
+    } else {
+        ""
+    };
+    println!(
+        "shadow consolidation complete {mode}\n  categories consolidated: {}\n  \
+         action-named lessons:    {}\n  candidate tightenings:   {}\n  \
+         seed finding cards:      {}\n  total Fable cost:        ${:.4}\n  \
+         suggested budget.per_layer[\"consolidation\"].limit_usd: ${:.4}\n  \
+         artifacts written to:    {}",
+        summary.batches,
+        summary.lessons,
+        summary.proposals,
+        summary.findings,
+        summary.total_cost_usd,
+        summary.suggested_per_invocation_limit_usd,
+        summary.out_dir.display(),
+    );
+    Ok(())
+}

--- a/crates/arkavo-shadow-consolidation/src/main.rs
+++ b/crates/arkavo-shadow-consolidation/src/main.rs
@@ -15,7 +15,7 @@ struct Args {
     #[arg(long, env = "ARKAVO_LEARNING_DB")]
     db: PathBuf,
 
-    /// Directory the four artifacts are written to (created if absent).
+    /// Directory the artifacts are written to (created if absent).
     #[arg(
         long,
         env = "ARKAVO_SHADOW_OUT",
@@ -39,6 +39,12 @@ struct Args {
     #[arg(long, default_value = "high")]
     effort: String,
 
+    /// Hard ceiling on cumulative run spend in USD. The run stops between
+    /// batches once reached, keeps partial outputs, and marks the ledger
+    /// budget-exhausted.
+    #[arg(long, default_value_t = 25.0)]
+    max_run_cost_usd: f64,
+
     /// Build batches and write prompts without calling Fable (no spend).
     #[arg(long)]
     dry_run: bool,
@@ -48,6 +54,7 @@ struct Args {
 #[allow(clippy::disallowed_methods)] // #[tokio::main] expands to Runtime::block_on
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
+    let dry_run = args.dry_run;
     let cfg = Config {
         db_path: args.db,
         out_dir: args.out,
@@ -55,29 +62,35 @@ async fn main() -> anyhow::Result<()> {
         min_episodes: args.min_episodes,
         max_tokens: args.max_tokens,
         effort: args.effort,
-        dry_run: args.dry_run,
+        max_run_cost_usd: args.max_run_cost_usd,
+        dry_run,
     };
 
     let summary = execute(cfg).await.context("shadow consolidation failed")?;
 
-    let mode = if summary.total_cost_usd == 0.0 && summary.lessons == 0 && summary.proposals == 0 {
-        "(dry-run / no output)"
-    } else {
-        ""
-    };
+    let mode = if dry_run { " (dry-run)" } else { "" };
     println!(
-        "shadow consolidation complete {mode}\n  categories consolidated: {}\n  \
+        "shadow consolidation complete{mode}\n  categories consolidated: {}\n  \
          action-named lessons:    {}\n  candidate tightenings:   {}\n  \
-         seed finding cards:      {}\n  total Fable cost:        ${:.4}\n  \
+         seed finding cards:      {}\n  rejects:                 {}\n  \
+         contract conformance:    {:.1}%\n  total Fable cost:        ${:.4}\n  \
          suggested budget.per_layer[\"consolidation\"].limit_usd: ${:.4}\n  \
          artifacts written to:    {}",
-        summary.batches,
+        summary.categories_consolidated,
         summary.lessons,
         summary.proposals,
         summary.findings,
+        summary.rejects,
+        summary.contract_conformance_rate * 100.0,
         summary.total_cost_usd,
         summary.suggested_per_invocation_limit_usd,
         summary.out_dir.display(),
     );
+    if summary.budget_exhausted {
+        eprintln!(
+            "warning: run-level cost ceiling reached — outputs are partial; \
+             see categories_budget_stopped in cost_ledger.json"
+        );
+    }
     Ok(())
 }

--- a/crates/arkavo-shadow-consolidation/src/proposal.rs
+++ b/crates/arkavo-shadow-consolidation/src/proposal.rs
@@ -33,15 +33,18 @@ pub enum Severity {
 }
 
 impl Severity {
-    /// Parse a model-emitted severity string, defaulting to [`Severity::Medium`]
-    /// when the value is missing or unrecognized — a candidate tightening with
-    /// an unclear severity still warrants human review.
-    #[must_use]
-    pub fn parse_lenient(raw: Option<&str>) -> Self {
+    /// Parse a model-emitted severity string strictly. Only the contract
+    /// values `low | medium | high` (plus `critical` as a high alias) are
+    /// accepted; anything else is a contract violation the caller must record
+    /// as a reject — leniency here would hide non-conformance from the
+    /// morning's contract-conformance rate.
+    pub fn parse_strict(raw: Option<&str>) -> Result<Self, String> {
         match raw.map(str::trim).map(str::to_lowercase).as_deref() {
-            Some("low") => Self::Low,
-            Some("high" | "critical") => Self::High,
-            _ => Self::Medium,
+            Some("low") => Ok(Self::Low),
+            Some("medium") => Ok(Self::Medium),
+            Some("high" | "critical") => Ok(Self::High),
+            Some(other) => Err(format!("unrecognized severity {other:?}")),
+            None => Err("missing severity".to_string()),
         }
     }
 }
@@ -255,6 +258,10 @@ impl FindingCard {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LedgerEntry {
     pub category: String,
+    /// Store row ids of the episodes behind this batch — the batch→episode
+    /// linkage that lets a proposal be backfilled into trace references and
+    /// findings-inbox cards keep their evidence.
+    pub episode_ids: Vec<String>,
     pub episode_count: u32,
     pub input_tokens: u64,
     pub output_tokens: u64,
@@ -292,6 +299,12 @@ pub struct CostLedger {
     pub categories_total: u64,
     pub categories_consolidated: u64,
     pub categories_skipped: u64,
+    pub categories_budget_stopped: u64,
+    pub run_budget: RunBudget,
+    pub conformance: Conformance,
+    /// Headline metric: share of model-emitted items that conformed to the
+    /// output contract ([`Conformance::rate`]).
+    pub contract_conformance_rate: f64,
     pub fable_calls: u64,
     pub input_tokens: u64,
     pub output_tokens: u64,
@@ -315,6 +328,47 @@ pub struct RunStats {
     pub episodes_consolidated: u64,
     pub categories_total: u64,
     pub categories_skipped: u64,
+    /// Categories left unconsolidated because the run-level cost ceiling was
+    /// hit before they were reached.
+    pub categories_budget_stopped: u64,
+}
+
+/// Accepted/rejected tallies for the run — the source of the morning's
+/// contract-conformance rate.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Conformance {
+    pub lessons_accepted: u64,
+    pub lessons_rejected: u64,
+    pub tightenings_accepted: u64,
+    pub tightenings_rejected: u64,
+    /// Replies that could not be parsed as the output contract at all.
+    pub responses_rejected: u64,
+}
+
+impl Conformance {
+    /// Share of emitted items that conformed to the output contract.
+    /// `1.0` when the model emitted nothing (an empty run is not a violation).
+    #[must_use]
+    pub fn rate(&self) -> f64 {
+        let accepted = self.lessons_accepted + self.tightenings_accepted;
+        let rejected = self.lessons_rejected + self.tightenings_rejected + self.responses_rejected;
+        let total = accepted + rejected;
+        if total == 0 {
+            1.0
+        } else {
+            accepted as f64 / total as f64
+        }
+    }
+}
+
+/// Run-level spend ceiling state, recorded in the ledger.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct RunBudget {
+    /// The hard ceiling the run was given (`--max-run-cost-usd`).
+    pub max_run_cost_usd: f64,
+    /// True when the run stopped early because cumulative spend reached the
+    /// ceiling; the artifacts on disk are then partial by design.
+    pub exhausted: bool,
 }
 
 impl CostLedger {
@@ -326,13 +380,17 @@ impl CostLedger {
         model: String,
         dry_run: bool,
         stats: RunStats,
+        conformance: Conformance,
+        run_budget: RunBudget,
         entries: Vec<LedgerEntry>,
         headroom: f64,
     ) -> Self {
         let fable_calls = entries.len() as u64;
         let input_tokens = entries.iter().map(|e| e.input_tokens).sum();
         let output_tokens = entries.iter().map(|e| e.output_tokens).sum();
-        let total_cost_usd: f64 = entries.iter().map(|e| e.cost_usd).sum();
+        // `+ 0.0` normalizes the `-0.0` that f64's empty Sum identity yields,
+        // which would otherwise surface as "$-0.0000" in reports.
+        let total_cost_usd: f64 = entries.iter().map(|e| e.cost_usd).sum::<f64>() + 0.0;
         let max_call_cost_usd = entries.iter().map(|e| e.cost_usd).fold(0.0_f64, f64::max);
         let mean_call_cost_usd = if fable_calls == 0 {
             0.0
@@ -359,6 +417,10 @@ impl CostLedger {
             categories_total: stats.categories_total,
             categories_consolidated: fable_calls,
             categories_skipped: stats.categories_skipped,
+            categories_budget_stopped: stats.categories_budget_stopped,
+            run_budget,
+            contract_conformance_rate: conformance.rate(),
+            conformance,
             fable_calls,
             input_tokens,
             output_tokens,
@@ -409,11 +471,32 @@ mod tests {
     }
 
     #[test]
-    fn severity_parse_is_lenient() {
-        assert_eq!(Severity::parse_lenient(Some("LOW")), Severity::Low);
-        assert_eq!(Severity::parse_lenient(Some("critical")), Severity::High);
-        assert_eq!(Severity::parse_lenient(Some("weird")), Severity::Medium);
-        assert_eq!(Severity::parse_lenient(None), Severity::Medium);
+    fn severity_parse_is_strict() {
+        assert_eq!(Severity::parse_strict(Some("LOW")).unwrap(), Severity::Low);
+        assert_eq!(
+            Severity::parse_strict(Some("medium")).unwrap(),
+            Severity::Medium
+        );
+        assert_eq!(
+            Severity::parse_strict(Some("critical")).unwrap(),
+            Severity::High
+        );
+        assert!(Severity::parse_strict(Some("weird")).is_err());
+        assert!(Severity::parse_strict(None).is_err());
+    }
+
+    #[test]
+    fn conformance_rate_over_emitted_items() {
+        let c = Conformance {
+            lessons_accepted: 3,
+            lessons_rejected: 1,
+            tightenings_accepted: 4,
+            tightenings_rejected: 1,
+            responses_rejected: 1,
+        };
+        // 7 accepted / 10 total
+        assert!((c.rate() - 0.7).abs() < 1e-9);
+        assert!((Conformance::default().rate() - 1.0).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -468,6 +551,7 @@ mod tests {
         let entries = vec![
             LedgerEntry {
                 category: "a".into(),
+                episode_ids: vec!["ep-1".into(), "ep-2".into(), "ep-3".into()],
                 episode_count: 3,
                 input_tokens: 1000,
                 output_tokens: 500,
@@ -478,6 +562,7 @@ mod tests {
             },
             LedgerEntry {
                 category: "b".into(),
+                episode_ids: vec!["ep-4".into(); 4],
                 episode_count: 4,
                 input_tokens: 2000,
                 output_tokens: 800,
@@ -492,9 +577,30 @@ mod tests {
             episodes_consolidated: 7,
             categories_total: 5,
             categories_skipped: 3,
+            categories_budget_stopped: 0,
         };
-        let ledger = CostLedger::summarize("claude-fable-5".into(), false, stats, entries, 1.5);
+        let conformance = Conformance {
+            lessons_accepted: 2,
+            tightenings_accepted: 2,
+            ..Conformance::default()
+        };
+        let run_budget = RunBudget {
+            max_run_cost_usd: 25.0,
+            exhausted: false,
+        };
+        let ledger = CostLedger::summarize(
+            "claude-fable-5".into(),
+            false,
+            stats,
+            conformance,
+            run_budget,
+            entries,
+            1.5,
+        );
         assert_eq!(ledger.fable_calls, 2);
+        assert_eq!(ledger.per_call[0].episode_ids.len(), 3);
+        assert!((ledger.contract_conformance_rate - 1.0).abs() < f64::EPSILON);
+        assert!(!ledger.run_budget.exhausted);
         assert_eq!(ledger.input_tokens, 3000);
         assert_eq!(ledger.output_tokens, 1300);
         assert!((ledger.total_cost_usd - 0.095).abs() < 1e-9);
@@ -518,8 +624,20 @@ mod tests {
             episodes_consolidated: 0,
             categories_total: 0,
             categories_skipped: 0,
+            categories_budget_stopped: 0,
         };
-        let ledger = CostLedger::summarize("claude-fable-5".into(), true, stats, vec![], 1.5);
+        let ledger = CostLedger::summarize(
+            "claude-fable-5".into(),
+            true,
+            stats,
+            Conformance::default(),
+            RunBudget {
+                max_run_cost_usd: 25.0,
+                exhausted: false,
+            },
+            vec![],
+            1.5,
+        );
         assert_eq!(ledger.fable_calls, 0);
         assert!((ledger.mean_call_cost_usd).abs() < f64::EPSILON);
         assert!(

--- a/crates/arkavo-shadow-consolidation/src/proposal.rs
+++ b/crates/arkavo-shadow-consolidation/src/proposal.rs
@@ -296,6 +296,9 @@ pub struct CostLedger {
     pub dry_run: bool,
     pub episodes_total: u64,
     pub episodes_consolidated: u64,
+    /// Episodes dropped by the per-category sampling cap — non-zero means
+    /// the run sampled rather than consolidated everything.
+    pub episodes_sampled_out: u64,
     pub categories_total: u64,
     pub categories_consolidated: u64,
     pub categories_skipped: u64,
@@ -326,6 +329,8 @@ fn ceil_cents(usd: f64) -> f64 {
 pub struct RunStats {
     pub episodes_total: u64,
     pub episodes_consolidated: u64,
+    /// Episodes dropped by the per-category sampling cap.
+    pub episodes_sampled_out: u64,
     pub categories_total: u64,
     pub categories_skipped: u64,
     /// Categories left unconsolidated because the run-level cost ceiling was
@@ -414,6 +419,7 @@ impl CostLedger {
             dry_run,
             episodes_total: stats.episodes_total,
             episodes_consolidated: stats.episodes_consolidated,
+            episodes_sampled_out: stats.episodes_sampled_out,
             categories_total: stats.categories_total,
             categories_consolidated: fable_calls,
             categories_skipped: stats.categories_skipped,
@@ -573,6 +579,7 @@ mod tests {
             },
         ];
         let stats = RunStats {
+            episodes_sampled_out: 0,
             episodes_total: 20,
             episodes_consolidated: 7,
             categories_total: 5,
@@ -620,6 +627,7 @@ mod tests {
     #[test]
     fn ledger_empty_run_is_zeroed() {
         let stats = RunStats {
+            episodes_sampled_out: 0,
             episodes_total: 0,
             episodes_consolidated: 0,
             categories_total: 0,

--- a/crates/arkavo-shadow-consolidation/src/proposal.rs
+++ b/crates/arkavo-shadow-consolidation/src/proposal.rs
@@ -1,0 +1,533 @@
+//! Draft output contract for shadow consolidation.
+//!
+//! These types are the wire shape the overnight job writes to disk and the
+//! shape a future runtime / findings-inbox UI is expected to read. They are
+//! deliberately self-contained (no dependency on any runtime crate) so the
+//! audit-plane job and the contract it validates stay decoupled by
+//! construction.
+//!
+//! Three artifacts map onto these types:
+//!   * [`ActionLesson`] — action-named lessons.
+//!   * [`Proposal`] — candidate tightenings (the draft `proposal.rs` shape).
+//!   * [`CostLedger`] — the cost ledger that produces real budget numbers.
+//!
+//! [`FindingCard`] is the seed-card projection of the first two, so the
+//! findings inbox can be populated from genuine consolidation output instead
+//! of invented fixtures.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Identifier the job stamps on everything it emits, so downstream consumers
+/// can tell shadow-consolidation output apart from runtime-synthesized data.
+pub const SOURCE: &str = "fable-shadow-consolidation";
+
+/// How urgently a candidate tightening should be reviewed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    Low,
+    Medium,
+    High,
+}
+
+impl Severity {
+    /// Parse a model-emitted severity string, defaulting to [`Severity::Medium`]
+    /// when the value is missing or unrecognized — a candidate tightening with
+    /// an unclear severity still warrants human review.
+    #[must_use]
+    pub fn parse_lenient(raw: Option<&str>) -> Self {
+        match raw.map(str::trim).map(str::to_lowercase).as_deref() {
+            Some("low") => Self::Low,
+            Some("high" | "critical") => Self::High,
+            _ => Self::Medium,
+        }
+    }
+}
+
+/// Review state of a [`Proposal`]. Everything the job emits starts as
+/// [`ProposalStatus::Draft`]; acceptance/rejection is a human or runtime
+/// decision made later.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProposalStatus {
+    Draft,
+    Accepted,
+    Rejected,
+}
+
+/// An action-named lesson: a strategic rule that names a concrete action.
+///
+/// Mirrors the runtime lesson contract (condition / action / expected_outcome /
+/// confidence) but is generated offline from existing traces.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ActionLesson {
+    pub id: Uuid,
+    /// Task category the lesson was distilled from.
+    pub category: String,
+    /// The named action this lesson is about (leading token of `action`),
+    /// so the inbox can group lessons by the action they recommend.
+    pub action_name: String,
+    /// Situation that triggers the action.
+    pub condition: String,
+    /// Concrete action recommendation.
+    pub action: String,
+    /// Measurable result the action is expected to produce.
+    pub expected_outcome: String,
+    /// Model confidence in the lesson, clamped to `[0, 1]`.
+    pub confidence: f64,
+    /// Number of episodes that backed this lesson.
+    pub episode_count: u32,
+    pub source: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl ActionLesson {
+    /// Build a lesson, deriving [`ActionLesson::action_name`] from the leading
+    /// token of `action` (the tool name, before any space or `(`).
+    #[must_use]
+    pub fn new(
+        category: String,
+        condition: String,
+        action: String,
+        expected_outcome: String,
+        confidence: f64,
+        episode_count: u32,
+    ) -> Self {
+        let action_name = action_token(&action);
+        Self {
+            id: Uuid::new_v4(),
+            category,
+            action_name,
+            condition,
+            action,
+            expected_outcome,
+            confidence: confidence.clamp(0.0, 1.0),
+            episode_count,
+            source: SOURCE.to_string(),
+            created_at: Utc::now(),
+        }
+    }
+}
+
+/// Extract the action-naming token from a free-form action string: the part
+/// before the first whitespace or `(`. Falls back to the trimmed whole string.
+fn action_token(action: &str) -> String {
+    let trimmed = action.trim();
+    let end = trimmed
+        .find(|c: char| c.is_whitespace() || c == '(')
+        .unwrap_or(trimmed.len());
+    let token = trimmed[..end].trim_end_matches([':', ',', '.']);
+    if token.is_empty() {
+        trimmed.to_string()
+    } else {
+        token.to_string()
+    }
+}
+
+/// A candidate tightening — the draft `proposal.rs` JSON shape. Describes a
+/// policy constraint Fable judged worth adding, given the action→outcome
+/// evidence in a category.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Proposal {
+    pub id: Uuid,
+    pub category: String,
+    /// Short imperative title of the tightening.
+    pub title: String,
+    /// Why the tightening is warranted, grounded in the observed outcomes.
+    pub rationale: String,
+    /// The behavior as it stands today (what the agent currently does).
+    pub current_behavior: String,
+    /// The constraint to add — the actual tightening.
+    pub proposed_constraint: String,
+    pub severity: Severity,
+    /// Model confidence in the tightening, clamped to `[0, 1]`.
+    pub confidence: f64,
+    /// How many episodes back this proposal.
+    pub evidence_episode_count: u32,
+    pub status: ProposalStatus,
+    pub source: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl Proposal {
+    #[must_use]
+    #[allow(clippy::too_many_arguments)] // plain field-by-field constructor
+    pub fn new(
+        category: String,
+        title: String,
+        rationale: String,
+        current_behavior: String,
+        proposed_constraint: String,
+        severity: Severity,
+        confidence: f64,
+        evidence_episode_count: u32,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            category,
+            title,
+            rationale,
+            current_behavior,
+            proposed_constraint,
+            severity,
+            confidence: confidence.clamp(0.0, 1.0),
+            evidence_episode_count,
+            status: ProposalStatus::Draft,
+            source: SOURCE.to_string(),
+            created_at: Utc::now(),
+        }
+    }
+}
+
+/// What a [`FindingCard`] was projected from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FindingKind {
+    Lesson,
+    Tightening,
+}
+
+/// A seed card for the findings-inbox UI, projected from a real lesson or
+/// proposal so the inbox shows genuine consolidation output.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FindingCard {
+    pub id: Uuid,
+    pub kind: FindingKind,
+    pub title: String,
+    pub body: String,
+    pub category: String,
+    pub confidence: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub severity: Option<Severity>,
+    /// Back-link to the source artifact, so accepting a card can act on the
+    /// underlying lesson or proposal.
+    pub source_id: Uuid,
+    pub source: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl FindingCard {
+    #[must_use]
+    pub fn from_lesson(lesson: &ActionLesson) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            kind: FindingKind::Lesson,
+            title: format!("Lesson: {}", lesson.action_name),
+            body: format!(
+                "When {}, {} (expect: {}).",
+                lesson.condition.trim(),
+                lesson.action.trim(),
+                lesson.expected_outcome.trim()
+            ),
+            category: lesson.category.clone(),
+            confidence: lesson.confidence,
+            severity: None,
+            source_id: lesson.id,
+            source: SOURCE.to_string(),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[must_use]
+    pub fn from_proposal(proposal: &Proposal) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            kind: FindingKind::Tightening,
+            title: format!("Tightening: {}", proposal.title.trim()),
+            body: format!(
+                "{} Constraint: {}",
+                proposal.rationale.trim(),
+                proposal.proposed_constraint.trim()
+            ),
+            category: proposal.category.clone(),
+            confidence: proposal.confidence,
+            severity: Some(proposal.severity),
+            source_id: proposal.id,
+            source: SOURCE.to_string(),
+            created_at: Utc::now(),
+        }
+    }
+}
+
+/// Per-call accounting row in the [`CostLedger`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LedgerEntry {
+    pub category: String,
+    pub episode_count: u32,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cost_usd: f64,
+    pub latency_ms: u64,
+    pub lessons: u32,
+    pub tightenings: u32,
+}
+
+/// The empirical budget number this whole job exists to produce: a concrete
+/// value to set `budget.per_layer["consolidation"]`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BudgetRecommendation {
+    /// Layer key the recommendation is for.
+    pub layer: String,
+    /// Suggested per-invocation ceiling — the unit `LayerBudget.limit_usd`
+    /// uses (a single consolidation completion). Max observed call cost with
+    /// headroom.
+    pub suggested_per_invocation_limit_usd: f64,
+    /// Suggested ceiling for one full overnight run across all categories.
+    pub suggested_per_run_total_usd: f64,
+    /// Plain-language explanation of how the numbers were derived.
+    pub basis: String,
+}
+
+/// The cost ledger: real token and dollar accounting for the run, plus the
+/// derived budget recommendation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CostLedger {
+    pub model: String,
+    pub generated_at: DateTime<Utc>,
+    pub dry_run: bool,
+    pub episodes_total: u64,
+    pub episodes_consolidated: u64,
+    pub categories_total: u64,
+    pub categories_consolidated: u64,
+    pub categories_skipped: u64,
+    pub fable_calls: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub total_cost_usd: f64,
+    pub max_call_cost_usd: f64,
+    pub mean_call_cost_usd: f64,
+    pub per_call: Vec<LedgerEntry>,
+    pub budget_recommendation: BudgetRecommendation,
+}
+
+/// Round a dollar amount up to whole cents, so a recommended ceiling never
+/// sits a fraction of a cent below an observed cost.
+fn ceil_cents(usd: f64) -> f64 {
+    (usd * 100.0).ceil() / 100.0
+}
+
+/// Episode/category tallies for a run, threaded into [`CostLedger::summarize`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunStats {
+    pub episodes_total: u64,
+    pub episodes_consolidated: u64,
+    pub categories_total: u64,
+    pub categories_skipped: u64,
+}
+
+impl CostLedger {
+    /// Aggregate per-call entries into a ledger and derive the budget
+    /// recommendation. `headroom` (e.g. `1.5`) is applied to the worst-observed
+    /// call cost to set the per-invocation ceiling.
+    #[must_use]
+    pub fn summarize(
+        model: String,
+        dry_run: bool,
+        stats: RunStats,
+        entries: Vec<LedgerEntry>,
+        headroom: f64,
+    ) -> Self {
+        let fable_calls = entries.len() as u64;
+        let input_tokens = entries.iter().map(|e| e.input_tokens).sum();
+        let output_tokens = entries.iter().map(|e| e.output_tokens).sum();
+        let total_cost_usd: f64 = entries.iter().map(|e| e.cost_usd).sum();
+        let max_call_cost_usd = entries.iter().map(|e| e.cost_usd).fold(0.0_f64, f64::max);
+        let mean_call_cost_usd = if fable_calls == 0 {
+            0.0
+        } else {
+            total_cost_usd / fable_calls as f64
+        };
+
+        let per_invocation = ceil_cents(max_call_cost_usd * headroom);
+        let per_run = ceil_cents(total_cost_usd * 1.25);
+        let basis = format!(
+            "{fable_calls} Fable call(s) over {} episode(s); \
+             worst call ${max_call_cost_usd:.4}, mean ${mean_call_cost_usd:.4}, \
+             run total ${total_cost_usd:.4}. Per-invocation ceiling = worst call \
+             x {headroom} headroom; per-run ceiling = total x 1.25.",
+            stats.episodes_consolidated
+        );
+
+        Self {
+            model,
+            generated_at: Utc::now(),
+            dry_run,
+            episodes_total: stats.episodes_total,
+            episodes_consolidated: stats.episodes_consolidated,
+            categories_total: stats.categories_total,
+            categories_consolidated: fable_calls,
+            categories_skipped: stats.categories_skipped,
+            fable_calls,
+            input_tokens,
+            output_tokens,
+            total_cost_usd,
+            max_call_cost_usd,
+            mean_call_cost_usd,
+            per_call: entries,
+            budget_recommendation: BudgetRecommendation {
+                layer: "consolidation".to_string(),
+                suggested_per_invocation_limit_usd: per_invocation,
+                suggested_per_run_total_usd: per_run,
+                basis,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn action_token_takes_leading_tool_name() {
+        assert_eq!(action_token("game-rl:step(Action=...)"), "game-rl:step");
+        assert_eq!(action_token("  set_priority high  "), "set_priority");
+        assert_eq!(action_token("reset:"), "reset");
+    }
+
+    #[test]
+    fn action_token_falls_back_to_whole_string() {
+        assert_eq!(action_token("avoid"), "avoid");
+        assert_eq!(action_token("((("), "(((");
+    }
+
+    #[test]
+    fn lesson_derives_action_name_and_clamps_confidence() {
+        let lesson = ActionLesson::new(
+            "colony".into(),
+            "food low".into(),
+            "set_priority(Growing)".into(),
+            "food recovers".into(),
+            1.7,
+            5,
+        );
+        assert_eq!(lesson.action_name, "set_priority");
+        assert!((lesson.confidence - 1.0).abs() < f64::EPSILON);
+        assert_eq!(lesson.source, SOURCE);
+    }
+
+    #[test]
+    fn severity_parse_is_lenient() {
+        assert_eq!(Severity::parse_lenient(Some("LOW")), Severity::Low);
+        assert_eq!(Severity::parse_lenient(Some("critical")), Severity::High);
+        assert_eq!(Severity::parse_lenient(Some("weird")), Severity::Medium);
+        assert_eq!(Severity::parse_lenient(None), Severity::Medium);
+    }
+
+    #[test]
+    fn proposal_starts_as_draft() {
+        let p = Proposal::new(
+            "colony".into(),
+            "Guard reset".into(),
+            "reset wipes colony".into(),
+            "agent resets on reconnect".into(),
+            "only reset when TotalReward < -20".into(),
+            Severity::High,
+            0.9,
+            7,
+        );
+        assert_eq!(p.status, ProposalStatus::Draft);
+        assert_eq!(p.severity, Severity::High);
+    }
+
+    #[test]
+    fn finding_cards_back_link_to_source() {
+        let lesson = ActionLesson::new(
+            "colony".into(),
+            "food low".into(),
+            "set_priority(Growing)".into(),
+            "food recovers".into(),
+            0.8,
+            5,
+        );
+        let card = FindingCard::from_lesson(&lesson);
+        assert_eq!(card.kind, FindingKind::Lesson);
+        assert_eq!(card.source_id, lesson.id);
+        assert!(card.title.contains("set_priority"));
+
+        let proposal = Proposal::new(
+            "colony".into(),
+            "Guard reset".into(),
+            "reset wipes colony".into(),
+            "agent resets on reconnect".into(),
+            "only reset when TotalReward < -20".into(),
+            Severity::High,
+            0.9,
+            7,
+        );
+        let pcard = FindingCard::from_proposal(&proposal);
+        assert_eq!(pcard.kind, FindingKind::Tightening);
+        assert_eq!(pcard.severity, Some(Severity::High));
+        assert_eq!(pcard.source_id, proposal.id);
+    }
+
+    #[test]
+    fn ledger_derives_budget_from_worst_call() {
+        let entries = vec![
+            LedgerEntry {
+                category: "a".into(),
+                episode_count: 3,
+                input_tokens: 1000,
+                output_tokens: 500,
+                cost_usd: 0.0350,
+                latency_ms: 1200,
+                lessons: 1,
+                tightenings: 2,
+            },
+            LedgerEntry {
+                category: "b".into(),
+                episode_count: 4,
+                input_tokens: 2000,
+                output_tokens: 800,
+                cost_usd: 0.0600,
+                latency_ms: 1500,
+                lessons: 1,
+                tightenings: 0,
+            },
+        ];
+        let stats = RunStats {
+            episodes_total: 20,
+            episodes_consolidated: 7,
+            categories_total: 5,
+            categories_skipped: 3,
+        };
+        let ledger = CostLedger::summarize("claude-fable-5".into(), false, stats, entries, 1.5);
+        assert_eq!(ledger.fable_calls, 2);
+        assert_eq!(ledger.input_tokens, 3000);
+        assert_eq!(ledger.output_tokens, 1300);
+        assert!((ledger.total_cost_usd - 0.095).abs() < 1e-9);
+        assert!((ledger.max_call_cost_usd - 0.06).abs() < 1e-9);
+        // worst call 0.06 * 1.5 = 0.09, ceil to cents = 0.09
+        assert!(
+            (ledger
+                .budget_recommendation
+                .suggested_per_invocation_limit_usd
+                - 0.09)
+                .abs()
+                < 1e-9
+        );
+        assert_eq!(ledger.budget_recommendation.layer, "consolidation");
+    }
+
+    #[test]
+    fn ledger_empty_run_is_zeroed() {
+        let stats = RunStats {
+            episodes_total: 0,
+            episodes_consolidated: 0,
+            categories_total: 0,
+            categories_skipped: 0,
+        };
+        let ledger = CostLedger::summarize("claude-fable-5".into(), true, stats, vec![], 1.5);
+        assert_eq!(ledger.fable_calls, 0);
+        assert!((ledger.mean_call_cost_usd).abs() < f64::EPSILON);
+        assert!(
+            (ledger
+                .budget_recommendation
+                .suggested_per_invocation_limit_usd)
+                .abs()
+                < f64::EPSILON
+        );
+    }
+}

--- a/crates/arkavo-shadow-consolidation/src/run.rs
+++ b/crates/arkavo-shadow-consolidation/src/run.rs
@@ -361,6 +361,7 @@ mod tests {
     use super::*;
     use crate::episodes::ActionOutcome;
     use crate::proposal::Severity;
+    use arkavo_test_macros::spec;
 
     fn batch() -> CategoryBatch {
         CategoryBatch {
@@ -386,6 +387,7 @@ mod tests {
         }
     }
 
+    #[spec("SC-002")]
     #[tokio::test]
     async fn dry_run_makes_no_call_and_zero_cost() {
         let (output, entry, preview, raw) = consolidate_category(None, &batch()).await.unwrap();
@@ -400,6 +402,7 @@ mod tests {
         assert!(preview.user.contains("set_priority"));
     }
 
+    #[spec("SC-005")]
     #[test]
     fn validate_output_accepts_conformant_and_rejects_violations() {
         let b = batch();
@@ -452,6 +455,7 @@ mod tests {
         assert!((conformance.rate() - 2.0 / 3.0).abs() < 1e-9);
     }
 
+    #[spec("SC-005")]
     #[test]
     fn validate_output_rejects_lesson_not_in_evidence() {
         let b = batch();
@@ -511,6 +515,7 @@ mod tests {
         db
     }
 
+    #[spec("SC-002")]
     #[tokio::test]
     async fn dry_run_execute_writes_artifacts() {
         let tmp = tempfile::TempDir::new().unwrap();
@@ -558,6 +563,7 @@ mod tests {
         assert!((ledger["contract_conformance_rate"].as_f64().unwrap() - 1.0).abs() < 1e-9);
     }
 
+    #[spec("SC-001")]
     #[tokio::test]
     async fn ceiling_at_or_below_zero_stops_before_first_live_call() {
         // With a zero ceiling and dry_run=false, the run must stop before

--- a/crates/arkavo-shadow-consolidation/src/run.rs
+++ b/crates/arkavo-shadow-consolidation/src/run.rs
@@ -177,6 +177,9 @@ fn validate_output(
             RejectKind::Lesson => conformance.lessons_rejected += 1,
             RejectKind::Tightening => conformance.tightenings_rejected += 1,
             RejectKind::Response => conformance.responses_rejected += 1,
+            // Operational failures never reach this path (recorded directly
+            // by the run loop) and never count against conformance.
+            RejectKind::Call => {}
         }
     }
 
@@ -268,7 +271,24 @@ pub async fn execute(cfg: Config) -> anyhow::Result<RunSummary> {
             client = Some(FableClient::new(fable_cfg)?);
         }
 
-        let (output, entry, preview, raw) = consolidate_category(client.as_ref(), batch).await?;
+        // One failed call must not abort the run: the ledger has to account
+        // for money already spent on earlier batches, so the failure is
+        // recorded as a call reject (its own usage never came back) and the
+        // run moves on. Call failures are operational, not contract
+        // violations — conformance is untouched.
+        let (output, entry, preview, raw) = match consolidate_category(client.as_ref(), batch).await
+        {
+            Ok(parts) => parts,
+            Err(e) => {
+                rejects.push(Reject::new(
+                    &batch.category,
+                    RejectKind::Call,
+                    format!("{e:#}"),
+                    serde_json::Value::Null,
+                ));
+                continue;
+            }
+        };
         cumulative_cost += entry.cost_usd;
 
         if let Some(raw) = raw {

--- a/crates/arkavo-shadow-consolidation/src/run.rs
+++ b/crates/arkavo-shadow-consolidation/src/run.rs
@@ -1,5 +1,6 @@
-//! Orchestration: read traces, batch to Fable (or dry-run), and write the
-//! four artifacts to disk.
+//! Orchestration: read traces, batch to Fable (or dry-run) under a hard
+//! run-level cost ceiling, validate output post-hoc, and write the artifacts
+//! to disk.
 
 use std::path::{Path, PathBuf};
 
@@ -7,9 +8,12 @@ use anyhow::Context;
 use serde::Serialize;
 
 use crate::episodes::{CategoryBatch, EpisodeReader, LoadResult};
-use crate::fable::{FableClient, FableConfig};
-use crate::proposal::{ActionLesson, CostLedger, FindingCard, LedgerEntry, Proposal, RunStats};
+use crate::fable::{FableClient, FableConfig, Usage};
+use crate::proposal::{
+    ActionLesson, Conformance, CostLedger, FindingCard, LedgerEntry, Proposal, RunBudget, RunStats,
+};
 use crate::synthesis::{self, ConsolidationOutput};
+use crate::validate::{self, Reject, RejectKind};
 
 /// Headroom multiplier applied to the worst observed call cost when
 /// recommending the per-invocation consolidation budget.
@@ -24,16 +28,24 @@ pub struct Config {
     pub min_episodes: usize,
     pub max_tokens: u32,
     pub effort: String,
+    /// Hard ceiling on cumulative run spend; the run stops between batches
+    /// once reached and the ledger is marked `budget_exhausted`.
+    pub max_run_cost_usd: f64,
     pub dry_run: bool,
 }
 
 /// What the run produced, for the binary to print.
 #[derive(Debug, Clone)]
 pub struct RunSummary {
-    pub batches: usize,
+    /// Categories actually sent to (or previewed for) Fable — excludes any
+    /// stopped by the cost ceiling.
+    pub categories_consolidated: usize,
     pub lessons: usize,
     pub proposals: usize,
     pub findings: usize,
+    pub rejects: usize,
+    pub contract_conformance_rate: f64,
+    pub budget_exhausted: bool,
     pub total_cost_usd: f64,
     pub suggested_per_invocation_limit_usd: f64,
     pub out_dir: PathBuf,
@@ -49,12 +61,30 @@ struct PromptPreview {
     user: String,
 }
 
+/// One archived Fable reply, written verbatim to `raw/batch_N.json` for
+/// contract-evolution regression.
+#[derive(Debug, Serialize)]
+struct RawResponse {
+    category: String,
+    model: String,
+    input_tokens: u64,
+    output_tokens: u64,
+    latency_ms: u64,
+    text: String,
+}
+
 /// Drive a single category: build the prompt, call Fable (unless dry-run), and
-/// return the parsed output plus a ledger entry.
+/// return the parsed output, a ledger entry, the prompt preview, and the raw
+/// reply for archival.
 async fn consolidate_category(
     client: Option<&FableClient>,
     batch: &CategoryBatch,
-) -> anyhow::Result<(ConsolidationOutput, LedgerEntry, PromptPreview)> {
+) -> anyhow::Result<(
+    ConsolidationOutput,
+    LedgerEntry,
+    PromptPreview,
+    Option<RawResponse>,
+)> {
     let episode_count = batch.outcomes.len();
     let user = synthesis::build_user_prompt(batch);
     let preview = PromptPreview {
@@ -68,6 +98,7 @@ async fn consolidate_category(
         // Dry-run: no call, no cost, no parsed output.
         let entry = LedgerEntry {
             category: batch.category.clone(),
+            episode_ids: batch.episode_ids.clone(),
             episode_count: episode_count as u32,
             input_tokens: 0,
             output_tokens: 0,
@@ -76,11 +107,7 @@ async fn consolidate_category(
             lessons: 0,
             tightenings: 0,
         };
-        let output = ConsolidationOutput {
-            lesson: None,
-            proposals: Vec::new(),
-        };
-        return Ok((output, entry, preview));
+        return Ok((ConsolidationOutput::default(), entry, preview, None));
     };
 
     let completion = client
@@ -88,25 +115,112 @@ async fn consolidate_category(
         .await
         .with_context(|| format!("consolidating category {}", batch.category))?;
     let output = synthesis::parse_response(&batch.category, &completion.text, episode_count as u32);
+    let Usage {
+        input_tokens,
+        output_tokens,
+    } = completion.usage;
+    let raw = RawResponse {
+        category: batch.category.clone(),
+        model: client.model().to_string(),
+        input_tokens,
+        output_tokens,
+        latency_ms: completion.latency_ms,
+        text: completion.text,
+    };
     let entry = LedgerEntry {
         category: batch.category.clone(),
+        episode_ids: batch.episode_ids.clone(),
         episode_count: episode_count as u32,
-        input_tokens: completion.usage.input_tokens,
-        output_tokens: completion.usage.output_tokens,
+        input_tokens,
+        output_tokens,
         cost_usd: completion.usage.cost_usd(),
         latency_ms: completion.latency_ms,
         lessons: u32::from(output.lesson.is_some()),
         tightenings: output.proposals.len() as u32,
     };
-    Ok((output, entry, preview))
+    Ok((output, entry, preview, Some(raw)))
 }
 
 fn write_json<T: Serialize>(dir: &Path, name: &str, value: &T) -> anyhow::Result<()> {
     let path = dir.join(name);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
     let json =
         serde_json::to_string_pretty(value).with_context(|| format!("serializing {name}"))?;
     std::fs::write(&path, json).with_context(|| format!("writing {}", path.display()))?;
     Ok(())
+}
+
+/// Validate one category's parsed output post-hoc, splitting it into accepted
+/// artifacts and rejects, and updating the conformance tallies.
+struct Accepted {
+    lessons: Vec<ActionLesson>,
+    proposals: Vec<Proposal>,
+    rejects: Vec<Reject>,
+}
+
+fn validate_output(
+    batch: &CategoryBatch,
+    output: ConsolidationOutput,
+    conformance: &mut Conformance,
+) -> Accepted {
+    let mut accepted = Accepted {
+        lessons: Vec::new(),
+        proposals: Vec::new(),
+        rejects: output.rejects,
+    };
+    // Parse-level rejects are already contract violations — tally them.
+    for reject in &accepted.rejects {
+        match reject.kind {
+            RejectKind::Lesson => conformance.lessons_rejected += 1,
+            RejectKind::Tightening => conformance.tightenings_rejected += 1,
+            RejectKind::Response => conformance.responses_rejected += 1,
+        }
+    }
+
+    let evidence = validate::evidence_actions(&batch.outcomes);
+
+    if let Some(lesson) = output.lesson {
+        match validate::lesson_violation(&lesson, &evidence) {
+            None => {
+                conformance.lessons_accepted += 1;
+                accepted.lessons.push(lesson);
+            }
+            Some(reason) => {
+                conformance.lessons_rejected += 1;
+                let payload = serde_json::to_value(&lesson).unwrap_or_default();
+                accepted.rejects.push(Reject::new(
+                    &batch.category,
+                    RejectKind::Lesson,
+                    reason,
+                    payload,
+                ));
+            }
+        }
+    }
+
+    for proposal in output.proposals {
+        match validate::tightening_violation(&proposal) {
+            None => {
+                conformance.tightenings_accepted += 1;
+                accepted.proposals.push(proposal);
+            }
+            Some(reason) => {
+                conformance.tightenings_rejected += 1;
+                let payload = serde_json::to_value(&proposal).unwrap_or_default();
+                accepted.rejects.push(Reject::new(
+                    &batch.category,
+                    RejectKind::Tightening,
+                    reason,
+                    payload,
+                ));
+            }
+        }
+    }
+
+    accepted
 }
 
 /// Execute the full overnight job.
@@ -123,30 +237,54 @@ pub async fn execute(cfg: Config) -> anyhow::Result<RunSummary> {
     std::fs::create_dir_all(&cfg.out_dir)
         .with_context(|| format!("creating output dir {}", cfg.out_dir.display()))?;
 
-    let client = if cfg.dry_run {
-        None
-    } else {
-        let fable_cfg =
-            FableConfig::from_env(cfg.model.clone(), cfg.max_tokens, cfg.effort.clone())?;
-        Some(FableClient::new(fable_cfg)?)
-    };
+    // Constructed lazily on the first batch that clears the ceiling check, so
+    // a run that can never spend (ceiling 0, or nothing to consolidate) needs
+    // no credentials at all.
+    let mut client: Option<FableClient> = None;
 
     let mut lessons: Vec<ActionLesson> = Vec::new();
     let mut proposals: Vec<Proposal> = Vec::new();
     let mut findings: Vec<FindingCard> = Vec::new();
+    let mut rejects: Vec<Reject> = Vec::new();
     let mut entries: Vec<LedgerEntry> = Vec::new();
     let mut previews: Vec<PromptPreview> = Vec::new();
+    let mut conformance = Conformance::default();
+    let mut cumulative_cost = 0.0_f64;
+    let mut budget_exhausted = false;
+    let mut categories_budget_stopped = 0_u64;
 
-    for batch in &batches {
-        let (output, entry, preview) = consolidate_category(client.as_ref(), batch).await?;
-        if let Some(lesson) = output.lesson {
+    for (idx, batch) in batches.iter().enumerate() {
+        // Hard run-level ceiling: an unattended overnight job with frontier
+        // spend must obey the same discipline it is calibrating. Stop between
+        // batches, keep partial outputs, and mark the ledger.
+        if !cfg.dry_run && cumulative_cost >= cfg.max_run_cost_usd {
+            budget_exhausted = true;
+            categories_budget_stopped = (batches.len() - idx) as u64;
+            break;
+        }
+        if !cfg.dry_run && client.is_none() {
+            let fable_cfg =
+                FableConfig::from_env(cfg.model.clone(), cfg.max_tokens, cfg.effort.clone())?;
+            client = Some(FableClient::new(fable_cfg)?);
+        }
+
+        let (output, entry, preview, raw) = consolidate_category(client.as_ref(), batch).await?;
+        cumulative_cost += entry.cost_usd;
+
+        if let Some(raw) = raw {
+            write_json(&cfg.out_dir, &format!("raw/batch_{idx:03}.json"), &raw)?;
+        }
+
+        let accepted = validate_output(batch, output, &mut conformance);
+        for lesson in accepted.lessons {
             findings.push(FindingCard::from_lesson(&lesson));
             lessons.push(lesson);
         }
-        for proposal in output.proposals {
+        for proposal in accepted.proposals {
             findings.push(FindingCard::from_proposal(&proposal));
             proposals.push(proposal);
         }
+        rejects.extend(accepted.rejects);
         entries.push(entry);
         previews.push(preview);
     }
@@ -159,6 +297,12 @@ pub async fn execute(cfg: Config) -> anyhow::Result<RunSummary> {
             episodes_consolidated,
             categories_total,
             categories_skipped,
+            categories_budget_stopped,
+        },
+        conformance,
+        RunBudget {
+            max_run_cost_usd: cfg.max_run_cost_usd,
+            exhausted: budget_exhausted,
         },
         entries,
         BUDGET_HEADROOM,
@@ -168,15 +312,19 @@ pub async fn execute(cfg: Config) -> anyhow::Result<RunSummary> {
     write_json(&cfg.out_dir, "proposals.json", &proposals)?;
     write_json(&cfg.out_dir, "cost_ledger.json", &ledger)?;
     write_json(&cfg.out_dir, "findings.json", &findings)?;
+    write_json(&cfg.out_dir, "rejects.json", &rejects)?;
     if cfg.dry_run {
         write_json(&cfg.out_dir, "prompts.json", &previews)?;
     }
 
     Ok(RunSummary {
-        batches: batches.len(),
+        categories_consolidated: ledger.categories_consolidated as usize,
         lessons: lessons.len(),
         proposals: proposals.len(),
         findings: findings.len(),
+        rejects: rejects.len(),
+        contract_conformance_rate: ledger.contract_conformance_rate,
+        budget_exhausted,
         total_cost_usd: ledger.total_cost_usd,
         suggested_per_invocation_limit_usd: ledger
             .budget_recommendation
@@ -192,10 +340,12 @@ mod tests {
 
     use super::*;
     use crate::episodes::ActionOutcome;
+    use crate::proposal::Severity;
 
     fn batch() -> CategoryBatch {
         CategoryBatch {
             category: "colony".into(),
+            episode_ids: vec!["ep-1".into(), "ep-2".into(), "ep-3".into()],
             outcomes: vec![
                 ActionOutcome {
                     actions: vec!["set_priority".into()],
@@ -218,53 +368,133 @@ mod tests {
 
     #[tokio::test]
     async fn dry_run_makes_no_call_and_zero_cost() {
-        let (output, entry, preview) = consolidate_category(None, &batch()).await.unwrap();
+        let (output, entry, preview, raw) = consolidate_category(None, &batch()).await.unwrap();
         assert!(output.lesson.is_none());
         assert!(output.proposals.is_empty());
         assert!((entry.cost_usd).abs() < f64::EPSILON);
         assert_eq!(entry.episode_count, 3);
+        assert_eq!(entry.episode_ids.len(), 3);
+        assert!(raw.is_none());
         assert_eq!(preview.episode_count, 3);
         assert!(preview.system.contains("consolidation teacher"));
         assert!(preview.user.contains("set_priority"));
     }
 
-    #[tokio::test]
-    async fn dry_run_execute_writes_artifacts() {
-        // Seed a temp store with one consolidatable category.
-        let tmp = tempfile::TempDir::new().unwrap();
-        let db = tmp.path().join("learning.db");
-        {
-            use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
-            let opts = SqliteConnectOptions::new()
-                .filename(&db)
-                .create_if_missing(true);
-            let pool = SqlitePoolOptions::new()
-                .max_connections(1)
-                .connect_with(opts)
-                .await
-                .unwrap();
-            sqlx::query(
-                "CREATE TABLE episodes (id TEXT PRIMARY KEY, task_category TEXT NOT NULL, \
-                 observation_json TEXT NOT NULL, outcome_json TEXT NOT NULL)",
-            )
-            .execute(&pool)
+    #[test]
+    fn validate_output_accepts_conformant_and_rejects_violations() {
+        let b = batch();
+        let mut conformance = Conformance::default();
+        let output = ConsolidationOutput {
+            // Conformant: names an evidence action.
+            lesson: Some(ActionLesson::new(
+                "colony".into(),
+                "food low".into(),
+                "set_priority(Growing)".into(),
+                "food recovers".into(),
+                0.8,
+                3,
+            )),
+            proposals: vec![
+                // Conformant tightening.
+                Proposal::new(
+                    "colony".into(),
+                    "Guard reset".into(),
+                    "reset wiped colony".into(),
+                    "resets on reconnect".into(),
+                    "only reset when TotalReward < -20".into(),
+                    Severity::High,
+                    0.9,
+                    3,
+                ),
+                // Loosening masquerading as a tightening — must be rejected.
+                Proposal::new(
+                    "colony".into(),
+                    "Free the reset".into(),
+                    "resets are fine".into(),
+                    "guarded".into(),
+                    "relax the reset guard".into(),
+                    Severity::Low,
+                    0.4,
+                    3,
+                ),
+            ],
+            rejects: Vec::new(),
+        };
+
+        let accepted = validate_output(&b, output, &mut conformance);
+        assert_eq!(accepted.lessons.len(), 1);
+        assert_eq!(accepted.proposals.len(), 1);
+        assert_eq!(accepted.rejects.len(), 1);
+        assert!(accepted.rejects[0].reason.contains("loosens"));
+        assert_eq!(conformance.lessons_accepted, 1);
+        assert_eq!(conformance.tightenings_accepted, 1);
+        assert_eq!(conformance.tightenings_rejected, 1);
+        assert!((conformance.rate() - 2.0 / 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn validate_output_rejects_lesson_not_in_evidence() {
+        let b = batch();
+        let mut conformance = Conformance::default();
+        let output = ConsolidationOutput {
+            lesson: Some(ActionLesson::new(
+                "colony".into(),
+                "anything".into(),
+                "teleport home".into(),
+                "safe".into(),
+                0.9,
+                3,
+            )),
+            proposals: Vec::new(),
+            rejects: Vec::new(),
+        };
+        let accepted = validate_output(&b, output, &mut conformance);
+        assert!(accepted.lessons.is_empty());
+        assert_eq!(accepted.rejects.len(), 1);
+        assert_eq!(conformance.lessons_rejected, 1);
+    }
+
+    async fn seed_store(dir: &Path, categories: &[(&str, usize)]) -> PathBuf {
+        use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+        let db = dir.join("learning.db");
+        let opts = SqliteConnectOptions::new()
+            .filename(&db)
+            .create_if_missing(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(opts)
             .await
             .unwrap();
-            for i in 0..3 {
+        sqlx::query(
+            "CREATE TABLE episodes (id TEXT PRIMARY KEY, task_category TEXT NOT NULL, \
+             observation_json TEXT NOT NULL, outcome_json TEXT NOT NULL)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        for (cat, count) in categories {
+            for i in 0..*count {
                 sqlx::query(
                     "INSERT INTO episodes (id, task_category, observation_json, outcome_json) \
                      VALUES (?, ?, ?, ?)",
                 )
-                .bind(format!("id-{i}"))
-                .bind("colony")
+                .bind(format!("{cat}-{i}"))
+                .bind(*cat)
                 .bind(r#"{"tools_used":["observe","set_priority"]}"#)
                 .bind(r#"{"success":true,"quality_metrics":{"correctness":0.8}}"#)
                 .execute(&pool)
                 .await
                 .unwrap();
             }
-            pool.close().await;
         }
+        pool.close().await;
+        db
+    }
+
+    #[tokio::test]
+    async fn dry_run_execute_writes_artifacts() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db = seed_store(tmp.path(), &[("colony", 3)]).await;
 
         let out = tmp.path().join("out");
         let cfg = Config {
@@ -274,16 +504,19 @@ mod tests {
             min_episodes: 3,
             max_tokens: 8192,
             effort: "high".into(),
+            max_run_cost_usd: 25.0,
             dry_run: true,
         };
         let summary = execute(cfg).await.unwrap();
-        assert_eq!(summary.batches, 1);
+        assert_eq!(summary.categories_consolidated, 1);
         assert!((summary.total_cost_usd).abs() < f64::EPSILON);
+        assert!(!summary.budget_exhausted);
         for name in [
             "lessons.json",
             "proposals.json",
             "cost_ledger.json",
             "findings.json",
+            "rejects.json",
             "prompts.json",
         ] {
             assert!(out.join(name).exists(), "missing {name}");
@@ -293,5 +526,48 @@ mod tests {
                 .unwrap();
         assert_eq!(ledger["budget_recommendation"]["layer"], "consolidation");
         assert!(ledger["dry_run"].as_bool().unwrap());
+        assert!(!ledger["run_budget"]["exhausted"].as_bool().unwrap());
+        // Batch→episode linkage preserved for backfill.
+        assert_eq!(
+            ledger["per_call"][0]["episode_ids"]
+                .as_array()
+                .unwrap()
+                .len(),
+            3
+        );
+        assert!((ledger["contract_conformance_rate"].as_f64().unwrap() - 1.0).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn ceiling_at_or_below_zero_stops_before_first_live_call() {
+        // With a zero ceiling and dry_run=false, the run must stop before
+        // batch 0 — the ceiling check fires before the client is ever
+        // constructed, so no credentials and no network are needed.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db = seed_store(tmp.path(), &[("colony", 3), ("nav", 3)]).await;
+        let out = tmp.path().join("out");
+        let cfg = Config {
+            db_path: db,
+            out_dir: out.clone(),
+            model: "claude-fable-5".into(),
+            min_episodes: 3,
+            max_tokens: 8192,
+            effort: "high".into(),
+            max_run_cost_usd: 0.0,
+            dry_run: false,
+        };
+        let summary = execute(cfg).await.unwrap();
+        assert!(summary.budget_exhausted);
+        assert_eq!(summary.categories_consolidated, 0);
+        assert!((summary.total_cost_usd).abs() < f64::EPSILON);
+        assert!(summary.total_cost_usd.is_sign_positive());
+        // Partial outputs still written.
+        assert!(out.join("cost_ledger.json").exists());
+        let ledger: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(out.join("cost_ledger.json")).unwrap())
+                .unwrap();
+        assert!(ledger["run_budget"]["exhausted"].as_bool().unwrap());
+        assert_eq!(ledger["categories_budget_stopped"].as_u64().unwrap(), 2);
+        assert_eq!(ledger["fable_calls"].as_u64().unwrap(), 0);
     }
 }

--- a/crates/arkavo-shadow-consolidation/src/run.rs
+++ b/crates/arkavo-shadow-consolidation/src/run.rs
@@ -233,6 +233,7 @@ pub async fn execute(cfg: Config) -> anyhow::Result<RunSummary> {
         batches,
         episodes_total,
         episodes_consolidated,
+        episodes_sampled_out,
         categories_total,
         categories_skipped,
     } = reader.load_batches(cfg.min_episodes).await?;
@@ -315,6 +316,7 @@ pub async fn execute(cfg: Config) -> anyhow::Result<RunSummary> {
         RunStats {
             episodes_total,
             episodes_consolidated,
+            episodes_sampled_out,
             categories_total,
             categories_skipped,
             categories_budget_stopped,

--- a/crates/arkavo-shadow-consolidation/src/run.rs
+++ b/crates/arkavo-shadow-consolidation/src/run.rs
@@ -1,0 +1,297 @@
+//! Orchestration: read traces, batch to Fable (or dry-run), and write the
+//! four artifacts to disk.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use serde::Serialize;
+
+use crate::episodes::{CategoryBatch, EpisodeReader, LoadResult};
+use crate::fable::{FableClient, FableConfig};
+use crate::proposal::{ActionLesson, CostLedger, FindingCard, LedgerEntry, Proposal, RunStats};
+use crate::synthesis::{self, ConsolidationOutput};
+
+/// Headroom multiplier applied to the worst observed call cost when
+/// recommending the per-invocation consolidation budget.
+const BUDGET_HEADROOM: f64 = 1.5;
+
+/// Run configuration, built by the binary from CLI args.
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub db_path: PathBuf,
+    pub out_dir: PathBuf,
+    pub model: String,
+    pub min_episodes: usize,
+    pub max_tokens: u32,
+    pub effort: String,
+    pub dry_run: bool,
+}
+
+/// What the run produced, for the binary to print.
+#[derive(Debug, Clone)]
+pub struct RunSummary {
+    pub batches: usize,
+    pub lessons: usize,
+    pub proposals: usize,
+    pub findings: usize,
+    pub total_cost_usd: f64,
+    pub suggested_per_invocation_limit_usd: f64,
+    pub out_dir: PathBuf,
+}
+
+/// A category's prompt, recorded in dry-run so the operator can inspect exactly
+/// what would be sent before spending.
+#[derive(Debug, Serialize)]
+struct PromptPreview {
+    category: String,
+    episode_count: usize,
+    system: String,
+    user: String,
+}
+
+/// Drive a single category: build the prompt, call Fable (unless dry-run), and
+/// return the parsed output plus a ledger entry.
+async fn consolidate_category(
+    client: Option<&FableClient>,
+    batch: &CategoryBatch,
+) -> anyhow::Result<(ConsolidationOutput, LedgerEntry, PromptPreview)> {
+    let episode_count = batch.outcomes.len();
+    let user = synthesis::build_user_prompt(batch);
+    let preview = PromptPreview {
+        category: batch.category.clone(),
+        episode_count,
+        system: synthesis::SYSTEM_PROMPT.to_string(),
+        user: user.clone(),
+    };
+
+    let Some(client) = client else {
+        // Dry-run: no call, no cost, no parsed output.
+        let entry = LedgerEntry {
+            category: batch.category.clone(),
+            episode_count: episode_count as u32,
+            input_tokens: 0,
+            output_tokens: 0,
+            cost_usd: 0.0,
+            latency_ms: 0,
+            lessons: 0,
+            tightenings: 0,
+        };
+        let output = ConsolidationOutput {
+            lesson: None,
+            proposals: Vec::new(),
+        };
+        return Ok((output, entry, preview));
+    };
+
+    let completion = client
+        .complete(synthesis::SYSTEM_PROMPT, &user)
+        .await
+        .with_context(|| format!("consolidating category {}", batch.category))?;
+    let output = synthesis::parse_response(&batch.category, &completion.text, episode_count as u32);
+    let entry = LedgerEntry {
+        category: batch.category.clone(),
+        episode_count: episode_count as u32,
+        input_tokens: completion.usage.input_tokens,
+        output_tokens: completion.usage.output_tokens,
+        cost_usd: completion.usage.cost_usd(),
+        latency_ms: completion.latency_ms,
+        lessons: u32::from(output.lesson.is_some()),
+        tightenings: output.proposals.len() as u32,
+    };
+    Ok((output, entry, preview))
+}
+
+fn write_json<T: Serialize>(dir: &Path, name: &str, value: &T) -> anyhow::Result<()> {
+    let path = dir.join(name);
+    let json =
+        serde_json::to_string_pretty(value).with_context(|| format!("serializing {name}"))?;
+    std::fs::write(&path, json).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+/// Execute the full overnight job.
+pub async fn execute(cfg: Config) -> anyhow::Result<RunSummary> {
+    let reader = EpisodeReader::open(&cfg.db_path).await?;
+    let LoadResult {
+        batches,
+        episodes_total,
+        episodes_consolidated,
+        categories_total,
+        categories_skipped,
+    } = reader.load_batches(cfg.min_episodes).await?;
+
+    std::fs::create_dir_all(&cfg.out_dir)
+        .with_context(|| format!("creating output dir {}", cfg.out_dir.display()))?;
+
+    let client = if cfg.dry_run {
+        None
+    } else {
+        let fable_cfg =
+            FableConfig::from_env(cfg.model.clone(), cfg.max_tokens, cfg.effort.clone())?;
+        Some(FableClient::new(fable_cfg)?)
+    };
+
+    let mut lessons: Vec<ActionLesson> = Vec::new();
+    let mut proposals: Vec<Proposal> = Vec::new();
+    let mut findings: Vec<FindingCard> = Vec::new();
+    let mut entries: Vec<LedgerEntry> = Vec::new();
+    let mut previews: Vec<PromptPreview> = Vec::new();
+
+    for batch in &batches {
+        let (output, entry, preview) = consolidate_category(client.as_ref(), batch).await?;
+        if let Some(lesson) = output.lesson {
+            findings.push(FindingCard::from_lesson(&lesson));
+            lessons.push(lesson);
+        }
+        for proposal in output.proposals {
+            findings.push(FindingCard::from_proposal(&proposal));
+            proposals.push(proposal);
+        }
+        entries.push(entry);
+        previews.push(preview);
+    }
+
+    let ledger = CostLedger::summarize(
+        cfg.model.clone(),
+        cfg.dry_run,
+        RunStats {
+            episodes_total,
+            episodes_consolidated,
+            categories_total,
+            categories_skipped,
+        },
+        entries,
+        BUDGET_HEADROOM,
+    );
+
+    write_json(&cfg.out_dir, "lessons.json", &lessons)?;
+    write_json(&cfg.out_dir, "proposals.json", &proposals)?;
+    write_json(&cfg.out_dir, "cost_ledger.json", &ledger)?;
+    write_json(&cfg.out_dir, "findings.json", &findings)?;
+    if cfg.dry_run {
+        write_json(&cfg.out_dir, "prompts.json", &previews)?;
+    }
+
+    Ok(RunSummary {
+        batches: batches.len(),
+        lessons: lessons.len(),
+        proposals: proposals.len(),
+        findings: findings.len(),
+        total_cost_usd: ledger.total_cost_usd,
+        suggested_per_invocation_limit_usd: ledger
+            .budget_recommendation
+            .suggested_per_invocation_limit_usd,
+        out_dir: cfg.out_dir.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    // #[tokio::test] expands to Runtime::block_on; harmless in tests.
+    #![allow(clippy::disallowed_methods)]
+
+    use super::*;
+    use crate::episodes::ActionOutcome;
+
+    fn batch() -> CategoryBatch {
+        CategoryBatch {
+            category: "colony".into(),
+            outcomes: vec![
+                ActionOutcome {
+                    actions: vec!["set_priority".into()],
+                    success: true,
+                    quality: 0.9,
+                },
+                ActionOutcome {
+                    actions: vec!["reset".into()],
+                    success: false,
+                    quality: 0.1,
+                },
+                ActionOutcome {
+                    actions: vec!["set_priority".into()],
+                    success: true,
+                    quality: 0.8,
+                },
+            ],
+        }
+    }
+
+    #[tokio::test]
+    async fn dry_run_makes_no_call_and_zero_cost() {
+        let (output, entry, preview) = consolidate_category(None, &batch()).await.unwrap();
+        assert!(output.lesson.is_none());
+        assert!(output.proposals.is_empty());
+        assert!((entry.cost_usd).abs() < f64::EPSILON);
+        assert_eq!(entry.episode_count, 3);
+        assert_eq!(preview.episode_count, 3);
+        assert!(preview.system.contains("consolidation teacher"));
+        assert!(preview.user.contains("set_priority"));
+    }
+
+    #[tokio::test]
+    async fn dry_run_execute_writes_artifacts() {
+        // Seed a temp store with one consolidatable category.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db = tmp.path().join("learning.db");
+        {
+            use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+            let opts = SqliteConnectOptions::new()
+                .filename(&db)
+                .create_if_missing(true);
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect_with(opts)
+                .await
+                .unwrap();
+            sqlx::query(
+                "CREATE TABLE episodes (id TEXT PRIMARY KEY, task_category TEXT NOT NULL, \
+                 observation_json TEXT NOT NULL, outcome_json TEXT NOT NULL)",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+            for i in 0..3 {
+                sqlx::query(
+                    "INSERT INTO episodes (id, task_category, observation_json, outcome_json) \
+                     VALUES (?, ?, ?, ?)",
+                )
+                .bind(format!("id-{i}"))
+                .bind("colony")
+                .bind(r#"{"tools_used":["observe","set_priority"]}"#)
+                .bind(r#"{"success":true,"quality_metrics":{"correctness":0.8}}"#)
+                .execute(&pool)
+                .await
+                .unwrap();
+            }
+            pool.close().await;
+        }
+
+        let out = tmp.path().join("out");
+        let cfg = Config {
+            db_path: db,
+            out_dir: out.clone(),
+            model: "claude-fable-5".into(),
+            min_episodes: 3,
+            max_tokens: 8192,
+            effort: "high".into(),
+            dry_run: true,
+        };
+        let summary = execute(cfg).await.unwrap();
+        assert_eq!(summary.batches, 1);
+        assert!((summary.total_cost_usd).abs() < f64::EPSILON);
+        for name in [
+            "lessons.json",
+            "proposals.json",
+            "cost_ledger.json",
+            "findings.json",
+            "prompts.json",
+        ] {
+            assert!(out.join(name).exists(), "missing {name}");
+        }
+        let ledger: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(out.join("cost_ledger.json")).unwrap())
+                .unwrap();
+        assert_eq!(ledger["budget_recommendation"]["layer"], "consolidation");
+        assert!(ledger["dry_run"].as_bool().unwrap());
+    }
+}

--- a/crates/arkavo-shadow-consolidation/src/synthesis.rs
+++ b/crates/arkavo-shadow-consolidation/src/synthesis.rs
@@ -3,12 +3,15 @@
 //!
 //! The prompt enforces the lesson-synthesis rule at the instruction level: the
 //! evidence already has observe/list calls stripped, and the model is told not
-//! to reason about tool sequencing.
+//! to reason about tool sequencing. Compliance is **not trusted** — every item
+//! that fails to parse becomes a [`Reject`] record rather than a silent drop,
+//! so non-conformance is counted, not hidden.
 
 use serde_json::{Value, json};
 
 use crate::episodes::CategoryBatch;
 use crate::proposal::{ActionLesson, Proposal, Severity};
+use crate::validate::{Reject, RejectKind};
 
 /// System prompt: defines Fable's role as the offline consolidation teacher
 /// and pins the exact JSON output contract.
@@ -31,7 +34,8 @@ Return ONLY a single JSON object with this exact shape:\n\
       \"title\": \"short imperative tightening\",\n\
       \"rationale\": \"why, grounded in the observed outcomes\",\n\
       \"current_behavior\": \"what the agent does today\",\n\
-      \"proposed_constraint\": \"the guard/precondition to add\",\n\
+      \"proposed_constraint\": \"the guard/precondition to add — it must RESTRICT \
+behavior, never relax or remove an existing restriction\",\n\
       \"severity\": \"low|medium|high\",\n\
       \"confidence\": 0.0,\n\
       \"evidence_episode_count\": 0\n\
@@ -65,11 +69,13 @@ pub fn build_user_prompt(batch: &CategoryBatch) -> String {
     )
 }
 
-/// Parsed consolidation output for one category.
-#[derive(Debug, Clone, PartialEq)]
+/// Parsed consolidation output for one category. Items that violated the
+/// contract are in `rejects`, with reasons.
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ConsolidationOutput {
     pub lesson: Option<ActionLesson>,
     pub proposals: Vec<Proposal>,
+    pub rejects: Vec<Reject>,
 }
 
 /// Slice the first balanced-looking JSON object out of a model reply and
@@ -88,20 +94,29 @@ fn extract_json(content: &str) -> Option<String> {
     Some(sanitized)
 }
 
-fn parse_lesson(category: &str, value: &Value, episode_count: u32) -> Option<ActionLesson> {
-    let obj = value.as_object()?;
-    let condition = obj.get("condition").and_then(Value::as_str)?.trim();
-    let action = obj.get("action").and_then(Value::as_str)?.trim();
-    if condition.is_empty() || action.is_empty() {
-        return None;
-    }
+fn parse_lesson(category: &str, value: &Value, episode_count: u32) -> Result<ActionLesson, String> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| "lesson is not a JSON object".to_string())?;
+    let condition = obj
+        .get("condition")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|c| !c.is_empty())
+        .ok_or_else(|| "lesson missing condition".to_string())?;
+    let action = obj
+        .get("action")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|a| !a.is_empty())
+        .ok_or_else(|| "lesson missing action".to_string())?;
     let expected = obj
         .get("expected_outcome")
         .and_then(Value::as_str)
         .unwrap_or("improved_outcome")
         .trim();
     let confidence = obj.get("confidence").and_then(Value::as_f64).unwrap_or(0.5);
-    Some(ActionLesson::new(
+    Ok(ActionLesson::new(
         category.to_string(),
         condition.to_string(),
         action.to_string(),
@@ -111,16 +126,27 @@ fn parse_lesson(category: &str, value: &Value, episode_count: u32) -> Option<Act
     ))
 }
 
-fn parse_proposal(category: &str, value: &Value, default_episodes: u32) -> Option<Proposal> {
-    let obj = value.as_object()?;
-    let title = obj.get("title").and_then(Value::as_str)?.trim();
+fn parse_proposal(
+    category: &str,
+    value: &Value,
+    default_episodes: u32,
+) -> Result<Proposal, String> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| "tightening is not a JSON object".to_string())?;
+    let title = obj
+        .get("title")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .ok_or_else(|| "tightening missing title".to_string())?;
     let constraint = obj
         .get("proposed_constraint")
-        .and_then(Value::as_str)?
-        .trim();
-    if title.is_empty() || constraint.is_empty() {
-        return None;
-    }
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|c| !c.is_empty())
+        .ok_or_else(|| "tightening missing proposed_constraint".to_string())?;
+    let severity = Severity::parse_strict(obj.get("severity").and_then(Value::as_str))?;
     let rationale = obj
         .get("rationale")
         .and_then(Value::as_str)
@@ -131,13 +157,12 @@ fn parse_proposal(category: &str, value: &Value, default_episodes: u32) -> Optio
         .and_then(Value::as_str)
         .unwrap_or("")
         .trim();
-    let severity = Severity::parse_lenient(obj.get("severity").and_then(Value::as_str));
     let confidence = obj.get("confidence").and_then(Value::as_f64).unwrap_or(0.5);
     let evidence = obj
         .get("evidence_episode_count")
         .and_then(Value::as_u64)
         .map_or(default_episodes, |n| n as u32);
-    Some(Proposal::new(
+    Ok(Proposal::new(
         category.to_string(),
         title.to_string(),
         rationale.to_string(),
@@ -149,41 +174,54 @@ fn parse_proposal(category: &str, value: &Value, default_episodes: u32) -> Optio
     ))
 }
 
-/// Parse a Fable reply into lessons + candidate tightenings.
+/// Parse a Fable reply into lessons + candidate tightenings + rejects.
 ///
-/// Tolerant by design: a malformed reply yields empty output rather than an
-/// error, so one bad category never aborts an overnight run.
+/// A reply that fails to parse at all becomes a single [`RejectKind::Response`]
+/// record; individually malformed items become [`RejectKind::Lesson`] /
+/// [`RejectKind::Tightening`] records. The run never aborts on a bad reply.
 #[must_use]
 pub fn parse_response(category: &str, reply: &str, episode_count: u32) -> ConsolidationOutput {
-    let Some(json_str) = extract_json(reply) else {
-        return ConsolidationOutput {
-            lesson: None,
-            proposals: Vec::new(),
-        };
+    let mut output = ConsolidationOutput::default();
+
+    let parsed = extract_json(reply).and_then(|s| serde_json::from_str::<Value>(&s).ok());
+    let Some(root) = parsed else {
+        output.rejects.push(Reject::new(
+            category,
+            RejectKind::Response,
+            "reply does not contain a parseable JSON object".to_string(),
+            Value::String(reply.to_string()),
+        ));
+        return output;
     };
-    let Ok(root) = serde_json::from_str::<Value>(&json_str) else {
-        return ConsolidationOutput {
-            lesson: None,
-            proposals: Vec::new(),
-        };
-    };
 
-    let lesson = root
-        .get("lesson")
-        .filter(|v| !v.is_null())
-        .and_then(|v| parse_lesson(category, v, episode_count));
+    match root.get("lesson") {
+        None | Some(Value::Null) => {}
+        Some(value) => match parse_lesson(category, value, episode_count) {
+            Ok(lesson) => output.lesson = Some(lesson),
+            Err(reason) => output.rejects.push(Reject::new(
+                category,
+                RejectKind::Lesson,
+                reason,
+                value.clone(),
+            )),
+        },
+    }
 
-    let proposals = root
-        .get("tightenings")
-        .and_then(Value::as_array)
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| parse_proposal(category, v, episode_count))
-                .collect()
-        })
-        .unwrap_or_default();
+    if let Some(arr) = root.get("tightenings").and_then(Value::as_array) {
+        for value in arr {
+            match parse_proposal(category, value, episode_count) {
+                Ok(proposal) => output.proposals.push(proposal),
+                Err(reason) => output.rejects.push(Reject::new(
+                    category,
+                    RejectKind::Tightening,
+                    reason,
+                    value.clone(),
+                )),
+            }
+        }
+    }
 
-    ConsolidationOutput { lesson, proposals }
+    output
 }
 
 #[cfg(test)]
@@ -195,6 +233,7 @@ mod tests {
     fn batch() -> CategoryBatch {
         CategoryBatch {
             category: "colony".into(),
+            episode_ids: vec!["ep-1".into(), "ep-2".into()],
             outcomes: vec![
                 ActionOutcome {
                     actions: vec!["set_priority".into()],
@@ -251,35 +290,59 @@ done"#;
         assert_eq!(p.severity, Severity::High);
         assert_eq!(p.evidence_episode_count, 4);
         assert_eq!(p.status, ProposalStatus::Draft);
+        assert!(out.rejects.is_empty());
     }
 
     #[test]
-    fn null_lesson_and_empty_tightenings() {
+    fn null_lesson_and_empty_tightenings_is_conformant() {
         let reply = r#"{"lesson": null, "tightenings": []}"#;
         let out = parse_response("colony", reply, 3);
         assert!(out.lesson.is_none());
         assert!(out.proposals.is_empty());
+        assert!(out.rejects.is_empty());
     }
 
     #[test]
-    fn malformed_reply_is_empty_not_error() {
+    fn malformed_reply_becomes_response_reject() {
         let out = parse_response("colony", "the model refused", 3);
         assert!(out.lesson.is_none());
         assert!(out.proposals.is_empty());
+        assert_eq!(out.rejects.len(), 1);
+        assert_eq!(out.rejects[0].kind, RejectKind::Response);
+        assert!(out.rejects[0].reason.contains("parseable"));
     }
 
     #[test]
-    fn lesson_missing_action_is_dropped() {
+    fn lesson_missing_action_becomes_lesson_reject() {
         let reply = r#"{"lesson": {"condition": "x", "action": "  "}, "tightenings": []}"#;
         let out = parse_response("colony", reply, 3);
         assert!(out.lesson.is_none());
+        assert_eq!(out.rejects.len(), 1);
+        assert_eq!(out.rejects[0].kind, RejectKind::Lesson);
+        assert!(out.rejects[0].reason.contains("missing action"));
     }
 
     #[test]
-    fn tightening_missing_constraint_is_dropped() {
-        let reply = r#"{"lesson": null, "tightenings": [{"title": "t"}]}"#;
+    fn tightening_missing_constraint_becomes_tightening_reject() {
+        let reply = r#"{"lesson": null, "tightenings": [{"title": "t", "severity": "low"}]}"#;
         let out = parse_response("colony", reply, 3);
         assert!(out.proposals.is_empty());
+        assert_eq!(out.rejects.len(), 1);
+        assert_eq!(out.rejects[0].kind, RejectKind::Tightening);
+        assert!(out.rejects[0].reason.contains("proposed_constraint"));
+    }
+
+    #[test]
+    fn unrecognized_severity_becomes_tightening_reject() {
+        let reply = r#"{"lesson": null, "tightenings": [{
+            "title": "Guard reset",
+            "proposed_constraint": "only reset when colony dead",
+            "severity": "catastrophic-ish"
+        }]}"#;
+        let out = parse_response("colony", reply, 3);
+        assert!(out.proposals.is_empty());
+        assert_eq!(out.rejects.len(), 1);
+        assert!(out.rejects[0].reason.contains("severity"));
     }
 
     #[test]

--- a/crates/arkavo-shadow-consolidation/src/synthesis.rs
+++ b/crates/arkavo-shadow-consolidation/src/synthesis.rs
@@ -1,0 +1,293 @@
+//! Turn a per-category batch of action→outcome pairs into a Fable prompt and
+//! parse Fable's reply into the output contract (lessons + tightenings).
+//!
+//! The prompt enforces the lesson-synthesis rule at the instruction level: the
+//! evidence already has observe/list calls stripped, and the model is told not
+//! to reason about tool sequencing.
+
+use serde_json::{Value, json};
+
+use crate::episodes::CategoryBatch;
+use crate::proposal::{ActionLesson, Proposal, Severity};
+
+/// System prompt: defines Fable's role as the offline consolidation teacher
+/// and pins the exact JSON output contract.
+pub const SYSTEM_PROMPT: &str = "\
+You are the offline consolidation teacher for an agent swarm. You are given \
+action->outcome evidence from many episodes in one task category, with \
+read-only observe/list calls already removed. Reason about WHICH ACTION \
+produces good outcomes under WHICH CONDITION. Do not discuss observe, list, \
+or tool sequencing — the agent loop handles that.\n\n\
+Return ONLY a single JSON object with this exact shape:\n\
+{\n\
+  \"lesson\": {\n\
+    \"condition\": \"specific situation that triggers the action\",\n\
+    \"action\": \"concrete tool call recommendation, naming a tool used above\",\n\
+    \"expected_outcome\": \"measurable result\",\n\
+    \"confidence\": 0.0\n\
+  },\n\
+  \"tightenings\": [\n\
+    {\n\
+      \"title\": \"short imperative tightening\",\n\
+      \"rationale\": \"why, grounded in the observed outcomes\",\n\
+      \"current_behavior\": \"what the agent does today\",\n\
+      \"proposed_constraint\": \"the guard/precondition to add\",\n\
+      \"severity\": \"low|medium|high\",\n\
+      \"confidence\": 0.0,\n\
+      \"evidence_episode_count\": 0\n\
+    }\n\
+  ]\n\
+}\n\
+Set \"lesson\" to null if no action-named pattern is clear. Use an empty \
+\"tightenings\" array if no constraint is warranted. A valid lesson MUST name \
+a specific action from the evidence.";
+
+/// Render the action→outcome evidence for the user turn.
+#[must_use]
+pub fn build_user_prompt(batch: &CategoryBatch) -> String {
+    let evidence: Vec<Value> = batch
+        .outcomes
+        .iter()
+        .map(|o| {
+            json!({
+                "actions": o.actions,
+                "success": o.success,
+                "quality": o.quality,
+            })
+        })
+        .collect();
+    let success = batch.outcomes.iter().filter(|o| o.success).count();
+    let failure = batch.outcomes.len() - success;
+    let evidence_str = serde_json::to_string_pretty(&evidence).unwrap_or_default();
+    format!(
+        "Category: {}\n\nAction->outcome pairs ({} successes, {} failures):\n{}",
+        batch.category, success, failure, evidence_str
+    )
+}
+
+/// Parsed consolidation output for one category.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConsolidationOutput {
+    pub lesson: Option<ActionLesson>,
+    pub proposals: Vec<Proposal>,
+}
+
+/// Slice the first balanced-looking JSON object out of a model reply and
+/// neutralize control characters that break `serde_json` (LLMs emit raw
+/// newlines inside string values). Mirrors the runtime synthesis parser.
+fn extract_json(content: &str) -> Option<String> {
+    let start = content.find('{')?;
+    let end = content.rfind('}')?;
+    if end < start {
+        return None;
+    }
+    let sanitized: String = content[start..=end]
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect();
+    Some(sanitized)
+}
+
+fn parse_lesson(category: &str, value: &Value, episode_count: u32) -> Option<ActionLesson> {
+    let obj = value.as_object()?;
+    let condition = obj.get("condition").and_then(Value::as_str)?.trim();
+    let action = obj.get("action").and_then(Value::as_str)?.trim();
+    if condition.is_empty() || action.is_empty() {
+        return None;
+    }
+    let expected = obj
+        .get("expected_outcome")
+        .and_then(Value::as_str)
+        .unwrap_or("improved_outcome")
+        .trim();
+    let confidence = obj.get("confidence").and_then(Value::as_f64).unwrap_or(0.5);
+    Some(ActionLesson::new(
+        category.to_string(),
+        condition.to_string(),
+        action.to_string(),
+        expected.to_string(),
+        confidence,
+        episode_count,
+    ))
+}
+
+fn parse_proposal(category: &str, value: &Value, default_episodes: u32) -> Option<Proposal> {
+    let obj = value.as_object()?;
+    let title = obj.get("title").and_then(Value::as_str)?.trim();
+    let constraint = obj
+        .get("proposed_constraint")
+        .and_then(Value::as_str)?
+        .trim();
+    if title.is_empty() || constraint.is_empty() {
+        return None;
+    }
+    let rationale = obj
+        .get("rationale")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim();
+    let current = obj
+        .get("current_behavior")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim();
+    let severity = Severity::parse_lenient(obj.get("severity").and_then(Value::as_str));
+    let confidence = obj.get("confidence").and_then(Value::as_f64).unwrap_or(0.5);
+    let evidence = obj
+        .get("evidence_episode_count")
+        .and_then(Value::as_u64)
+        .map_or(default_episodes, |n| n as u32);
+    Some(Proposal::new(
+        category.to_string(),
+        title.to_string(),
+        rationale.to_string(),
+        current.to_string(),
+        constraint.to_string(),
+        severity,
+        confidence,
+        evidence,
+    ))
+}
+
+/// Parse a Fable reply into lessons + candidate tightenings.
+///
+/// Tolerant by design: a malformed reply yields empty output rather than an
+/// error, so one bad category never aborts an overnight run.
+#[must_use]
+pub fn parse_response(category: &str, reply: &str, episode_count: u32) -> ConsolidationOutput {
+    let Some(json_str) = extract_json(reply) else {
+        return ConsolidationOutput {
+            lesson: None,
+            proposals: Vec::new(),
+        };
+    };
+    let Ok(root) = serde_json::from_str::<Value>(&json_str) else {
+        return ConsolidationOutput {
+            lesson: None,
+            proposals: Vec::new(),
+        };
+    };
+
+    let lesson = root
+        .get("lesson")
+        .filter(|v| !v.is_null())
+        .and_then(|v| parse_lesson(category, v, episode_count));
+
+    let proposals = root
+        .get("tightenings")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| parse_proposal(category, v, episode_count))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    ConsolidationOutput { lesson, proposals }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::episodes::ActionOutcome;
+    use crate::proposal::ProposalStatus;
+
+    fn batch() -> CategoryBatch {
+        CategoryBatch {
+            category: "colony".into(),
+            outcomes: vec![
+                ActionOutcome {
+                    actions: vec!["set_priority".into()],
+                    success: true,
+                    quality: 0.9,
+                },
+                ActionOutcome {
+                    actions: vec!["reset".into()],
+                    success: false,
+                    quality: 0.1,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn user_prompt_carries_evidence_and_counts() {
+        let prompt = build_user_prompt(&batch());
+        assert!(prompt.contains("Category: colony"));
+        assert!(prompt.contains("1 successes, 1 failures"));
+        assert!(prompt.contains("set_priority"));
+    }
+
+    #[test]
+    fn parses_lesson_and_tightening() {
+        let reply = r#"Here you go:
+{
+  "lesson": {
+    "condition": "food is low",
+    "action": "set_priority(Growing)",
+    "expected_outcome": "food recovers",
+    "confidence": 0.85
+  },
+  "tightenings": [
+    {
+      "title": "Guard reset",
+      "rationale": "reset wiped the colony in failures",
+      "current_behavior": "agent resets on reconnect",
+      "proposed_constraint": "only reset when TotalReward < -20",
+      "severity": "high",
+      "confidence": 0.9,
+      "evidence_episode_count": 4
+    }
+  ]
+}
+done"#;
+        let out = parse_response("colony", reply, 6);
+        let lesson = out.lesson.unwrap();
+        assert_eq!(lesson.action_name, "set_priority");
+        assert!((lesson.confidence - 0.85).abs() < 1e-9);
+        assert_eq!(lesson.episode_count, 6);
+        assert_eq!(out.proposals.len(), 1);
+        let p = &out.proposals[0];
+        assert_eq!(p.severity, Severity::High);
+        assert_eq!(p.evidence_episode_count, 4);
+        assert_eq!(p.status, ProposalStatus::Draft);
+    }
+
+    #[test]
+    fn null_lesson_and_empty_tightenings() {
+        let reply = r#"{"lesson": null, "tightenings": []}"#;
+        let out = parse_response("colony", reply, 3);
+        assert!(out.lesson.is_none());
+        assert!(out.proposals.is_empty());
+    }
+
+    #[test]
+    fn malformed_reply_is_empty_not_error() {
+        let out = parse_response("colony", "the model refused", 3);
+        assert!(out.lesson.is_none());
+        assert!(out.proposals.is_empty());
+    }
+
+    #[test]
+    fn lesson_missing_action_is_dropped() {
+        let reply = r#"{"lesson": {"condition": "x", "action": "  "}, "tightenings": []}"#;
+        let out = parse_response("colony", reply, 3);
+        assert!(out.lesson.is_none());
+    }
+
+    #[test]
+    fn tightening_missing_constraint_is_dropped() {
+        let reply = r#"{"lesson": null, "tightenings": [{"title": "t"}]}"#;
+        let out = parse_response("colony", reply, 3);
+        assert!(out.proposals.is_empty());
+    }
+
+    #[test]
+    fn tolerates_raw_control_characters() {
+        let reply = "{\"lesson\": {\"condition\": \"load\nhigh\", \"action\": \"throttle\nnow\", \"confidence\": 0.7}, \"tightenings\": []}";
+        let out = parse_response("net", reply, 3);
+        let lesson = out.lesson.unwrap();
+        assert_eq!(lesson.condition, "load high");
+        assert_eq!(lesson.action_name, "throttle");
+    }
+}

--- a/crates/arkavo-shadow-consolidation/src/validate.rs
+++ b/crates/arkavo-shadow-consolidation/src/validate.rs
@@ -25,6 +25,10 @@ pub enum RejectKind {
     Tightening,
     /// The whole reply failed to parse as the output contract.
     Response,
+    /// The call itself failed (transport or API error after retries) — an
+    /// operational failure, not a contract violation, so it never counts
+    /// against conformance.
+    Call,
 }
 
 /// A contract violation: the offending payload plus why it was rejected.

--- a/crates/arkavo-shadow-consolidation/src/validate.rs
+++ b/crates/arkavo-shadow-consolidation/src/validate.rs
@@ -202,6 +202,7 @@ mod tests {
     use super::*;
     use crate::episodes::ActionOutcome;
     use crate::proposal::Severity;
+    use arkavo_test_macros::spec;
 
     fn evidence() -> BTreeSet<String> {
         evidence_actions(&[
@@ -250,6 +251,7 @@ mod tests {
         assert!(lesson_violation(&lesson("game-rl:set_priority"), &evidence()).is_none());
     }
 
+    #[spec("SC-005")]
     #[test]
     fn lesson_naming_unknown_action_rejected() {
         let reason = lesson_violation(&lesson("teleport"), &evidence()).unwrap();
@@ -268,6 +270,7 @@ mod tests {
         assert!(tightening_violation(&proposal("must not reset on reconnect")).is_none());
     }
 
+    #[spec("SC-005")]
     #[test]
     fn loosening_constraint_rejected() {
         let reason =

--- a/crates/arkavo-shadow-consolidation/src/validate.rs
+++ b/crates/arkavo-shadow-consolidation/src/validate.rs
@@ -1,0 +1,294 @@
+//! Post-hoc validation of Fable output against the consolidation contract.
+//!
+//! The contract is enforced after the fact, not trusted: every emitted item
+//! either passes validation or lands in `rejects.json` with a reason. The
+//! accept/reject split is what produces the morning's contract-conformance
+//! rate — the number that decides how the runtime wiring is designed.
+
+use std::collections::BTreeSet;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::proposal::{ActionLesson, Proposal, SOURCE};
+
+/// Cap on the raw payload preserved in a reject record — the full reply lives
+/// in the raw response archive, the reject only needs enough to diagnose.
+const PAYLOAD_CAP: usize = 2000;
+
+/// What kind of emitted item was rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RejectKind {
+    Lesson,
+    Tightening,
+    /// The whole reply failed to parse as the output contract.
+    Response,
+}
+
+/// A contract violation: the offending payload plus why it was rejected.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Reject {
+    pub category: String,
+    pub kind: RejectKind,
+    pub reason: String,
+    /// The offending model output (truncated), kept for contract evolution.
+    pub payload: Value,
+    pub source: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl Reject {
+    #[must_use]
+    pub fn new(category: &str, kind: RejectKind, reason: String, payload: Value) -> Self {
+        Self {
+            category: category.to_string(),
+            kind,
+            reason,
+            payload: truncate_payload(payload),
+            source: SOURCE.to_string(),
+            created_at: Utc::now(),
+        }
+    }
+}
+
+/// Truncate string payloads so rejects.json stays reviewable.
+fn truncate_payload(payload: Value) -> Value {
+    match payload {
+        Value::String(s) if s.len() > PAYLOAD_CAP => {
+            let cut: String = s.chars().take(PAYLOAD_CAP).collect();
+            Value::String(format!("{cut}...(truncated from {} chars)", s.len()))
+        }
+        other => other,
+    }
+}
+
+/// Case-insensitive action-name set from a batch's stripped evidence.
+#[must_use]
+pub fn evidence_actions(outcomes: &[crate::episodes::ActionOutcome]) -> BTreeSet<String> {
+    outcomes
+        .iter()
+        .flat_map(|o| o.actions.iter())
+        .map(|a| a.to_lowercase())
+        .collect()
+}
+
+/// True when a lesson's action token names one of the evidence tools, allowing
+/// for namespace prefixes in either direction (`reset` ↔ `game-rl:reset`).
+fn names_evidence_action(token: &str, evidence: &BTreeSet<String>) -> bool {
+    let t = token.to_lowercase();
+    evidence
+        .iter()
+        .any(|e| e == &t || e.ends_with(&format!(":{t}")) || t.ends_with(&format!(":{e}")))
+}
+
+/// Validate a lesson against the batch it came from. Returns the rejection
+/// reason, or `None` when the lesson conforms.
+#[must_use]
+pub fn lesson_violation(lesson: &ActionLesson, evidence: &BTreeSet<String>) -> Option<String> {
+    if !crate::episodes::is_action_tool(&lesson.action_name) {
+        return Some(format!(
+            "lesson names a read-only tool {:?} — observe/list/hash/summary are \
+             stripped from evidence and may not be recommended",
+            lesson.action_name
+        ));
+    }
+    if !names_evidence_action(&lesson.action_name, evidence) {
+        return Some(format!(
+            "lesson action {:?} does not name any action tool in the batch \
+             evidence ({:?})",
+            lesson.action_name,
+            evidence.iter().cloned().collect::<Vec<_>>()
+        ));
+    }
+    None
+}
+
+/// Phrases that mark a constraint as loosening rather than tightening.
+const LOOSENING_PHRASES: &[&str] = &[
+    "relax",
+    "loosen",
+    "remove the guard",
+    "remove guard",
+    "remove the restriction",
+    "remove restriction",
+    "remove the limit",
+    "remove limit",
+    "lift the restriction",
+    "lift restriction",
+    "increase the limit",
+    "increase limit",
+    "raise the limit",
+    "raise limit",
+    "allow more",
+    "allow all",
+    "always allow",
+    "permit all",
+    "disable the check",
+    "disable check",
+    "skip validation",
+    "skip the check",
+    "no longer require",
+    "drop the requirement",
+    "expand access",
+    "widen access",
+    "without restriction",
+    "unrestricted",
+];
+
+/// Cues that restricting language is present. Generous on purpose: a false
+/// positive here just means a human reviews the card; a false negative
+/// silently passes a non-tightening through as a "tightening".
+const RESTRICTIVE_CUES: &[&str] = &[
+    "only",
+    "never",
+    "must",
+    "not ",
+    "n't",
+    "require",
+    "deny",
+    "block",
+    "reject",
+    "limit",
+    "guard",
+    "unless",
+    "max",
+    "cap",
+    "at most",
+    "at least",
+    "no more than",
+    "forbid",
+    "prohibit",
+    "restrict",
+    "exclusively",
+    "solely",
+    "before",
+    "verify",
+    "confirm",
+    "check",
+    "validate",
+    "gate",
+    "<",
+    ">",
+];
+
+/// Validate that a proposal's constraint actually tightens. Returns the
+/// rejection reason, or `None` when it conforms.
+#[must_use]
+pub fn tightening_violation(proposal: &Proposal) -> Option<String> {
+    let text = proposal.proposed_constraint.to_lowercase();
+    if let Some(phrase) = LOOSENING_PHRASES.iter().find(|p| text.contains(*p)) {
+        return Some(format!(
+            "proposed constraint loosens rather than tightens (contains {phrase:?})"
+        ));
+    }
+    if !RESTRICTIVE_CUES.iter().any(|c| text.contains(c)) {
+        return Some(
+            "proposed constraint contains no restricting language — cannot be \
+             reviewed as a tightening"
+                .to_string(),
+        );
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::episodes::ActionOutcome;
+    use crate::proposal::Severity;
+
+    fn evidence() -> BTreeSet<String> {
+        evidence_actions(&[
+            ActionOutcome {
+                actions: vec!["game-rl:reset".into(), "set_priority".into()],
+                success: false,
+                quality: 0.1,
+            },
+            ActionOutcome {
+                actions: vec!["set_priority".into()],
+                success: true,
+                quality: 0.9,
+            },
+        ])
+    }
+
+    fn lesson(action: &str) -> ActionLesson {
+        ActionLesson::new(
+            "colony".into(),
+            "food low".into(),
+            action.into(),
+            "food recovers".into(),
+            0.8,
+            5,
+        )
+    }
+
+    fn proposal(constraint: &str) -> Proposal {
+        Proposal::new(
+            "colony".into(),
+            "Guard reset".into(),
+            "reset wiped the colony".into(),
+            "agent resets on reconnect".into(),
+            constraint.into(),
+            Severity::High,
+            0.9,
+            5,
+        )
+    }
+
+    #[test]
+    fn lesson_naming_evidence_action_passes() {
+        assert!(lesson_violation(&lesson("set_priority(Growing)"), &evidence()).is_none());
+        // Namespace-tolerant in both directions.
+        assert!(lesson_violation(&lesson("reset"), &evidence()).is_none());
+        assert!(lesson_violation(&lesson("game-rl:set_priority"), &evidence()).is_none());
+    }
+
+    #[test]
+    fn lesson_naming_unknown_action_rejected() {
+        let reason = lesson_violation(&lesson("teleport"), &evidence()).unwrap();
+        assert!(reason.contains("teleport"));
+    }
+
+    #[test]
+    fn lesson_naming_read_only_tool_rejected() {
+        let reason = lesson_violation(&lesson("observe first"), &evidence()).unwrap();
+        assert!(reason.contains("read-only"));
+    }
+
+    #[test]
+    fn tightening_with_restrictive_language_passes() {
+        assert!(tightening_violation(&proposal("only reset when TotalReward < -20")).is_none());
+        assert!(tightening_violation(&proposal("must not reset on reconnect")).is_none());
+    }
+
+    #[test]
+    fn loosening_constraint_rejected() {
+        let reason =
+            tightening_violation(&proposal("relax the reset guard to allow more retries")).unwrap();
+        assert!(reason.contains("loosens"));
+        assert!(tightening_violation(&proposal("always allow reset")).is_some());
+    }
+
+    #[test]
+    fn constraint_without_restricting_language_rejected() {
+        let reason = tightening_violation(&proposal("reset behavior is fine")).unwrap();
+        assert!(reason.contains("no restricting language"));
+    }
+
+    #[test]
+    fn reject_payload_truncated() {
+        let long = "x".repeat(5000);
+        let reject = Reject::new(
+            "colony",
+            RejectKind::Response,
+            "unparseable".into(),
+            Value::String(long),
+        );
+        let s = reject.payload.as_str().unwrap();
+        assert!(s.len() < 2100);
+        assert!(s.contains("truncated from 5000"));
+    }
+}

--- a/crates/arkavo-shadow-consolidation/tests/call_failure_resilience.rs
+++ b/crates/arkavo-shadow-consolidation/tests/call_failure_resilience.rs
@@ -10,6 +10,7 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
 use arkavo_shadow_consolidation::{Config, execute};
+use arkavo_test_macros::spec;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
@@ -92,6 +93,7 @@ async fn seed_store(dir: &Path, categories: &[(&str, usize)]) -> PathBuf {
     db
 }
 
+#[spec("SC-003")]
 #[tokio::test]
 async fn call_failures_still_write_ledger_and_artifacts() {
     let addr = serve_400_forever().await;

--- a/crates/arkavo-shadow-consolidation/tests/call_failure_resilience.rs
+++ b/crates/arkavo-shadow-consolidation/tests/call_failure_resilience.rs
@@ -1,0 +1,150 @@
+//! A failing Fable call must not abort the run: money already spent has to be
+//! accounted for, so the ledger and all artifacts are still written and the
+//! failure is recorded as a `call` reject that does not count against
+//! contract conformance.
+
+// #[tokio::test] expands to Runtime::block_on; harmless in tests.
+#![allow(clippy::disallowed_methods)]
+
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+
+use arkavo_shadow_consolidation::{Config, execute};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// Answer every connection with a non-retryable 400 — the fastest way to make
+/// each category's call fail deterministically without backoff sleeps.
+async fn serve_400_forever() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            // Drain headers + content-length body before responding so the
+            // client never sees a reset mid-request.
+            let mut data = Vec::new();
+            let mut buf = [0u8; 4096];
+            loop {
+                let n = sock.read(&mut buf).await.unwrap_or(0);
+                if n == 0 {
+                    break;
+                }
+                data.extend_from_slice(&buf[..n]);
+                if let Some(pos) = data.windows(4).position(|w| w == b"\r\n\r\n") {
+                    let headers = String::from_utf8_lossy(&data[..pos]).to_lowercase();
+                    let len = headers
+                        .lines()
+                        .find_map(|l| l.strip_prefix("content-length:"))
+                        .and_then(|v| v.trim().parse::<usize>().ok())
+                        .unwrap_or(0);
+                    if data.len() >= pos + 4 + len {
+                        break;
+                    }
+                }
+            }
+            let body = "bad request";
+            let resp = format!(
+                "HTTP/1.1 400 BAD\r\ncontent-type: text/plain\r\n\
+                 content-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = sock.write_all(resp.as_bytes()).await;
+        }
+    });
+    addr
+}
+
+async fn seed_store(dir: &Path, categories: &[(&str, usize)]) -> PathBuf {
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+    let db = dir.join("learning.db");
+    let opts = SqliteConnectOptions::new()
+        .filename(&db)
+        .create_if_missing(true);
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(opts)
+        .await
+        .unwrap();
+    sqlx::query(
+        "CREATE TABLE episodes (id TEXT PRIMARY KEY, task_category TEXT NOT NULL, \
+         observation_json TEXT NOT NULL, outcome_json TEXT NOT NULL)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    for (cat, count) in categories {
+        for i in 0..*count {
+            sqlx::query(
+                "INSERT INTO episodes (id, task_category, observation_json, outcome_json) \
+                 VALUES (?, ?, ?, ?)",
+            )
+            .bind(format!("{cat}-{i}"))
+            .bind(*cat)
+            .bind(r#"{"tools_used":["observe","set_priority"]}"#)
+            .bind(r#"{"success":true,"quality_metrics":{"correctness":0.8}}"#)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+    }
+    pool.close().await;
+    db
+}
+
+#[tokio::test]
+async fn call_failures_still_write_ledger_and_artifacts() {
+    let addr = serve_400_forever().await;
+    // SAFETY: this integration-test binary runs only this test, on a
+    // current-thread runtime — nothing reads the environment concurrently.
+    unsafe {
+        std::env::set_var("ANTHROPIC_API_KEY", "test-key");
+        std::env::set_var("ANTHROPIC_BASE_URL", format!("http://{addr}"));
+    }
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db = seed_store(tmp.path(), &[("colony", 3), ("nav", 3)]).await;
+    let out = tmp.path().join("out");
+    let cfg = Config {
+        db_path: db,
+        out_dir: out.clone(),
+        model: "claude-fable-5".into(),
+        min_episodes: 3,
+        max_tokens: 8192,
+        effort: "high".into(),
+        max_run_cost_usd: 25.0,
+        dry_run: false,
+    };
+
+    let summary = execute(cfg).await.unwrap();
+    assert_eq!(summary.rejects, 2);
+    assert_eq!(summary.categories_consolidated, 0);
+    assert!(summary.total_cost_usd.abs() < f64::EPSILON);
+    assert!(!summary.budget_exhausted);
+
+    for name in [
+        "lessons.json",
+        "proposals.json",
+        "cost_ledger.json",
+        "findings.json",
+        "rejects.json",
+    ] {
+        assert!(out.join(name).exists(), "missing {name}");
+    }
+
+    let rejects: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(out.join("rejects.json")).unwrap()).unwrap();
+    let rejects = rejects.as_array().unwrap();
+    assert_eq!(rejects.len(), 2);
+    for reject in rejects {
+        assert_eq!(reject["kind"], "call");
+        assert!(reject["reason"].as_str().unwrap().contains("400"));
+    }
+
+    // Operational failures are not contract violations.
+    let ledger: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(out.join("cost_ledger.json")).unwrap())
+            .unwrap();
+    assert!((ledger["contract_conformance_rate"].as_f64().unwrap() - 1.0).abs() < 1e-9);
+    assert_eq!(ledger["fable_calls"].as_u64().unwrap(), 0);
+}

--- a/crates/arkavo-swarmkit-runtime/Cargo.toml
+++ b/crates/arkavo-swarmkit-runtime/Cargo.toml
@@ -31,6 +31,7 @@ parking_lot = { workspace = true }
 ureq = { version = "2.10", features = ["json", "tls"], default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tracing = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 uuid = { workspace = true }

--- a/crates/arkavo-swarmkit-runtime/examples/swarm_flight_demo.rs
+++ b/crates/arkavo-swarmkit-runtime/examples/swarm_flight_demo.rs
@@ -6,6 +6,9 @@
 //!   cargo run -p arkavo-swarmkit-runtime --example swarm_flight_demo \
 //!     -- examples/campaign-kit/campaign-kit.swarmkit.yaml
 
+// #[tokio::main] expands to Runtime::block_on.
+#![allow(clippy::disallowed_methods)]
+
 use std::path::PathBuf;
 
 use arkavo_swarmkit::{parse_json, parse_yaml};

--- a/crates/arkavo-swarmkit-runtime/examples/swarmkit_agui_demo.rs
+++ b/crates/arkavo-swarmkit-runtime/examples/swarmkit_agui_demo.rs
@@ -10,6 +10,9 @@
 //!   cargo run -p arkavo-swarmkit-runtime --example swarmkit_agui_demo \
 //!     -- examples/campaign-kit/campaign-kit.swarmkit.yaml
 
+// #[tokio::main] expands to Runtime::block_on.
+#![allow(clippy::disallowed_methods)]
+
 use std::sync::Arc;
 
 use arkavo_agui::arp_handler::ArpHandler;

--- a/crates/arkavo-swarmkit-runtime/src/derive.rs
+++ b/crates/arkavo-swarmkit-runtime/src/derive.rs
@@ -233,6 +233,7 @@ mod tests {
         RoleSpec {
             id: id.into(),
             role_type: "specialist".into(),
+            plane: None,
             description: None,
             agent_provisioning: AgentProvisioning::default(),
             skills: vec![],

--- a/crates/arkavo-swarmkit-runtime/src/derive.rs
+++ b/crates/arkavo-swarmkit-runtime/src/derive.rs
@@ -12,13 +12,17 @@
 
 use arkavo_arp::ArpDocument;
 use arkavo_arp::adaptation::{Adaptation, AdaptationMethod};
-use arkavo_arp::constraints::{Budget, BudgetExhaustionAction, Velocity};
+use arkavo_arp::constraints::{ApprovalMechanism, Budget, BudgetExhaustionAction, Velocity};
 use arkavo_arp::feedback::{
     DecayStrategy, FeedbackLoops, ImmediateFeedback, PolicyCacheConfig, QualityFailureAction,
     QualityGate, QualityMetric, ShortTermFeedback,
 };
 use arkavo_arp::model::AdlRef;
-use arkavo_swarmkit::{GlobalBudget, RoleSpec};
+use arkavo_arp::proposal::{BlastRadius, ProposalOrigin, ProposalPolicy};
+use arkavo_swarmkit::{
+    GlobalBudget, ProposalApprovalMechanism, ProposalBlastRadius, ProposalGovernanceSpec,
+    ProposalOriginSpec, RoleSpec,
+};
 
 /// Tunables for the default-ARP derivation.
 ///
@@ -79,6 +83,21 @@ pub fn derive_arp_for_role(
     role_count: usize,
     opts: DeriveOptions,
 ) -> ArpDocument {
+    derive_arp_for_role_with_governance(role, global, role_count, opts, None)
+}
+
+/// Same derivation, plus a per-role `proposal_policy` derived from the kit's
+/// `proposal_governance` block — the same kit-config-to-role-ARP pattern as
+/// the global budget split. No governance means no proposal policy: the
+/// role's queue rejects every ingest.
+pub fn derive_arp_for_role_with_governance(
+    role: &RoleSpec,
+    global: &GlobalBudget,
+    role_count: usize,
+    opts: DeriveOptions,
+    governance: Option<&ProposalGovernanceSpec>,
+) -> ArpDocument {
+    let proposal_policy = governance.map(|gov| derive_proposal_policy(role, gov));
     let role_count = role_count.max(1) as f64;
     let task_ceiling = (global.max_cost_usd / role_count).max(f64::EPSILON);
     let velocity_per_min = (task_ceiling / opts.velocity_window_minutes).max(f64::EPSILON);
@@ -144,8 +163,63 @@ pub fn derive_arp_for_role(
         session: None,
         state_storage: None,
         observability: None,
-        proposal_policy: None,
+        proposal_policy,
         metadata: None,
+    }
+}
+
+/// Map the kit-level governance block onto one role's ARP proposal policy.
+fn derive_proposal_policy(role: &RoleSpec, gov: &ProposalGovernanceSpec) -> ProposalPolicy {
+    // Conservative default when the kit lists no origins: human only.
+    let accepted_origins = if gov.accepted_origins.is_empty() {
+        vec![ProposalOrigin::Human]
+    } else {
+        gov.accepted_origins.iter().map(map_origin).collect()
+    };
+    // Per-role ceiling, defaulting to single_entity. Mesh is rejected at
+    // manifest validation; clamp defensively anyway.
+    let ceiling = gov
+        .role_ceilings
+        .iter()
+        .find(|c| c.role == role.id)
+        .map(|c| map_radius(c.auto_apply_max_blast_radius))
+        .unwrap_or(BlastRadius::SingleEntity)
+        .min(BlastRadius::Flight);
+    ProposalPolicy {
+        accepted_origins,
+        auto_apply_max_blast_radius: ceiling,
+        review: gov.flight_approval.map(map_approval),
+        observation_window_sec: gov.observation_window_sec,
+    }
+}
+
+fn map_origin(o: &ProposalOriginSpec) -> ProposalOrigin {
+    match o {
+        ProposalOriginSpec::Consolidation => ProposalOrigin::Consolidation,
+        ProposalOriginSpec::Critic => ProposalOrigin::Critic,
+        ProposalOriginSpec::Historian => ProposalOrigin::Historian,
+        ProposalOriginSpec::Human => ProposalOrigin::Human,
+    }
+}
+
+fn map_radius(r: ProposalBlastRadius) -> BlastRadius {
+    match r {
+        ProposalBlastRadius::SingleEntity => BlastRadius::SingleEntity,
+        ProposalBlastRadius::SingleAgent => BlastRadius::SingleAgent,
+        ProposalBlastRadius::Flight => BlastRadius::Flight,
+        ProposalBlastRadius::Mesh => BlastRadius::Mesh,
+    }
+}
+
+fn map_approval(a: ProposalApprovalMechanism) -> ApprovalMechanism {
+    match a {
+        ProposalApprovalMechanism::CredentialPresentation => {
+            ApprovalMechanism::CredentialPresentation
+        }
+        ProposalApprovalMechanism::SignedCommand => ApprovalMechanism::SignedCommand,
+        ProposalApprovalMechanism::InteractiveConfirmation => {
+            ApprovalMechanism::InteractiveConfirmation
+        }
     }
 }
 
@@ -221,5 +295,102 @@ mod tests {
     fn zero_role_count_does_not_divide_by_zero() {
         let doc = derive_arp_for_role(&role("r1"), &budget(), 0, DeriveOptions::default());
         assert!(doc.budget.task_ceiling_usd > 0.0);
+    }
+    #[test]
+    fn no_governance_derives_no_proposal_policy() {
+        let doc = derive_arp_for_role(&role("r1"), &budget(), 1, DeriveOptions::default());
+        assert!(doc.proposal_policy.is_none());
+    }
+
+    #[test]
+    fn governance_derives_per_role_policy() {
+        use arkavo_swarmkit::{
+            ProposalApprovalMechanism, ProposalBlastRadius, ProposalGovernanceSpec,
+            ProposalOriginSpec, RoleProposalCeiling,
+        };
+        let gov = ProposalGovernanceSpec {
+            accepted_origins: vec![ProposalOriginSpec::Consolidation, ProposalOriginSpec::Human],
+            role_ceilings: vec![RoleProposalCeiling {
+                role: "commander".into(),
+                auto_apply_max_blast_radius: ProposalBlastRadius::SingleAgent,
+            }],
+            flight_approval: Some(ProposalApprovalMechanism::InteractiveConfirmation),
+            observation_window_sec: Some(900),
+        };
+
+        // Role with an explicit ceiling.
+        let doc = derive_arp_for_role_with_governance(
+            &role("commander"),
+            &budget(),
+            2,
+            DeriveOptions::default(),
+            Some(&gov),
+        );
+        let policy = doc.proposal_policy.unwrap();
+        assert_eq!(policy.auto_apply_max_blast_radius, BlastRadius::SingleAgent);
+        assert_eq!(policy.accepted_origins.len(), 2);
+        assert_eq!(policy.observation_window_sec, Some(900));
+        assert_eq!(
+            policy.review,
+            Some(ApprovalMechanism::InteractiveConfirmation)
+        );
+
+        // Role without an entry derives the single_entity default.
+        let doc = derive_arp_for_role_with_governance(
+            &role("historian"),
+            &budget(),
+            2,
+            DeriveOptions::default(),
+            Some(&gov),
+        );
+        let policy = doc.proposal_policy.unwrap();
+        assert_eq!(
+            policy.auto_apply_max_blast_radius,
+            BlastRadius::SingleEntity
+        );
+    }
+
+    #[test]
+    fn empty_origins_default_to_human_only() {
+        use arkavo_swarmkit::ProposalGovernanceSpec;
+        let gov = ProposalGovernanceSpec {
+            accepted_origins: vec![],
+            role_ceilings: vec![],
+            flight_approval: None,
+            observation_window_sec: None,
+        };
+        let doc = derive_arp_for_role_with_governance(
+            &role("r1"),
+            &budget(),
+            1,
+            DeriveOptions::default(),
+            Some(&gov),
+        );
+        let policy = doc.proposal_policy.unwrap();
+        assert_eq!(policy.accepted_origins, vec![ProposalOrigin::Human]);
+    }
+
+    #[test]
+    fn derived_document_passes_arp_validation() {
+        use arkavo_swarmkit::{
+            ProposalBlastRadius, ProposalGovernanceSpec, ProposalOriginSpec, RoleProposalCeiling,
+        };
+        let gov = ProposalGovernanceSpec {
+            accepted_origins: vec![ProposalOriginSpec::Consolidation],
+            role_ceilings: vec![RoleProposalCeiling {
+                role: "r1".into(),
+                auto_apply_max_blast_radius: ProposalBlastRadius::Flight,
+            }],
+            flight_approval: None,
+            observation_window_sec: None,
+        };
+        let doc = derive_arp_for_role_with_governance(
+            &role("r1"),
+            &budget(),
+            1,
+            DeriveOptions::default(),
+            Some(&gov),
+        );
+        assert!(arkavo_arp::validate::validate(&doc).is_ok());
     }
 }

--- a/crates/arkavo-swarmkit-runtime/src/derive.rs
+++ b/crates/arkavo-swarmkit-runtime/src/derive.rs
@@ -144,6 +144,7 @@ pub fn derive_arp_for_role(
         session: None,
         state_storage: None,
         observability: None,
+        proposal_policy: None,
         metadata: None,
     }
 }

--- a/crates/arkavo-swarmkit-runtime/src/flight.rs
+++ b/crates/arkavo-swarmkit-runtime/src/flight.rs
@@ -18,7 +18,7 @@ use arkavo_arp_runtime::{ArpRuntime, ToolOutcomeContext};
 use arkavo_swarmkit::Manifest;
 use uuid::Uuid;
 
-use crate::derive::{DeriveOptions, derive_arp_for_role};
+use crate::derive::{DeriveOptions, derive_arp_for_role_with_governance};
 
 /// Per-role task envelope handed to a [`RoleTaskTransport`] for delivery.
 #[derive(Debug, Clone)]
@@ -234,11 +234,12 @@ impl SwarmFlight {
                 .get(&role.id)
                 .cloned()
                 .unwrap_or_else(|| {
-                    derive_arp_for_role(
+                    derive_arp_for_role_with_governance(
                         role,
                         &manifest.constraints.global_budget,
                         role_count,
                         options.derive_options,
+                        manifest.proposal_governance.as_ref(),
                     )
                 });
             let arp = Arc::new(ArpRuntime::from_document(&arp_doc));

--- a/crates/arkavo-swarmkit-runtime/src/flight_apply.rs
+++ b/crates/arkavo-swarmkit-runtime/src/flight_apply.rs
@@ -1,0 +1,148 @@
+//! Atomic apply of flight-radius tightening proposals across every role ARP
+//! in a flight (#609).
+//!
+//! Design decision (recorded): **check-then-apply with trace-emitting revert
+//! on partial failure**, not two-phase commit. The flight is an in-process
+//! orchestrator — every role queue is reachable under a lock — so a
+//! side-effect-free admission check against all roles first removes the
+//! common divergence case outright, and the proposal queue's revert path
+//! (already auditable, never erased) handles the residual one. 2PC machinery
+//! would serve an A2A distribution layer that is still aspirational.
+//!
+//! Mesh-radius proposals are never applied here: they are per-agent,
+//! human-reviewed, always.
+
+use arkavo_arp::proposal::{BlastRadius, ProposalState, TighteningProposal};
+
+use crate::flight::SwarmFlight;
+
+/// Why a flight-wide apply did not (fully) happen.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FlightApplyError {
+    /// Only flight-radius proposals ride this path.
+    WrongRadius(BlastRadius),
+    /// A role failed the admission check; nothing was applied anywhere.
+    PrecheckFailed { role_id: String, reason: String },
+    /// A role failed during apply after others had applied; the applied
+    /// roles were reverted (each revert emitted its trace entry).
+    PartialFailureReverted { role_id: String, reason: String },
+}
+
+impl std::fmt::Display for FlightApplyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::WrongRadius(r) => write!(
+                f,
+                "flight apply accepts only flight-radius proposals, got {r:?} \
+                 (mesh is never auto-applied; narrower radii use per-role ingest)"
+            ),
+            Self::PrecheckFailed { role_id, reason } => {
+                write!(f, "admission check failed on role {role_id}: {reason}")
+            }
+            Self::PartialFailureReverted { role_id, reason } => write!(
+                f,
+                "apply failed on role {role_id} ({reason}); previously applied roles reverted"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FlightApplyError {}
+
+/// Apply a kit-approved flight-radius proposal to every role ARP in the
+/// flight, atomically from the caller's perspective: on return it is either
+/// applied everywhere (observed) or applied nowhere (with any partial
+/// application reverted and trace-logged).
+pub async fn apply_flight_proposal(
+    flight: &SwarmFlight,
+    proposal: &TighteningProposal,
+    reviewer: &str,
+    now_epoch_sec: u64,
+) -> Result<(), FlightApplyError> {
+    if proposal.blast_radius != BlastRadius::Flight {
+        return Err(FlightApplyError::WrongRadius(proposal.blast_radius));
+    }
+
+    // Phase 1: side-effect-free admission check on every role. A single
+    // refusal blocks the whole flight before anything mutates.
+    for role in flight.roles() {
+        let queue = role.arp().proposal_queue();
+        let guard = queue.lock().await;
+        if let Err(reason) = guard.check(proposal) {
+            return Err(FlightApplyError::PrecheckFailed {
+                role_id: role.role_id().to_string(),
+                reason,
+            });
+        }
+    }
+
+    // Phase 2: apply role by role. On failure, revert the roles already
+    // applied so the flight converges back to the pre-proposal state.
+    let mut applied: Vec<String> = Vec::new();
+    for role in flight.roles() {
+        let queue = role.arp().proposal_queue();
+        let mut guard = queue.lock().await;
+        match guard.ingest_reviewed(proposal.clone(), reviewer, now_epoch_sec) {
+            Ok(_) => applied.push(role.role_id().to_string()),
+            Err(reason) => {
+                drop(guard);
+                revert_from_roles(flight, &applied, &proposal.id, &reason).await;
+                return Err(FlightApplyError::PartialFailureReverted {
+                    role_id: role.role_id().to_string(),
+                    reason,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Reconcile a flight after a crash mid-apply: if any role lacks the
+/// proposal in an applied state, revert it from the roles that have it.
+/// Returns the role ids that were reverted. Idempotent — a converged flight
+/// reconciles to no-ops.
+pub async fn reconcile_flight_proposal(flight: &SwarmFlight, proposal_id: &str) -> Vec<String> {
+    let mut have: Vec<String> = Vec::new();
+    let mut missing = false;
+    for role in flight.roles() {
+        let queue = role.arp().proposal_queue();
+        let guard = queue.lock().await;
+        match guard.proposal_state(proposal_id) {
+            Some(ProposalState::Applied | ProposalState::Observed) => {
+                have.push(role.role_id().to_string());
+            }
+            Some(ProposalState::Confirmed) => {
+                // Confirmed proposals survived their observation window;
+                // treat as present.
+                have.push(role.role_id().to_string());
+            }
+            _ => missing = true,
+        }
+    }
+    if !missing || have.is_empty() {
+        return Vec::new();
+    }
+    revert_from_roles(
+        flight,
+        &have,
+        proposal_id,
+        "flight apply did not reach every role; reconciling to pre-proposal state",
+    )
+    .await;
+    have
+}
+
+async fn revert_from_roles(flight: &SwarmFlight, role_ids: &[String], id: &str, reason: &str) {
+    for role_id in role_ids {
+        if let Some(role) = flight.role(role_id) {
+            let queue = role.arp().proposal_queue();
+            let mut guard = queue.lock().await;
+            if let Err(e) = guard.force_revert(id, reason) {
+                // A failed revert is loud, never silent: it means manual
+                // attention is required on this role.
+                tracing::error!(role_id = %role_id, proposal_id = %id, error = %e,
+                    "flight revert failed on role");
+            }
+        }
+    }
+}

--- a/crates/arkavo-swarmkit-runtime/src/lib.rs
+++ b/crates/arkavo-swarmkit-runtime/src/lib.rs
@@ -66,6 +66,9 @@ pub fn canonical_full_manifest(
 
 #[cfg(test)]
 mod tests {
+    // #[tokio::test] expands to Runtime::block_on; harmless in tests.
+    #![allow(clippy::disallowed_methods)]
+
     use crate::{LaunchOptions, SwarmFlight};
     use arkavo_swarmkit::parse_yaml;
     use arkavo_test_macros::spec;

--- a/crates/arkavo-swarmkit-runtime/src/lib.rs
+++ b/crates/arkavo-swarmkit-runtime/src/lib.rs
@@ -14,16 +14,18 @@
 
 pub mod derive;
 pub mod flight;
+pub mod flight_apply;
 pub mod path_dispatch;
 pub mod skill_resolver;
 #[cfg(feature = "tdf")]
 pub mod tdf;
 
-pub use derive::{DeriveOptions, derive_arp_for_role};
+pub use derive::{DeriveOptions, derive_arp_for_role, derive_arp_for_role_with_governance};
 pub use flight::{
     DispatchHandle, FlightError, LaunchError, LaunchOptions, RoleRuntime, RoleTaskEnvelope,
     RoleTaskTransport, SwarmFlight,
 };
+pub use flight_apply::{FlightApplyError, apply_flight_proposal, reconcile_flight_proposal};
 pub use path_dispatch::{KitPathKind, classify_kit_path, is_tdf_path};
 pub use skill_resolver::{
     DidWebPublicKeyResolver, MockPublicKeyResolver, PublicKeyResolver, ResolveError, ResolvedSkill,

--- a/crates/arkavo-swarmkit-runtime/src/tdf.rs
+++ b/crates/arkavo-swarmkit-runtime/src/tdf.rs
@@ -634,13 +634,13 @@ provenance:
     #[spec("SK-053")]
     #[test]
     fn role_policy_splits_attributes_at_last_slash() {
-        use arkavo_swarmkit::ArpRule;
+        use arkavo_swarmkit::TdfReleaseRule;
         let arp = TdfAttributeReleasePolicy {
             attributes: vec![
                 "https://attr.arkavo.com/role/planner".to_string(),
                 "https://attr.arkavo.com/clearance/internal".to_string(),
             ],
-            rule: ArpRule::AllOf,
+            rule: TdfReleaseRule::AllOf,
         };
         let pol = role_policy("planner-1", &arp, None).unwrap();
         assert_eq!(pol.attributes.len(), 2);
@@ -662,13 +662,13 @@ provenance:
     #[spec("SK-053")]
     #[test]
     fn role_policy_merges_repeated_fqns() {
-        use arkavo_swarmkit::ArpRule;
+        use arkavo_swarmkit::TdfReleaseRule;
         let arp = TdfAttributeReleasePolicy {
             attributes: vec![
                 "https://attr.arkavo.com/role/planner".to_string(),
                 "https://attr.arkavo.com/role/critic".to_string(),
             ],
-            rule: ArpRule::AnyOf,
+            rule: TdfReleaseRule::AnyOf,
         };
         let pol = role_policy("multi", &arp, None).unwrap();
         assert_eq!(pol.attributes.len(), 1);
@@ -680,10 +680,10 @@ provenance:
     #[spec("SK-053")]
     #[test]
     fn role_policy_binds_to_agent_did_via_dissemination() {
-        use arkavo_swarmkit::ArpRule;
+        use arkavo_swarmkit::TdfReleaseRule;
         let arp = TdfAttributeReleasePolicy {
             attributes: vec!["https://attr.arkavo.com/clearance/public".to_string()],
-            rule: ArpRule::AllOf,
+            rule: TdfReleaseRule::AllOf,
         };
         let pol = role_policy("worker", &arp, Some("did:web:specialist.example.com")).unwrap();
         assert_eq!(
@@ -695,11 +695,11 @@ provenance:
     #[spec("SK-054")]
     #[test]
     fn role_policy_rejects_malformed_attribute() {
-        use arkavo_swarmkit::ArpRule;
+        use arkavo_swarmkit::TdfReleaseRule;
         let arp = TdfAttributeReleasePolicy {
             // Missing a slash → cannot split into (fqn, value).
             attributes: vec!["malformed".to_string()],
-            rule: ArpRule::AllOf,
+            rule: TdfReleaseRule::AllOf,
         };
         let err = role_policy("r1", &arp, None).unwrap_err();
         assert!(matches!(err, TdfError::Policy(_)));

--- a/crates/arkavo-swarmkit-runtime/tests/campaign_kit_flight.rs
+++ b/crates/arkavo-swarmkit-runtime/tests/campaign_kit_flight.rs
@@ -6,6 +6,9 @@
 //! described in spec §1.2 / §5 actually works end-to-end on a real
 //! manifest from arkavo-org/arkavo-edge#573.
 
+// #[tokio::test] expands to Runtime::block_on; harmless in tests.
+#![allow(clippy::disallowed_methods)]
+
 use arkavo_swarmkit::parse_yaml;
 use arkavo_swarmkit_runtime::{LaunchOptions, SwarmFlight};
 use arkavo_test_macros::spec;

--- a/crates/arkavo-swarmkit-runtime/tests/campaign_kit_skill_resolver.rs
+++ b/crates/arkavo-swarmkit-runtime/tests/campaign_kit_skill_resolver.rs
@@ -2,6 +2,9 @@
 //! example end-to-end with skill resolution enabled, asserting every
 //! role's skill resolves and verifies.
 
+// #[tokio::test] expands to Runtime::block_on; harmless in tests.
+#![allow(clippy::disallowed_methods)]
+
 use std::sync::Arc;
 
 use arkavo_swarmkit::parse_yaml;

--- a/crates/arkavo-swarmkit-runtime/tests/code_review_kit_skill_resolver.rs
+++ b/crates/arkavo-swarmkit-runtime/tests/code_review_kit_skill_resolver.rs
@@ -2,6 +2,9 @@
 //! skill resolution enabled, asserting every role's skill resolves with
 //! verified=true.
 
+// #[tokio::test] expands to Runtime::block_on; harmless in tests.
+#![allow(clippy::disallowed_methods)]
+
 use std::sync::Arc;
 
 use arkavo_swarmkit::parse_yaml;

--- a/crates/arkavo-swarmkit-runtime/tests/compliance_kit_skill_resolver.rs
+++ b/crates/arkavo-swarmkit-runtime/tests/compliance_kit_skill_resolver.rs
@@ -2,6 +2,9 @@
 //! skill resolution enabled, asserting every role's skill resolves with
 //! verified=true.
 
+// #[tokio::test] expands to Runtime::block_on; harmless in tests.
+#![allow(clippy::disallowed_methods)]
+
 use std::sync::Arc;
 
 use arkavo_swarmkit::parse_yaml;

--- a/crates/arkavo-swarmkit-runtime/tests/flight_proposal_apply.rs
+++ b/crates/arkavo-swarmkit-runtime/tests/flight_proposal_apply.rs
@@ -215,6 +215,54 @@ async fn kill_one_role_mid_apply_reconciles_to_convergence() {
 
 #[spec("SK-095")]
 #[tokio::test]
+async fn reconcile_reverts_a_confirmed_role_to_converge() {
+    // Regression (#609): a delayed reconcile can find a role whose proposal
+    // already passed its observation window and confirmed, while a peer never
+    // received it. Reconcile must still revert the confirmed role — otherwise
+    // it stays permanently tightened and the flight never converges.
+    let flight = launch();
+    let p = flight_proposal(
+        "fp-5",
+        TighteningEffect::DenyTool {
+            tool: "game-rl:reset".into(),
+        },
+    );
+    // commander + survival applied the proposal and then confirmed it (clean
+    // observation window elapsed); historian crashed before receiving it.
+    for role_id in ["commander", "survival"] {
+        let role = flight.role(role_id).unwrap();
+        let queue = role.arp().proposal_queue();
+        let mut guard = queue.lock().await;
+        guard
+            .ingest_reviewed(p.clone(), "kit-approver", 1_000)
+            .unwrap();
+        for _ in 0..10 {
+            guard.record_quality_gate(true);
+        }
+        let transitions = guard.evaluate_observations(1_700);
+        assert_eq!(transitions, vec![("fp-5".into(), ProposalState::Confirmed)]);
+    }
+
+    let reverted = reconcile_flight_proposal(&flight, "fp-5").await;
+    assert_eq!(
+        reverted,
+        vec!["commander".to_string(), "survival".to_string()]
+    );
+    for role in flight.roles() {
+        let queue = role.arp().proposal_queue();
+        let guard = queue.lock().await;
+        // Converged: the confirmed tightening was undone everywhere.
+        assert!(!guard.is_tool_denied("game-rl:reset"));
+        if ["commander", "survival"].contains(&role.role_id()) {
+            assert_eq!(guard.proposal_state("fp-5"), Some(ProposalState::Reverted));
+        }
+    }
+    // Idempotent: a second reconcile finds nothing left to revert.
+    assert!(reconcile_flight_proposal(&flight, "fp-5").await.is_empty());
+}
+
+#[spec("SK-095")]
+#[tokio::test]
 async fn converged_flight_reconciles_as_noop() {
     let flight = launch();
     let p = flight_proposal(

--- a/crates/arkavo-swarmkit-runtime/tests/flight_proposal_apply.rs
+++ b/crates/arkavo-swarmkit-runtime/tests/flight_proposal_apply.rs
@@ -11,6 +11,7 @@ use arkavo_swarmkit_runtime::flight::{LaunchOptions, SwarmFlight};
 use arkavo_swarmkit_runtime::flight_apply::{
     FlightApplyError, apply_flight_proposal, reconcile_flight_proposal,
 };
+use arkavo_test_macros::spec;
 
 const KIT: &str = r#"
 spec_version: "1.0.0"
@@ -73,6 +74,7 @@ fn flight_proposal(id: &str, effect: TighteningEffect) -> TighteningProposal {
     }
 }
 
+#[spec("SK-094")]
 #[tokio::test]
 async fn flight_apply_reaches_every_role() {
     let flight = launch();
@@ -99,6 +101,8 @@ async fn flight_apply_reaches_every_role() {
     }
 }
 
+#[spec("SK-094")]
+#[spec("ARP-006")]
 #[tokio::test]
 async fn mesh_radius_is_refused_outright() {
     let flight = launch();
@@ -114,6 +118,7 @@ async fn mesh_radius_is_refused_outright() {
     }
 }
 
+#[spec("SK-094")]
 #[tokio::test]
 async fn precheck_failure_applies_nothing_anywhere() {
     let flight = launch();
@@ -163,6 +168,7 @@ async fn precheck_failure_applies_nothing_anywhere() {
     }
 }
 
+#[spec("SK-095")]
 #[tokio::test]
 async fn kill_one_role_mid_apply_reconciles_to_convergence() {
     let flight = launch();
@@ -207,6 +213,7 @@ async fn kill_one_role_mid_apply_reconciles_to_convergence() {
     assert!(reconcile_flight_proposal(&flight, "fp-3").await.is_empty());
 }
 
+#[spec("SK-095")]
 #[tokio::test]
 async fn converged_flight_reconciles_as_noop() {
     let flight = launch();

--- a/crates/arkavo-swarmkit-runtime/tests/flight_proposal_apply.rs
+++ b/crates/arkavo-swarmkit-runtime/tests/flight_proposal_apply.rs
@@ -1,0 +1,227 @@
+//! Flight-radius proposal apply: atomicity and convergence (#609).
+
+// #[tokio::test] expands to Runtime::block_on; harmless in tests.
+#![allow(clippy::disallowed_methods)]
+
+use arkavo_arp::proposal::{
+    BlastRadius, ProposalOrigin, ProposalState, TighteningEffect, TighteningProposal, TraceRef,
+};
+use arkavo_swarmkit::parse_yaml;
+use arkavo_swarmkit_runtime::flight::{LaunchOptions, SwarmFlight};
+use arkavo_swarmkit_runtime::flight_apply::{
+    FlightApplyError, apply_flight_proposal, reconcile_flight_proposal,
+};
+
+const KIT: &str = r#"
+spec_version: "1.0.0"
+kit:
+  id: ""
+  name: "proposal-apply-kit"
+  version: "1.0.0"
+  authors: [{did: "did:web:example.com"}]
+  created: "2026-06-01T00:00:00Z"
+  expires: "2026-06-29T00:00:00Z"
+  nonce: "thz1Cz8aWOUURbyQQfvA0Q"
+objective:
+  goal: "exercise flight-radius proposal apply"
+roles:
+  - {id: "commander", role_type: "coordinator", agent_provisioning: {}}
+  - {id: "survival", role_type: "specialist", agent_provisioning: {}}
+  - {id: "historian", role_type: "auditor", plane: "audit", agent_provisioning: {}}
+coordination:
+  topology: "hub-spoke"
+  protocol: "a2a-jsonrpc-2.0"
+  routing: {strategy: "static"}
+constraints:
+  global_budget: {max_wallclock_seconds: 60, max_total_tokens: 8000, max_cost_usd: 0.30}
+  data_classifications: ["public"]
+  network: {egress_allowed: false, egress_allowlist: []}
+proposal_governance:
+  accepted_origins: ["consolidation", "human"]
+  role_ceilings:
+    - {role: "commander", auto_apply_max_blast_radius: "single_agent"}
+  observation_window_sec: 600
+completion:
+  rules: ["all deliverables present"]
+  on_failure: "abort"
+  max_retries: 0
+provenance:
+  signatures: [{signer_did: "did:web:example.com", algorithm: "ed25519", signature: "AAA"}]
+"#;
+
+fn launch() -> SwarmFlight {
+    let manifest = parse_yaml(KIT).unwrap();
+    SwarmFlight::launch(&manifest, LaunchOptions::default()).unwrap()
+}
+
+fn flight_proposal(id: &str, effect: TighteningEffect) -> TighteningProposal {
+    TighteningProposal {
+        id: id.into(),
+        origin: ProposalOrigin::Consolidation,
+        state: ProposalState::Proposed,
+        effect,
+        rationale: "flight-wide tightening from nightly consolidation".into(),
+        blast_radius: BlastRadius::Flight,
+        evidence: vec![TraceRef {
+            trace_id: "t-1".into(),
+            episode_ids: vec!["ep-1".into()],
+        }],
+        created_at: "2026-06-10T00:00:00Z".into(),
+        applied_at: None,
+        reviewed_by: None,
+        disposition_reason: None,
+    }
+}
+
+#[tokio::test]
+async fn flight_apply_reaches_every_role() {
+    let flight = launch();
+    let p = flight_proposal(
+        "fp-1",
+        TighteningEffect::DenyTool {
+            tool: "game-rl:reset".into(),
+        },
+    );
+    apply_flight_proposal(&flight, &p, "kit-approver", 1_000)
+        .await
+        .unwrap();
+
+    for role in flight.roles() {
+        let queue = role.arp().proposal_queue();
+        let guard = queue.lock().await;
+        assert_eq!(
+            guard.proposal_state("fp-1"),
+            Some(ProposalState::Observed),
+            "role {} should be observing the applied proposal",
+            role.role_id()
+        );
+        assert!(guard.is_tool_denied("game-rl:reset"));
+    }
+}
+
+#[tokio::test]
+async fn mesh_radius_is_refused_outright() {
+    let flight = launch();
+    let mut p = flight_proposal("mp-1", TighteningEffect::DenyTool { tool: "x".into() });
+    p.blast_radius = BlastRadius::Mesh;
+    let err = apply_flight_proposal(&flight, &p, "kit-approver", 1_000)
+        .await
+        .unwrap_err();
+    assert_eq!(err, FlightApplyError::WrongRadius(BlastRadius::Mesh));
+    for role in flight.roles() {
+        let queue = role.arp().proposal_queue();
+        assert!(queue.lock().await.proposal_state("mp-1").is_none());
+    }
+}
+
+#[tokio::test]
+async fn precheck_failure_applies_nothing_anywhere() {
+    let flight = launch();
+    // Pre-deny the tool on one role only: the flight-wide apply must now
+    // fail admission there and leave every role untouched.
+    {
+        let role = flight.role("survival").unwrap();
+        let queue = role.arp().proposal_queue();
+        queue
+            .lock()
+            .await
+            .ingest_reviewed(
+                {
+                    let mut p = flight_proposal(
+                        "pre-existing",
+                        TighteningEffect::DenyTool {
+                            tool: "game-rl:reset".into(),
+                        },
+                    );
+                    p.blast_radius = BlastRadius::SingleEntity;
+                    p
+                },
+                "operator",
+                500,
+            )
+            .unwrap();
+    }
+
+    let p = flight_proposal(
+        "fp-2",
+        TighteningEffect::DenyTool {
+            tool: "game-rl:reset".into(),
+        },
+    );
+    let err = apply_flight_proposal(&flight, &p, "kit-approver", 1_000)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        FlightApplyError::PrecheckFailed { ref role_id, .. } if role_id == "survival"
+    ));
+    // Atomicity: no role carries fp-2 — including roles checked before the
+    // failing one.
+    for role in flight.roles() {
+        let queue = role.arp().proposal_queue();
+        assert!(queue.lock().await.proposal_state("fp-2").is_none());
+    }
+}
+
+#[tokio::test]
+async fn kill_one_role_mid_apply_reconciles_to_convergence() {
+    let flight = launch();
+    // Simulate a crash between per-role applies: the proposal landed on
+    // commander and survival, then the process died before historian.
+    let p = flight_proposal(
+        "fp-3",
+        TighteningEffect::DenyTool {
+            tool: "game-rl:reset".into(),
+        },
+    );
+    for role_id in ["commander", "survival"] {
+        let role = flight.role(role_id).unwrap();
+        let queue = role.arp().proposal_queue();
+        queue
+            .lock()
+            .await
+            .ingest_reviewed(p.clone(), "kit-approver", 1_000)
+            .unwrap();
+    }
+
+    // Recovery: reconcile detects the partial application and reverts it
+    // from the roles that have it.
+    let reverted = reconcile_flight_proposal(&flight, "fp-3").await;
+    assert_eq!(
+        reverted,
+        vec!["commander".to_string(), "survival".to_string()]
+    );
+
+    for role in flight.roles() {
+        let queue = role.arp().proposal_queue();
+        let guard = queue.lock().await;
+        // Converged: nobody enforces the partial proposal.
+        assert!(!guard.is_tool_denied("game-rl:reset"));
+        // And on the roles that had applied it, the revert is auditable.
+        if ["commander", "survival"].contains(&role.role_id()) {
+            assert_eq!(guard.proposal_state("fp-3"), Some(ProposalState::Reverted));
+        }
+    }
+
+    // Idempotence: a second reconcile is a no-op.
+    assert!(reconcile_flight_proposal(&flight, "fp-3").await.is_empty());
+}
+
+#[tokio::test]
+async fn converged_flight_reconciles_as_noop() {
+    let flight = launch();
+    let p = flight_proposal(
+        "fp-4",
+        TighteningEffect::DenyTool {
+            tool: "game-rl:reset".into(),
+        },
+    );
+    apply_flight_proposal(&flight, &p, "kit-approver", 1_000)
+        .await
+        .unwrap();
+    assert!(reconcile_flight_proposal(&flight, "fp-4").await.is_empty());
+    for role in flight.roles() {
+        let queue = role.arp().proposal_queue();
+        assert!(queue.lock().await.is_tool_denied("game-rl:reset"));
+    }
+}

--- a/crates/arkavo-swarmkit-runtime/tests/skill_resolver_flight.rs
+++ b/crates/arkavo-swarmkit-runtime/tests/skill_resolver_flight.rs
@@ -1,5 +1,8 @@
 //! Integration tests for SwarmFlight::launch with skill resolution.
 
+// #[tokio::test] expands to Runtime::block_on; harmless in tests.
+#![allow(clippy::disallowed_methods)]
+
 use std::sync::Arc;
 
 use arkavo_swarmkit::{Manifest, SkillContent, parse_yaml};

--- a/crates/arkavo-swarmkit-runtime/tests/vrm_production_kit_skill_resolver.rs
+++ b/crates/arkavo-swarmkit-runtime/tests/vrm_production_kit_skill_resolver.rs
@@ -2,6 +2,9 @@
 //! skill resolution enabled, asserting every role's skill resolves with
 //! verified=true.
 
+// #[tokio::test] expands to Runtime::block_on; harmless in tests.
+#![allow(clippy::disallowed_methods)]
+
 use std::sync::Arc;
 
 use arkavo_swarmkit::parse_yaml;

--- a/crates/arkavo-swarmkit/src/governance.rs
+++ b/crates/arkavo-swarmkit/src/governance.rs
@@ -1,0 +1,115 @@
+//! Kit-level tightening-proposal governance: how far audit-plane proposals
+//! may auto-apply per role, and how flight-radius proposals are approved.
+//!
+//! These are SwarmKit spec types — deliberately independent of arkavo-arp
+//! (this crate is parser + validator only). The runtime derives each role's
+//! ARP `proposal_policy` from this block, the same way the global budget is
+//! split per role.
+
+use serde::{Deserialize, Serialize};
+
+/// Blast radius vocabulary for governance ceilings. Ordering is declaration
+/// order: `single_entity < single_agent < flight < mesh`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum ProposalBlastRadius {
+    SingleEntity,
+    SingleAgent,
+    Flight,
+    Mesh,
+}
+
+/// Audit-plane origins a kit accepts proposals from.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProposalOriginSpec {
+    Consolidation,
+    Critic,
+    Historian,
+    Human,
+}
+
+/// Approval mechanism for proposals above a role's auto-apply ceiling.
+/// Mirrors ARP §15.1 `ApprovalMechanism`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProposalApprovalMechanism {
+    CredentialPresentation,
+    SignedCommand,
+    InteractiveConfirmation,
+}
+
+/// Per-role governance ceiling.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RoleProposalCeiling {
+    /// Role id — must exist in the manifest's `roles`.
+    pub role: String,
+    /// Largest blast radius this role's ARP may auto-apply. `mesh` is never
+    /// permitted as an auto-apply ceiling and fails validation.
+    pub auto_apply_max_blast_radius: ProposalBlastRadius,
+}
+
+/// Kit-level proposal governance block.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ProposalGovernanceSpec {
+    /// Origins every role in this kit accepts proposals from. Empty means
+    /// the conservative default (human only) at derivation time.
+    #[serde(default)]
+    pub accepted_origins: Vec<ProposalOriginSpec>,
+    /// Per-role ceilings. Roles without an entry derive the default
+    /// (`single_entity`).
+    #[serde(default)]
+    pub role_ceilings: Vec<RoleProposalCeiling>,
+    /// Approval mechanism for proposals above a role's auto-apply ceiling —
+    /// notably flight-radius proposals.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub flight_approval: Option<ProposalApprovalMechanism>,
+    /// Observation window applied to derived proposal policies, seconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observation_window_sec: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blast_radius_ordering_and_wire_format() {
+        assert!(ProposalBlastRadius::SingleEntity < ProposalBlastRadius::Mesh);
+        assert_eq!(
+            serde_json::to_string(&ProposalBlastRadius::SingleAgent).unwrap(),
+            "\"single_agent\""
+        );
+    }
+
+    #[test]
+    fn governance_round_trips() {
+        let json = r#"{
+            "accepted_origins": ["consolidation", "human"],
+            "role_ceilings": [
+                {"role": "commander", "auto_apply_max_blast_radius": "single_agent"},
+                {"role": "historian", "auto_apply_max_blast_radius": "single_entity"}
+            ],
+            "flight_approval": "interactive_confirmation",
+            "observation_window_sec": 3600
+        }"#;
+        let g: ProposalGovernanceSpec = serde_json::from_str(json).unwrap();
+        assert_eq!(g.accepted_origins.len(), 2);
+        assert_eq!(g.role_ceilings.len(), 2);
+        assert_eq!(
+            g.flight_approval,
+            Some(ProposalApprovalMechanism::InteractiveConfirmation)
+        );
+        let back = serde_json::to_string(&g).unwrap();
+        let g2: ProposalGovernanceSpec = serde_json::from_str(&back).unwrap();
+        assert_eq!(g, g2);
+    }
+
+    #[test]
+    fn minimal_governance_defaults() {
+        let g: ProposalGovernanceSpec = serde_json::from_str("{}").unwrap();
+        assert!(g.accepted_origins.is_empty());
+        assert!(g.role_ceilings.is_empty());
+        assert!(g.flight_approval.is_none());
+    }
+}

--- a/crates/arkavo-swarmkit/src/lib.rs
+++ b/crates/arkavo-swarmkit/src/lib.rs
@@ -23,9 +23,12 @@ pub use coordination::{
     Routing, Signature,
 };
 pub use manifest::{Author, DeliverableSpec, InputSpec, KitMetadata, Manifest, Objective};
+#[allow(deprecated)]
+pub use role::ArpRule;
 pub use role::{
-    AgentProvisioning, ArpRule, Budget, ContextScope, Failure, Handoff, Inference, McpToolGrant,
-    Model, Observability, RoleSpec, Skill, SkillSource, TdfAttributeReleasePolicy, ToolUse,
+    AgentProvisioning, Budget, ContextScope, Failure, Handoff, Inference, McpToolGrant, Model,
+    Observability, RoleSpec, Skill, SkillSource, TdfAttributeReleasePolicy, TdfReleaseRule,
+    ToolUse,
 };
 pub use skill_content::{SkillContent, SkillResource};
 pub use validate::{ValidationError, validate};

--- a/crates/arkavo-swarmkit/src/lib.rs
+++ b/crates/arkavo-swarmkit/src/lib.rs
@@ -32,7 +32,7 @@ pub use manifest::{Author, DeliverableSpec, InputSpec, KitMetadata, Manifest, Ob
 pub use role::ArpRule;
 pub use role::{
     AgentProvisioning, Budget, ContextScope, Failure, Handoff, Inference, McpToolGrant, Model,
-    Observability, RoleSpec, Skill, SkillSource, TdfAttributeReleasePolicy, TdfReleaseRule,
+    Observability, Plane, RoleSpec, Skill, SkillSource, TdfAttributeReleasePolicy, TdfReleaseRule,
     ToolUse,
 };
 pub use skill_content::{SkillContent, SkillResource};

--- a/crates/arkavo-swarmkit/src/lib.rs
+++ b/crates/arkavo-swarmkit/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod canonical;
 pub mod coordination;
+pub mod governance;
 pub mod manifest;
 pub mod role;
 pub mod skill_content;
@@ -21,6 +22,10 @@ pub use coordination::{
     CompactionSpec, CompletionSpec, ConstraintsSpec, CoordinationSpec, EvaluationDimension,
     EvaluationRubric, EvaluationSpec, GlobalBudget, NetworkConstraints, OnFailure, ProvenanceSpec,
     Routing, Signature,
+};
+pub use governance::{
+    ProposalApprovalMechanism, ProposalBlastRadius, ProposalGovernanceSpec, ProposalOriginSpec,
+    RoleProposalCeiling,
 };
 pub use manifest::{Author, DeliverableSpec, InputSpec, KitMetadata, Manifest, Objective};
 #[allow(deprecated)]

--- a/crates/arkavo-swarmkit/src/manifest.rs
+++ b/crates/arkavo-swarmkit/src/manifest.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::coordination::{
     CompletionSpec, ConstraintsSpec, CoordinationSpec, EvaluationSpec, ProvenanceSpec,
 };
+use crate::governance::ProposalGovernanceSpec;
 use crate::role::RoleSpec;
 
 /// Top-level SwarmKit manifest. Cleartext document inside the TDF payload.
@@ -22,6 +23,10 @@ pub struct Manifest {
     pub constraints: ConstraintsSpec,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub evaluation: Option<EvaluationSpec>,
+    /// Kit-level tightening-proposal governance. Optional: absent means no
+    /// derived proposal policy (roles ingest nothing).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proposal_governance: Option<ProposalGovernanceSpec>,
     pub completion: CompletionSpec,
     pub provenance: ProvenanceSpec,
 }

--- a/crates/arkavo-swarmkit/src/role.rs
+++ b/crates/arkavo-swarmkit/src/role.rs
@@ -257,16 +257,25 @@ pub enum AuthMode {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TdfAttributeReleasePolicy {
     pub attributes: Vec<String>,
-    pub rule: ArpRule,
+    pub rule: TdfReleaseRule,
 }
 
+/// TDF attribute-release rule (allOf/anyOf/hierarchy), evaluated KAS-side.
+///
+/// Unrelated to Agent Runtime Policy — renamed from `ArpRule` so the name
+/// can't collide with ARP proposal vocabulary. The wire format is only the
+/// camelCase variant names, so existing manifests are unaffected.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub enum ArpRule {
+pub enum TdfReleaseRule {
     AllOf,
     AnyOf,
     Hierarchy,
 }
+
+/// Compatibility alias for the pre-rename name.
+#[deprecated(since = "0.79.0", note = "renamed to TdfReleaseRule")]
+pub type ArpRule = TdfReleaseRule;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Handoff {
@@ -306,9 +315,23 @@ mod tests {
     }
 
     #[test]
-    fn arp_rule_serializes_camel_case() {
-        let r = ArpRule::AllOf;
+    fn tdf_release_rule_serializes_camel_case() {
+        let r = TdfReleaseRule::AllOf;
         assert_eq!(serde_json::to_string(&r).unwrap(), "\"allOf\"");
+    }
+
+    #[test]
+    fn tdf_release_rule_wire_format_unchanged_by_rename() {
+        // Regression for the ArpRule → TdfReleaseRule rename: manifests
+        // serialized before the rename must still deserialize.
+        for (json, expected) in [
+            ("\"allOf\"", TdfReleaseRule::AllOf),
+            ("\"anyOf\"", TdfReleaseRule::AnyOf),
+            ("\"hierarchy\"", TdfReleaseRule::Hierarchy),
+        ] {
+            let parsed: TdfReleaseRule = serde_json::from_str(json).unwrap();
+            assert_eq!(parsed, expected);
+        }
     }
 
     #[spec("SK-016")]

--- a/crates/arkavo-swarmkit/src/role.rs
+++ b/crates/arkavo-swarmkit/src/role.rs
@@ -2,11 +2,30 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Which plane a role operates on. Coordination roles drive work;
+/// learning and audit roles observe it. The wiring rule is type-level:
+/// learning/audit roles may not have coordination outputs — no handoff
+/// delegation and no shared-context writes (enforced by validation). They
+/// emit only tightening proposals and provenance-tagged prior observations.
+/// This is the encoding of "the teacher rides the audit plane, never the
+/// coordination plane."
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Plane {
+    Coordination,
+    Learning,
+    Audit,
+}
+
 /// RoleSpec per §4.3. `role_type` is free-form per Appendix C.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RoleSpec {
     pub id: String,
     pub role_type: String,
+    /// Plane declaration. Absent means coordination (the historical
+    /// default for every existing manifest).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plane: Option<Plane>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub agent_provisioning: AgentProvisioning,

--- a/crates/arkavo-swarmkit/src/validate.rs
+++ b/crates/arkavo-swarmkit/src/validate.rs
@@ -511,7 +511,7 @@ mod tests {
                 "https://attr.arkavo.com/jurisdiction/us-ca".into(),
                 "https://attr.arkavo.com/audit_authority/true".into(),
             ],
-            rule: ArpRule::AllOf,
+            rule: TdfReleaseRule::AllOf,
         });
         validate(&m).expect("custom attribute strings should validate");
         let attrs = &m.roles[0]

--- a/crates/arkavo-swarmkit/src/validate.rs
+++ b/crates/arkavo-swarmkit/src/validate.rs
@@ -69,6 +69,15 @@ pub enum ValidationError {
     )]
     MeshAutoApplyCeiling { role: String },
 
+    #[error(
+        "role {role:?} declares plane={plane} but has coordination outputs ({output}); learning/audit roles may emit only tightening proposals and provenance-tagged prior observations"
+    )]
+    PlaneWiringViolation {
+        role: String,
+        plane: &'static str,
+        output: &'static str,
+    },
+
     #[error("evaluation.rubric.dimensions weight sum {sum} is not 1.0 (within ±1e-6)")]
     RubricWeightsDoNotSumToOne { sum: f64 },
 
@@ -139,6 +148,7 @@ pub fn validate(m: &Manifest) -> Result<(), ValidationError> {
         }
         validate_role_budget(role, &m.constraints.global_budget)?;
         validate_network_egress(role, m.constraints.network.egress_allowed)?;
+        validate_plane_wiring(role)?;
     }
 
     if let Some(eval) = &m.evaluation {
@@ -164,6 +174,35 @@ pub fn validate(m: &Manifest) -> Result<(), ValidationError> {
         validate_kit_id(m)?;
     }
 
+    Ok(())
+}
+
+/// Learning/audit roles must not have coordination outputs: no handoff
+/// delegation, no shared-context writes. The type-level half of "Fable on
+/// the audit plane, never the coordination plane".
+fn validate_plane_wiring(role: &crate::role::RoleSpec) -> Result<(), ValidationError> {
+    use crate::role::Plane;
+    let plane = match role.plane {
+        Some(Plane::Learning) => "learning",
+        Some(Plane::Audit) => "audit",
+        Some(Plane::Coordination) | None => return Ok(()),
+    };
+    if !role.handoffs.is_empty() {
+        return Err(ValidationError::PlaneWiringViolation {
+            role: role.id.clone(),
+            plane,
+            output: "handoffs (A2A delegation)",
+        });
+    }
+    if let Some(scope) = &role.context_scope
+        && !scope.can_write.is_empty()
+    {
+        return Err(ValidationError::PlaneWiringViolation {
+            role: role.id.clone(),
+            plane,
+            output: "context_scope.can_write",
+        });
+    }
     Ok(())
 }
 
@@ -311,6 +350,7 @@ mod tests {
             roles: vec![RoleSpec {
                 id: "r1".into(),
                 role_type: "specialist".into(),
+                plane: None,
                 description: None,
                 agent_provisioning: AgentProvisioning::default(),
                 skills: vec![],
@@ -623,5 +663,58 @@ mod tests {
             validate(&m),
             Err(ValidationError::MeshAutoApplyCeiling { role }) if role == "r1"
         ));
+    }
+    #[test]
+    fn audit_plane_role_with_handoffs_rejected() {
+        let mut m = minimal_manifest();
+        m.roles[0].plane = Some(crate::role::Plane::Audit);
+        m.roles[0].handoffs = vec![Handoff {
+            to: "r1".into(),
+            on: "done".into(),
+        }];
+        assert!(matches!(
+            validate(&m),
+            Err(ValidationError::PlaneWiringViolation { plane: "audit", .. })
+        ));
+    }
+
+    #[test]
+    fn learning_plane_role_with_context_writes_rejected() {
+        let mut m = minimal_manifest();
+        m.roles[0].plane = Some(crate::role::Plane::Learning);
+        m.roles[0].context_scope = Some(ContextScope {
+            can_read: vec!["*".into()],
+            can_write: vec!["lessons".into()],
+        });
+        assert!(matches!(
+            validate(&m),
+            Err(ValidationError::PlaneWiringViolation {
+                plane: "learning",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn audit_plane_role_without_outputs_validates() {
+        let mut m = minimal_manifest();
+        m.roles[0].plane = Some(crate::role::Plane::Audit);
+        m.roles[0].context_scope = Some(ContextScope {
+            can_read: vec!["*".into()],
+            can_write: vec![],
+        });
+        assert!(validate(&m).is_ok());
+    }
+
+    #[test]
+    fn coordination_role_keeps_handoffs() {
+        // Handoffs stay legal for coordination roles (declared or default).
+        let mut m = minimal_manifest();
+        m.roles[0].plane = Some(crate::role::Plane::Coordination);
+        m.roles[0].handoffs = vec![Handoff {
+            to: "r1".into(),
+            on: "done".into(),
+        }];
+        assert!(validate(&m).is_ok());
     }
 }

--- a/crates/arkavo-swarmkit/src/validate.rs
+++ b/crates/arkavo-swarmkit/src/validate.rs
@@ -59,6 +59,16 @@ pub enum ValidationError {
     #[error("evaluation.rubric.dimensions is empty; at least one dimension is required (§4.6)")]
     EmptyRubricDimensions,
 
+    #[error(
+        "proposal_governance.role_ceilings references role {0:?} which does not resolve to a known role"
+    )]
+    UnresolvedGovernanceRole(String),
+
+    #[error(
+        "proposal_governance.role_ceilings: role {role:?} sets auto_apply_max_blast_radius=mesh; mesh-radius proposals are never auto-applied"
+    )]
+    MeshAutoApplyCeiling { role: String },
+
     #[error("evaluation.rubric.dimensions weight sum {sum} is not 1.0 (within ±1e-6)")]
     RubricWeightsDoNotSumToOne { sum: f64 },
 
@@ -146,12 +156,35 @@ pub fn validate(m: &Manifest) -> Result<(), ValidationError> {
         }
     }
 
+    validate_proposal_governance(m, &role_ids)?;
+
     validate_expiry(m)?;
 
     if !m.kit.id.is_empty() {
         validate_kit_id(m)?;
     }
 
+    Ok(())
+}
+
+fn validate_proposal_governance(
+    m: &Manifest,
+    role_ids: &HashSet<&str>,
+) -> Result<(), ValidationError> {
+    if let Some(gov) = &m.proposal_governance {
+        for ceiling in &gov.role_ceilings {
+            if !role_ids.contains(ceiling.role.as_str()) {
+                return Err(ValidationError::UnresolvedGovernanceRole(
+                    ceiling.role.clone(),
+                ));
+            }
+            if ceiling.auto_apply_max_blast_radius == crate::governance::ProposalBlastRadius::Mesh {
+                return Err(ValidationError::MeshAutoApplyCeiling {
+                    role: ceiling.role.clone(),
+                });
+            }
+        }
+    }
     Ok(())
 }
 
@@ -309,6 +342,7 @@ mod tests {
                 },
             },
             evaluation: None,
+            proposal_governance: None,
             completion: CompletionSpec {
                 rules: vec!["all deliverables present".into()],
                 on_failure: OnFailure::Abort,
@@ -534,5 +568,60 @@ mod tests {
         ];
         validate(&m).expect("custom data_classifications should validate");
         assert_eq!(m.constraints.data_classifications.len(), 3);
+    }
+    #[test]
+    fn governance_with_known_roles_validates() {
+        use crate::governance::{
+            ProposalBlastRadius, ProposalGovernanceSpec, ProposalOriginSpec, RoleProposalCeiling,
+        };
+        let mut m = minimal_manifest();
+        m.proposal_governance = Some(ProposalGovernanceSpec {
+            accepted_origins: vec![ProposalOriginSpec::Human],
+            role_ceilings: vec![RoleProposalCeiling {
+                role: "r1".into(),
+                auto_apply_max_blast_radius: ProposalBlastRadius::SingleAgent,
+            }],
+            flight_approval: None,
+            observation_window_sec: None,
+        });
+        assert!(validate(&m).is_ok());
+    }
+
+    #[test]
+    fn governance_unknown_role_rejected() {
+        use crate::governance::{ProposalBlastRadius, ProposalGovernanceSpec, RoleProposalCeiling};
+        let mut m = minimal_manifest();
+        m.proposal_governance = Some(ProposalGovernanceSpec {
+            accepted_origins: vec![],
+            role_ceilings: vec![RoleProposalCeiling {
+                role: "ghost".into(),
+                auto_apply_max_blast_radius: ProposalBlastRadius::SingleEntity,
+            }],
+            flight_approval: None,
+            observation_window_sec: None,
+        });
+        assert!(matches!(
+            validate(&m),
+            Err(ValidationError::UnresolvedGovernanceRole(r)) if r == "ghost"
+        ));
+    }
+
+    #[test]
+    fn governance_mesh_auto_apply_rejected() {
+        use crate::governance::{ProposalBlastRadius, ProposalGovernanceSpec, RoleProposalCeiling};
+        let mut m = minimal_manifest();
+        m.proposal_governance = Some(ProposalGovernanceSpec {
+            accepted_origins: vec![],
+            role_ceilings: vec![RoleProposalCeiling {
+                role: "r1".into(),
+                auto_apply_max_blast_radius: ProposalBlastRadius::Mesh,
+            }],
+            flight_approval: None,
+            observation_window_sec: None,
+        });
+        assert!(matches!(
+            validate(&m),
+            Err(ValidationError::MeshAutoApplyCeiling { role }) if role == "r1"
+        ));
     }
 }

--- a/crates/arkavo-swarmkit/src/validate.rs
+++ b/crates/arkavo-swarmkit/src/validate.rs
@@ -664,6 +664,7 @@ mod tests {
             Err(ValidationError::MeshAutoApplyCeiling { role }) if role == "r1"
         ));
     }
+    #[spec("SK-093")]
     #[test]
     fn audit_plane_role_with_handoffs_rejected() {
         let mut m = minimal_manifest();
@@ -678,6 +679,7 @@ mod tests {
         ));
     }
 
+    #[spec("SK-093")]
     #[test]
     fn learning_plane_role_with_context_writes_rejected() {
         let mut m = minimal_manifest();
@@ -695,6 +697,7 @@ mod tests {
         ));
     }
 
+    #[spec("SK-093")]
     #[test]
     fn audit_plane_role_without_outputs_validates() {
         let mut m = minimal_manifest();

--- a/docs/substrate-trade-study.md
+++ b/docs/substrate-trade-study.md
@@ -1,0 +1,103 @@
+# Substrate trade study: torg circuits and WASM components
+
+Decision record for issue #615. Status: **ratified** (pending review).
+
+## Decision
+
+Evolved capability in arkavo-edge is split across two substrates with a hard
+boundary between them:
+
+- **Decision plane — TØRG circuits.** Whether and when an action may happen
+  is decided by torg boolean graphs, compiled to `CompiledCircuit` for
+  nanosecond evaluation. This stays the only substrate for gating decisions.
+- **Effect plane — WASM Component Model via wasmtime.** How an effectful
+  capability does its work (parsing, transformation, API choreography) is the
+  domain of evolved WASM components, executed under wasmtime with fuel and
+  capability-scoped imports.
+
+Every evolved capability is gated by a torg-verified circuit: the circuit
+decides whether/when, the component decides only how. A component call that
+the gating circuit denies never executes.
+
+## Why the split
+
+The verification power of torg circuits comes from their **inexpressiveness**.
+A boolean graph over typed features has no loops, no allocation, no I/O — so
+the verifier surface is real and total:
+
+- `arkavo-sat` extracts CNF (Tseitin) and uses a CDCL solver to probe
+  decision boundaries, find policy holes, and prove tautology/contradiction.
+- `arkavo-sbe` layers circuits hierarchically (Invariant / Policy / Adaptive)
+  with Ed25519-signed invariant contracts that lower layers cannot modify by
+  construction, and bounded model checking on policy updates.
+- `arkavo-torg-circuits` compiles graphs to pre-allocated buffers evaluated
+  in nanoseconds — cheap enough to gate every request.
+
+Generalizing circuits toward effectful capability would destroy exactly the
+property that makes them verifiable. Conversely, effectful code needs a real
+execution substrate; that substrate must be sandboxed, metered, and
+deny-by-default. The WASM Component Model is the only candidate that gives
+us all three plus a typed contract surface (WIT) and a production embedder
+(wasmtime) with fuel/epoch interruption and per-instance import control.
+
+## Alternatives considered
+
+| Alternative | Rejected because |
+|---|---|
+| Extend torg with effectful nodes | Destroys SAT-verifiability — the whole value of the decision plane. |
+| Native dynamic libraries (dlopen) | No sandbox, no metering, no capability scoping; a single evolved bug is process compromise. |
+| Embedded scripting (Lua/Rhai/JS) | Weaker isolation than WASM, no typed contract surface, another language in the threat model. |
+| Subprocess-per-capability | Sandbox possible but heavyweight (process per call), capability scoping via OS only, poor portability to the supported targets. |
+| WASM core modules (no component model) | Loses typed interfaces (WIT) and structured imports; capability scoping degenerates to hand-rolled ABI conventions. |
+
+## Version pinning
+
+- **WIT contract format: WASI 0.2 worlds for v1.** WASI 0.3 (async, shipped
+  February 2026) is adopted only after one wasmtime LTS cycle on 0.3 —
+  contract churn is the main schedule risk for evolved-capability stability.
+- wasmtime is pinned to an LTS release and upgraded deliberately, never
+  floated.
+
+## Security invariants
+
+- **No hot evolved code.** Components execute only as members of a signed,
+  TDF-wrapped kit. The kit signature (ed25519 over BLAKE3 of the canonical
+  manifest) covers the component digest; an unsigned or re-signed-without-
+  review component does not load.
+- **Deny-by-default imports.** A component's imports are derived from the
+  role's ARP: network egress rules → outbound host grants, fs scopes →
+  preopened dirs, `McpToolGrant` → callable tool imports. No ambient
+  authority.
+- **Metered execution.** Fuel/epoch budgets derive from the role ARP budget
+  config; exhaustion is a trap, recorded in the DecisionTrace, never a hang.
+- **Canary first.** New capability runs under an ARP Quarantine-scoped canary
+  before general availability (see CapabilityProposal gates, issue #617).
+
+## Empirical gate (issue #616)
+
+Labels are insufficient — the same lesson as MoE effective parameters. The
+spike must demonstrate, with numbers on M-series and mini-DC hardware:
+
+1. Fuel/epoch budgets driven from ARP budget config.
+2. Import grants derived from a role ARP (network→egress, fs→allowed_paths,
+   McpToolGrant mapping).
+3. Cold instantiate, pooled instantiate, and call overhead vs an in-process
+   tool.
+4. One toy evolved tool end to end: WIT world → component → kit-signed →
+   executed under a quarantine canary.
+
+Binary-size note: wasmtime is a multi-megabyte dependency and the repo has a
+≤60MB binary budget plus a Windows no-C++ default build. The embedding crate
+stays out of `default-members` and behind a non-default feature until the
+spike numbers justify promotion.
+
+## Consequences
+
+- Capability addition is structurally separate from policy tightening: a new
+  component cannot ride the TighteningProposal channel (closed effect enum);
+  it goes through the CapabilityProposal gates (#617) — verifier pass
+  (sbe+sat), WIT conformance, SwarmKit conformance, quarantine canary, human
+  approval, kit re-sign. Two channels, asymmetric friction: tightenings
+  flow, capabilities crawl.
+- The decision plane remains formally analyzable forever; growth pressure
+  lands on the effect plane where the sandbox absorbs it.

--- a/docs/swarmkit-stability.md
+++ b/docs/swarmkit-stability.md
@@ -208,13 +208,13 @@ The current published spec drafts are `swarmkit-spec-draft-00` and `swarmkit-spe
 | `McpToolGrant.auth` (AuthMode) | stable | |
 | `AuthMode` (enum: Delegated, Passthrough, None) | stable | Runtime grant issuance is aspirational; field set stable. |
 
-## TdfAttributeReleasePolicy / ArpRule
+## TdfAttributeReleasePolicy / TdfReleaseRule
 
 | Field | Tier | Note |
 |---|---|---|
 | `TdfAttributeReleasePolicy.attributes` (Vec<String>) | stable | Free-form FQN strings (SK-008). Each must be `<fqn>/<value>` form. |
-| `TdfAttributeReleasePolicy.rule` (ArpRule) | stable | |
-| `ArpRule` (enum: AllOf, AnyOf, Hierarchy) | stable | Hierarchy semantics evaluated KAS-side at attribute-definition time. |
+| `TdfAttributeReleasePolicy.rule` (TdfReleaseRule) | stable | |
+| `TdfReleaseRule` (enum: AllOf, AnyOf, Hierarchy) | stable | Hierarchy semantics evaluated KAS-side at attribute-definition time. Renamed from `ArpRule` (it is a TDF attribute-release rule, not Agent Runtime Policy); wire format unchanged — only camelCase variant names are serialized. A deprecated `ArpRule` type alias remains for one release. |
 
 ## Handoff / ContextScope
 

--- a/examples/shadow-teacher-kit/.gitignore
+++ b/examples/shadow-teacher-kit/.gitignore
@@ -1,0 +1,7 @@
+logs/
+out/
+.agent_pids
+code-reviewer/.arkavo/
+test-writer/.arkavo/
+code-reviewer/workspace/
+test-writer/workspace/

--- a/examples/shadow-teacher-kit/README.md
+++ b/examples/shadow-teacher-kit/README.md
@@ -1,0 +1,77 @@
+# Shadow Teacher Kit
+
+A small data-gathering swarm for the shadow consolidation teacher. Two
+coordination-plane workers execute tool-driven tasks with local models,
+producing real episode traces in the learning store; the audit-plane
+`shadow-teacher` role in the kit manifest demonstrates the plane
+separation rule (no handoffs, no context writes — the teacher observes,
+it never drives work). The `arkavo-shadow-consolidation` job then reads
+the gathered episodes read-only and previews the consolidation batch
+with a zero-spend dry run.
+
+## What it demonstrates
+
+- **Plane declaration**: the kit manifest carries `plane: "audit"` on the
+  shadow-teacher role; kit validation rejects audit-plane roles with
+  handoffs or context writes.
+- **Episode gathering**: tasks force the workers to read files with their
+  filesystem tools, so tool observations flow through the learning
+  pipeline (`observations -> synthesized episodes -> .arkavo/learning/lessons.db`).
+- **Shadow consolidation**: the standalone job opens the merged store
+  read-only, strips observe/list calls per the lesson-synthesis rule,
+  batches each task category, and (in dry-run) writes the exact prompts
+  it would send to Fable — plus the cost ledger scaffolding — without
+  spending anything.
+
+## Requirements
+
+- `cargo build` from the repo root (debug binary is fine)
+- The local model: `hf download ggml-org/gemma-4-E4B-it-GGUF gemma-4-E4B-it-Q4_K_M.gguf`
+  (both workers share it; episode synthesis reuses the loaded model)
+- `jq`, `curl`, `sqlite3`
+- `node`/`npx` — the workers get filesystem tools from
+  `@modelcontextprotocol/server-filesystem` (auto-fetched on first run,
+  rooted at each agent's `workspace/`)
+
+## Run
+
+```bash
+cd examples/shadow-teacher-kit
+./run.sh
+```
+
+The script validates and launches the kit manifest, starts both agents,
+submits the six tasks from `tasks.json` sequentially (local inference
+takes minutes per task), waits for episode synthesis, merges the two
+agents' learning stores into `out/episodes.db`, and runs:
+
+```bash
+arkavo-shadow-consolidation --db out/episodes.db --out out/shadow --min-episodes 2 --dry-run
+```
+
+Artifacts land in `out/shadow/`:
+
+- `prompts.json` — the exact per-category prompts Fable would receive
+- `cost_ledger.json` — zeroed ledger with batch/episode accounting
+- `lessons.json`, `proposals.json`, `findings.json`, `rejects.json` —
+  empty in dry-run; populated by a live run
+
+## Live run (optional, real spend)
+
+```bash
+export ANTHROPIC_API_KEY=...
+cargo run -p arkavo-shadow-consolidation -- \
+  --db examples/shadow-teacher-kit/out/episodes.db \
+  --out examples/shadow-teacher-kit/out/shadow-live \
+  --min-episodes 2 --max-run-cost-usd 1.0
+```
+
+The run-level ceiling stops the job between batches and marks the ledger
+`budget_exhausted`; partial outputs always survive.
+
+## Stop / cleanup
+
+```bash
+./stop.sh                  # stop agents
+rm -rf out logs */workspace */.arkavo   # reset gathered data
+```

--- a/examples/shadow-teacher-kit/code-reviewer/AGENTS.md
+++ b/examples/shadow-teacher-kit/code-reviewer/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## code-reviewer-agent
+purpose: |
+  You review source code for security and quality issues.
+
+  For every task, FIRST read the file named in the task with your
+  filesystem tools, then review what you actually read. Never review
+  from memory — the file on disk is the source of truth.
+
+  When reviewing, report:
+  - The exact vulnerable or low-quality lines
+  - Why each finding matters (injection, panic path, complexity)
+  - A concrete fix as a code snippet
+
+  Keep answers under 300 words. Specific findings beat prose.
+
+model:   gemma-4-e4b
+listen:  0.0.0.0:8430
+
+discovery:
+  mdns: true
+
+mcp_servers:
+  - name: filesystem
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "workspace"]

--- a/examples/shadow-teacher-kit/run.sh
+++ b/examples/shadow-teacher-kit/run.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+# Shadow Teacher Kit — gather real episode traces with local models, then
+# preview the shadow-consolidation batch with a zero-spend dry run.
+#
+# Stages:
+#   1. Validate and launch the kit manifest (plane separation included)
+#   2. Start the two worker agents with local models
+#   3. Submit the tool-driven tasks from tasks.json
+#   4. Wait for episodes to land in the learning stores
+#   5. Merge the stores and run arkavo-shadow-consolidation --dry-run
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BINARY="${BINARY:-${PROJECT_ROOT}/target/debug/arkavo}"
+if [ ! -f "$BINARY" ]; then
+    BINARY="${PROJECT_ROOT}/target/release/arkavo"
+fi
+LOG_DIR="$SCRIPT_DIR/logs"
+OUT_DIR="$SCRIPT_DIR/out"
+PID_FILE="$SCRIPT_DIR/.agent_pids"
+MANIFEST="$SCRIPT_DIR/shadow-teacher-kit.swarmkit.yaml"
+TASKS_FILE="$SCRIPT_DIR/tasks.json"
+AGENTS=("code-reviewer:8430" "test-writer:8432")
+# Local inference is slow; allow generous per-task and episode waits.
+TASK_TIMEOUT="${TASK_TIMEOUT:-420}"
+EPISODE_WAIT="${EPISODE_WAIT:-300}"
+SQLITE="${SQLITE:-sqlite3}"
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; BLUE='\033[0;34m'; NC='\033[0m'
+info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
+ok()      { echo -e "${GREEN}[OK]${NC} $1"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
+fail()    { echo -e "${RED}[ERROR]${NC} $1"; }
+
+mkdir -p "$LOG_DIR" "$OUT_DIR"
+
+check_prerequisites() {
+    [ -f "$BINARY" ] || { fail "arkavo binary not found — run: cargo build"; exit 1; }
+    ok "arkavo binary: $BINARY"
+    for cmd in jq curl "$SQLITE"; do
+        command -v "$cmd" >/dev/null || { fail "$cmd is required"; exit 1; }
+    done
+    local hf_cache="${HF_HOME:-$HOME/.cache/huggingface}/hub"
+    if [ -d "$hf_cache/models--ggml-org--gemma-4-E4B-it-GGUF" ]; then
+        ok "gemma-4-e4b model cached"
+    else
+        warn "gemma-4-e4b not cached; first task will be slow or fail."
+        warn "Download: hf download ggml-org/gemma-4-E4B-it-GGUF gemma-4-E4B-it-Q4_K_M.gguf"
+    fi
+}
+
+validate_kit() {
+    info "Validating kit manifest (parse + flight launch + per-role ARP)..."
+    (cd "$PROJECT_ROOT" && cargo run -q -p arkavo-swarmkit-runtime \
+        --example swarm_flight_demo -- "$MANIFEST") \
+        > "$LOG_DIR/kit-validation.log" 2>&1 \
+        || { fail "kit manifest failed validation — see logs/kit-validation.log"; exit 1; }
+    ok "kit manifest valid; flight launched (see logs/kit-validation.log)"
+}
+
+stop_agents() {
+    if [ -f "$PID_FILE" ]; then
+        while IFS= read -r pid; do
+            kill "$pid" 2>/dev/null || true
+        done < "$PID_FILE"
+        rm -f "$PID_FILE"
+    fi
+    # Belt and suspenders: an agent that survives across runs keeps its
+    # ports and an open handle to a learning store we are about to reset,
+    # which then fails writes with SQLITE_READONLY_DBMOVED. Kill any
+    # stragglers and wait for the ports to actually free.
+    pkill -f "$BINARY agent run" 2>/dev/null || true
+    for entry in "${AGENTS[@]}"; do
+        local port="${entry#*:}"
+        for _ in $(seq 1 20); do
+            lsof -iTCP:"$port" -sTCP:LISTEN -n >/dev/null 2>&1 || break
+            sleep 0.5
+        done
+    done
+}
+
+start_agents() {
+    : > "$PID_FILE"
+    for entry in "${AGENTS[@]}"; do
+        local name="${entry%:*}" port="${entry#*:}"
+        local dir="$SCRIPT_DIR/$name"
+        # Each agent reads the sample files from its own workspace so the
+        # filesystem tools operate inside the agent's working directory.
+        mkdir -p "$dir/workspace"
+        cp "$SCRIPT_DIR"/sample/*.rs "$dir/workspace/"
+        info "Starting $name (port $port)..."
+        (cd "$dir" && RUST_LOG=info nohup "$BINARY" agent run \
+            > "$LOG_DIR/$name.log" 2>&1 & echo $! >> "$PID_FILE")
+    done
+
+    info "Waiting for agents to come up..."
+    for entry in "${AGENTS[@]}"; do
+        local name="${entry%:*}" port="${entry#*:}"
+        for _ in $(seq 1 60); do
+            if curl -sf "http://localhost:$port/.well-known/agent.json" >/dev/null 2>&1; then
+                ok "$name ready on port $port"
+                continue 2
+            fi
+            sleep 2
+        done
+        fail "$name never became ready — see logs/$name.log"
+        exit 1
+    done
+}
+
+submit_tasks() {
+    local count
+    count=$(jq '.tasks | length' "$TASKS_FILE")
+    info "Submitting $count tool-driven tasks (sequential; local inference takes minutes per task)..."
+    for i in $(seq 0 $((count - 1))); do
+        local id prompt port
+        id=$(jq -r ".tasks[$i].id" "$TASKS_FILE")
+        prompt=$(jq -r ".tasks[$i].prompt" "$TASKS_FILE")
+        port=$(jq -r ".tasks[$i].port" "$TASKS_FILE")
+        info "Task $((i + 1))/$count [$id] -> port $port"
+        local response
+        response=$(curl -sf --max-time "$TASK_TIMEOUT" -X POST "http://localhost:$port" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg t "$prompt" '{
+                jsonrpc: "2.0", id: 1, method: "message/send",
+                params: { request: { message: { parts: [{ type: "text", content: $t }] } } }
+            }')" || echo "")
+        if [ -n "$response" ] && ! echo "$response" | jq -e '.error' >/dev/null 2>&1; then
+            ok "task $id completed"
+        else
+            warn "task $id failed or timed out (continuing): ${response:0:160}"
+        fi
+    done
+}
+
+episode_count() {
+    local total=0
+    for entry in "${AGENTS[@]}"; do
+        local name="${entry%:*}"
+        local db="$SCRIPT_DIR/$name/.arkavo/learning/lessons.db"
+        if [ -f "$db" ]; then
+            local n
+            n=$("$SQLITE" "file:$db?mode=ro" \
+                "SELECT COUNT(*) FROM episodes" 2>/dev/null || echo 0)
+            total=$((total + n))
+        fi
+    done
+    echo "$total"
+}
+
+wait_for_episodes() {
+    info "Waiting for episode synthesis (threshold: 2 observations per category)..."
+    local waited=0
+    while [ "$waited" -lt "$EPISODE_WAIT" ]; do
+        local n
+        n=$(episode_count)
+        if [ "$n" -ge 2 ]; then
+            ok "$n episodes recorded"
+            return 0
+        fi
+        sleep 10
+        waited=$((waited + 10))
+    done
+    warn "Only $(episode_count) episodes after ${EPISODE_WAIT}s — continuing with what exists"
+}
+
+merge_stores() {
+    local merged="$OUT_DIR/episodes.db"
+    rm -f "$merged"
+    "$SQLITE" "$merged" "CREATE TABLE episodes (id TEXT PRIMARY KEY, \
+        task_category TEXT NOT NULL, observation_json TEXT NOT NULL, \
+        outcome_json TEXT NOT NULL)"
+    for entry in "${AGENTS[@]}"; do
+        local name="${entry%:*}"
+        local db="$SCRIPT_DIR/$name/.arkavo/learning/lessons.db"
+        [ -f "$db" ] || continue
+        "$SQLITE" "$merged" "ATTACH '$db' AS src; \
+            INSERT OR IGNORE INTO episodes \
+            SELECT id, task_category, observation_json, outcome_json \
+            FROM src.episodes; DETACH src;" 2>/dev/null || true
+    done
+    local n
+    n=$("$SQLITE" "$merged" "SELECT COUNT(*) FROM episodes")
+    ok "merged store: $n episodes -> out/episodes.db"
+    "$SQLITE" "$merged" "SELECT task_category, COUNT(*) FROM episodes GROUP BY task_category" \
+        | sed 's/^/    /'
+}
+
+run_shadow_dry() {
+    info "Running shadow-consolidation dry run (zero spend, no API key)..."
+    (cd "$PROJECT_ROOT" && cargo run -q -p arkavo-shadow-consolidation -- \
+        --db "$OUT_DIR/episodes.db" \
+        --out "$OUT_DIR/shadow" \
+        --min-episodes 2 \
+        --dry-run) | sed 's/^/    /'
+    echo ""
+    ok "Artifacts in out/shadow/ — prompts.json shows exactly what Fable would receive."
+    info "Live run (real spend, capped): cargo run -p arkavo-shadow-consolidation -- \\"
+    info "  --db examples/shadow-teacher-kit/out/episodes.db --out .../shadow-live --max-run-cost-usd 1.0"
+}
+
+main() {
+    echo "=========================================================="
+    echo "  Shadow Teacher Kit — episode gathering with local models"
+    echo "=========================================================="
+    check_prerequisites
+    validate_kit
+    stop_agents
+    start_agents
+    submit_tasks
+    wait_for_episodes
+    stop_agents
+    merge_stores
+    run_shadow_dry
+}
+
+main "$@"

--- a/examples/shadow-teacher-kit/sample/auth.rs
+++ b/examples/shadow-teacher-kit/sample/auth.rs
@@ -1,0 +1,23 @@
+//! Deliberately vulnerable authentication sample for the review tasks.
+
+pub fn authenticate(username: &str, password: &str) -> bool {
+    let query = format!(
+        "SELECT * FROM users WHERE name='{}' AND pass='{}'",
+        username, password
+    );
+    db::execute(&query).is_ok()
+}
+
+pub fn generate_session_token() -> String {
+    let seed = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+    format!("{:x}", seed)
+}
+
+mod db {
+    pub fn execute(_query: &str) -> Result<(), ()> {
+        Ok(())
+    }
+}

--- a/examples/shadow-teacher-kit/sample/cache.rs
+++ b/examples/shadow-teacher-kit/sample/cache.rs
@@ -1,0 +1,47 @@
+//! Small LRU cache sample for the test-generation tasks.
+
+use std::collections::{HashMap, VecDeque};
+use std::hash::Hash;
+
+pub struct LruCache<K, V> {
+    capacity: usize,
+    map: HashMap<K, V>,
+    order: VecDeque<K>,
+}
+
+impl<K: Hash + Eq + Clone, V> LruCache<K, V> {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            map: HashMap::new(),
+            order: VecDeque::new(),
+        }
+    }
+
+    pub fn get(&mut self, key: &K) -> Option<&V> {
+        if self.map.contains_key(key) {
+            self.order.retain(|k| k != key);
+            self.order.push_back(key.clone());
+        }
+        self.map.get(key)
+    }
+
+    pub fn put(&mut self, key: K, value: V) {
+        if self.map.len() >= self.capacity && !self.map.contains_key(&key) {
+            if let Some(oldest) = self.order.pop_front() {
+                self.map.remove(&oldest);
+            }
+        }
+        self.order.retain(|k| k != &key);
+        self.order.push_back(key.clone());
+        self.map.insert(key, value);
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+}

--- a/examples/shadow-teacher-kit/sample/parser.rs
+++ b/examples/shadow-teacher-kit/sample/parser.rs
@@ -1,0 +1,13 @@
+//! Deliberately fragile request parsing sample for the review tasks.
+
+pub fn process_request(data: &[u8]) -> String {
+    let parsed: serde_json::Value = serde_json::from_slice(data).unwrap();
+    let id = parsed["id"].as_str().unwrap();
+    let payload = parsed["payload"].as_str().unwrap();
+    let decoded = base64_decode(payload).unwrap();
+    format!("{}:{}", id, String::from_utf8(decoded).unwrap())
+}
+
+fn base64_decode(_input: &str) -> Result<Vec<u8>, ()> {
+    Ok(vec![104, 105])
+}

--- a/examples/shadow-teacher-kit/shadow-teacher-kit.swarmkit.yaml
+++ b/examples/shadow-teacher-kit/shadow-teacher-kit.swarmkit.yaml
@@ -1,0 +1,75 @@
+spec_version: "1.0.0"
+kit:
+  id: ""
+  name: "Shadow Teacher Kit"
+  version: "0.1.0"
+  description: >-
+    A small data-gathering swarm for the shadow consolidation teacher.
+    Two coordination-plane workers (code reviewer, test writer) execute
+    tool-driven tasks with local models, producing episode traces in the
+    learning store. The audit-plane shadow-teacher role observes only:
+    it has no handoffs and no context writes, so the kit demonstrates the
+    plane separation rule — the teacher rides the audit plane, never the
+    coordination plane. The arkavo-shadow-consolidation job then reads
+    the gathered episodes read-only and previews the consolidation batch.
+  authors:
+    - did: "did:web:arkavo.com"
+      name: "Arkavo"
+  created: "2026-06-10T12:00:00Z"
+  expires: "2026-12-31T00:00:00Z"
+  nonce: "shdwTchrKit0606AAAA"
+objective:
+  goal: "Gather diverse, tool-driven episode traces for shadow consolidation."
+  success_criteria:
+    - "episodes recorded in at least two task categories"
+    - "shadow-consolidation dry-run produces at least one batch"
+roles:
+  - id: "code-reviewer"
+    role_type: "reviewer"
+    description: "Reviews sample source files for security and quality issues using filesystem tools."
+    agent_provisioning:
+      model:
+        family: "gemma-4"
+        size: "E4B"
+        backend: "llama.cpp"
+      budget:
+        max_inference_calls: 24
+        max_wallclock_ms: 1800000
+        max_total_tokens: 96000
+  - id: "test-writer"
+    role_type: "specialist"
+    description: "Generates unit tests for sample source files using filesystem tools."
+    agent_provisioning:
+      model:
+        family: "gemma-4"
+        size: "E4B"
+        backend: "llama.cpp"
+      budget:
+        max_inference_calls: 24
+        max_wallclock_ms: 1800000
+        max_total_tokens: 96000
+  - id: "shadow-teacher"
+    role_type: "auditor"
+    plane: "audit"
+    description: "Audit-plane consolidation teacher: reads episode traces offline, never drives work."
+    agent_provisioning: {}
+coordination:
+  topology: "hub-spoke"
+  protocol: "a2a-jsonrpc-2.0"
+  routing: {strategy: "static"}
+constraints:
+  global_budget: {max_wallclock_seconds: 3600, max_total_tokens: 200000, max_cost_usd: 0.0}
+  data_classifications: ["public"]
+  network: {egress_allowed: false, egress_allowlist: []}
+proposal_governance:
+  accepted_origins: ["consolidation", "human"]
+  role_ceilings:
+    - {role: "code-reviewer", auto_apply_max_blast_radius: "single_agent"}
+    - {role: "test-writer", auto_apply_max_blast_radius: "single_agent"}
+  observation_window_sec: 600
+completion:
+  rules: ["episodes recorded for every submitted task category"]
+  on_failure: "abort"
+  max_retries: 0
+provenance:
+  signatures: [{signer_did: "did:web:arkavo.com", algorithm: "ed25519", signature: "AAA"}]

--- a/examples/shadow-teacher-kit/stop.sh
+++ b/examples/shadow-teacher-kit/stop.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Stop all shadow-teacher-kit agents.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PID_FILE="$SCRIPT_DIR/.agent_pids"
+if [ -f "$PID_FILE" ]; then
+    while IFS= read -r pid; do
+        kill "$pid" 2>/dev/null || true
+    done < "$PID_FILE"
+    rm -f "$PID_FILE"
+fi
+# Kill any straggler agents so they cannot hold ports or stale db handles.
+pkill -f "arkavo agent run" 2>/dev/null || true
+echo "shadow-teacher-kit agents stopped"

--- a/examples/shadow-teacher-kit/tasks.json
+++ b/examples/shadow-teacher-kit/tasks.json
@@ -1,0 +1,40 @@
+{
+  "tasks": [
+    {
+      "id": "review-auth-injection",
+      "agent": "code-reviewer",
+      "port": 8430,
+      "prompt": "Read the file auth.rs and review the authenticate function for security issues. Report the vulnerable lines and a fixed version."
+    },
+    {
+      "id": "review-auth-token",
+      "agent": "code-reviewer",
+      "port": 8430,
+      "prompt": "Read the file auth.rs and audit generate_session_token for cryptographic weaknesses. Explain why the current token is predictable and show a safe replacement."
+    },
+    {
+      "id": "review-parser-panics",
+      "agent": "code-reviewer",
+      "port": 8430,
+      "prompt": "Read the file parser.rs and review process_request for error handling problems. List every line that can panic on untrusted input and rewrite it to return a Result."
+    },
+    {
+      "id": "tests-cache-basics",
+      "agent": "test-writer",
+      "port": 8432,
+      "prompt": "Read the file cache.rs and write unit tests for LruCache::put and LruCache::get covering insertion, retrieval, and a missing key."
+    },
+    {
+      "id": "tests-cache-eviction",
+      "agent": "test-writer",
+      "port": 8432,
+      "prompt": "Read the file cache.rs and write a unit test proving the least-recently-used entry is evicted when the cache is at capacity."
+    },
+    {
+      "id": "tests-cache-update",
+      "agent": "test-writer",
+      "port": 8432,
+      "prompt": "Read the file cache.rs and write a unit test showing that putting an existing key updates its value without evicting anything."
+    }
+  ]
+}

--- a/examples/shadow-teacher-kit/test-writer/AGENTS.md
+++ b/examples/shadow-teacher-kit/test-writer/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## test-writer-agent
+purpose: |
+  You write unit tests for source code.
+
+  For every task, FIRST read the file named in the task with your
+  filesystem tools, then write tests against the code you actually
+  read. Never invent an API — the file on disk is the source of truth.
+
+  When writing tests:
+  - Cover the happy path, one edge case, and one failure case
+  - Use idiomatic Rust #[test] functions
+  - Name each test for the behavior it proves
+
+  Keep answers under 300 words of prose; the tests carry the value.
+
+model:   gemma-4-e4b
+listen:  0.0.0.0:8432
+
+discovery:
+  mdns: true
+
+mcp_servers:
+  - name: filesystem
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "workspace"]

--- a/specs/arkavo-edge/agui.spec.yaml
+++ b/specs/arkavo-edge/agui.spec.yaml
@@ -185,3 +185,44 @@ scenarios:
       - Ring gauges show actual context window pressure
     refs: [crates/arkavo-server/src/server/conductor.rs:17-20, crates/arkavo-server/src/server/mod.rs:1272-1280]
     changed: "2026-03-24"
+
+  - id: AGUI-013
+    name: Findings inbox renders tightening proposals as per-agent cards
+    criticality: high
+    given:
+      - An ArpStatusUpdate snapshot carrying per-agent proposal lists
+    when: renderArp runs
+    then:
+      - Each proposal renders as a card keyed by agent, never gateway-global
+      - Card shows state, effect summary, rationale, and evidence counts
+      - Proposals in proposed state expose Approve/Reject buttons carrying
+        the agent id and proposal id
+    refs: [crates/arkavo-agui/static/js/panels/arp.js, crates/arkavo-agui/src/arp_handler.rs]
+    changed: "2026-06-10"
+
+  - id: AGUI-014
+    name: Proposal review action round-trips to a fresh snapshot
+    criticality: high
+    given:
+      - A held proposal rendered in the findings inbox
+    when: RequestArpProposalAction arrives from the client
+    then:
+      - The review is applied to that agent's ProposalQueue
+      - An ArpProposalActionResult plus a fresh ArpStatusUpdate push to the
+        acting client without waiting for the panel poll
+      - Direction is re-checked at approval time
+    refs: [crates/arkavo-agui/src/arp_handler.rs, crates/arkavo-agui/src/gateway_ws.rs]
+    changed: "2026-06-10"
+
+  - id: AGUI-015
+    name: Bandit health view summarizes adaptation priors per agent
+    criticality: medium
+    given:
+      - Agent snapshots carrying adaptation prior summaries
+    when: the bandit health view renders
+    then:
+      - Beta curves render from alpha/beta counts as inline SVG
+      - Evidence split separates live from distilled mass
+      - Numeric interpolation only — no remote strings enter attributes
+    refs: [crates/arkavo-agui/static/js/panels/arp.js, crates/arkavo-agui/src/types.rs]
+    changed: "2026-06-10"

--- a/specs/arkavo-edge/arp.spec.yaml
+++ b/specs/arkavo-edge/arp.spec.yaml
@@ -1,0 +1,121 @@
+# yaml-language-server: $schema=../schema.json
+
+feature: ARP Proposal Lifecycle and Capability Gates
+module: arkavo_arp
+version: 0.80.0
+
+invariants:
+  - TighteningEffect is a closed enum with no loosening variant — capability
+    additions cannot ride the tightening channel
+  - Proposals auto-apply only within the policy's blast-radius ceiling;
+    Mesh radius never auto-applies
+  - Every applied proposal records its displaced value and reverts restore it
+  - Every apply/revert/confirm transition emits a DecisionTrace entry
+  - Duplicate proposal ids and overlapping scalar observations are refused
+  - Capability proposals require every gate plus a named human approver
+
+scenarios:
+  - id: ARP-001
+    name: Auto-apply within blast radius moves proposal to observed
+    criticality: critical
+    given:
+      - ARP document with proposal_policy auto_apply_max_blast_radius single_entity
+      - Tightening proposal with single_entity radius and evidence
+    when: ProposalQueue::ingest called
+    then:
+      - Proposal state becomes observed
+      - Effect is live in the document (tool denied / ceiling lowered)
+      - A proposal_lifecycle trace entry is emitted
+    refs: [crates/arkavo-arp-runtime/src/proposal_queue.rs]
+    changed: "2026-06-10"
+
+  - id: ARP-002
+    name: Wider-radius proposal holds for review and applies on approval
+    criticality: critical
+    given:
+      - Proposal whose blast_radius exceeds the auto-apply ceiling
+    when: ingest then review(approve) called
+    then:
+      - Proposal holds in proposed state with no document change
+      - Approval re-checks direction and overlap against current values
+      - Approved proposal applies and records reviewer identity
+      - Denial rejects with a disposition reason and no document change
+    refs: [crates/arkavo-arp-runtime/src/proposal_queue.rs]
+    changed: "2026-06-10"
+
+  - id: ARP-003
+    name: Revert restores the displaced value and emits a trace
+    criticality: critical
+    given:
+      - An observed proposal whose observation window regressed, or a
+        force_revert call from flight reconciliation
+    when: the revert path runs
+    then:
+      - The displaced value is restored to the document
+      - Proposal state becomes reverted with a disposition reason
+      - A reverted trace entry is emitted
+    refs: [crates/arkavo-arp-runtime/src/proposal_queue.rs]
+    changed: "2026-06-10"
+
+  - id: ARP-004
+    name: Duplicate proposal id is refused everywhere
+    criticality: critical
+    given:
+      - A proposal id already present in the queue
+    when: ingest, check, or ingest_reviewed sees the same id again
+    then:
+      - The replay is refused without creating a second entry
+      - Id-keyed lookups (state, review, revert) keep the original entry
+      - The original observation's displaced value is untouched
+    refs: [crates/arkavo-arp-runtime/src/proposal_queue.rs]
+    changed: "2026-06-10"
+
+  - id: ARP-005
+    name: Scalar field under observation refuses overlapping proposals
+    criticality: critical
+    given:
+      - An observed proposal on a scalar field (ceiling, layer budget,
+        threshold, rate limit)
+    when: a second proposal targets the same field before confirm/revert
+    then:
+      - The second proposal is rejected with the owning proposal named
+      - Reverting the first cannot loosen past a later tightening
+      - The field frees once the observation confirms or reverts
+    refs: [crates/arkavo-arp-runtime/src/proposal_queue.rs]
+    changed: "2026-06-10"
+
+  - id: ARP-006
+    name: Mesh blast radius never auto-applies
+    criticality: critical
+    given:
+      - ARP document text whose proposal_policy sets auto_apply_max_blast_radius mesh
+    when: arkavo_arp::parse validates the document
+    then:
+      - Validation rejects the document (mesh exceeds the auto-apply ceiling)
+    refs: [crates/arkavo-arp/src/validate.rs]
+    changed: "2026-06-10"
+
+  - id: ARP-007
+    name: Loosening cannot be expressed as a tightening
+    criticality: critical
+    given:
+      - JSON payloads for allow_tool, add_capability, and raise_task_ceiling effects
+    when: deserialized as TighteningEffect
+    then:
+      - Deserialization fails — the enum has no loosening variant
+      - The exclusion is structural, not a bypassable validation layer
+    refs: [crates/arkavo-arp/src/proposal.rs]
+    changed: "2026-06-10"
+
+  - id: ARP-008
+    name: Capability proposal is approvable only with every gate and a human
+    criticality: critical
+    given:
+      - CapabilityProposal with gates for conformance, canary, and human approval
+    when: is_approvable evaluated
+    then:
+      - Any single missing gate makes the proposal unapprovable
+      - Human approval is a recorded identity, never a boolean
+      - No auto-apply field exists on the type
+    refs: [crates/arkavo-arp/src/capability.rs]
+    changed: "2026-06-10"

--- a/specs/arkavo-edge/index.yaml
+++ b/specs/arkavo-edge/index.yaml
@@ -1,7 +1,7 @@
 # Arkavo Edge Behavior Specification Index
 
-version: 0.67.6
-last_updated: 2026-03-22
+version: 0.80.0
+last_updated: 2026-06-10
 
 components:
   - name: trusted-agent
@@ -552,7 +552,7 @@ components:
     module: arkavo_agui
     description: Arkavo GUI application gateway
     criticality: high
-    scenario_count: 12
+    scenario_count: 15
     invariants:
       - AgUiGateway manages connections
       - mDNS discovery for peers
@@ -564,7 +564,7 @@ components:
     module: arkavo_swarmkit
     description: SwarmKit manifest, runtime, and AG-UI gateway integration
     criticality: high
-    scenario_count: 48
+    scenario_count: 51
     invariants:
       - kit.id equals BLAKE3 of canonical manifest
       - SwarmFlight builds one ArpRuntime per role at launch
@@ -860,7 +860,7 @@ components:
     module: arkavo_server
     description: A2A server and runtime orchestration
     criticality: critical
-    scenario_count: 10
+    scenario_count: 12
     invariants:
       - Server binds localhost by default
       - JSON-RPC 2.0 protocol
@@ -877,10 +877,34 @@ components:
       - Validation errors descriptive
       - Schema-driven validation
 
+  - name: arp
+    file: arp.spec.yaml
+    module: arkavo_arp
+    description: ARP proposal lifecycle, tightening guards, and capability gates
+    criticality: critical
+    scenario_count: 8
+    invariants:
+      - TighteningEffect is a closed enum with no loosening variant
+      - Mesh blast radius never auto-applies
+      - Reverts restore displaced values and emit traces
+      - Duplicate ids and overlapping scalar observations are refused
+
+  - name: shadow-consolidation
+    file: shadow-consolidation.spec.yaml
+    module: arkavo_shadow_consolidation
+    description: Standalone audit-plane consolidation job for Fable
+    criticality: critical
+    scenario_count: 6
+    invariants:
+      - Zero runtime contact with the episode store opened read-only
+      - Run-level cost ceiling enforced between batches
+      - Partial outputs survive budget exhaustion and call failures
+      - Sampling caps are recorded in the ledger, never silent
+
 stats:
-  total_specs: 73
-  total_scenarios: 621
-  critical_scenarios: 160
+  total_specs: 77
+  total_scenarios: 702
+  critical_scenarios: 193
   coverage_areas:
     - authentication
     - authorization

--- a/specs/arkavo-edge/server.spec.yaml
+++ b/specs/arkavo-edge/server.spec.yaml
@@ -156,3 +156,29 @@ scenarios:
       - Resources reclaimed
     refs: [crates/arkavo-server/src/server.rs]
     changed: "2026-03-19"
+
+  - id: SRV-011
+    name: Consolidation teacher requires a layer budget for frontier models
+    criticality: critical
+    given:
+      - A non-local teacher model (Fable)
+    when: run_teacher starts
+    then:
+      - A missing budget.per_layer consolidation limit refuses the run
+      - A local teacher runs without a layer budget
+      - Every reply's cost accrues against the limit
+    refs: [crates/arkavo-server/src/server/consolidation_teacher.rs]
+    changed: "2026-06-10"
+
+  - id: SRV-012
+    name: Teacher budget exhaustion stops between batches keeping partial output
+    criticality: critical
+    given:
+      - Cumulative teacher spend reaching the consolidation layer limit
+    when: the next batch would start
+    then:
+      - The run stops between batches, never mid-call
+      - Lessons and proposals from completed batches are preserved
+      - A budget_exhausted BudgetEvent is traced
+    refs: [crates/arkavo-server/src/server/consolidation_teacher.rs]
+    changed: "2026-06-10"

--- a/specs/arkavo-edge/shadow-consolidation.spec.yaml
+++ b/specs/arkavo-edge/shadow-consolidation.spec.yaml
@@ -1,0 +1,88 @@
+# yaml-language-server: $schema=../schema.json
+
+feature: Shadow Consolidation Audit Job
+module: arkavo_shadow_consolidation
+version: 0.80.0
+
+invariants:
+  - Zero runtime contact — episode store opened read-only, no arkavo runtime
+    crate dependency
+  - The run-level cost ceiling is enforced between batches and the ledger
+    records real token/dollar accounting
+  - Partial outputs survive both budget exhaustion and call failures
+  - Contract violations land in rejects.json with a reason; operational
+    failures never count against conformance
+
+scenarios:
+  - id: SC-001
+    name: Run-level cost ceiling stops between batches and marks the ledger
+    criticality: critical
+    given:
+      - Episode store with multiple categories
+      - max_run_cost_usd at or below cumulative spend
+    when: execute runs
+    then:
+      - The run stops before the next batch, never mid-call
+      - cost_ledger.json marks run_budget exhausted with categories_budget_stopped
+      - Partial artifacts are written
+      - A zero ceiling stops before the first call with no credentials needed
+    refs: [crates/arkavo-shadow-consolidation/src/run.rs]
+    changed: "2026-06-10"
+
+  - id: SC-002
+    name: Dry-run spends zero tokens and previews prompts
+    criticality: critical
+    given:
+      - --dry-run set
+    when: execute runs
+    then:
+      - No Fable client is constructed and no network call is made
+      - The ledger records zero cost
+      - prompts.json records every prompt that would have been sent
+    refs: [crates/arkavo-shadow-consolidation/src/run.rs]
+    changed: "2026-06-10"
+
+  - id: SC-003
+    name: A failed call records a reject and the run continues
+    criticality: critical
+    given:
+      - A category whose Fable call fails after retries
+    when: execute processes the remaining batches
+    then:
+      - The failure lands in rejects.json with kind call and the error reason
+      - The ledger and all artifacts are still written
+      - Conformance rate is untouched — operational failure is not a
+        contract violation
+    refs:
+      - crates/arkavo-shadow-consolidation/src/run.rs
+      - crates/arkavo-shadow-consolidation/tests/call_failure_resilience.rs
+    changed: "2026-06-10"
+
+  - id: SC-004
+    name: Transient API failures retry with backoff, billed calls never re-send
+    criticality: high
+    given:
+      - Fable returns 429/5xx then succeeds
+    when: FableClient::complete runs
+    then:
+      - Transient statuses retry with exponential backoff up to the attempt cap
+      - Non-retryable 4xx fails immediately
+      - A decode failure after a billed 200 is never re-sent
+    refs: [crates/arkavo-shadow-consolidation/src/fable.rs]
+    changed: "2026-06-10"
+
+  - id: SC-005
+    name: Contract violations are rejected with reasons, never dropped
+    criticality: critical
+    given:
+      - Fable output containing a lesson naming a non-evidence action and a
+        loosening phrased as a tightening
+    when: post-hoc validation runs
+    then:
+      - Both land in rejects.json with reasons and truncated payloads
+      - Conformance tallies count them against the contract rate
+      - Accepted lessons must name an action from the stripped evidence
+    refs:
+      - crates/arkavo-shadow-consolidation/src/validate.rs
+      - crates/arkavo-shadow-consolidation/src/run.rs
+    changed: "2026-06-10"

--- a/specs/arkavo-edge/shadow-consolidation.spec.yaml
+++ b/specs/arkavo-edge/shadow-consolidation.spec.yaml
@@ -86,3 +86,17 @@ scenarios:
       - crates/arkavo-shadow-consolidation/src/validate.rs
       - crates/arkavo-shadow-consolidation/src/run.rs
     changed: "2026-06-10"
+
+  - id: SC-006
+    name: Oversized categories sample the most recent episodes, never silently
+    criticality: high
+    given:
+      - A category holding more episodes than the per-category cap
+    when: load_batches groups the store rows
+    then:
+      - The batch keeps the most recent episodes up to the cap
+      - episode_ids stay aligned with the sampled outcomes for backfill
+      - The dropped count lands in the ledger as episodes_sampled_out
+      - Categories within the cap are untouched
+    refs: [crates/arkavo-shadow-consolidation/src/episodes.rs]
+    changed: "2026-06-10"

--- a/specs/arkavo-edge/swarmkit.spec.yaml
+++ b/specs/arkavo-edge/swarmkit.spec.yaml
@@ -796,3 +796,46 @@ scenarios:
     refs:
       - crates/arkavo-swarmkit-runtime/src/skill_resolver/mod.rs (t8_registry_cache_hit, t9_registry_cache_miss)
     changed: "2026-05-08"
+
+  # --- Plane governance and flight proposal apply ---------------------------
+
+  - id: SK-093
+    name: Audit-plane roles cannot ride the coordination plane
+    criticality: critical
+    given:
+      - A kit manifest with a role declaring plane learning or audit
+    when: manifest validation runs
+    then:
+      - A learning/audit role with handoffs fails validation
+      - A learning/audit role with context_scope.can_write fails validation
+      - Coordination roles are unaffected
+    refs: [crates/arkavo-swarmkit/src/validate.rs, crates/arkavo-swarmkit/src/governance.rs]
+    changed: "2026-06-10"
+
+  - id: SK-094
+    name: Flight-wide proposal apply is all-or-reverted
+    criticality: critical
+    given:
+      - A flight whose roles each hold a ProposalQueue
+      - A flight-radius tightening proposal
+    when: apply_flight_proposal runs
+    then:
+      - Phase one prechecks every role side-effect-free before any apply
+      - A precheck failure rejects the whole flight with no role touched
+      - A phase-two failure force-reverts the roles already applied
+      - Success applies to every role with reviewer recorded
+    refs: [crates/arkavo-swarmkit-runtime/src/flight_apply.rs]
+    changed: "2026-06-10"
+
+  - id: SK-095
+    name: Reconciliation converges a crash-partial flight apply
+    criticality: high
+    given:
+      - Some flight roles hold an applied proposal and others never saw it
+    when: reconcile_flight_proposal runs
+    then:
+      - Roles holding the proposal in a revertible state are force-reverted
+      - The reverted role ids are returned for the audit trail
+      - A converged flight reconciles to a no-op
+    refs: [crates/arkavo-swarmkit-runtime/src/flight_apply.rs, crates/arkavo-swarmkit-runtime/tests/flight_proposal_apply.rs]
+    changed: "2026-06-10"


### PR DESCRIPTION
Introduce arkavo-shadow-consolidation, an audit-plane job that runs the
consolidation teacher outside the runtime. It reads existing episode
traces from the learning store read-only, strips observe/list/hash/
summary calls per the lesson-synthesis rule, batches each task category
to Fable, and writes four artifacts:

  - lessons.json     action-named lessons
  - proposals.json   candidate tightenings (draft proposal.rs JSON shape)
  - cost_ledger.json real token/dollar accounting plus a recommended
                     value for budget.per_layer["consolidation"]
  - findings.json    seed cards for the findings-inbox UI, projected
                     from the genuine lessons and proposals

The job has zero runtime contact: it depends on no arkavo runtime crate,
opens the episode store read-only, talks only to Fable over rustls HTTP
with adaptive thinking, and supports --dry-run to preview prompts and
batch counts without spending. The proposal/lesson/ledger types are the
draft output contract a future runtime and inbox UI consume.

----
## Summary by Gitar

- **ARP proposal lifecycle:**
  - Added `ProposalQueue` to manage tightening lifecycle states (`proposed` to `confirmed`/`reverted`) with validation and regression monitoring.
  - Implemented `review_proposal` and `apply_flight_proposal` for HITL integration and mesh-wide atomicity during tightening.
- **Shadow consolidation:**
  - Created `arkavo-shadow-consolidation` for offline trace distillation and Fable teacher integration.
  - Added `consolidation_teacher` with contract enforcement, cost accounting, and budget-exhaustion handling.
- **Audit plane & observability:**
  - Added `findings-inbox` card types and `CostLedger` for budget recommendation.
  - Added mesh-wide ARP polling via `spawn_arp_poller` to sync documents dynamically.
  - Introduced `substrate-trade-study.md` on TØRG/WASM architecture and updated specifications.
- **Example kit:**
  - Added `shadow-teacher-kit` with vulnerability patterns to exercise audit-plane distillation.


<sub>This will update automatically on new commits.</sub>