### PR TITLE
Game-RL convergence: env expansion, structured building, Zomboid adapter + SwarmKit live execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-test-macros",
  "serde",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "chrono",
  "serde",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-test-macros",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "git2",
  "tempfile",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1124,11 +1124,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-lesson-synthesis"
-version = "0.80.1"
+version = "0.80.2"
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "bindgen",
  "cc",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "lru 0.16.4",
  "serde",
@@ -1698,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-shadow-consolidation"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-lesson-synthesis",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "libc",
@@ -1889,7 +1889,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1989,7 +1989,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.80.1"
+version = "0.80.2"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,6 +728,7 @@ dependencies = [
  "arkavo-router",
  "arkavo-server",
  "arkavo-session",
+ "arkavo-swarmkit",
  "arkavo-terminal",
  "arkavo-ucp",
  "arkavo-ui-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.80.1"
+version = "0.80.2"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-cli/Cargo.toml
+++ b/crates/arkavo-cli/Cargo.toml
@@ -48,6 +48,7 @@ arkavo-mcp = { path = "../arkavo-mcp" }
 arkavo-mcp-runtime = { path = "../arkavo-mcp-runtime" }
 arkavo-dataflow = { path = "../arkavo-dataflow", default-features = false, features = ["nl", "sandbox"] }
 arkavo-protocol = { path = "../arkavo-protocol" }
+arkavo-swarmkit = { path = "../arkavo-swarmkit" }
 arkavo-session = { path = "../arkavo-session" }
 arkavo-server = { path = "../arkavo-server" }
 arkavo-repo = { path = "../arkavo-repo" }

--- a/crates/arkavo-cli/src/commands/mod.rs
+++ b/crates/arkavo-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod mesh;
 pub mod model;
 pub mod rlm_integration;
 pub mod security_audit;
+pub mod swarmkit;
 pub mod task;
 pub mod terminal;
 pub mod terminal_ui;

--- a/crates/arkavo-cli/src/commands/swarmkit.rs
+++ b/crates/arkavo-cli/src/commands/swarmkit.rs
@@ -133,6 +133,82 @@ fn slug(name: &str) -> String {
         .to_string()
 }
 
+/// `arkavo swarmkit play <kit.yaml> [--role <id>]`
+#[allow(clippy::disallowed_methods)]
+pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let mut kit_path: Option<String> = None;
+    let mut only_role: Option<String> = None;
+    let mut sub: Option<&str> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "play" => sub = Some("play"),
+            "--role" if i + 1 < args.len() => {
+                only_role = Some(args[i + 1].clone());
+                i += 1;
+            }
+            "-h" | "--help" | "help" => {
+                print_usage();
+                return Ok(());
+            }
+            p if !p.starts_with('-') && kit_path.is_none() => kit_path = Some(p.to_string()),
+            other => return Err(format!("Unknown swarmkit arg '{other}'").into()),
+        }
+        i += 1;
+    }
+    if sub != Some("play") {
+        print_usage();
+        return Err("expected: arkavo swarmkit play <kit.yaml>".into());
+    }
+    let kit_path = kit_path.ok_or("missing <kit.yaml> path")?;
+
+    let yaml = std::fs::read_to_string(&kit_path)
+        .map_err(|e| format!("cannot read kit '{kit_path}': {e}"))?;
+    let manifest =
+        arkavo_swarmkit::parse_yaml(&yaml).map_err(|e| format!("kit parse error: {e}"))?;
+    arkavo_swarmkit::validate(&manifest).map_err(|e| format!("kit invalid: {e}"))?;
+
+    let mut configs = kit_to_agent_configs(&manifest);
+    if let Some(role) = &only_role {
+        configs.retain(|c| &c.name == role);
+        if configs.is_empty() {
+            return Err(format!("no role named '{role}' in kit").into());
+        }
+    }
+
+    println!(
+        "[swarmkit] {} v{} — launching {} role(s): {}",
+        manifest.kit.name,
+        manifest.kit.version,
+        configs.len(),
+        configs
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    // `start_agent_server`'s future is not `Send` (it holds a `Box<dyn Error>`
+    // across an await), so we can't `tokio::spawn` it. Instead we run every
+    // role's agent loop concurrently on the single `block_on` thread via
+    // `join_all`, which has no `Send` requirement.
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async move {
+        let tasks = configs.into_iter().map(|cfg| async move {
+            let name = cfg.name.clone();
+            if let Err(e) = crate::commands::agent::start_agent_server(&cfg, false).await {
+                eprintln!("[swarmkit] role '{name}' exited: {e}");
+            }
+        });
+        futures::future::join_all(tasks).await;
+    });
+    Ok(())
+}
+
+fn print_usage() {
+    eprintln!("Usage: arkavo swarmkit play <kit.yaml> [--role <id>]");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/arkavo-cli/src/commands/swarmkit.rs
+++ b/crates/arkavo-cli/src/commands/swarmkit.rs
@@ -237,9 +237,14 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     // threads. Give each role its OWN OS thread with its own current-thread
     // runtime, so blocking/CPU work (e.g. local inference) in one role does
     // not stall the others' tick loops.
+    // Track each role name alongside its thread handle so that a panicked
+    // role thread (whose closure never returns a value) is still counted as a
+    // failure on join — otherwise `join().ok().flatten()` would silently drop
+    // the panic and the command would exit 0 despite a crashed role.
     let mut handles = Vec::new();
     for cfg in configs {
-        handles.push(std::thread::spawn(move || -> Option<String> {
+        let role_name = cfg.name.clone();
+        let handle = std::thread::spawn(move || -> Option<String> {
             let name = cfg.name.clone();
             let rt = match tokio::runtime::Builder::new_current_thread()
                 .enable_all()
@@ -258,12 +263,20 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
                     Some(name)
                 }
             }
-        }));
+        });
+        handles.push((role_name, handle));
     }
-    let failures: Vec<String> = handles
-        .into_iter()
-        .filter_map(|h| h.join().ok().flatten())
-        .collect();
+    let mut failures: Vec<String> = Vec::new();
+    for (role_name, handle) in handles {
+        match handle.join() {
+            Ok(Some(failed)) => failures.push(failed),
+            Ok(None) => {}
+            Err(_) => {
+                eprintln!("[swarmkit] role '{role_name}' panicked");
+                failures.push(role_name);
+            }
+        }
+    }
     if !failures.is_empty() {
         return Err(format!("swarmkit roles failed: {}", failures.join(", ")).into());
     }

--- a/crates/arkavo-cli/src/commands/swarmkit.rs
+++ b/crates/arkavo-cli/src/commands/swarmkit.rs
@@ -5,7 +5,7 @@
 //! [`kit_to_agent_configs`]; the command/dispatch layer is a separate task.
 
 use crate::commands::agent::{AgentConfig, McpServerConfig};
-use arkavo_protocol::agent_config::{AgentMode, expand_env};
+use arkavo_protocol::agent_config::AgentMode;
 use arkavo_swarmkit::{McpServerDef, manifest::Manifest};
 
 /// First listen port assigned to role index 0; subsequent roles get
@@ -51,9 +51,11 @@ pub fn kit_to_agent_configs(manifest: &Manifest) -> Vec<AgentConfig> {
                     servers
                         .get(grant.server.as_str())
                         .map(|def| McpServerConfig {
+                            // ${VAR} is expanded once at the spawn site
+                            // (McpClient::new_with_command); do not pre-expand here.
                             name: def.name.clone(),
-                            command: Some(expand_env(&def.command)),
-                            args: def.args.iter().map(|a| expand_env(a)).collect(),
+                            command: Some(def.command.clone()),
+                            args: def.args.clone(),
                             url: None,
                         })
                 })
@@ -174,6 +176,11 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
         if configs.is_empty() {
             return Err(format!("no role named '{role}' in kit").into());
         }
+        // A single isolated role has no live peers to reach; clear the
+        // full-topology peer wiring so it doesn't spin retrying absent A2A peers.
+        for c in &mut configs {
+            c.peers.clear();
+        }
     }
 
     println!(
@@ -188,28 +195,75 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
             .join(", ")
     );
 
-    // `start_agent_server`'s future is not `Send` (it holds a `Box<dyn Error>`
-    // across an await), so we can't `tokio::spawn` it. Instead we run every
-    // role's agent loop concurrently on the single `block_on` thread via
-    // `join_all`, which has no `Send` requirement.
-    let rt = tokio::runtime::Runtime::new()?;
-    let failures: Vec<String> = rt.block_on(async move {
-        let tasks = configs.into_iter().map(|cfg| async move {
+    // The CLI agent runtime (AgentConfig) does not yet carry per-role budgets,
+    // inference params, context limits, or completion.rules. Warn loudly rather
+    // than dropping them silently (tracked: swarmkit play provisioning passthrough).
+    let mut unenforced: Vec<&str> = Vec::new();
+    if manifest
+        .roles
+        .iter()
+        .any(|r| r.agent_provisioning.budget.is_some())
+    {
+        unenforced.push("agent_provisioning.budget");
+    }
+    if manifest
+        .roles
+        .iter()
+        .any(|r| r.agent_provisioning.inference.is_some())
+    {
+        unenforced.push("agent_provisioning.inference");
+    }
+    if manifest
+        .roles
+        .iter()
+        .any(|r| r.agent_provisioning.context.is_some())
+    {
+        unenforced.push("agent_provisioning.context");
+    }
+    // `completion` is a required `CompletionSpec`; its `rules` is a `Vec<String>`.
+    // Treat a non-empty rule set as a declared-but-unenforced control.
+    if !manifest.completion.rules.is_empty() {
+        unenforced.push("completion.rules");
+    }
+    if !unenforced.is_empty() {
+        eprintln!(
+            "[swarmkit] note: these kit fields are NOT yet enforced by `swarmkit play` and are ignored this run: {}",
+            unenforced.join(", ")
+        );
+    }
+
+    // `start_agent_server`'s future is `!Send` (it holds a `Box<dyn Error>`
+    // across an await), so it cannot be `tokio::spawn`ed onto shared worker
+    // threads. Give each role its OWN OS thread with its own current-thread
+    // runtime, so blocking/CPU work (e.g. local inference) in one role does
+    // not stall the others' tick loops.
+    let mut handles = Vec::new();
+    for cfg in configs {
+        handles.push(std::thread::spawn(move || -> Option<String> {
             let name = cfg.name.clone();
-            match crate::commands::agent::start_agent_server(&cfg, false).await {
+            let rt = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => rt,
+                Err(e) => {
+                    eprintln!("[swarmkit] role '{name}' runtime init failed: {e}");
+                    return Some(name);
+                }
+            };
+            match rt.block_on(crate::commands::agent::start_agent_server(&cfg, false)) {
                 Ok(()) => None,
                 Err(e) => {
                     eprintln!("[swarmkit] role '{name}' exited: {e}");
                     Some(name)
                 }
             }
-        });
-        futures::future::join_all(tasks)
-            .await
-            .into_iter()
-            .flatten()
-            .collect()
-    });
+        }));
+    }
+    let failures: Vec<String> = handles
+        .into_iter()
+        .filter_map(|h| h.join().ok().flatten())
+        .collect();
     if !failures.is_empty() {
         return Err(format!("swarmkit roles failed: {}", failures.join(", ")).into());
     }

--- a/crates/arkavo-cli/src/commands/swarmkit.rs
+++ b/crates/arkavo-cli/src/commands/swarmkit.rs
@@ -1,0 +1,166 @@
+//! `arkavo swarmkit play <kit>` — run a SwarmKit as a live agent flight by
+//! mapping each role to the existing agent runtime (`start_agent_server`).
+//!
+//! This module currently provides only the pure mapping function
+//! [`kit_to_agent_configs`]; the command/dispatch layer is a separate task.
+
+use crate::commands::agent::{AgentConfig, McpServerConfig};
+use arkavo_protocol::agent_config::{AgentMode, expand_env};
+use arkavo_swarmkit::{McpServerDef, manifest::Manifest};
+
+/// First listen port assigned to role index 0; subsequent roles get
+/// consecutive ports. Deterministic so peer wiring is reproducible.
+const BASE_PORT: u16 = 8450;
+
+/// Build the per-role agent configs for a parsed, validated kit.
+///
+/// Index order is the manifest role order, which keeps port assignment
+/// deterministic. A role with one or more `mcp_tools` grants becomes an
+/// [`AgentMode::Orchestrator`] (hub); all other roles are
+/// [`AgentMode::Specialist`] spokes that peer back to the hub.
+pub fn kit_to_agent_configs(manifest: &Manifest) -> Vec<AgentConfig> {
+    let servers: std::collections::HashMap<&str, &McpServerDef> = manifest
+        .mcp_servers
+        .iter()
+        .map(|s| (s.name.as_str(), s))
+        .collect();
+
+    let listens: Vec<String> = manifest
+        .roles
+        .iter()
+        .enumerate()
+        .map(|(i, _)| format!("0.0.0.0:{}", BASE_PORT + i as u16))
+        .collect();
+
+    // The hub is the first role holding an MCP grant. Spokes peer to it.
+    let hub_idx = manifest.roles.iter().position(|r| !r.mcp_tools.is_empty());
+
+    let port_of = |listen: &str| listen.rsplit(':').next().unwrap_or("").to_string();
+
+    manifest
+        .roles
+        .iter()
+        .enumerate()
+        .map(|(i, role)| {
+            let has_grant = !role.mcp_tools.is_empty();
+
+            let mcp_servers: Vec<McpServerConfig> = role
+                .mcp_tools
+                .iter()
+                .filter_map(|grant| {
+                    servers
+                        .get(grant.server.as_str())
+                        .map(|def| McpServerConfig {
+                            name: def.name.clone(),
+                            command: Some(expand_env(&def.command)),
+                            args: def.args.iter().map(|a| expand_env(a)).collect(),
+                            url: None,
+                        })
+                })
+                .collect();
+
+            // Hub peers to every spoke; each spoke peers only to the hub.
+            let peers: Vec<String> = if has_grant {
+                listens
+                    .iter()
+                    .enumerate()
+                    .filter(|(j, _)| *j != i)
+                    .map(|(_, l)| format!("http://localhost:{}", port_of(l)))
+                    .collect()
+            } else if let Some(h) = hub_idx {
+                vec![format!("http://localhost:{}", port_of(&listens[h]))]
+            } else {
+                vec![]
+            };
+
+            // Inline-skill instructions become the agent's system prompt.
+            // `Skill.payload` is a free-form JSON `Value`; the SkillContent
+            // shape exposes the prompt under `instructions`.
+            let purpose = role
+                .skills
+                .iter()
+                .find_map(|s| {
+                    s.payload
+                        .as_ref()
+                        .and_then(|p| p.get("instructions"))
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string)
+                })
+                .unwrap_or_else(|| format!("Role: {}", role.role_type));
+
+            // `agent_provisioning` is always present; `model` is optional.
+            let model = role
+                .agent_provisioning
+                .model
+                .as_ref()
+                .map(|m| match &m.size {
+                    Some(sz) => format!("{}-{}", m.family, sz),
+                    None => m.family.clone(),
+                })
+                .unwrap_or_default();
+
+            AgentConfig {
+                name: role.id.clone(),
+                purpose,
+                model,
+                mode: if has_grant {
+                    AgentMode::Orchestrator
+                } else {
+                    AgentMode::Specialist
+                },
+                listen: listens[i].clone(),
+                mdns_enabled: true,
+                mcp_servers,
+                api_keys: std::collections::HashMap::new(),
+                quiet: true,
+                peers,
+                a2a_enabled: true,
+                a2a_service_type: None,
+                swarm: Some(slug(&manifest.kit.name)),
+            }
+        })
+        .collect()
+}
+
+/// Lowercase, hyphenate non-alphanumerics, and trim leading/trailing hyphens.
+/// Used to derive a stable swarm identifier from the kit name.
+fn slug(name: &str) -> String {
+    name.to_lowercase()
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '-' })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_grant_role_to_orchestrator_with_mcp_server() {
+        let yaml = include_str!("../../../arkavo-swarmkit/tests/fixtures/declared_mcp_server.yaml");
+        let manifest = arkavo_swarmkit::parse_yaml(yaml).unwrap();
+        let configs = kit_to_agent_configs(&manifest);
+
+        assert_eq!(configs.len(), manifest.roles.len());
+
+        let survivor = configs.iter().find(|c| c.name == "survivor").unwrap();
+        // A role with an mcp_tools grant is the hub/orchestrator.
+        assert_eq!(survivor.mode, AgentMode::Orchestrator);
+        // Role index 0 -> BASE_PORT.
+        assert_eq!(survivor.listen, "0.0.0.0:8450");
+        // The grant resolves to the declared `game-rl` MCP server.
+        assert_eq!(survivor.mcp_servers.len(), 1);
+        assert_eq!(survivor.mcp_servers[0].name, "game-rl");
+        // ${VAR} stays literal when unset, so the command is visible downstream.
+        assert_eq!(
+            survivor.mcp_servers[0].command.as_deref(),
+            Some("${GAME_RL_SERVER}")
+        );
+        // No inline skill -> purpose falls back to the role_type label.
+        assert_eq!(survivor.purpose, "Role: specialist");
+        // swarm identifier is the slugified kit name.
+        assert_eq!(survivor.swarm.as_deref(), Some("declared-mcp-server-kit"));
+    }
+}

--- a/crates/arkavo-cli/src/commands/swarmkit.rs
+++ b/crates/arkavo-cli/src/commands/swarmkit.rs
@@ -193,15 +193,26 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     // role's agent loop concurrently on the single `block_on` thread via
     // `join_all`, which has no `Send` requirement.
     let rt = tokio::runtime::Runtime::new()?;
-    rt.block_on(async move {
+    let failures: Vec<String> = rt.block_on(async move {
         let tasks = configs.into_iter().map(|cfg| async move {
             let name = cfg.name.clone();
-            if let Err(e) = crate::commands::agent::start_agent_server(&cfg, false).await {
-                eprintln!("[swarmkit] role '{name}' exited: {e}");
+            match crate::commands::agent::start_agent_server(&cfg, false).await {
+                Ok(()) => None,
+                Err(e) => {
+                    eprintln!("[swarmkit] role '{name}' exited: {e}");
+                    Some(name)
+                }
             }
         });
-        futures::future::join_all(tasks).await;
+        futures::future::join_all(tasks)
+            .await
+            .into_iter()
+            .flatten()
+            .collect()
     });
+    if !failures.is_empty() {
+        return Err(format!("swarmkit roles failed: {}", failures.join(", ")).into());
+    }
     Ok(())
 }
 

--- a/crates/arkavo-cli/src/lib.rs
+++ b/crates/arkavo-cli/src/lib.rs
@@ -63,6 +63,7 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
 
     match args[0].as_str() {
         "agent" => commands::agent::execute(&args[1..]),
+        "swarmkit" => commands::swarmkit::execute(&args[1..]),
         "chat" => commands::chat::execute(&args[1..]),
         "task" => commands::task::execute(&args[1..]),
         "ui" => commands::ui::execute(&args[1..]),

--- a/crates/arkavo-cli/src/mcp_client.rs
+++ b/crates/arkavo-cli/src/mcp_client.rs
@@ -161,11 +161,19 @@ impl McpClient {
         cmd: &str,
         args: &[String],
     ) -> Result<Self, Box<dyn std::error::Error>> {
+        // Expand ${VAR} at the spawn site so every config parse path
+        // (frontmatter, markdown format, protocol crate) benefits.
+        let cmd = arkavo_protocol::agent_config::expand_env(cmd);
+        let cmd = cmd.as_str();
+        let args: Vec<String> = args
+            .iter()
+            .map(|a| arkavo_protocol::agent_config::expand_env(a))
+            .collect();
         log_mcp(&format!("Starting: {cmd} {}", args.join(" ")));
 
         // Start MCP server process
         let mut child = Command::new(cmd)
-            .args(args)
+            .args(&args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/crates/arkavo-protocol/src/agent_config.rs
+++ b/crates/arkavo-protocol/src/agent_config.rs
@@ -66,6 +66,34 @@ pub struct McpServerConfig {
     pub url: Option<String>,
 }
 
+/// Expand `${VAR}` references from the process environment.
+///
+/// Unset variables are left literal so the misconfiguration stays visible in
+/// downstream errors instead of silently collapsing to an empty string.
+pub fn expand_env(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(start) = rest.find("${") {
+        out.push_str(&rest[..start]);
+        match rest[start + 2..].find('}') {
+            Some(end) => {
+                let var = &rest[start + 2..start + 2 + end];
+                match std::env::var(var) {
+                    Ok(value) => out.push_str(&value),
+                    Err(_) => out.push_str(&rest[start..=start + 2 + end]),
+                }
+                rest = &rest[start + 2 + end + 1..];
+            }
+            None => {
+                out.push_str(&rest[start..]);
+                rest = "";
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
 /// Parse AGENTS.md configuration content
 pub fn parse_agents_config(content: &str) -> Result<Vec<AgentConfig>, Box<dyn std::error::Error>> {
     let mut agents = Vec::new();
@@ -150,14 +178,13 @@ pub fn parse_agents_config(content: &str) -> Result<Vec<AgentConfig>, Box<dyn st
             && let Some(server) = current_mcp_server.as_mut()
         {
             if trimmed.starts_with("command:") {
-                server.command = Some(
+                server.command = Some(expand_env(
                     trimmed
                         .strip_prefix("command:")
                         .unwrap_or("")
                         .trim()
-                        .trim_matches('"')
-                        .to_string(),
-                );
+                        .trim_matches('"'),
+                ));
             } else if trimmed.starts_with("args:") {
                 // Parse array format: ["arg1", "arg2"]
                 let args_str = trimmed.strip_prefix("args:").unwrap_or("").trim();
@@ -165,19 +192,18 @@ pub fn parse_agents_config(content: &str) -> Result<Vec<AgentConfig>, Box<dyn st
                     let args_content = &args_str[1..args_str.len() - 1];
                     server.args = args_content
                         .split(',')
-                        .map(|s| s.trim().trim_matches('"').to_string())
+                        .map(|s| expand_env(s.trim().trim_matches('"')))
                         .filter(|s| !s.is_empty())
                         .collect();
                 }
             } else if trimmed.starts_with("url:") {
-                server.url = Some(
+                server.url = Some(expand_env(
                     trimmed
                         .strip_prefix("url:")
                         .unwrap_or("")
                         .trim()
-                        .trim_matches('"')
-                        .to_string(),
-                );
+                        .trim_matches('"'),
+                ));
             } else if !trimmed.is_empty() && !trimmed.starts_with(' ') && !trimmed.starts_with('-')
             {
                 // End of MCP section
@@ -391,6 +417,59 @@ pub fn parse_runtime_config(content: &str) -> RuntimeConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_expand_env_substitutes_set_variables() {
+        unsafe {
+            std::env::set_var("ARKAVO_TEST_EXPAND_SET", "/opt/bin/game-rl-server");
+        }
+        assert_eq!(
+            expand_env("${ARKAVO_TEST_EXPAND_SET}"),
+            "/opt/bin/game-rl-server"
+        );
+        assert_eq!(
+            expand_env("prefix-${ARKAVO_TEST_EXPAND_SET}-suffix"),
+            "prefix-/opt/bin/game-rl-server-suffix"
+        );
+    }
+
+    #[test]
+    fn test_expand_env_leaves_unset_variables_literal() {
+        // Unset vars stay literal so misconfiguration is visible downstream
+        assert_eq!(
+            expand_env("${ARKAVO_TEST_EXPAND_DEFINITELY_UNSET}"),
+            "${ARKAVO_TEST_EXPAND_DEFINITELY_UNSET}"
+        );
+        assert_eq!(expand_env("no variables here"), "no variables here");
+        assert_eq!(expand_env("dangling ${unclosed"), "dangling ${unclosed");
+    }
+
+    #[test]
+    fn test_mcp_server_config_expands_env_in_command_args_url() {
+        unsafe {
+            std::env::set_var("ARKAVO_TEST_GAME_RL_BIN", "/tmp/game-rl-server");
+            std::env::set_var("ARKAVO_TEST_GAME_RL_PORT", "8182");
+        }
+        let content = r#"
+## commander
+
+purpose: "test agent"
+mcp_servers:
+  - name: game-rl
+    command: ${ARKAVO_TEST_GAME_RL_BIN}
+    args: ["--scenario", "${ARKAVO_TEST_UNSET_SCENARIO}"]
+  - name: remote
+    url: "http://localhost:${ARKAVO_TEST_GAME_RL_PORT}"
+"#;
+        let agents = parse_agents_config(content).unwrap();
+        assert_eq!(agents.len(), 1);
+        let servers = &agents[0].mcp_servers;
+        assert_eq!(servers.len(), 2);
+        assert_eq!(servers[0].command.as_deref(), Some("/tmp/game-rl-server"));
+        assert_eq!(servers[0].args[0], "--scenario");
+        assert_eq!(servers[0].args[1], "${ARKAVO_TEST_UNSET_SCENARIO}");
+        assert_eq!(servers[1].url.as_deref(), Some("http://localhost:8182"));
+    }
 
     #[test]
     fn test_parse_workspace_paths_relative() {

--- a/crates/arkavo-swarmkit/src/lib.rs
+++ b/crates/arkavo-swarmkit/src/lib.rs
@@ -13,6 +13,7 @@ pub mod canonical;
 pub mod coordination;
 pub mod governance;
 pub mod manifest;
+pub mod mcp;
 pub mod role;
 pub mod skill_content;
 pub mod validate;
@@ -30,6 +31,7 @@ pub use governance::{
 pub use manifest::{Author, DeliverableSpec, InputSpec, KitMetadata, Manifest, Objective};
 #[allow(deprecated)]
 pub use role::ArpRule;
+pub use mcp::{McpServerDef, Transport};
 pub use role::{
     AgentProvisioning, Budget, ContextScope, Failure, Handoff, Inference, McpToolGrant, Model,
     Observability, Plane, RoleSpec, Skill, SkillSource, TdfAttributeReleasePolicy, TdfReleaseRule,

--- a/crates/arkavo-swarmkit/src/lib.rs
+++ b/crates/arkavo-swarmkit/src/lib.rs
@@ -29,9 +29,9 @@ pub use governance::{
     RoleProposalCeiling,
 };
 pub use manifest::{Author, DeliverableSpec, InputSpec, KitMetadata, Manifest, Objective};
+pub use mcp::{McpServerDef, Transport};
 #[allow(deprecated)]
 pub use role::ArpRule;
-pub use mcp::{McpServerDef, Transport};
 pub use role::{
     AgentProvisioning, Budget, ContextScope, Failure, Handoff, Inference, McpToolGrant, Model,
     Observability, Plane, RoleSpec, Skill, SkillSource, TdfAttributeReleasePolicy, TdfReleaseRule,

--- a/crates/arkavo-swarmkit/src/manifest.rs
+++ b/crates/arkavo-swarmkit/src/manifest.rs
@@ -6,6 +6,7 @@ use crate::coordination::{
     CompletionSpec, ConstraintsSpec, CoordinationSpec, EvaluationSpec, ProvenanceSpec,
 };
 use crate::governance::ProposalGovernanceSpec;
+use crate::mcp::McpServerDef;
 use crate::role::RoleSpec;
 
 /// Top-level SwarmKit manifest. Cleartext document inside the TDF payload.
@@ -20,6 +21,10 @@ pub struct Manifest {
     pub deliverables: Vec<DeliverableSpec>,
     pub roles: Vec<RoleSpec>,
     pub coordination: CoordinationSpec,
+    /// MCP servers this kit can launch/connect (spec §4.x). Roles reference
+    /// these by name from `mcp_tools[].server`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mcp_servers: Vec<McpServerDef>,
     pub constraints: ConstraintsSpec,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub evaluation: Option<EvaluationSpec>,

--- a/crates/arkavo-swarmkit/src/mcp.rs
+++ b/crates/arkavo-swarmkit/src/mcp.rs
@@ -1,0 +1,59 @@
+//! MCP server declarations for kits (spec §4.x): how a role's `mcp_tools`
+//! grant is actually launched/connected at play time.
+
+use serde::{Deserialize, Serialize};
+
+/// Transport for an MCP server connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Transport {
+    #[default]
+    Stdio,
+    Http,
+    Sse,
+}
+
+/// A named MCP server a kit can launch/connect. Roles reference it by `name`
+/// from their `mcp_tools[].server`. `command`/`args` may contain `${VAR}`
+/// placeholders expanded at play time (not parse time), keeping the kit
+/// portable and its `kit.id` stable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpServerDef {
+    pub name: String,
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub transport: Transport,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_minimal_server() {
+        let yaml = r#"
+name: game-rl
+command: ${GAME_RL_SERVER}
+"#;
+        let def: McpServerDef = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(def.name, "game-rl");
+        assert_eq!(def.command, "${GAME_RL_SERVER}");
+        assert!(def.args.is_empty());
+        assert_eq!(def.transport, Transport::Stdio);
+    }
+
+    #[test]
+    fn round_trips_with_args_and_transport() {
+        let def = McpServerDef {
+            name: "game-rl".into(),
+            command: "game-rl-server".into(),
+            args: vec!["--http".into()],
+            transport: Transport::Http,
+        };
+        let yaml = serde_yaml::to_string(&def).unwrap();
+        let back: McpServerDef = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(def, back);
+    }
+}

--- a/crates/arkavo-swarmkit/src/validate.rs
+++ b/crates/arkavo-swarmkit/src/validate.rs
@@ -33,6 +33,9 @@ pub enum ValidationError {
     #[error("handoff target {target:?} from role {from:?} does not resolve to a known role")]
     UnresolvedHandoff { from: String, target: String },
 
+    #[error("unknown mcp server '{server}' referenced by role '{role}'")]
+    UnknownMcpServer { role: String, server: String },
+
     #[error("evaluation.critic_role {0:?} does not resolve to a known role")]
     UnresolvedCriticRole(String),
 
@@ -128,12 +131,23 @@ pub fn validate(m: &Manifest) -> Result<(), ValidationError> {
         }
     }
 
+    // Every mcp_tools grant must reference a declared mcp_servers entry.
+    let known_servers: HashSet<&str> = m.mcp_servers.iter().map(|s| s.name.as_str()).collect();
+
     for role in &m.roles {
         for h in &role.handoffs {
             if !role_ids.contains(h.to.as_str()) {
                 return Err(ValidationError::UnresolvedHandoff {
                     from: role.id.clone(),
                     target: h.to.clone(),
+                });
+            }
+        }
+        for grant in &role.mcp_tools {
+            if !known_servers.contains(grant.server.as_str()) {
+                return Err(ValidationError::UnknownMcpServer {
+                    role: role.id.clone(),
+                    server: grant.server.clone(),
                 });
             }
         }
@@ -368,6 +382,7 @@ mod tests {
                 },
                 context_sharing: None,
             },
+            mcp_servers: vec![],
             constraints: ConstraintsSpec {
                 global_budget: GlobalBudget {
                     max_wallclock_seconds: 60,
@@ -402,6 +417,31 @@ mod tests {
     #[test]
     fn minimal_validates() {
         validate(&minimal_manifest()).unwrap();
+    }
+
+    #[test]
+    fn rejects_grant_referencing_undeclared_mcp_server() {
+        // `parse_yaml` bundles `validate`, so deserialize directly here to
+        // isolate the validation step under test (the grant references a
+        // server that is not declared in `mcp_servers`).
+        let yaml = include_str!("../tests/fixtures/undeclared_mcp_server.yaml");
+        let manifest: Manifest = serde_yaml::from_str(yaml).expect("parses");
+        let err = crate::validate(&manifest).expect_err("must reject");
+        assert!(
+            format!("{err}").contains("unknown mcp server 'game-rl'"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn accepts_grant_with_declared_mcp_server() {
+        let yaml = include_str!("../tests/fixtures/declared_mcp_server.yaml");
+        let manifest = crate::parse_yaml(yaml).expect("parses");
+        assert!(
+            crate::validate(&manifest).is_ok(),
+            "expected valid, got: {:?}",
+            crate::validate(&manifest).err()
+        );
     }
 
     #[spec("SK-002")]

--- a/crates/arkavo-swarmkit/tests/fixtures/declared_mcp_server.yaml
+++ b/crates/arkavo-swarmkit/tests/fixtures/declared_mcp_server.yaml
@@ -1,0 +1,55 @@
+spec_version: "1.0.0"
+kit:
+  id: "blake3:9GChbk8OzJLxjvlxbJvN8c7stFpdi7vytdigP1YjPak"
+  name: "Declared MCP Server Kit"
+  version: "0.1.0"
+  authors:
+    - did: "did:web:arkavo.com"
+      name: "Arkavo"
+  created: "2026-04-29T00:00:00Z"
+  nonce: "thz1Cz8aWOUURbyQQfvA0Q"
+
+objective:
+  goal: "Exercise the mcp_servers registry validation rule."
+
+roles:
+  - id: "survivor"
+    role_type: "specialist"
+    agent_provisioning: {}
+    mcp_tools:
+      - server: "game-rl"
+        tools: ["observe", "step"]
+        auth: "none"
+
+coordination:
+  topology: "hub-spoke"
+  protocol: "a2a-jsonrpc-2.0"
+  routing:
+    strategy: "static"
+
+mcp_servers:
+  - name: "game-rl"
+    command: "${GAME_RL_SERVER}"
+
+constraints:
+  global_budget:
+    max_wallclock_seconds: 60
+    max_total_tokens: 8000
+    max_cost_usd: 0.01
+  data_classifications:
+    - "public"
+  network:
+    egress_allowed: false
+    egress_allowlist: []
+
+completion:
+  rules:
+    - "all deliverables present"
+  on_failure: "abort"
+  max_retries: 0
+
+provenance:
+  signatures:
+    - signer_did: "did:web:arkavo.com"
+      algorithm: "ed25519"
+      signature: "AAA"

--- a/crates/arkavo-swarmkit/tests/fixtures/undeclared_mcp_server.yaml
+++ b/crates/arkavo-swarmkit/tests/fixtures/undeclared_mcp_server.yaml
@@ -1,0 +1,51 @@
+spec_version: "1.0.0"
+kit:
+  id: "blake3:v-yQLd0-0wfsnEQZA7-MI1m9ZcTS3tfHu-B8GgCNH7g"
+  name: "Declared MCP Server Kit"
+  version: "0.1.0"
+  authors:
+    - did: "did:web:arkavo.com"
+      name: "Arkavo"
+  created: "2026-04-29T00:00:00Z"
+  nonce: "thz1Cz8aWOUURbyQQfvA0Q"
+
+objective:
+  goal: "Exercise the mcp_servers registry validation rule."
+
+roles:
+  - id: "survivor"
+    role_type: "specialist"
+    agent_provisioning: {}
+    mcp_tools:
+      - server: "game-rl"
+        tools: ["observe", "step"]
+        auth: "none"
+
+coordination:
+  topology: "hub-spoke"
+  protocol: "a2a-jsonrpc-2.0"
+  routing:
+    strategy: "static"
+
+constraints:
+  global_budget:
+    max_wallclock_seconds: 60
+    max_total_tokens: 8000
+    max_cost_usd: 0.01
+  data_classifications:
+    - "public"
+  network:
+    egress_allowed: false
+    egress_allowlist: []
+
+completion:
+  rules:
+    - "all deliverables present"
+  on_failure: "abort"
+  max_retries: 0
+
+provenance:
+  signatures:
+    - signer_did: "did:web:arkavo.com"
+      algorithm: "ed25519"
+      signature: "AAA"

--- a/crates/arkavo-swarmkit/tests/zomboid_kit.rs
+++ b/crates/arkavo-swarmkit/tests/zomboid_kit.rs
@@ -1,0 +1,34 @@
+//! Pins the shipped Zomboid Survival Kit so an edit cannot silently stale its
+//! kit.id, and confirms it parses + validates with the expected role topology.
+
+use arkavo_swarmkit::{kit_id_for, parse_yaml};
+use std::path::PathBuf;
+
+fn load_zomboid_kit() -> String {
+    // tests/ is at CARGO_MANIFEST_DIR (crates/arkavo-swarmkit); the example lives
+    // two levels up under examples/.
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/zomboid-survival-kit/zomboid-survival-kit.swarmkit.yaml");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+#[test]
+fn zomboid_kit_parses_and_validates() {
+    // parse_yaml runs validate() internally — success here means the kit is valid.
+    let manifest = parse_yaml(&load_zomboid_kit()).expect("zomboid kit must parse + validate");
+    assert_eq!(manifest.kit.name, "Zomboid Survival Kit");
+    assert_eq!(manifest.roles.len(), 5);
+    let ids: Vec<&str> = manifest.roles.iter().map(|r| r.id.as_str()).collect();
+    assert_eq!(ids, ["survivor", "threat", "scavenger", "medic", "critic"]);
+}
+
+#[test]
+fn zomboid_kit_id_is_not_stale() {
+    let yaml = load_zomboid_kit();
+    let manifest = parse_yaml(&yaml).expect("parses");
+    let recomputed = kit_id_for(&manifest).expect("hash computes");
+    assert_eq!(
+        manifest.kit.id, recomputed,
+        "examples/zomboid-survival-kit kit.id is stale — re-run validate_kit and update the kit.id field"
+    );
+}

--- a/examples/gridcolony/README.md
+++ b/examples/gridcolony/README.md
@@ -1,0 +1,51 @@
+# GridColony — headless Game-RL playtest example
+
+GridColony is the Game-RL **reference environment** (`game-rl-reference`, spec
+draft-02 conformance Level 3) from the [game-rl](https://github.com/arkavo-ai/game-rl)
+repository. It is deterministic, headless, and instant to reset — the ideal
+target for Edge agent playtesting without launching a real game.
+
+## Why this example exists
+
+The `fertile-corner` scenario is a **behavioral probe for spatial decision
+quality**: all fertile soil is in the NE corner, far from the map center. An
+agent that anchors placements to `MapCenter` (the historical center-bias
+failure) scores **zero** on the `farm_fertility_quality` reward component; an
+agent that reads `Landmarks` and anchors to `FertileCluster_0` scores ~1.3.
+Use it as a regression test for spatial policy quality.
+
+## Scenarios
+
+| Scenario | Probe |
+|----------|-------|
+| `default` | Balanced colony start; fertile soil near (but not at) center |
+| `fertile-corner` | **Anti-center-bias probe** — fertile soil only in the NE |
+| `threat-south` | Hostiles approach from the south; tests alert→DefendColony |
+| `scattered-resources` | Resources in all compass regions; tests landmark navigation |
+
+Append `+dr` to any scenario name for domain-randomized fertility.
+
+## Run the scripted policy probe (no LLM required)
+
+```bash
+# Build the reference env first (in the game-rl repo):
+#   cargo build --release -p game-rl-reference
+python3 playtest_probe.py            # runs center-biased vs landmark-aware policies
+python3 playtest_probe.py --steps 40 # longer episodes
+```
+
+This drives both policies through every scenario over real MCP stdio and
+reports `farm_fertility_quality` and `TotalReward` side by side.
+
+## Run the LLM agent swarm
+
+```bash
+export GAME_RL_REFERENCE=~/Projects/intelligence/game-rl/target/release/game-rl-reference
+export GRIDCOLONY_SCENARIO=fertile-corner
+./launch_gridcolony.sh
+```
+
+Requires a local model (see `agents/commander/AGENTS.md`) or router-configured
+provider. The commander's prompt teaches the draft-02 spatial workflow:
+discover anchors via `observe(Include=["landmarks","terrain"])`, preview with
+`resolveSpatial`, and never anchor farms to `MapCenter`.

--- a/examples/gridcolony/agents/commander/AGENTS.md
+++ b/examples/gridcolony/agents/commander/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md
+
+## commander
+purpose: |
+  GridColony controller. You MUST call the step tool every cycle.
+
+  Do NOT write analysis. Do NOT explain your reasoning. ONLY call tools.
+
+  ==================================================================
+  HARD RULES — apply BEFORE any other instruction or cached lesson:
+  ==================================================================
+
+  RULE 1 — Cycle 1 only: registerAgent(AgentId="player1", AgentType="Controller").
+           Skip the rest of these rules on cycle 1.
+
+  RULE 2 — Cycle 2 only: observe(Include=["landmarks","terrain","alerts"]).
+           Memorize the FertileCluster ids and Region ids from Landmarks.
+           These are your placement anchors for the whole episode.
+
+  RULE 3 — Spatial discipline (the most important rule):
+           NEVER use "Near":"MapCenter" for EstablishFarm. Farms go on
+           fertile soil: use the largest FertileCluster from Landmarks,
+           e.g. {"Type":"EstablishFarm","Near":"FertileCluster_0","Crop":"Rice"}.
+           Buildings and storage anchor to "ColonyCenter" or an existing
+           building id — never to MapCenter unless the colony lives there.
+           If unsure a placement will work, preview it first with
+           resolveSpatial({"Intent":{...}}) — it is free and does not act.
+           If a spatial action errors, READ the error: it lists feasible
+           alternative anchors. Use one of them next cycle.
+
+  RULE 4 — Alert priority. Read Observation.Alerts. Pick the alert with the
+           HIGHEST Severity and address that ONE alert this cycle:
+    | Alert Label              | Action                                                                    |
+    |--------------------------|---------------------------------------------------------------------------|
+    | "Starvation imminent"    | step Action={"Type":"Harvest","Target":"Berries"}                         |
+    | "Low food"               | step Action={"Type":"Harvest","Target":"Berries"}                         |
+    | "UnderAttack"            | step Action={"Type":"DefendColony"}                                       |
+    | "No farm established"    | step Action={"Type":"EstablishFarm","Near":"<largest FertileCluster id>"} |
+    | (no alerts present)      | step Action={"Type":"Wait"} with Ticks=120                                |
+
+  RULE 5 — Output discipline: emit EXACTLY ONE tool call per cycle. No prose.
+
+  RULE 6 — Never call observe two cycles in a row — prefer an action.
+           Every 10 cycles: call episodeSummary() and check the
+           farm_fertility_quality component. If it is 0 and you built a farm,
+           your anchor choice was wrong — re-observe landmarks and improve.
+
+  RULE 7 — Reset is destructive. Only reset after episodeSummary shows
+           TotalReward < -20, with reset(Scenario="${GRIDCOLONY_SCENARIO}").
+
+# Supported local models (single-line swap); blank = auto-select loaded model
+model: gemma-4-26b-a4b
+action_interval: 60
+listen: 0.0.0.0:8431
+mdns: true
+
+game_evaluation:
+  domain: gridcolony
+  criteria_mapping:
+    survival_trajectory: goal_fidelity
+    spatial_quality: efficiency
+    threat_awareness: state_coherence
+    compound_value: adaptability
+
+mcp_servers:
+  - name: game-rl
+    command: ${GAME_RL_REFERENCE}
+    args: ["--scenario", "${GRIDCOLONY_SCENARIO}"]

--- a/examples/gridcolony/launch_gridcolony.sh
+++ b/examples/gridcolony/launch_gridcolony.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# GridColony — single-agent Game-RL playtest against the reference environment
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BINARY="${BINARY:-${PROJECT_ROOT}/target/debug/arkavo}"
+if [ ! -f "$BINARY" ]; then
+    BINARY="${PROJECT_ROOT}/target/release/arkavo"
+fi
+LOG_DIR="$SCRIPT_DIR/logs"
+mkdir -p "$LOG_DIR"
+
+# The Game-RL reference environment binary (spec draft-02 Level 3).
+# Resolution order: explicit env, PATH, sibling game-rl repo.
+export GAME_RL_REFERENCE="${GAME_RL_REFERENCE:-$(command -v game-rl-reference || echo "$HOME/Projects/intelligence/game-rl/target/release/game-rl-reference")}"
+# Scenario: default | fertile-corner | threat-south | scattered-resources (append +dr for randomization)
+export GRIDCOLONY_SCENARIO="${GRIDCOLONY_SCENARIO:-fertile-corner}"
+
+if [ ! -x "$GAME_RL_REFERENCE" ]; then
+    echo "[ERROR] game-rl-reference not found (GAME_RL_REFERENCE=$GAME_RL_REFERENCE)"
+    echo "        Build it: cargo build --release -p game-rl-reference  (in the game-rl repo)"
+    exit 1
+fi
+
+case "${1:-start}" in
+    stop)
+        pkill -f "arkavo agent.*gridcolony" 2>/dev/null || true
+        echo "[OK] stopped"
+        exit 0
+        ;;
+esac
+
+echo "[INFO] server:   $GAME_RL_REFERENCE"
+echo "[INFO] scenario: $GRIDCOLONY_SCENARIO"
+echo "[INFO] starting commander on :8431 (logs: $LOG_DIR/commander.log)"
+
+cd "$SCRIPT_DIR/agents/commander"
+exec "$BINARY" agent --config AGENTS.md 2>&1 | tee "$LOG_DIR/commander.log"

--- a/examples/gridcolony/playtest_probe.py
+++ b/examples/gridcolony/playtest_probe.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""GridColony policy probe — measures spatial decision quality across scenarios.
+
+Drives two scripted policies through the Game-RL reference environment over
+real MCP stdio (the same wire path an Edge agent uses):
+
+  center-biased   : EstablishFarm anchored to MapCenter (the historical failure)
+  landmark-aware  : observe Landmarks, anchor to the largest FertileCluster
+
+The fertile-corner scenario is the regression probe: a center-biased policy
+must score 0 on farm_fertility_quality there; a landmark-aware policy ~1.3.
+
+Usage:
+  python3 playtest_probe.py [--steps 20] [--server path/to/game-rl-reference]
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCENARIOS = ["default", "fertile-corner", "threat-south", "scattered-resources"]
+SEED = 42
+
+
+class McpClient:
+    def __init__(self, server_path):
+        self.proc = subprocess.Popen(
+            [server_path],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        self.next_id = 1
+
+    def request(self, method, params):
+        rid = self.next_id
+        self.next_id += 1
+        msg = json.dumps(
+            {"jsonrpc": "2.0", "id": rid, "method": method, "params": params}
+        )
+        self.proc.stdin.write(msg + "\n")
+        self.proc.stdin.flush()
+        while True:
+            line = self.proc.stdout.readline()
+            if not line:
+                raise RuntimeError(f"server closed during {method}")
+            try:
+                response = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if response.get("id") == rid:
+                return response
+
+    def initialize(self):
+        result = self.request(
+            "initialize",
+            {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {"tools": {}},
+                "clientInfo": {"name": "playtest-probe", "version": "1.0"},
+            },
+        )
+        self.proc.stdin.write(
+            json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}) + "\n"
+        )
+        self.proc.stdin.flush()
+        return result
+
+    def tool(self, name, arguments):
+        """Returns (ok, payload_or_error_message)."""
+        response = self.request(
+            "tools/call", {"name": name, "arguments": arguments}
+        )
+        if "error" in response:
+            return False, response["error"].get("message", "")
+        result = response.get("result", {})
+        text = (result.get("content") or [{}])[0].get("text", "")
+        if result.get("isError"):
+            return False, text
+        try:
+            return True, json.loads(text)
+        except json.JSONDecodeError:
+            return True, text
+
+    def close(self):
+        try:
+            self.proc.stdin.close()
+            self.proc.wait(timeout=3)
+        except Exception:
+            self.proc.kill()
+
+
+def run_policy(server_path, scenario, policy, steps):
+    """Returns episode metrics for one policy on one scenario."""
+    client = McpClient(server_path)
+    try:
+        client.initialize()
+        client.tool("registerAgent", {"AgentId": "probe", "AgentType": "Controller"})
+        client.tool("reset", {"Seed": SEED, "Scenario": scenario})
+
+        def step(action, ticks=0):
+            return client.tool(
+                "step", {"AgentId": "probe", "Action": action, "Ticks": ticks}
+            )
+
+        # Keep the colony fed identically under both policies
+        step({"Type": "Harvest", "Target": "Berries"})
+        step({"Type": "Harvest", "Target": "Berries"})
+
+        # The policy decision under test: where does the farm go?
+        if policy == "center-biased":
+            farm_ok, farm_detail = step(
+                {"Type": "EstablishFarm", "Near": "MapCenter", "Size": 16}
+            )
+        else:  # landmark-aware
+            ok, obs = client.tool("observe", {"Include": ["landmarks"], "Limit": 50})
+            landmarks = []
+            if isinstance(obs, dict):
+                # Landmarks may sit at top level or nested under Observation
+                landmarks = (
+                    obs.get("Landmarks")
+                    or obs.get("Observation", {}).get("Landmarks")
+                    or []
+                )
+            clusters = [
+                l["Id"]
+                for l in landmarks
+                if isinstance(l, dict) and str(l.get("Id", "")).startswith("FertileCluster")
+            ]
+            anchor = clusters[0] if clusters else "ColonyCenter"
+            farm_ok, farm_detail = step(
+                {"Type": "EstablishFarm", "Near": anchor, "Size": 16}
+            )
+
+        # Let the world run; defend if the scenario brings hostiles
+        for _ in range(steps):
+            ok, payload = step({"Type": "Wait"}, ticks=120)
+            alerts = (payload.get("Alerts") if isinstance(payload, dict) else None) or []
+            if any(a.get("Label") == "UnderAttack" for a in alerts if isinstance(a, dict)):
+                step({"Type": "DefendColony"})
+
+        ok, summary = client.tool("episodeSummary", {})
+        breakdown = summary.get("RewardBreakdown", {}) if isinstance(summary, dict) else {}
+        return {
+            "scenario": scenario,
+            "policy": policy,
+            "farm_placed": bool(farm_ok),
+            "farm_error": None if farm_ok else str(farm_detail)[:120],
+            "farm_fertility_quality": round(breakdown.get("farm_fertility_quality", 0.0), 3),
+            "food_production": round(breakdown.get("food_production", 0.0), 3),
+            "total_reward": round(summary.get("TotalReward", 0.0), 3)
+            if isinstance(summary, dict)
+            else 0.0,
+        }
+    finally:
+        client.close()
+
+
+def default_server():
+    candidates = [
+        os.environ.get("GAME_RL_REFERENCE"),
+        str(Path.home() / "Projects/intelligence/game-rl/target/release/game-rl-reference"),
+        str(Path.home() / "Projects/intelligence/game-rl/target/debug/game-rl-reference"),
+    ]
+    for c in candidates:
+        if c and Path(c).is_file():
+            return c
+    return "game-rl-reference"  # hope for PATH
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--server", default=default_server())
+    parser.add_argument("--steps", type=int, default=20)
+    parser.add_argument("--json", help="write results JSON to this path")
+    args = parser.parse_args()
+
+    results = []
+    for scenario in SCENARIOS:
+        for policy in ["center-biased", "landmark-aware"]:
+            result = run_policy(args.server, scenario, policy, args.steps)
+            results.append(result)
+
+    header = f"{'scenario':<21} {'policy':<15} {'farm':<5} {'fertility':>9} {'food':>7} {'total':>8}"
+    print(header)
+    print("-" * len(header))
+    for r in results:
+        print(
+            f"{r['scenario']:<21} {r['policy']:<15} "
+            f"{'yes' if r['farm_placed'] else 'NO':<5} "
+            f"{r['farm_fertility_quality']:>9} {r['food_production']:>7} {r['total_reward']:>8}"
+        )
+
+    # The probe assertion: on fertile-corner, landmark-aware must beat center-biased
+    probe = {r["policy"]: r for r in results if r["scenario"] == "fertile-corner"}
+    passed = (
+        probe["landmark-aware"]["farm_fertility_quality"] >= 1.0
+        and probe["center-biased"]["farm_fertility_quality"] == 0.0
+    )
+    print(
+        f"\nfertile-corner probe: {'PASS' if passed else 'FAIL'} — "
+        f"landmark-aware fertility {probe['landmark-aware']['farm_fertility_quality']} "
+        f"vs center-biased {probe['center-biased']['farm_fertility_quality']}"
+    )
+
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump({"seed": SEED, "steps": args.steps, "results": results}, f, indent=2)
+        print(f"results written to {args.json}")
+
+    sys.exit(0 if passed else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/gridcolony/results-2026-06-11.json
+++ b/examples/gridcolony/results-2026-06-11.json
@@ -1,0 +1,78 @@
+{
+  "seed": 42,
+  "steps": 20,
+  "results": [
+    {
+      "scenario": "default",
+      "policy": "center-biased",
+      "farm_placed": true,
+      "farm_error": null,
+      "farm_fertility_quality": 1.072,
+      "food_production": 3.058,
+      "total_reward": 8.93
+    },
+    {
+      "scenario": "default",
+      "policy": "landmark-aware",
+      "farm_placed": true,
+      "farm_error": null,
+      "farm_fertility_quality": 1.4,
+      "food_production": 3.688,
+      "total_reward": 9.888
+    },
+    {
+      "scenario": "fertile-corner",
+      "policy": "center-biased",
+      "farm_placed": false,
+      "farm_error": "Invalid action: EstablishFarm near 'MapCenter': only 0 fertile cells within radius 8 of MapCenter (need 16). Alternative",
+      "farm_fertility_quality": 0.0,
+      "food_production": 1.0,
+      "total_reward": 5.8
+    },
+    {
+      "scenario": "fertile-corner",
+      "policy": "landmark-aware",
+      "farm_placed": true,
+      "farm_error": null,
+      "farm_fertility_quality": 1.378,
+      "food_production": 3.646,
+      "total_reward": 9.824
+    },
+    {
+      "scenario": "threat-south",
+      "policy": "center-biased",
+      "farm_placed": true,
+      "farm_error": null,
+      "farm_fertility_quality": 1.072,
+      "food_production": 1.72,
+      "total_reward": 4.112
+    },
+    {
+      "scenario": "threat-south",
+      "policy": "landmark-aware",
+      "farm_placed": true,
+      "farm_error": null,
+      "farm_fertility_quality": 1.4,
+      "food_production": 1.941,
+      "total_reward": 4.661
+    },
+    {
+      "scenario": "scattered-resources",
+      "policy": "center-biased",
+      "farm_placed": false,
+      "farm_error": "Invalid action: EstablishFarm near 'MapCenter': only 0 fertile cells within radius 8 of MapCenter (need 16). Alternative",
+      "farm_fertility_quality": 0.0,
+      "food_production": 1.0,
+      "total_reward": 5.8
+    },
+    {
+      "scenario": "scattered-resources",
+      "policy": "landmark-aware",
+      "farm_placed": true,
+      "farm_error": null,
+      "farm_fertility_quality": 1.069,
+      "food_production": 3.052,
+      "total_reward": 8.921
+    }
+  ]
+}

--- a/examples/rimworld/agents/commander/AGENTS.md
+++ b/examples/rimworld/agents/commander/AGENTS.md
@@ -26,17 +26,17 @@ purpose: |
     | "Major break risk"       | step Action={"Type":"SetSpeed","Speed":0}    (pause; manual intervention)                    |
     | "Minor break risk"       | step Action={"Type":"SetSpeed","Speed":2}    (KEEP PLAYING; break risk resolves with rest)  |
     | "Minor break risk x2"    | step Action={"Type":"SetSpeed","Speed":2}    (KEEP PLAYING; break risk resolves with rest)  |
-    | "UnderAttack"            | step Action={"Type":"SetSpeed","Speed":0}    then next cycle Draft a colonist                |
-    | "Need defenses"          | step Action={"Type":"PlaceBuildingNear","Building":"Sandbags","Near":"MapCenter","Count":5}  |
-    | "Need colonist beds"     | step Action={"Type":"PlaceBuildingNear","Building":"Bed","Near":"MapCenter","Count":3}       |
-    | "Need meal source"       | step Action={"Type":"EstablishFarm","Crop":"Potato","Near":"MapCenter","Size":"Medium"}      |
+    | "UnderAttack"            | step Action={"Type":"DefendColony"}                                                           |
+    | "Need defenses"          | step Action={"Type":"PlaceBuildingNear","Building":"Sandbags","Near":"ColonyCenter","Count":5}|
+    | "Need colonist beds"     | step Action={"Type":"PlaceBuildingNear","Building":"Bed","Near":"ColonyCenter","Count":3}    |
+    | "Need meal source"       | step Action={"Type":"EstablishFarm","Crop":"Potato","Near":"ColonyCenter","Size":"Medium","AllowFallback":true}|
     | "Medical emergency"      | step Action={"Type":"SetMedicalCare","ColonistId":<see RULE 4>,"Care":"Best"}                |
     | "Medical treatment needed"| step Action={"Type":"SetMedicalCare","ColonistId":<see RULE 4>,"Care":"Best"}               |
     | "Need doctor"            | step Action={"Type":"SetWorkPriority","ColonistId":<see RULE 4>,"WorkType":"Doctor","Priority":1}|
-    | "Need warm clothes"      | step Action={"Type":"PlaceBuildingNear","Building":"TailorBench","Near":"MapCenter","Count":1}|
+    | "Need warm clothes"      | step Action={"Type":"PlaceBuildingNear","Building":"TailorBench","Near":"ColonyCenter","Count":1}|
     | "Need research project"  | step Action={"Type":"SelectResearch","ProjectDefName":"Batteries"}                           |
-    | "Pen needed"             | step Action={"Type":"PlaceBuildingNear","Building":"Wall","Near":"MapCenter","Count":4}      |
-    | "Need recreation variety"| step Action={"Type":"PlaceBuildingNear","Building":"Chess","Near":"MapCenter","Count":1}     |
+    | "Pen needed"             | step Action={"Type":"PlaceBuildingNear","Building":"Wall","Near":"ColonyCenter","Count":4}   |
+    | "Need recreation variety"| step Action={"Type":"PlaceBuildingNear","Building":"ChessTable","Near":"ColonyCenter","Count":1}|
     | "colonist idle" / "colonists idle" | step Action={"Type":"SetWorkPriority","ColonistId":<see RULE 4>,"WorkType":"Construction","Priority":1}|
     | (no alerts present)      | step Action={"Type":"SetSpeed","Speed":2}                                                    |
 
@@ -55,6 +55,14 @@ purpose: |
            cannot recover (eat, work, sleep) while paused. Never pause two
            cycles in a row. Never call observe twice in a row either —
            prefer an action.
+
+  RULE 8 — Spatial anchors. Valid Near values: "ColonyCenter" (preferred),
+           a building/zone id from observations, "FertileCluster_0"
+           (best farmland), "Region_N".."Region_NW", or "MapCenter" (last
+           resort). If a spatial action errors, the error message lists
+           feasible alternative anchors — use one of them next cycle.
+           Farms: prefer "FertileCluster_0"; "AllowFallback":true lets the
+           game relocate to good soil and reports where it went.
 
   RULE 7 — Reset is destructive. NEVER call reset unless you JUST called
            episodeSummary() this cycle or last cycle AND its TotalReward

--- a/examples/rimworld/agents/commander/AGENTS.md
+++ b/examples/rimworld/agents/commander/AGENTS.md
@@ -28,7 +28,7 @@ purpose: |
     | "Minor break risk x2"    | step Action={"Type":"SetSpeed","Speed":2}    (KEEP PLAYING; break risk resolves with rest)  |
     | "UnderAttack"            | step Action={"Type":"DefendColony"}                                                           |
     | "Need defenses"          | step Action={"Type":"PlaceBuildingNear","Building":"Sandbags","Near":"ColonyCenter","Count":5}|
-    | "Need colonist beds"     | no room yet: step Action={"Type":"BuildRoom","Width":9,"Height":6,"Door":"S","Label":"barracks"}; room exists: step Action={"Type":"PlaceBuildingNear","Building":"Bed","Count":3,"Inside":"Room_1"} |
+    | "Need colonist beds"     | step Action={"Type":"BuildRoom","Width":9,"Height":6,"Door":"S","Label":"barracks"} — if it errors "still EMPTY", run the exact JSON action from the error message next cycle |
     | "Need meal source"       | step Action={"Type":"EstablishFarm","Crop":"Potato","Near":"ColonyCenter","Size":"Medium","AllowFallback":true}|
     | "Medical emergency"      | step Action={"Type":"SetMedicalCare","ColonistId":<see RULE 4>,"Care":"Best"}                |
     | "Medical treatment needed"| step Action={"Type":"SetMedicalCare","ColonistId":<see RULE 4>,"Care":"Best"}               |
@@ -76,6 +76,9 @@ purpose: |
            NEVER place loose Wall buildings to make enclosures — use
            BuildRoom. RenderMap is free (no time advance): use it before
            and after building decisions.
+           BuildRoom REFUSES to build while an earlier room is still empty
+           — its error message contains the exact furnish action to run
+           next cycle. Never build two rooms in a row.
 
   RULE 7 — Reset is destructive. NEVER call reset unless you JUST called
            episodeSummary() this cycle or last cycle AND its TotalReward

--- a/examples/rimworld/agents/commander/AGENTS.md
+++ b/examples/rimworld/agents/commander/AGENTS.md
@@ -28,14 +28,14 @@ purpose: |
     | "Minor break risk x2"    | step Action={"Type":"SetSpeed","Speed":2}    (KEEP PLAYING; break risk resolves with rest)  |
     | "UnderAttack"            | step Action={"Type":"DefendColony"}                                                           |
     | "Need defenses"          | step Action={"Type":"PlaceBuildingNear","Building":"Sandbags","Near":"ColonyCenter","Count":5}|
-    | "Need colonist beds"     | step Action={"Type":"PlaceBuildingNear","Building":"Bed","Near":"ColonyCenter","Count":3}    |
+    | "Need colonist beds"     | no room yet: step Action={"Type":"BuildRoom","Width":9,"Height":6,"Door":"S","Label":"barracks"}; room exists: step Action={"Type":"PlaceBuildingNear","Building":"Bed","Count":3,"Inside":"Room_1"} |
     | "Need meal source"       | step Action={"Type":"EstablishFarm","Crop":"Potato","Near":"ColonyCenter","Size":"Medium","AllowFallback":true}|
     | "Medical emergency"      | step Action={"Type":"SetMedicalCare","ColonistId":<see RULE 4>,"Care":"Best"}                |
     | "Medical treatment needed"| step Action={"Type":"SetMedicalCare","ColonistId":<see RULE 4>,"Care":"Best"}               |
     | "Need doctor"            | step Action={"Type":"SetWorkPriority","ColonistId":<see RULE 4>,"WorkType":"Doctor","Priority":1}|
     | "Need warm clothes"      | step Action={"Type":"PlaceBuildingNear","Building":"TailorBench","Near":"ColonyCenter","Count":1}|
     | "Need research project"  | step Action={"Type":"SelectResearch","ProjectDefName":"Batteries"}                           |
-    | "Pen needed"             | step Action={"Type":"PlaceBuildingNear","Building":"Wall","Near":"ColonyCenter","Count":4}   |
+    | "Pen needed"             | step Action={"Type":"BuildRoom","Width":8,"Height":8,"Door":"S","Label":"pen"}               |
     | "Need recreation variety"| step Action={"Type":"PlaceBuildingNear","Building":"ChessTable","Near":"ColonyCenter","Count":1}|
     | "colonist idle" / "colonists idle" | step Action={"Type":"SetWorkPriority","ColonistId":<see RULE 4>,"WorkType":"Construction","Priority":1}|
     | (no alerts present)      | step Action={"Type":"SetSpeed","Speed":2}                                                    |
@@ -57,12 +57,25 @@ purpose: |
            prefer an action.
 
   RULE 8 — Spatial anchors. Valid Near values: "ColonyCenter" (preferred),
-           a building/zone id from observations, "FertileCluster_0"
-           (best farmland), "Region_N".."Region_NW", or "MapCenter" (last
-           resort). If a spatial action errors, the error message lists
-           feasible alternative anchors — use one of them next cycle.
+           a building/zone id from observations, "Room_1" (rooms you built),
+           "FertileCluster_0" (best farmland), "Region_N".."Region_NW",
+           coordinates "(x,z)", or "MapCenter" (last resort). If a spatial
+           action errors, the error message lists feasible alternative
+           anchors — use one of them next cycle.
            Farms: prefer "FertileCluster_0"; "AllowFallback":true lets the
            game relocate to good soil and reports where it went.
+
+  RULE 9 — Build STRUCTURES, not wall spam. Buildings live in rooms:
+           1. step {"Type":"BuildRoom","Width":9,"Height":6,"Door":"S","Label":"barracks"}
+              → returns Room_1 with wall bounds and door position.
+           2. Furnish it: step {"Type":"PlaceBuildingNear","Building":"Bed","Count":3,"Inside":"Room_1"}
+           3. Verify: step {"Type":"RenderMap","Near":"Room_1","Radius":14} with Ticks=0
+              — an ASCII map (N=up, # wall, D door, B bed, P colonist) with
+              coordinate rulers; coordinates you read off it work as Near
+              anchors. Check the door is reachable and beds are inside.
+           NEVER place loose Wall buildings to make enclosures — use
+           BuildRoom. RenderMap is free (no time advance): use it before
+           and after building decisions.
 
   RULE 7 — Reset is destructive. NEVER call reset unless you JUST called
            episodeSummary() this cycle or last cycle AND its TotalReward

--- a/examples/rimworld/agents/commander/AGENTS.md
+++ b/examples/rimworld/agents/commander/AGENTS.md
@@ -28,7 +28,7 @@ purpose: |
     | "Minor break risk x2"    | step Action={"Type":"SetSpeed","Speed":2}    (KEEP PLAYING; break risk resolves with rest)  |
     | "UnderAttack"            | step Action={"Type":"DefendColony"}                                                           |
     | "Need defenses"          | step Action={"Type":"PlaceBuildingNear","Building":"Sandbags","Near":"ColonyCenter","Count":5}|
-    | "Need colonist beds"     | step Action={"Type":"BuildRoom","Width":9,"Height":6,"Door":"S","Label":"barracks"} — if it errors "still EMPTY", run the exact JSON action from the error message next cycle |
+    | "Need colonist beds"     | step Action={"Type":"BuildRoom","Width":9,"Height":6,"Door":"S","Label":"barracks","Furnish":"Bed:3"} |
     | "Need meal source"       | step Action={"Type":"EstablishFarm","Crop":"Potato","Near":"ColonyCenter","Size":"Medium","AllowFallback":true}|
     | "Medical emergency"      | step Action={"Type":"SetMedicalCare","ColonistId":<see RULE 4>,"Care":"Best"}                |
     | "Medical treatment needed"| step Action={"Type":"SetMedicalCare","ColonistId":<see RULE 4>,"Care":"Best"}               |
@@ -66,9 +66,10 @@ purpose: |
            game relocate to good soil and reports where it went.
 
   RULE 9 — Build STRUCTURES, not wall spam. Buildings live in rooms:
-           1. step {"Type":"BuildRoom","Width":9,"Height":6,"Door":"S","Label":"barracks"}
-              → returns Room_1 with wall bounds and door position.
-           2. Furnish it: step {"Type":"PlaceBuildingNear","Building":"Bed","Count":3,"Inside":"Room_1"}
+           1. step {"Type":"BuildRoom","Width":9,"Height":6,"Door":"S","Label":"barracks","Furnish":"Bed:3"}
+              → builds the room AND places the furniture in one action.
+              Furnish format: "<Building>:<count>", e.g. "Bed:3", "ChessTable:1".
+           2. Add more later: step {"Type":"PlaceBuildingNear","Building":"Bed","Count":2,"Inside":"Room_1"}
            3. Verify: step {"Type":"RenderMap","Near":"Room_1","Radius":14} with Ticks=0
               — an ASCII map (N=up, # wall, D door, B bed, P colonist) with
               coordinate rulers; coordinates you read off it work as Near

--- a/examples/rimworld/agents/commander/AGENTS.md
+++ b/examples/rimworld/agents/commander/AGENTS.md
@@ -101,5 +101,5 @@ a2a:
 
 mcp_servers:
   - name: game-rl
-    command: /Users/arkavo/Projects/intelligence/game-rl/target/release/game-rl-server
+    command: ${GAME_RL_SERVER}
     args: []

--- a/examples/rimworld/launch_rimworld.sh
+++ b/examples/rimworld/launch_rimworld.sh
@@ -21,6 +21,10 @@ LOG_DIR="$SCRIPT_DIR/logs"
 PIDS_FILE="$SCRIPT_DIR/.pids"
 RIMWORLD_SOCKET="/tmp/gamerl-rimworld.sock"
 
+# Game-RL MCP server binary. Resolution order: explicit env, PATH, sibling repo.
+# Referenced as ${GAME_RL_SERVER} in agents/commander/AGENTS.md.
+export GAME_RL_SERVER="${GAME_RL_SERVER:-$(command -v game-rl-server || echo "$HOME/Projects/intelligence/game-rl/target/release/game-rl-server")}"
+
 mkdir -p "$LOG_DIR"
 
 print_status() {
@@ -178,6 +182,13 @@ main() {
     esac
 
     check_binary
+
+    if [ ! -x "$GAME_RL_SERVER" ]; then
+        print_status "WARN" "game-rl-server not found (GAME_RL_SERVER=$GAME_RL_SERVER)"
+        print_status "INFO" "Set GAME_RL_SERVER or add game-rl-server to PATH"
+    else
+        print_status "INFO" "Using game-rl-server: $GAME_RL_SERVER"
+    fi
 
     # Check for RimWorld socket (warn but don't fail)
     if ! check_socket; then

--- a/examples/zomboid-survival-kit/README.md
+++ b/examples/zomboid-survival-kit/README.md
@@ -1,0 +1,57 @@
+# Zomboid Survival Kit
+
+A SwarmKit that plays Project Zomboid as a hub-spoke survivor swarm. One `survivor` role is the embodied agent that holds the game-rl MCP grant and drives every in-game action; four supporting roles — `threat`, `scavenger`, `medic`, and `critic` — operate purely through A2A messaging, advising or evaluating the survivor without touching the game directly.
+
+## Roles
+
+| Role | What it does |
+|---|---|
+| `survivor` | Hub agent. Drives Project Zomboid each cycle via game-rl (`observe` / `step`). Weighs advisor input and executes exactly one tool call per cycle. |
+| `threat` | Advisor. Reads the survivor's relayed zombie observations and recommends attack, shove-and-flee, or repositioning. |
+| `scavenger` | Advisor. Reads relayed nearby items and the rendered map; recommends the highest-value loot and a safe route to it. |
+| `medic` | Advisor. Reads relayed survivor stats; recommends when to eat, drink, rest, or break contact to treat injuries. |
+| `critic` | Evaluator. Scores the completed episode against the survival rubric and flags cycles where critical alerts were ignored. |
+
+Only `survivor` connects to the game. The three advisors (`threat`, `scavenger`, `medic`) exchange A2A recommendations with the survivor, the `critic` evaluates the episode, and none of these four call game-rl tools directly.
+
+## The kit is the source of truth
+
+The kit is a single content-addressed YAML file. `kit.id` is a BLAKE3 hash of its canonical form — any edit changes the identity. The game-rl MCP server is declared inside the kit under `mcp_servers`:
+
+```yaml
+mcp_servers:
+  - name: "game-rl"
+    command: "${GAME_RL_SERVER}"
+    args: []
+    transport: "stdio"
+```
+
+Because the server declaration is part of the kit, it is part of the kit's identity and provenance. Validate the kit with:
+
+```bash
+cargo run -p arkavo-swarmkit --example validate_kit -- examples/zomboid-survival-kit/zomboid-survival-kit.swarmkit.yaml
+```
+
+## How it runs
+
+`arkavo swarmkit play <kit>` maps each role to the existing agent runtime (`start_agent_server`) and ticks the live MCP loop. The `survivor` connects to game-rl and calls `registerAgent` → `observe` / `step` each cycle; the advisors receive the relayed observation and reply via A2A before the next cycle begins.
+
+This is different from the panel-only path (`ARKAVO_SWARMKIT_PATH` + `arkavo ui`), which only visualizes a kit's structure in the UI and does **not** drive a live game loop.
+
+## Prerequisites
+
+1. **Project Zomboid** installed with the GameRL Lua mod symlinked into `~/Zomboid/mods/GameRL`, and a save loaded so `~/Zomboid/Lua/gamerl_response.json` exists.
+2. **game-rl-server** built (`cargo build --release` in the game-rl repo at `~/Projects/intelligence/game-rl`) or available on `PATH`.
+3. **arkavo** built: `cargo build -p arkavo` in this repo.
+
+## Run
+
+```bash
+./examples/zomboid-survival-kit/run-kit.sh
+```
+
+Set `GAME_RL_SERVER=/path/to/game-rl-server` to override the server binary path.
+
+---
+
+`examples/zomboid/` is the simpler single-agent (non-kit) version of the same game.

--- a/examples/zomboid-survival-kit/README.md
+++ b/examples/zomboid-survival-kit/README.md
@@ -52,6 +52,23 @@ This is different from the panel-only path (`ARKAVO_SWARMKIT_PATH` + `arkavo ui`
 
 Set `GAME_RL_SERVER=/path/to/game-rl-server` to override the server binary path.
 
+## Verification status (2026-06-12)
+
+The kit-execution chain is verified end-to-end up to the game boundary: `arkavo
+swarmkit play` parses and validates the kit, prints `[swarmkit] Zomboid Survival
+Kit v0.1.0 — launching 5 role(s): survivor, threat, scavenger, medic, critic`,
+and the `survivor` role's `game-rl` grant (declared in the kit's `mcp_servers`)
+spawns the game-rl MCP server, which auto-detects and connects to the Project
+Zomboid IPC at `~/Zomboid/Lua/`.
+
+Completing the final in-game handshake (`registerAgent` → `observe`/`step`)
+requires Project Zomboid running with the GameRL mod and a **save loaded** (so
+the Lua side sends its `Ready` message). The identical game-side survivor loop —
+`registerAgent` as an embodied `Entity`, then `observe`/`step` driving the
+character — was confirmed live against this same mod and server via the
+single-agent `examples/zomboid/` path earlier the same day. To watch the full
+swarm play: load a PZ save, then run `run-kit.sh`.
+
 ---
 
 `examples/zomboid/` is the simpler single-agent (non-kit) version of the same game.

--- a/examples/zomboid-survival-kit/run-kit.sh
+++ b/examples/zomboid-survival-kit/run-kit.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Zomboid Survival Kit — run the SwarmKit live against Project Zomboid.
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BINARY="${BINARY:-${PROJECT_ROOT}/target/debug/arkavo}"
+[ -f "$BINARY" ] || BINARY="${PROJECT_ROOT}/target/release/arkavo"
+
+# game-rl-server auto-detects Project Zomboid via ~/Zomboid/Lua/ file IPC.
+# Resolution: explicit env -> PATH -> sibling game-rl repo build.
+export GAME_RL_SERVER="${GAME_RL_SERVER:-$(command -v game-rl-server || echo "$HOME/Projects/intelligence/game-rl/target/release/game-rl-server")}"
+
+KIT="$SCRIPT_DIR/zomboid-survival-kit.swarmkit.yaml"
+
+if [ ! -x "$BINARY" ]; then
+    echo "[ERROR] arkavo binary not found at $BINARY — run: cargo build -p arkavo"
+    exit 1
+fi
+if [ ! -x "$GAME_RL_SERVER" ]; then
+    echo "[WARN] game-rl-server not executable at $GAME_RL_SERVER (set GAME_RL_SERVER or build it in the game-rl repo)"
+fi
+if [ ! -f "$HOME/Zomboid/Lua/gamerl_response.json" ]; then
+    echo "[WARN] Project Zomboid GameRL IPC not found — start Project Zomboid (GameRL mod, save loaded) first."
+fi
+
+echo "[INFO] server: $GAME_RL_SERVER"
+echo "[INFO] kit:    $KIT"
+exec "$BINARY" swarmkit play "$KIT"

--- a/examples/zomboid-survival-kit/zomboid-survival-kit.swarmkit.yaml
+++ b/examples/zomboid-survival-kit/zomboid-survival-kit.swarmkit.yaml
@@ -1,0 +1,331 @@
+spec_version: "1.0.0"
+kit:
+  id: "blake3:MnL_kCJFbmi0c5Unu_CLAqu8qAGoQKW7c_UKe-oDWqo"
+  name: "Zomboid Survival Kit"
+  version: "0.1.0"
+  description: >-
+    Five-role hub-spoke kit that plays Project Zomboid as a coordinated survivor
+    swarm: one survivor hub drives the game via game-rl, advised by threat,
+    scavenger, and medic roles, with a critic scoring the episode.
+  authors:
+    - did: "did:web:arkavo.com"
+      name: "Arkavo"
+  created: "2026-06-12T00:00:00Z"
+  expires: "2026-12-11T00:00:00Z"
+  nonce: "ZmbdSurv0kit2026"
+
+objective:
+  goal: "Survive and scavenge in Project Zomboid as a coordinated survivor swarm."
+  success_criteria:
+    - "survivor alive at episode end"
+    - "weapon equipped"
+    - "food or water secured"
+
+inputs:
+  - name: "game_state"
+    type: "json"
+    required: true
+
+deliverables:
+  - name: "survival_log"
+    type: "json"
+
+roles:
+  - id: "survivor"
+    role_type: "survivor"
+    description: "Hub survivor that drives Project Zomboid via game-rl, one tool call per cycle."
+    agent_provisioning:
+      model:
+        family: "gemma-4"
+        size: "9B"
+        backend: "llama.cpp"
+      inference:
+        max_tokens: 1024
+        temperature: 0.3
+        thinking: false
+      budget:
+        max_inference_calls: 50
+        max_wallclock_ms: 600000
+        max_total_tokens: 80000
+      context:
+        max_context_tokens: 32000
+        compaction_strategy: "summary"
+        persistence: "ephemeral"
+      isolation:
+        sandbox: "process"
+        network_egress: false
+    skills:
+      - id: "skill:survivor-playbook"
+        version: "0.1.0"
+        source: "inline"
+        payload:
+          name: "survivor-playbook"
+          description: "Drive one survivor in Project Zomboid via game-rl, one tool call per cycle."
+          instructions: |
+            You control ONE survivor in Project Zomboid. Call exactly one tool per cycle; no prose. Cycle 1: registerAgent(AgentId=player1, AgentType=Entity). Then each cycle: read Observation.Alerts (highest Severity first), Observation.Survivors[0] (Position, Health, Hunger, Thirst, weapon), Observation.VisibleZombies, and Observation.Landmarks (PlayerPosition + Region_* compass points 20 tiles out are Move targets). Threat priority: UnderAttack with a zombie within 5 tiles -> AttackNearest if armed else Shove then flee; Zombies nearby within 15 -> hold if armed else Walk to the Region_* away from the nearest zombie; Unarmed -> EquipBest if inventory has a weapon else PickUp a nearby weapon or explore; Critically injured -> Walk away to break contact; Hungry/Thirsty -> Eat the matching item id from Survivors[0].Inventory. IDs must come from the latest observation (VisibleZombies[].Id, NearbyItems[].Id, Inventory[].Id) — never invent ids. RenderMap (Ticks=0) is free perception: it returns an ASCII map centered on you with coordinate rulers (P=you, Z=zombie, #=wall, D=door, W=window, T=tree, i=item); Move to any (x,y) you read off it; north is -y. When healthy, armed, and no zombies within 15, scavenge: Walk toward an unvisited Region_* then PickUpAll when NearbyItems is non-empty. Weigh advisor recommendations (threat, scavenger, medic) but you make the final call each cycle.
+          resources: []
+        signature: "5vNHSwYFNJEE3_2oq3buUNkZ1Liu4HRaHlHzebif2k9uyENZJLoSbt-vdPxcyS3-mxsZJ8vHjGo2rGdgjrcBCg"
+        signed_by: "did:web:arkavo.com"
+    mcp_tools:
+      - server: "game-rl"
+        tools: ["registerAgent", "observe", "step", "episodeSummary", "reset"]
+        auth: "none"
+    tdf_attribute_release_policy:
+      attributes:
+        - "https://attr.arkavo.com/role/survivor"
+        - "https://attr.arkavo.com/clearance/internal"
+      rule: "allOf"
+    handoffs:
+      - to: "threat"
+        on: "always"
+      - to: "scavenger"
+        on: "always"
+      - to: "medic"
+        on: "always"
+    context_scope:
+      can_read: ["threat", "scavenger", "medic", "self"]
+      can_write: ["self"]
+
+  - id: "threat"
+    role_type: "threat_advisor"
+    description: "Advise the survivor on combat versus flight from relayed observations."
+    agent_provisioning:
+      model:
+        family: "gemma-4"
+        size: "9B"
+        backend: "llama.cpp"
+      inference:
+        max_tokens: 1024
+        temperature: 0.3
+        thinking: false
+      budget:
+        max_inference_calls: 50
+        max_wallclock_ms: 600000
+        max_total_tokens: 80000
+      context:
+        max_context_tokens: 32000
+        compaction_strategy: "summary"
+        persistence: "ephemeral"
+      isolation:
+        sandbox: "process"
+        network_egress: false
+    skills:
+      - id: "skill:threat-advisor"
+        version: "0.1.0"
+        source: "inline"
+        payload:
+          name: "threat-advisor"
+          description: "Advise the survivor on combat versus flight."
+          instructions: "Advise the survivor on combat vs flight. From the survivor's relayed Observation.VisibleZombies and Alerts, recommend: attack (zombie in melee range and armed), shove-and-flee (cornered and unarmed), or reposition to a named Region_* away from the zombie cluster. Reply with one concise recommendation."
+          resources: []
+        signature: "lHkLW_-22h3gbqfp7DYCS0MjskMEkYaWre9klt8KEnEVr60yxOp6IWF5uxvT9cMU8lXQQSiIhIoofbS-YvmCCg"
+        signed_by: "did:web:arkavo.com"
+    mcp_tools: []
+    tdf_attribute_release_policy:
+      attributes:
+        - "https://attr.arkavo.com/role/threat_advisor"
+        - "https://attr.arkavo.com/clearance/internal"
+      rule: "allOf"
+    handoffs:
+      - to: "survivor"
+        on: "always"
+    context_scope:
+      can_read: ["survivor", "self"]
+      can_write: ["self"]
+
+  - id: "scavenger"
+    role_type: "scavenge_advisor"
+    description: "Advise the survivor on loot and routing from relayed items and the rendered map."
+    agent_provisioning:
+      model:
+        family: "gemma-4"
+        size: "9B"
+        backend: "llama.cpp"
+      inference:
+        max_tokens: 1024
+        temperature: 0.3
+        thinking: false
+      budget:
+        max_inference_calls: 50
+        max_wallclock_ms: 600000
+        max_total_tokens: 80000
+      context:
+        max_context_tokens: 32000
+        compaction_strategy: "summary"
+        persistence: "ephemeral"
+      isolation:
+        sandbox: "process"
+        network_egress: false
+    skills:
+      - id: "skill:scavenge-advisor"
+        version: "0.1.0"
+        source: "inline"
+        payload:
+          name: "scavenge-advisor"
+          description: "Advise the survivor on loot and routing."
+          instructions: "Advise the survivor on loot and routing. From relayed NearbyItems and the RenderMap, recommend the highest-value nearby item to grab (weapon > food > medical > other) and a safe route (door/coordinate) to reach it. Reply with one concise recommendation."
+          resources: []
+        signature: "reL8v5kndK1M1kPWFjnsTOQc4Zn3NYIRyJoefdxBuwhOKHu-etNFGYGCLh71CHDzjfYQKfjCz_9MRvuQpv1iCg"
+        signed_by: "did:web:arkavo.com"
+    mcp_tools: []
+    tdf_attribute_release_policy:
+      attributes:
+        - "https://attr.arkavo.com/role/scavenge_advisor"
+        - "https://attr.arkavo.com/clearance/internal"
+      rule: "allOf"
+    handoffs:
+      - to: "survivor"
+        on: "always"
+    context_scope:
+      can_read: ["survivor", "self"]
+      can_write: ["self"]
+
+  - id: "medic"
+    role_type: "health_advisor"
+    description: "Advise the survivor on health and sustenance from relayed stats."
+    agent_provisioning:
+      model:
+        family: "gemma-4"
+        size: "9B"
+        backend: "llama.cpp"
+      inference:
+        max_tokens: 1024
+        temperature: 0.3
+        thinking: false
+      budget:
+        max_inference_calls: 50
+        max_wallclock_ms: 600000
+        max_total_tokens: 80000
+      context:
+        max_context_tokens: 32000
+        compaction_strategy: "summary"
+        persistence: "ephemeral"
+      isolation:
+        sandbox: "process"
+        network_egress: false
+    skills:
+      - id: "skill:health-advisor"
+        version: "0.1.0"
+        source: "inline"
+        payload:
+          name: "health-advisor"
+          description: "Advise the survivor on health and sustenance."
+          instructions: "Advise the survivor on health and sustenance. From relayed Survivors[0] stats, recommend when to eat/drink (Hunger/Thirst high), rest (Fatigue high), or break contact and treat injuries (low Health). Reply with one concise recommendation."
+          resources: []
+        signature: "5vNHSwYFNJEE3_2oq3buUNkZ1Liu4HRaHlHzebif2k9uyENZJLoSbt-vdPxcyS3-mxsZJ8vHjGo2rGdgjrcBCg"
+        signed_by: "did:web:arkavo.com"
+    mcp_tools: []
+    tdf_attribute_release_policy:
+      attributes:
+        - "https://attr.arkavo.com/role/health_advisor"
+        - "https://attr.arkavo.com/clearance/internal"
+      rule: "allOf"
+    handoffs:
+      - to: "survivor"
+        on: "always"
+    context_scope:
+      can_read: ["survivor", "self"]
+      can_write: ["self"]
+
+  - id: "critic"
+    role_type: "critic"
+    description: "Score the episode against the survival rubric and flag ignored critical alerts."
+    agent_provisioning:
+      model:
+        family: "gemma-4"
+        size: "9B"
+        backend: "llama.cpp"
+      inference:
+        max_tokens: 1024
+        temperature: 0.3
+        thinking: false
+      budget:
+        max_inference_calls: 50
+        max_wallclock_ms: 600000
+        max_total_tokens: 80000
+      context:
+        max_context_tokens: 32000
+        compaction_strategy: "summary"
+        persistence: "ephemeral"
+      isolation:
+        sandbox: "process"
+        network_egress: false
+    skills:
+      - id: "skill:survival-critic"
+        version: "0.1.0"
+        source: "inline"
+        payload:
+          name: "survival-critic"
+          description: "Score the episode against the survival rubric."
+          instructions: "Score the episode against the rubric: survival_trajectory (stayed alive, avoided damage), threat_response (handled zombies well), resource_security (secured weapon/food), coordination (used advisor input). Flag any cycle where the survivor ignored a critical alert."
+          resources: []
+        signature: "AzqNXKR_APggRBJKZ3XAkl5Kxlw21zoHyoVRbcG9-sTooJO4rlyidASm79nNHQWLZuheQ_oT-ivWugunwEMYcQ"
+        signed_by: "did:web:arkavo.com"
+    mcp_tools: []
+    tdf_attribute_release_policy:
+      attributes:
+        - "https://attr.arkavo.com/role/critic"
+        - "https://attr.arkavo.com/clearance/internal"
+      rule: "allOf"
+    handoffs: []
+    context_scope:
+      can_read: ["survivor", "threat", "scavenger", "medic", "self"]
+      can_write: ["self"]
+
+coordination:
+  topology: "hub-spoke"
+  protocol: "a2a-jsonrpc-2.0"
+  routing:
+    strategy: "static"
+  context_sharing:
+    store: "per-role"
+    compaction:
+      strategy: "tool_result"
+
+mcp_servers:
+  - name: "game-rl"
+    command: "${GAME_RL_SERVER}"
+    args: []
+    transport: "stdio"
+
+constraints:
+  global_budget:
+    max_wallclock_seconds: 1800
+    max_total_tokens: 400000
+    max_cost_usd: 2.0
+  data_classifications:
+    - "game"
+  network:
+    egress_allowed: false
+    egress_allowlist: []
+
+evaluation:
+  rubric:
+    reference: "game-rl-draft-03#survival"
+    dimensions:
+      - name: "survival_trajectory"
+        weight: 0.4
+        threshold: 0.6
+      - name: "threat_response"
+        weight: 0.3
+        threshold: 0.6
+      - name: "resource_security"
+        weight: 0.2
+        threshold: 0.5
+      - name: "coordination"
+        weight: 0.1
+        threshold: 0.5
+  critic_role: "critic"
+
+completion:
+  rules:
+    - "survivor registered and alive"
+    - "no role in error state"
+  on_failure: "retry"
+  max_retries: 1
+
+provenance:
+  signatures:
+    - signer_did: "did:web:arkavo.com"
+      algorithm: "ed25519"
+      signature: "AzqNXKR_APggRBJKZ3XAkl5Kxlw21zoHyoVRbcG9-sTooJO4rlyidASm79nNHQWLZuheQ_oT-ivWugunwEMYcQ"

--- a/examples/zomboid/agents/survivor/AGENTS.md
+++ b/examples/zomboid/agents/survivor/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md
+
+## survivor
+purpose: |
+  Project Zomboid survivor. You control ONE survivor in a zombie apocalypse.
+  You MUST call a tool every cycle. Do NOT write analysis. ONLY call tools.
+
+  ==================================================================
+  HARD RULES — apply BEFORE any other instruction or cached lesson:
+  ==================================================================
+
+  RULE 1 — Cycle 1 only: registerAgent(AgentId="player1", AgentType="Entity").
+           Skip the rest of these rules on cycle 1.
+
+  RULE 2 — Cycle 2 only: observe({}). Read Observation.Survivors[0]
+           (your Position, Health, Hunger, Thirst, primary weapon) and
+           Observation.Landmarks (PlayerPosition + Region_* compass points
+           20 tiles out — these are Move targets).
+
+  RULE 3 — Threat priority. Read Observation.Alerts (highest Severity first)
+           and Observation.VisibleZombies:
+    | Alert / situation        | Action                                                              |
+    |--------------------------|---------------------------------------------------------------------|
+    | "UnderAttack" (zombie ≤5)| armed: step Action={"Type":"AttackNearest"}; unarmed: step Action={"Type":"Shove"} then flee |
+    | "Zombies nearby" (≤15)   | armed: hold position; unarmed: Walk to the Region_* AWAY from the nearest zombie |
+    | "Unarmed"                | inventory has a weapon: step Action={"Type":"EquipBest"}; else PickUp a nearby weapon or Walk to explore |
+    | "Critically injured"     | step Action={"Type":"Walk","Direction":"<away from zombies>","Distance":8} to break contact |
+    | "Hungry"                 | step Action={"Type":"Eat","ItemId":"<food id from Survivors[0].Inventory>"} |
+    | "Thirsty"                | step Action={"Type":"Eat","ItemId":"<drink id>"} (Drink alias) |
+    | (no alerts)              | step Action={"Type":"Walk","Direction":"North","Distance":6} to explore/scavenge |
+
+  RULE 4 — IDs must come from the latest observation: zombie TargetId from
+           VisibleZombies[].Id, item ItemId from NearbyItems[].Id or
+           Survivors[0].Inventory[].Id. NEVER invent an id.
+
+  RULE 5 — Output discipline: emit EXACTLY ONE tool call per cycle. No prose.
+
+  RULE 6 — RenderMap is your eyes and costs no time. Use it to navigate:
+           step Action={"Type":"RenderMap","Radius":14} with Ticks=0 returns
+           an ASCII map centered on you (P=you, Z=zombie, #=wall, D=door,
+           W=window, T=tree, i=item). The coordinate rulers give exact tiles:
+           Move to any (x,y) you read off the map. North is -y. Use RenderMap
+           when you need to find a door to escape through or an item to grab.
+           Never call observe or RenderMap twice in a row — prefer an action.
+
+  RULE 7 — When healthy, armed, and no zombies are within 15 tiles, explore to
+           scavenge: Walk toward a Region_* you have not visited, then PickUpAll
+           when NearbyItems is non-empty.
+
+# Supported local models (single-line swap); blank = auto-select loaded model
+model: gemma-4-26b-a4b
+action_interval: 90
+listen: 0.0.0.0:8451
+mdns: true
+
+game_evaluation:
+  domain: zomboid
+  criteria_mapping:
+    survival_trajectory: goal_fidelity
+    threat_response: state_coherence
+    resource_scavenging: efficiency
+    compound_value: adaptability
+
+mcp_servers:
+  - name: game-rl
+    command: ${GAME_RL_SERVER}
+    args: []

--- a/examples/zomboid/launch_zomboid.sh
+++ b/examples/zomboid/launch_zomboid.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Project Zomboid — single survivor agent against the Game-RL mod (file IPC)
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BINARY="${BINARY:-${PROJECT_ROOT}/target/debug/arkavo}"
+if [ ! -f "$BINARY" ]; then
+    BINARY="${PROJECT_ROOT}/target/release/arkavo"
+fi
+LOG_DIR="$SCRIPT_DIR/logs"
+mkdir -p "$LOG_DIR"
+
+# game-rl-server auto-detects Project Zomboid via the Lua file IPC
+# (~/Zomboid/Lua/gamerl_response.json). Resolution: env, PATH, sibling repo.
+export GAME_RL_SERVER="${GAME_RL_SERVER:-$(command -v game-rl-server || echo "$HOME/Projects/intelligence/game-rl/target/release/game-rl-server")}"
+
+case "${1:-start}" in
+    stop)
+        pkill -f "arkavo agent.*zomboid" 2>/dev/null || true
+        pkill -f "agents/survivor" 2>/dev/null || true
+        echo "[OK] stopped"
+        exit 0
+        ;;
+esac
+
+if [ ! -S /tmp/.gamerl 2>/dev/null ] && [ ! -f "$HOME/Zomboid/Lua/gamerl_response.json" ]; then
+    echo "[WARN] Project Zomboid GameRL IPC not found at ~/Zomboid/Lua/"
+    echo "       Start Project Zomboid with the GameRL mod and load a save first."
+fi
+
+echo "[INFO] server:   $GAME_RL_SERVER"
+echo "[INFO] starting survivor on :8451 (logs: $LOG_DIR/survivor.log)"
+
+cd "$SCRIPT_DIR/agents/survivor"
+exec "$BINARY" agent --config AGENTS.md 2>&1 | tee "$LOG_DIR/survivor.log"

--- a/specs/arkavo-edge/index.yaml
+++ b/specs/arkavo-edge/index.yaml
@@ -564,7 +564,7 @@ components:
     module: arkavo_swarmkit
     description: SwarmKit manifest, runtime, and AG-UI gateway integration
     criticality: high
-    scenario_count: 51
+    scenario_count: 54
     invariants:
       - kit.id equals BLAKE3 of canonical manifest
       - SwarmFlight builds one ArpRuntime per role at launch
@@ -903,7 +903,7 @@ components:
 
 stats:
   total_specs: 77
-  total_scenarios: 702
+  total_scenarios: 705
   critical_scenarios: 193
   coverage_areas:
     - authentication

--- a/specs/arkavo-edge/swarmkit.spec.yaml
+++ b/specs/arkavo-edge/swarmkit.spec.yaml
@@ -2,7 +2,7 @@
 
 feature: SwarmKit Manifest, Runtime, and Gateway Integration
 module: arkavo_swarmkit
-version: 0.73.0
+version: 0.74.0
 
 invariants:
   - SwarmKit manifest is parser+validator only — no runtime side effects
@@ -20,6 +20,13 @@ invariants:
   - Skill resolution is eager at SwarmFlight::launch when LaunchOptions.resolver_config is Some
   - Inline skill payloads are deserialized into typed SkillContent before signature verification
   - ed25519 signature is computed over BLAKE3 of JCS-canonical SkillContent bytes (matches kit.id canonicalization)
+  - Kit MAY declare top-level mcp_servers — a registry of {name, command, args, transport} entries roles reference by name
+  - Every roles[].mcp_tools[].server MUST resolve to a declared mcp_servers[].name or validation fails (ValidationError::UnknownMcpServer)
+  - mcp_servers command/args MAY contain ${VAR} placeholders expanded by the runtime at launch, not at parse time (keeps kit.id stable)
+  - mcp_servers is part of the canonical manifest and therefore covered by kit.id
+  - A role with a non-empty mcp_tools grant is a live/orchestrator role that drives an MCP tool loop (observe→act) terminated by completion.rules; a role with no grants is advisory
+  - coordination.topology=hub-spoke with exactly one live role is the canonical embodied-agent-plus-advisors pattern
+  - A conformant runtime MAY realize a kit as a one-shot deliverable flight OR as a live MCP tool loop; arkavo swarmkit play is the reference for the live loop
 
 scenarios:
   # --- Manifest layer (arkavo-swarmkit) -----------------------------------
@@ -839,3 +846,51 @@ scenarios:
       - A converged flight reconciles to a no-op
     refs: [crates/arkavo-swarmkit-runtime/src/flight_apply.rs, crates/arkavo-swarmkit-runtime/tests/flight_proposal_apply.rs]
     changed: "2026-06-10"
+
+  # --- MCP server registry + interactive/live-role semantics ----------------
+
+  - id: SK-096
+    name: Validate rejects a role grant referencing an undeclared mcp server
+    criticality: critical
+    given:
+      - Manifest with a role whose mcp_tools[].server names a server not present in top-level mcp_servers
+    when: validate called
+    then:
+      - Returns ValidationError::UnknownMcpServer { role, server }
+      - Error Display contains "unknown mcp server '<name>' referenced by role '<id>'"
+    refs:
+      - crates/arkavo-swarmkit/src/validate.rs
+      - crates/arkavo-swarmkit/src/mcp.rs
+      - crates/arkavo-swarmkit/tests/fixtures/undeclared_mcp_server.yaml
+    changed: "2026-06-12"
+
+  - id: SK-097
+    name: Kit declares an mcp server and a role resolves it
+    criticality: high
+    given:
+      - Manifest with top-level mcp_servers [{name game-rl, command ${GAME_RL_SERVER}, transport stdio}]
+      - A role with mcp_tools [{server game-rl, tools [...], auth none}]
+    when: validate called
+    then:
+      - Validation succeeds (the grant resolves to the declared server)
+      - mcp_servers is included in the canonical form, so kit.id covers it
+    refs:
+      - crates/arkavo-swarmkit/src/manifest.rs
+      - crates/arkavo-swarmkit/tests/fixtures/declared_mcp_server.yaml
+      - examples/zomboid-survival-kit/zomboid-survival-kit.swarmkit.yaml
+    changed: "2026-06-12"
+
+  - id: SK-098
+    name: A kit runs as a live MCP tool loop via the agent runtime
+    criticality: high
+    given:
+      - A validated kit with a single live role (non-empty mcp_tools) and advisor roles, topology hub-spoke
+    when: arkavo swarmkit play <kit> is invoked
+    then:
+      - Each role maps to an AgentConfig; the live role's mcp_tools grants resolve to mcp_servers connections
+      - The live role connects to the declared MCP server and drives an observe→act loop terminated by completion.rules
+      - Advisor roles run advisory loops and exchange A2A recommendations with the live role
+    refs:
+      - crates/arkavo-cli/src/commands/swarmkit.rs
+      - examples/zomboid-survival-kit/README.md
+    changed: "2026-06-12"


### PR DESCRIPTION
Edge-side work for the Game-RL multi-game convergence (companion to game-rl adapter/spec changes and the SwarmKit/Game-RL spec amendments). Validated live against RimWorld 1.6 and Project Zomboid 41.78.

## Summary

- **MCP config env expansion** — `${VAR}` expansion in `mcp_servers` command/args, applied at the spawn site so every config-parse path benefits; `examples/rimworld` now uses `${GAME_RL_SERVER}` instead of a hardcoded path. Adds the headless `examples/gridcolony` playtest harness.
- **RimWorld commander, structured building** — landmark anchors (ColonyCenter, not MapCenter), `ChessTable` defName fix, and a `BuildRoom`/`Inside`/`RenderMap` workflow with one-shot `Furnish` so the agent builds rooms instead of wall-spam blobs.
- **Project Zomboid survivor example** — single embodied agent (`examples/zomboid`) playing the GameRL mod over file IPC.
- **SwarmKit live MCP execution** — the headline feature:
  - `mcp_servers` kit-level registry (`McpServerDef`) + validator rule that every `mcp_tools[].server` resolves to a declared server (folds into `kit.id`).
  - `arkavo swarmkit play <kit>` maps each role to the existing agent runtime (`start_agent_server`) and drives a live MCP loop — reusing the proven path rather than a new engine.
  - `examples/zomboid-survival-kit` — a validated 5-role hub-spoke kit (survivor + threat/scavenger/medic/critic) with game-rl declared inside it.
  - SwarmKit spec (`specs/arkavo-edge/swarmkit.spec.yaml`) amended: `mcp_servers` registry + interactive/live-role semantics (SK-093/094/095).

## Test plan

- [x] `cargo test -p arkavo-swarmkit -p arkavo-cli -p arkavo-protocol` green
- [x] `cargo run -p arkavo-swarmkit --example validate_kit -- examples/zomboid-survival-kit/zomboid-survival-kit.swarmkit.yaml` → `VALID`
- [x] `arkavo swarmkit play` launches all 5 roles; survivor's kit-declared game-rl grant spawns the MCP server and connects to the PZ IPC (chain verified to the game boundary)
- [ ] Full in-game handshake (`registerAgent`→`observe`/`step`) — load a PZ save then `run-kit.sh`; the identical game-side loop was confirmed live via the single-agent path
- [x] RimWorld: BuildRoom/Furnish/RenderMap verified live on 1.6.4850
- [x] clippy clean on touched crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)