### PR TITLE
Update behavior specs and traceability tooling

### DIFF
--- a/.cargo/xtask/Cargo.toml
+++ b/.cargo/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [[bin]]

--- a/.cargo/xtask/src/spec_test.rs
+++ b/.cargo/xtask/src/spec_test.rs
@@ -186,7 +186,7 @@ impl RefsValidator {
                 // so that bare line-range entries (e.g., "141-151") reuse the prior path.
                 let mut current_path: Option<String> = None;
                 for raw_ref in &scenario.refs {
-                    let parts: Vec<&str> = raw_ref.split(',').map(|s| s.trim()).collect();
+                    let parts = Self::split_ref_parts(raw_ref);
                     for part in parts {
                         if part.is_empty() {
                             continue;
@@ -223,6 +223,36 @@ impl RefsValidator {
             }
         }
         result
+    }
+
+    fn split_ref_parts(raw_ref: &str) -> Vec<&str> {
+        // Split on commas, but ignore commas inside parentheses or brackets
+        // so annotations like "path.rs (a, b)" stay as one part.
+        let mut parts = Vec::new();
+        let mut start = 0;
+        let mut paren_depth = 0i32;
+        let mut bracket_depth = 0i32;
+        for (i, c) in raw_ref.char_indices() {
+            match c {
+                '(' => paren_depth += 1,
+                ')' => paren_depth -= 1,
+                '[' => bracket_depth += 1,
+                ']' => bracket_depth -= 1,
+                ',' if paren_depth == 0 && bracket_depth == 0 => {
+                    let part = raw_ref[start..i].trim();
+                    if !part.is_empty() {
+                        parts.push(part);
+                    }
+                    start = i + c.len_utf8();
+                }
+                _ => {}
+            }
+        }
+        let last = raw_ref[start..].trim();
+        if !last.is_empty() {
+            parts.push(last);
+        }
+        parts
     }
 
     fn extract_path(part: &str) -> String {
@@ -452,6 +482,17 @@ scenarios:
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_split_ref_parts_respects_parentheses() {
+        let parts = RefsValidator::split_ref_parts(
+            "crates/a/src/lib.rs:1-10, crates/b/src/lib.rs (foo, bar), 20-30",
+        );
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts[0], "crates/a/src/lib.rs:1-10");
+        assert_eq!(parts[1], "crates/b/src/lib.rs (foo, bar)");
+        assert_eq!(parts[2], "20-30");
     }
 
     #[test]

--- a/.cargo/xtask/src/spec_test.rs
+++ b/.cargo/xtask/src/spec_test.rs
@@ -158,6 +158,93 @@ impl SpecParser {
     }
 }
 
+// --- RefsValidator ---
+
+#[derive(Debug, Clone)]
+pub struct StaleRef {
+    pub scenario_id: String,
+    pub raw_ref: String,
+    pub resolved_path: PathBuf,
+    pub wip: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct SpecStaleRefs {
+    pub spec_file: PathBuf,
+    pub stale_refs: Vec<StaleRef>,
+}
+
+pub struct RefsValidator;
+
+impl RefsValidator {
+    pub fn validate(specs: &[(PathBuf, Spec)]) -> Vec<SpecStaleRefs> {
+        let mut result = Vec::new();
+        for (spec_file, spec) in specs {
+            let mut stale = Vec::new();
+            for scenario in &spec.scenarios {
+                // Carry the last explicit file path across refs in the same scenario
+                // so that bare line-range entries (e.g., "141-151") reuse the prior path.
+                let mut current_path: Option<String> = None;
+                for raw_ref in &scenario.refs {
+                    let parts: Vec<&str> = raw_ref.split(',').map(|s| s.trim()).collect();
+                    for part in parts {
+                        if part.is_empty() {
+                            continue;
+                        }
+                        let path = if part.contains('/')
+                            || part.contains('.')
+                            || !Self::is_line_range(part)
+                        {
+                            Self::extract_path(part)
+                        } else if let Some(ref _path) = current_path {
+                            // Bare line range continuing previous path
+                            continue;
+                        } else {
+                            part.to_string()
+                        };
+                        current_path = Some(path.clone());
+                        let path_obj = Path::new(&path);
+                        if !path_obj.exists() {
+                            stale.push(StaleRef {
+                                scenario_id: scenario.id.clone(),
+                                raw_ref: raw_ref.clone(),
+                                resolved_path: path_obj.to_path_buf(),
+                                wip: scenario.wip,
+                            });
+                        }
+                    }
+                }
+            }
+            if !stale.is_empty() {
+                result.push(SpecStaleRefs {
+                    spec_file: spec_file.clone(),
+                    stale_refs: stale,
+                });
+            }
+        }
+        result
+    }
+
+    fn extract_path(part: &str) -> String {
+        // Split off line-range marker first, then strip any trailing
+        // annotation like " (foo)" or " [bar]".
+        let before_colon = part.find(':').map(|idx| &part[..idx]).unwrap_or(part);
+        let stripped = if let Some((p, _)) = before_colon.split_once(" (") {
+            p
+        } else if let Some((p, _)) = before_colon.split_once(" [") {
+            p
+        } else {
+            before_colon
+        }
+        .trim();
+        stripped.to_string()
+    }
+
+    fn is_line_range(s: &str) -> bool {
+        !s.is_empty() && s.chars().all(|c| c.is_ascii_digit() || c == '-')
+    }
+}
+
 // --- CoverageAnalyzer ---
 
 pub struct CoverageAnalyzer;
@@ -328,6 +415,43 @@ scenarios:
         assert_eq!(CoverageStatus::Missing.emoji(), "🔴");
         assert_eq!(Criticality::Critical.priority(), 4);
         assert_eq!(Criticality::Low.priority(), 1);
+    }
+
+    #[test]
+    fn test_refs_validator_skips_bare_line_ranges() {
+        let spec = Spec {
+            feature: "Test".into(),
+            module: "test".into(),
+            version: "0.1.0".into(),
+            invariants: vec![],
+            scenarios: vec![Scenario {
+                id: "TEST-001".into(),
+                name: "Test".into(),
+                criticality: Criticality::High,
+                given: vec![],
+                when: "action".into(),
+                then: vec![],
+                refs: vec![
+                    "crates/arkavo-crypto/src/lib.rs:335-339".into(),
+                    "350-355".into(),
+                ],
+                edge_cases: vec![],
+                wip: false,
+                issue: None,
+            }],
+        };
+        let stale = RefsValidator::validate(&[(PathBuf::from("test.spec.yaml"), spec)]);
+        // The crypto lib.rs file may or may not exist; we only care that the bare
+        // line range 350-355 is not reported as a missing path.
+        for spec_stale in &stale {
+            for r in &spec_stale.stale_refs {
+                assert!(
+                    r.resolved_path.to_str() != Some("350-355"),
+                    "bare line range should not be reported as missing path: {:?}",
+                    r
+                );
+            }
+        }
     }
 
     #[test]

--- a/.cargo/xtask/src/spec_test_cmds.rs
+++ b/.cargo/xtask/src/spec_test_cmds.rs
@@ -1,6 +1,6 @@
 use crate::spec_test::{
-    CoverageAnalyzer, CoverageStatus, Criticality, SpecCoverage, SpecParser, TestDiscovery,
-    TestGenerator,
+    CoverageAnalyzer, CoverageStatus, Criticality, RefsValidator, SpecCoverage, SpecParser,
+    SpecStaleRefs, StaleRef, TestDiscovery, TestGenerator,
 };
 use crate::spec_test_diff;
 use crate::spec_test_export;
@@ -77,6 +77,18 @@ pub enum Commands {
         #[arg(short, long)]
         output: Option<PathBuf>,
     },
+    /// Validate that spec refs point to existing source files
+    ValidateRefs {
+        /// Optional spec name filter
+        #[arg(long)]
+        spec: Option<String>,
+        /// Fail with non-zero exit code if any stale refs are found
+        #[arg(long)]
+        fail: bool,
+        /// Skip refs on scenarios marked wip (work-in-progress)
+        #[arg(long)]
+        skip_wip: bool,
+    },
 }
 
 pub fn run(command: Commands, specs_dir: PathBuf, crates_dir: PathBuf) -> Result<()> {
@@ -113,6 +125,11 @@ pub fn run(command: Commands, specs_dir: PathBuf, crates_dir: PathBuf) -> Result
         Commands::ExportJson { output } => cmd_export_json(&specs_dir, &crates_dir, output),
         Commands::ExportHtml { output } => cmd_export_html(&specs_dir, &crates_dir, output),
         Commands::Diff { baseline, output } => cmd_diff(&specs_dir, &crates_dir, baseline, output),
+        Commands::ValidateRefs {
+            spec,
+            fail,
+            skip_wip,
+        } => cmd_validate_refs(&specs_dir, spec, fail, skip_wip),
     }
 }
 
@@ -479,5 +496,90 @@ fn cmd_list(
         }
         println!();
     }
+    Ok(())
+}
+
+fn cmd_validate_refs(
+    specs_dir: &Path,
+    filter_spec: Option<String>,
+    fail: bool,
+    skip_wip: bool,
+) -> Result<()> {
+    println!(
+        "{}\n{}\n",
+        "Spec Refs Validation".bold().cyan(),
+        "====================".cyan()
+    );
+
+    let specs = SpecParser::parse_all_specs(specs_dir)?;
+    let stale_by_spec = RefsValidator::validate(&specs);
+
+    let mut stale_by_spec: Vec<SpecStaleRefs> = match filter_spec {
+        Some(f) => {
+            let f = f.to_lowercase();
+            stale_by_spec
+                .into_iter()
+                .filter(|s| spec_name(&s.spec_file).to_lowercase().contains(&f))
+                .collect()
+        }
+        None => stale_by_spec,
+    };
+
+    if skip_wip {
+        stale_by_spec = stale_by_spec
+            .into_iter()
+            .map(|mut s| {
+                s.stale_refs.retain(|r| !r.wip);
+                s
+            })
+            .filter(|s| !s.stale_refs.is_empty())
+            .collect();
+    }
+
+    let total_stale: usize = stale_by_spec.iter().map(|s| s.stale_refs.len()).sum();
+
+    if total_stale == 0 {
+        println!("{}", "All spec refs resolve to existing files.".green());
+        return Ok(());
+    }
+
+    println!(
+        "{} {} stale reference(s) found\n",
+        "⚠".yellow(),
+        total_stale
+    );
+
+    for spec_stale in &stale_by_spec {
+        let name = spec_name(&spec_stale.spec_file);
+        println!(
+            "{} {} ({} stale)",
+            "▶".yellow(),
+            name.bold(),
+            spec_stale.stale_refs.len()
+        );
+        // Group by scenario to avoid repeating the spec header
+        let mut by_scenario: std::collections::HashMap<&str, Vec<&StaleRef>> =
+            std::collections::HashMap::new();
+        for r in &spec_stale.stale_refs {
+            by_scenario.entry(&r.scenario_id).or_default().push(r);
+        }
+        for (scenario_id, refs) in by_scenario {
+            println!("  {} {}", "•".dimmed(), scenario_id.dimmed());
+            for r in refs {
+                println!(
+                    "    {} {}",
+                    "✗".red(),
+                    format!("{} -> {}", r.raw_ref, r.resolved_path.display()).dimmed()
+                );
+            }
+        }
+        println!();
+    }
+
+    if fail {
+        eprintln!("{} Stale spec refs detected", "FAILED:".red());
+        process::exit(1);
+    }
+
     Ok(())
 }

--- a/.cargo/xtask/src/spec_test_cmds.rs
+++ b/.cargo/xtask/src/spec_test_cmds.rs
@@ -557,9 +557,9 @@ fn cmd_validate_refs(
             name.bold(),
             spec_stale.stale_refs.len()
         );
-        // Group by scenario to avoid repeating the spec header
-        let mut by_scenario: std::collections::HashMap<&str, Vec<&StaleRef>> =
-            std::collections::HashMap::new();
+        // Group by scenario to avoid repeating the spec header (sorted for stable output)
+        let mut by_scenario: std::collections::BTreeMap<&str, Vec<&StaleRef>> =
+            std::collections::BTreeMap::new();
         for r in &spec_stale.stale_refs {
             by_scenario.entry(&r.scenario_id).or_default().push(r);
         }

--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -1533,7 +1533,7 @@ jobs:
 
       - name: Validate spec-to-code refs
         run: |
-          cargo run -p xtask -- spec-test validate-refs --skip-wip
+          cargo run -p xtask -- spec-test validate-refs --skip-wip --fail
 
       - name: Generate traceability report and coverage diff
         run: |

--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -1531,6 +1531,10 @@ jobs:
           echo "gate_exit_code=$?" >> "$GITHUB_OUTPUT"
           cat report.md
 
+      - name: Validate spec-to-code refs
+        run: |
+          cargo run -p xtask -- spec-test validate-refs --skip-wip
+
       - name: Generate traceability report and coverage diff
         run: |
           cargo run -p xtask -- spec-test export-html --output traceability.html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,6 +772,7 @@ name = "arkavo-config-encryption"
 version = "0.80.1"
 dependencies = [
  "arkavo-config-bundle",
+ "arkavo-test-macros",
  "base64 0.22.1",
  "chrono",
  "opentdf",
@@ -809,6 +810,7 @@ dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
  "arkavo-tdf-iroh",
+ "arkavo-test-macros",
  "async-trait",
  "serde",
  "tiktoken-rs",
@@ -997,6 +999,7 @@ dependencies = [
 name = "arkavo-gemini"
 version = "0.80.1"
 dependencies = [
+ "arkavo-test-macros",
  "base64 0.22.1",
  "bytes",
  "dashmap",
@@ -1158,6 +1161,7 @@ dependencies = [
  "arkavo-observability",
  "arkavo-qwen",
  "arkavo-snpe",
+ "arkavo-test-macros",
  "async-trait",
  "base64 0.22.1",
  "bytes",
@@ -1491,6 +1495,7 @@ dependencies = [
  "arkavo-router",
  "arkavo-swarmkit",
  "arkavo-swarmkit-runtime",
+ "arkavo-test-macros",
  "async-trait",
  "axum",
  "base64 0.22.1",
@@ -1946,6 +1951,7 @@ name = "arkavo-tdf"
 version = "0.80.1"
 dependencies = [
  "arkavo-crypto",
+ "arkavo-test-macros",
  "async-trait",
  "base64 0.22.1",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-test-macros",
  "serde",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "chrono",
  "serde",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-config-bundle",
  "base64 0.22.1",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "git2",
  "tempfile",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1120,11 +1120,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-lesson-synthesis"
-version = "0.80.0"
+version = "0.80.1"
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "bindgen",
  "cc",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "lru 0.16.4",
  "serde",
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-shadow-consolidation"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-lesson-synthesis",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "libc",
@@ -1883,7 +1883,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -1982,7 +1982,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2030,7 +2030,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.80.0"
+version = "0.80.1"
 dependencies = [
  "alloy-primitives",
  "bip39",
@@ -13016,7 +13016,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.80.0"
+version = "0.80.1"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-config-encryption/Cargo.toml
+++ b/crates/arkavo-config-encryption/Cargo.toml
@@ -21,6 +21,7 @@ base64 = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
+arkavo-test-macros = { path = "../arkavo-test-macros" }
 
 [features]
 default = []

--- a/crates/arkavo-config-encryption/src/keys.rs
+++ b/crates/arkavo-config-encryption/src/keys.rs
@@ -81,7 +81,9 @@ impl KeyPair {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("TDFS-011")]
     #[test]
     fn test_generate_key_pair() {
         let key_pair = KeyPair::generate().unwrap();
@@ -89,6 +91,7 @@ mod tests {
         assert!(!key_pair.public_key.as_bytes().is_empty());
     }
 
+    #[spec("TDFS-011")]
     #[test]
     fn test_sign_and_verify() {
         let key_pair = KeyPair::generate().unwrap();
@@ -101,6 +104,7 @@ mod tests {
         assert!(verified);
     }
 
+    #[spec("TDFS-011")]
     #[test]
     fn test_verify_invalid_signature() {
         let key_pair = KeyPair::generate().unwrap();
@@ -114,6 +118,7 @@ mod tests {
         assert!(!verified);
     }
 
+    #[spec("TDFS-011")]
     #[test]
     fn test_verify_wrong_message() {
         let key_pair = KeyPair::generate().unwrap();

--- a/crates/arkavo-config-encryption/src/lib.rs
+++ b/crates/arkavo-config-encryption/src/lib.rs
@@ -204,7 +204,9 @@ impl AgentCredential {
 mod tests {
     use super::*;
     use arkavo_config_bundle::{AgentRole, BundleTarget};
+    use arkavo_test_macros::spec;
 
+    #[spec("TDFS-002")]
     #[test]
     fn test_encrypt_bundle() {
         let mut bundle = ConfigurationBundle::new(
@@ -240,6 +242,7 @@ mod tests {
         assert_eq!(encrypted.policy_manifest.dissemination.len(), 1);
     }
 
+    #[spec("TDFS-002")]
     #[test]
     fn test_decrypt_requires_kas() {
         let mut bundle = ConfigurationBundle::new(
@@ -279,6 +282,7 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("KAS integration"));
     }
 
+    #[spec("TDFS-011")]
     #[test]
     fn test_agent_credential_creation() {
         let mut attributes = HashMap::new();
@@ -290,6 +294,7 @@ mod tests {
         assert!(credential.attributes.contains_key("agent.role"));
     }
 
+    #[spec("TDFS-011")]
     #[test]
     fn test_sign_request() {
         let mut attributes = HashMap::new();
@@ -303,6 +308,7 @@ mod tests {
         assert!(!signature.is_empty());
     }
 
+    #[spec("TDFS-008")]
     #[test]
     fn test_has_required_attributes() {
         let mut attributes = HashMap::new();

--- a/crates/arkavo-config-encryption/src/policy.rs
+++ b/crates/arkavo-config-encryption/src/policy.rs
@@ -53,6 +53,7 @@ impl Default for Policy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
     #[test]
     fn test_create_policy() {
@@ -70,6 +71,7 @@ mod tests {
         assert_eq!(policy.attributes[0].value, "internal");
     }
 
+    #[spec("TDFS-008")]
     #[test]
     fn test_create_fqn() {
         let fqn = create_fqn("data/clearance", "confidential");

--- a/crates/arkavo-context/Cargo.toml
+++ b/crates/arkavo-context/Cargo.toml
@@ -23,3 +23,6 @@ tiktoken-rs = { workspace = true }
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 tracing = { workspace = true }
 uuid = { workspace = true }
+
+[dev-dependencies]
+arkavo-test-macros = { path = "../arkavo-test-macros" }

--- a/crates/arkavo-context/src/rlm_detection.rs
+++ b/crates/arkavo-context/src/rlm_detection.rs
@@ -102,7 +102,10 @@ pub fn context_usage_percentage(content: &str, model_hint: Option<&str>, is_clou
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("ROUTER-016")]
+    #[spec("ROUTER-017")]
     #[test]
     fn test_check_rlm_below_threshold() {
         let content = "What is 2+2?";
@@ -110,6 +113,8 @@ mod tests {
         assert!(activation.is_none());
     }
 
+    #[spec("ROUTER-016")]
+    #[spec("ROUTER-017")]
     #[test]
     fn test_check_rlm_above_threshold() {
         // Create content that exceeds 70% of 2048 tokens (~1433 tokens)
@@ -120,6 +125,7 @@ mod tests {
         assert!(activation.unwrap().contains("context"));
     }
 
+    #[spec("ROUTER-016")]
     #[test]
     fn test_estimate_tokens() {
         let content = "Hello world"; // 11 chars
@@ -127,6 +133,7 @@ mod tests {
         assert!((2..=4).contains(&tokens));
     }
 
+    #[spec("ROUTER-017")]
     #[test]
     fn test_model_context_size_small() {
         assert_eq!(model_context_size(Some("270M"), false), 2048);
@@ -134,17 +141,21 @@ mod tests {
         assert_eq!(model_context_size(Some("7B"), false), 8192);
     }
 
+    #[spec("ROUTER-017")]
     #[test]
     fn test_model_context_size_cloud() {
         let size = model_context_size(Some("claude"), true);
         assert!(size >= 128_000);
     }
 
+    #[spec("ROUTER-017")]
     #[test]
     fn test_model_context_size_default() {
         assert_eq!(model_context_size(None, false), 4096);
     }
 
+    #[spec("ROUTER-016")]
+    #[spec("ROUTER-017")]
     #[test]
     fn test_context_usage_percentage() {
         // 100 chars = ~25 tokens, context size 4096
@@ -162,6 +173,8 @@ mod tests {
     }
 
     /// CTX-007: Verify RLM activates at exactly the 70% boundary
+    #[spec("ROUTER-016")]
+    #[spec("ROUTER-017")]
     #[test]
     fn test_rlm_exact_70_percent_boundary() {
         // Model "270M" has context_size = 2048
@@ -199,6 +212,7 @@ mod tests {
     }
 
     /// CTX-007: Unknown model names should fall back to the default context size
+    #[spec("ROUTER-017")]
     #[test]
     fn test_rlm_unknown_model_defaults() {
         let size = model_context_size(Some("totally-unknown-model-xyz"), false);

--- a/crates/arkavo-critic/src/checks/circuit.rs
+++ b/crates/arkavo-critic/src/checks/circuit.rs
@@ -175,6 +175,7 @@ mod tests {
     use super::*;
     use arkavo_llm::ProviderResponse;
     use arkavo_llm::tool_parser::ParsedToolCall;
+    use arkavo_test_macros::spec;
     use torg_core::{BoolOp, Node, Source};
     use torg_serde::to_bytes;
 
@@ -247,6 +248,7 @@ mod tests {
         assert!(check.is_empty());
     }
 
+    #[spec("CRIT-003")]
     #[tokio::test]
     async fn test_circuit_passes_or() {
         let check = CircuitCheck::new();
@@ -270,6 +272,7 @@ mod tests {
         assert!(result.is_pass());
     }
 
+    #[spec("CRIT-003")]
     #[tokio::test]
     async fn test_circuit_fails() {
         let check = CircuitCheck::new();
@@ -295,6 +298,7 @@ mod tests {
         assert!(evidence.description.contains("require_tools_or_code"));
     }
 
+    #[spec("CRIT-003")]
     #[tokio::test]
     async fn test_circuit_with_tools() {
         let check = CircuitCheck::new();
@@ -325,6 +329,7 @@ mod tests {
         assert!(result.is_pass());
     }
 
+    #[spec("CRIT-003")]
     #[tokio::test]
     async fn test_and_circuit() {
         let check = CircuitCheck::new();
@@ -382,6 +387,7 @@ mod tests {
         assert!(!check.is_applicable(&input));
     }
 
+    #[spec("CRIT-003")]
     #[tokio::test]
     async fn test_multiple_circuits() {
         let check = CircuitCheck::new();
@@ -473,6 +479,7 @@ mod tests {
     /// Full integration test: block guest writes policy.
     ///
     /// Uses Custom("is_guest") to extract guest status from context JSON.
+    #[spec("CRIT-003")]
     #[tokio::test]
     async fn test_circuit_check_blocks_guest_writes() {
         let check = CircuitCheck::new();

--- a/crates/arkavo-critic/src/checks/schema.rs
+++ b/crates/arkavo-critic/src/checks/schema.rs
@@ -100,6 +100,7 @@ mod tests {
     use arkavo_llm::ProviderResponse;
     use arkavo_llm::tool_parser::ParsedToolCall;
     use arkavo_mcp_tools::ToolInfo;
+    use arkavo_test_macros::spec;
     use serde_json::json;
 
     fn create_test_tool(name: &str) -> ToolInfo {
@@ -117,6 +118,7 @@ mod tests {
         }
     }
 
+    #[spec("CRIT-004")]
     #[tokio::test]
     async fn test_schema_check_pass() {
         let check = SchemaCheck::new();
@@ -141,6 +143,7 @@ mod tests {
         assert!(result.is_pass());
     }
 
+    #[spec("CRIT-004")]
     #[tokio::test]
     async fn test_schema_check_hallucinated_tool() {
         let check = SchemaCheck::new();
@@ -167,6 +170,7 @@ mod tests {
         assert!(evidence.description.contains("nonexistent"));
     }
 
+    #[spec("CRIT-004")]
     #[tokio::test]
     async fn test_schema_check_missing_param() {
         let check = SchemaCheck::new();

--- a/crates/arkavo-critic/src/checks/semantic.rs
+++ b/crates/arkavo-critic/src/checks/semantic.rs
@@ -188,6 +188,7 @@ mod tests {
     use super::*;
     use arkavo_llm::{Message, Provider, ProviderResponse};
     use arkavo_mcp_tools::ToolInfo;
+    use arkavo_test_macros::spec;
     use serde_json::json;
 
     /// Mock provider for testing
@@ -241,6 +242,7 @@ mod tests {
         }
     }
 
+    #[spec("CRIT-005")]
     #[tokio::test]
     async fn test_semantic_with_mock_pass() {
         let mock_provider = Arc::new(MockProvider {
@@ -273,6 +275,7 @@ mod tests {
         assert!(result.is_pass());
     }
 
+    #[spec("CRIT-005")]
     #[tokio::test]
     async fn test_semantic_with_mock_fail() {
         let mock_provider = Arc::new(MockProvider {

--- a/crates/arkavo-critic/src/evidence.rs
+++ b/crates/arkavo-critic/src/evidence.rs
@@ -170,6 +170,7 @@ impl VerificationEvidence {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
     #[test]
     fn test_severity_ordering() {
@@ -198,6 +199,7 @@ mod tests {
         assert!(!failed.is_passed());
     }
 
+    #[spec("CRIT-006")]
     #[test]
     fn test_evidence_creation() {
         let evidence = VerificationEvidence::passed("schema", "All schemas valid", 1);

--- a/crates/arkavo-critic/src/judge.rs
+++ b/crates/arkavo-critic/src/judge.rs
@@ -554,6 +554,7 @@ Your answer:"#,
 mod tests {
     use super::*;
     use arkavo_llm::tool_parser::ParsedToolCall;
+    use arkavo_test_macros::spec;
     use serde_json::json;
 
     struct MockJudgeProvider {
@@ -604,6 +605,7 @@ mod tests {
         }
     }
 
+    #[spec("CRIT-007")]
     #[tokio::test]
     async fn test_judgment_pass() {
         let provider = Arc::new(MockJudgeProvider {
@@ -634,6 +636,7 @@ mod tests {
         assert_eq!(result.issue_type, IssueType::None);
     }
 
+    #[spec("CRIT-007")]
     #[tokio::test]
     async fn test_judgment_fail_hallucinated() {
         let provider = Arc::new(MockJudgeProvider {
@@ -666,6 +669,7 @@ mod tests {
         assert!(result.reason.is_some());
     }
 
+    #[spec("CRIT-007")]
     #[tokio::test]
     async fn test_tool_error_ignored_claims_success() {
         let provider = Arc::new(MockJudgeProvider {

--- a/crates/arkavo-critic/src/pipeline.rs
+++ b/crates/arkavo-critic/src/pipeline.rs
@@ -185,6 +185,7 @@ mod tests {
     use super::*;
     use crate::checks::{LintCheck, PolicyCheck, SchemaCheck};
     use arkavo_llm::ProviderResponse;
+    use arkavo_test_macros::spec;
 
     fn response(content: &str) -> ProviderResponse {
         ProviderResponse {
@@ -197,6 +198,7 @@ mod tests {
         }
     }
 
+    #[spec("CRIT-001")]
     #[tokio::test]
     async fn test_empty_pipeline() {
         let pipeline = CriticPipeline::new();
@@ -208,6 +210,7 @@ mod tests {
         assert_eq!(result.checks_run, 0);
     }
 
+    #[spec("CRIT-002")]
     #[tokio::test]
     async fn test_pipeline_all_pass() {
         let pipeline = CriticPipeline::new()
@@ -227,6 +230,7 @@ mod tests {
         assert!(result.checks_run >= 1);
     }
 
+    #[spec("CRIT-008")]
     #[tokio::test]
     async fn test_pipeline_fail_fast() {
         let config = CriticConfig {

--- a/crates/arkavo-critic/src/response_analyzer.rs
+++ b/crates/arkavo-critic/src/response_analyzer.rs
@@ -299,33 +299,40 @@ pub fn issue_to_category(issue: &DetectedIssue, model_family: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("CRIT-017")]
     #[test]
     fn test_detect_model_family_glm() {
         assert_eq!(detect_model_family("glm-4.7-flash"), "glm");
     }
 
+    #[spec("CRIT-017")]
     #[test]
     fn test_detect_model_family_gemma() {
         assert_eq!(detect_model_family("gemma-2-9b"), "gemma");
     }
 
+    #[spec("CRIT-017")]
     #[test]
     fn test_detect_model_family_qwen() {
         assert_eq!(detect_model_family("qwen2.5-coder"), "qwen");
     }
 
+    #[spec("CRIT-017")]
     #[test]
     fn test_detect_model_family_mistral() {
         assert_eq!(detect_model_family("mistral-7b"), "mistral");
         assert_eq!(detect_model_family("ministral-3b"), "mistral");
     }
 
+    #[spec("CRIT-017")]
     #[test]
     fn test_detect_model_family_deepseek() {
         assert_eq!(detect_model_family("deepseek-r1"), "deepseek");
     }
 
+    #[spec("CRIT-017")]
     #[test]
     fn test_detect_model_family_unknown() {
         assert_eq!(detect_model_family("some-random-model"), "unknown");
@@ -345,6 +352,7 @@ mod tests {
         assert!(!is_simple_query("write a function to sort an array"));
     }
 
+    #[spec("CRIT-010")]
     #[test]
     fn test_detect_repetition() {
         let repeated = "line\nline\nline\nline\nline";
@@ -354,6 +362,7 @@ mod tests {
         assert!(!has_repetition(normal));
     }
 
+    #[spec("CRIT-009")]
     #[test]
     fn test_analyze_code_fence_issue() {
         let analyzer = ResponseAnalyzer::new("glm-4.7-flash");
@@ -365,6 +374,7 @@ mod tests {
         assert_eq!(r.category, "model:glm:code_fence");
     }
 
+    #[spec("CRIT-010")]
     #[test]
     fn test_analyze_output_loop() {
         let analyzer = ResponseAnalyzer::new("gemma-2-9b");
@@ -376,6 +386,7 @@ mod tests {
         assert_eq!(r.category, "model:gemma:loop");
     }
 
+    #[spec("CRIT-013")]
     #[test]
     fn test_analyze_wrong_expert_glm() {
         let analyzer = ResponseAnalyzer::new("glm-4.7-flash");
@@ -409,6 +420,7 @@ mod tests {
         assert!(result.is_none());
     }
 
+    #[spec("CRIT-014")]
     #[test]
     fn test_extract_first_answer_math() {
         assert_eq!(extract_first_answer("4\n4\n4\n4", true), "4");
@@ -416,6 +428,7 @@ mod tests {
         assert_eq!(extract_first_answer("", true), "");
     }
 
+    #[spec("CRIT-014")]
     #[test]
     fn test_extract_first_answer_nonmath() {
         let response =

--- a/crates/arkavo-gemini/Cargo.toml
+++ b/crates/arkavo-gemini/Cargo.toml
@@ -27,6 +27,7 @@ bytes = { workspace = true }
 [dev-dependencies]
 tracing-subscriber = { workspace = true }
 base64 = { workspace = true }
+arkavo-test-macros = { path = "../arkavo-test-macros" }
 
 [lints]
 workspace = true

--- a/crates/arkavo-gemini/src/dispatcher.rs
+++ b/crates/arkavo-gemini/src/dispatcher.rs
@@ -213,8 +213,10 @@ impl Default for ToolRegistry {
 #[allow(clippy::disallowed_methods)] // tokio::test uses block_on internally
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
     use uuid::Uuid;
 
+    #[spec("GEM-007")]
     #[tokio::test]
     async fn test_tool_registration() {
         let dispatcher = ToolDispatcher::new(4);
@@ -231,6 +233,7 @@ mod tests {
         assert_eq!(dispatcher.list_tools().len(), 1);
     }
 
+    #[spec("GEM-007")]
     #[tokio::test]
     async fn test_idempotency() {
         let dispatcher = ToolDispatcher::new(4);
@@ -262,6 +265,7 @@ mod tests {
         assert_eq!(results.len(), 1);
     }
 
+    #[spec("GEM-007")]
     #[tokio::test]
     async fn test_failed_call_id_can_be_retried() {
         let dispatcher = ToolDispatcher::new(4);
@@ -307,6 +311,7 @@ mod tests {
         assert!(second[0].1.is_ok());
     }
 
+    #[spec("GEM-007")]
     #[tokio::test]
     async fn test_successful_call_id_is_not_reprocessed() {
         let dispatcher = ToolDispatcher::new(4);
@@ -341,6 +346,8 @@ mod tests {
         assert_eq!(second.len(), 0);
     }
 
+    #[spec("GEM-007")]
+    #[spec("GEM-008")]
     #[tokio::test]
     async fn test_dispatch_returns_error_when_tool_task_panics() {
         let dispatcher = ToolDispatcher::new(4);

--- a/crates/arkavo-gemini/src/live_client.rs
+++ b/crates/arkavo-gemini/src/live_client.rs
@@ -91,6 +91,7 @@ pub struct LiveSessionClient {
     model: String,
     tools: Vec<Value>,
     modality: LiveModality,
+    endpoint_url: String,
     ws_writer: SharedWriter,
     tool_call_tx: mpsc::UnboundedSender<Vec<FunctionCall>>,
     tool_call_rx: Arc<RwLock<Option<mpsc::UnboundedReceiver<Vec<FunctionCall>>>>>,
@@ -130,11 +131,20 @@ impl LiveSessionClient {
             model: model.into(),
             tools,
             modality: LiveModality::Text,
+            endpoint_url: GEMINI_WS_ENDPOINT.to_string(),
             ws_writer: Arc::new(Mutex::new(None)),
             tool_call_tx: tx,
             tool_call_rx: Arc::new(RwLock::new(Some(rx))),
             connected: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Override the WebSocket endpoint URL. Intended for tests that use a
+    /// local mock server; production callers should leave the default.
+    #[doc(hidden)]
+    pub fn with_endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
+        self.endpoint_url = endpoint_url.into();
+        self
     }
 
     /// Override the response modality (default `Text`). Must be set before
@@ -174,7 +184,7 @@ impl LiveSessionClient {
     }
 
     async fn try_connect(&self) -> Result<()> {
-        let url_with_key = format!("{}?key={}", GEMINI_WS_ENDPOINT, self.api_key);
+        let url_with_key = format!("{}?key={}", self.endpoint_url, self.api_key);
         let _url = Url::parse(&url_with_key)?;
 
         debug!("Connecting to Gemini WebSocket endpoint");
@@ -386,6 +396,15 @@ impl LiveSessionClient {
         mime_type: String,
     ) -> Result<()> {
         let content = ClientContent::from_text_and_image(text, image_base64, mime_type);
+        self.send_message(ClientMessage::ClientContent {
+            client_content: content,
+        })
+        .await
+    }
+
+    /// Stream a base64-encoded audio chunk into the Live session.
+    pub async fn send_audio(&self, audio_base64: String, mime_type: String) -> Result<()> {
+        let content = ClientContent::from_audio(audio_base64, mime_type);
         self.send_message(ClientMessage::ClientContent {
             client_content: content,
         })

--- a/crates/arkavo-gemini/src/types.rs
+++ b/crates/arkavo-gemini/src/types.rs
@@ -125,6 +125,21 @@ impl ClientContent {
             turn_complete: true,
         }
     }
+
+    pub fn from_audio(audio_base64: String, mime_type: String) -> Self {
+        Self {
+            turns: vec![Turn {
+                role: "USER".to_string(),
+                parts: vec![Part::InlineData {
+                    inline_data: InlineData {
+                        mime_type,
+                        data: audio_base64,
+                    },
+                }],
+            }],
+            turn_complete: true,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/arkavo-gemini/tests/gemini_3_integration_test.rs
+++ b/crates/arkavo-gemini/tests/gemini_3_integration_test.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::collection_is_never_read, clippy::disallowed_methods)]
 
 use arkavo_gemini::{FunctionDeclaration, RestClient};
+use arkavo_test_macros::spec;
 use serde_json::{Value, json};
 
 fn get_api_key() -> String {
@@ -66,6 +67,9 @@ fn create_mock_calculator_tool() -> FunctionDeclaration {
     }
 }
 
+#[spec("GEM-001")]
+#[spec("GEM-002")]
+#[spec("GEM-003")]
 #[tokio::test]
 async fn test_parallel_tool_execution() {
     if should_skip_integration_tests() {
@@ -123,6 +127,9 @@ async fn test_parallel_tool_execution() {
     );
 }
 
+#[spec("GEM-001")]
+#[spec("GEM-003")]
+#[spec("GEM-010")]
 #[tokio::test]
 async fn test_json_mode_reliability() {
     if should_skip_integration_tests() {
@@ -169,6 +176,9 @@ Only respond with valid JSON, no other text."#;
     assert!(json.get("name").is_some(), "Missing 'name' field");
 }
 
+#[spec("GEM-001")]
+#[spec("GEM-002")]
+#[spec("GEM-003")]
 #[tokio::test]
 async fn test_tool_orchestration_complexity() {
     if should_skip_integration_tests() {
@@ -210,6 +220,10 @@ async fn test_tool_orchestration_complexity() {
     );
 }
 
+#[spec("GEM-001")]
+#[spec("GEM-002")]
+#[spec("GEM-003")]
+#[spec("GEM-008")]
 #[tokio::test]
 async fn test_error_recovery_malformed_tool() {
     if should_skip_integration_tests() {
@@ -259,6 +273,8 @@ async fn test_error_recovery_malformed_tool() {
     );
 }
 
+#[spec("GEM-001")]
+#[spec("GEM-003")]
 #[tokio::test]
 async fn test_multi_turn_consistency() {
     if should_skip_integration_tests() {

--- a/crates/arkavo-gemini/tests/integration_test.rs
+++ b/crates/arkavo-gemini/tests/integration_test.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::disallowed_methods)]
 
 use arkavo_gemini::{LiveSessionClient, ToolDispatcher, ToolRegistry};
+use arkavo_test_macros::spec;
 use serde_json::json;
 
 #[tokio::test]
@@ -12,6 +13,7 @@ async fn test_client_creation() {
     assert!(!client.is_connected());
 }
 
+#[spec("GEM-007")]
 #[tokio::test]
 async fn test_client_with_tools() {
     let dispatcher = ToolDispatcher::new(2);
@@ -30,6 +32,7 @@ async fn test_client_with_tools() {
     assert!(!client.is_connected());
 }
 
+#[spec("GEM-007")]
 #[tokio::test]
 async fn test_dispatcher_with_tools() {
     let dispatcher = ToolDispatcher::new(4);
@@ -62,6 +65,7 @@ async fn test_dispatcher_with_tools() {
     assert_eq!(tools[0]["name"], "create_stream");
 }
 
+#[spec("GEM-007")]
 #[tokio::test]
 async fn test_tool_execution() {
     let dispatcher = ToolDispatcher::new(2);

--- a/crates/arkavo-gemini/tests/list_models_live.rs
+++ b/crates/arkavo-gemini/tests/list_models_live.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::disallowed_methods)]
 
 use arkavo_gemini::RestClient;
+use arkavo_test_macros::spec;
 
 fn api_key_or_skip(test: &str) -> Option<String> {
     match std::env::var("GEMINI_API_KEY") {
@@ -19,6 +20,7 @@ fn api_key_or_skip(test: &str) -> Option<String> {
     }
 }
 
+#[spec("GEM-001")]
 #[tokio::test]
 async fn lists_gemini_3_5_flash_and_streaming_methods() {
     let Some(api_key) = api_key_or_skip("lists_gemini_3_5_flash_and_streaming_methods") else {

--- a/crates/arkavo-gemini/tests/live_bidi_handshake.rs
+++ b/crates/arkavo-gemini/tests/live_bidi_handshake.rs
@@ -11,6 +11,7 @@
 #![allow(clippy::disallowed_methods)]
 
 use arkavo_gemini::{LiveModality, LiveSessionClient, ToolDispatcher, ToolRegistry};
+use arkavo_test_macros::spec;
 use serde_json::json;
 use tokio::time::{Duration, timeout};
 
@@ -24,6 +25,9 @@ fn api_key_or_skip(test: &str) -> Option<String> {
     }
 }
 
+#[spec("GEM-004")]
+#[spec("GEM-007")]
+#[spec("GEM-009")]
 #[tokio::test]
 async fn live_bidi_setup_handshake() {
     let Some(api_key) = api_key_or_skip("live_bidi_setup_handshake") else {

--- a/crates/arkavo-gemini/tests/live_session_mock.rs
+++ b/crates/arkavo-gemini/tests/live_session_mock.rs
@@ -1,0 +1,221 @@
+//! Mock-server integration tests for the Gemini Live (WebSocket) client.
+//!
+//! These tests spin up a local WebSocket server so they exercise the real
+//! `LiveSessionClient` message framing without hitting the Gemini API.
+#![allow(clippy::disallowed_methods)]
+
+use arkavo_gemini::{LiveModality, LiveSessionClient, ToolDispatcher, ToolRegistry};
+use arkavo_test_macros::spec;
+use base64::{Engine as _, engine::general_purpose};
+use futures::{SinkExt, StreamExt};
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+use tokio::time::{Duration, timeout};
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{WebSocketStream, accept_async};
+
+type MockWs = WebSocketStream<tokio::net::TcpStream>;
+
+async fn start_mock_ws<F, Fut>(handler: F) -> (u16, tokio::task::JoinHandle<()>)
+where
+    F: FnOnce(MockWs) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = ()> + Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let handle = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let ws = accept_async(stream).await.unwrap();
+        handler(ws).await;
+    });
+    (port, handle)
+}
+
+fn b64(data: &[u8]) -> String {
+    general_purpose::STANDARD.encode(data)
+}
+
+#[spec("GEM-005")]
+#[tokio::test]
+async fn live_send_audio_content() {
+    let (port, server) = start_mock_ws(|mut ws| async move {
+        let setup = ws.next().await.unwrap().unwrap();
+        let setup_text = setup.to_text().unwrap();
+        let setup_value: Value = serde_json::from_str(setup_text).unwrap();
+        assert_eq!(
+            setup_value["setup"]["generationConfig"]["responseModalities"][0],
+            "AUDIO"
+        );
+
+        ws.send(Message::Text(r#"{"setupComplete":{}}"#.to_string()))
+            .await
+            .unwrap();
+
+        let audio_msg = ws.next().await.unwrap().unwrap();
+        let audio_text = audio_msg.to_text().unwrap();
+        let audio_value: Value = serde_json::from_str(audio_text).unwrap();
+        let parts = audio_value["clientContent"]["turns"][0]["parts"]
+            .as_array()
+            .unwrap();
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0]["inlineData"]["mimeType"], "audio/pcm");
+        assert_eq!(parts[0]["inlineData"]["data"], b64(b"\x00\x01\x02"));
+
+        ws.send(Message::Close(None)).await.unwrap();
+    })
+    .await;
+
+    let client = LiveSessionClient::new_with_tools(
+        "test_api_key",
+        "gemini-2.5-flash-native-audio-latest",
+        vec![],
+    )
+    .with_modality(LiveModality::Audio)
+    .with_endpoint_url(format!("ws://127.0.0.1:{port}/ws"));
+
+    timeout(Duration::from_secs(5), client.connect())
+        .await
+        .expect("connect timed out")
+        .expect("connect failed");
+    assert!(client.is_connected());
+
+    client
+        .send_audio(b64(b"\x00\x01\x02"), "audio/pcm".to_string())
+        .await
+        .expect("send_audio failed");
+
+    timeout(Duration::from_secs(5), client.close())
+        .await
+        .expect("close timed out")
+        .expect("close failed");
+    assert!(!client.is_connected());
+
+    server.await.unwrap();
+}
+
+#[spec("GEM-006")]
+#[tokio::test]
+async fn live_receives_server_tool_call() {
+    let (port, server) = start_mock_ws(|mut ws| async move {
+        let _setup = ws.next().await.unwrap().unwrap();
+        ws.send(Message::Text(r#"{"setupComplete":{}}"#.to_string()))
+            .await
+            .unwrap();
+
+        ws.send(Message::Text(
+            r#"{"toolCall":{"functionCalls":[{"name":"echo","args":{"message":"hello"},"id":"call-1"}]}}"#
+                .to_string(),
+        ))
+        .await
+        .unwrap();
+
+        let response = ws.next().await.unwrap().unwrap();
+        let response_text = response.to_text().unwrap();
+        let response_value: Value = serde_json::from_str(response_text).unwrap();
+        assert_eq!(
+            response_value["toolResponse"]["functionResponses"][0]["id"],
+            "call-1"
+        );
+        assert_eq!(
+            response_value["toolResponse"]["functionResponses"][0]["response"]["echo"],
+            "hello"
+        );
+
+        ws.send(Message::Close(None)).await.unwrap();
+    })
+    .await;
+
+    let dispatcher = ToolDispatcher::new(2);
+    let mut registry = ToolRegistry::new();
+    registry.register(
+        "echo",
+        "Echoes the input",
+        json!({"type": "object"}),
+        |args| Ok(json!({"echo": args["message"]})),
+    );
+    registry.build(&dispatcher);
+
+    let client = LiveSessionClient::new_with_tools(
+        "test_api_key",
+        "gemini-2.5-flash-native-audio-latest",
+        dispatcher.list_tools(),
+    )
+    .with_endpoint_url(format!("ws://127.0.0.1:{port}/ws"));
+
+    timeout(Duration::from_secs(5), client.connect())
+        .await
+        .expect("connect timed out")
+        .expect("connect failed");
+
+    let calls = timeout(Duration::from_secs(5), client.receive_tool_calls())
+        .await
+        .expect("receive_tool_calls timed out")
+        .expect("receive_tool_calls failed");
+
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].name, "echo");
+    assert_eq!(calls[0].args, json!({"message": "hello"}));
+    assert_eq!(calls[0].id, "call-1");
+
+    let results = dispatcher.dispatch(calls).await;
+    assert_eq!(results.len(), 1);
+    let (call_id, result) = results.into_iter().next().unwrap();
+    let response = result.expect("tool execution failed");
+
+    client
+        .send_tool_response(call_id, response)
+        .await
+        .expect("send_tool_response failed");
+
+    timeout(Duration::from_secs(5), client.close())
+        .await
+        .expect("close timed out")
+        .expect("close failed");
+
+    server.await.unwrap();
+}
+
+#[spec("GEM-006")]
+#[tokio::test]
+async fn live_ignores_empty_tool_call() {
+    let (port, server) = start_mock_ws(|mut ws| async move {
+        let _setup = ws.next().await.unwrap().unwrap();
+        ws.send(Message::Text(r#"{"setupComplete":{}}"#.to_string()))
+            .await
+            .unwrap();
+
+        ws.send(Message::Text(
+            r#"{"toolCall":{"functionCalls":[]}}"#.to_string(),
+        ))
+        .await
+        .unwrap();
+
+        ws.send(Message::Close(None)).await.unwrap();
+    })
+    .await;
+
+    let client = LiveSessionClient::new_with_tools(
+        "test_api_key",
+        "gemini-2.5-flash-native-audio-latest",
+        vec![],
+    )
+    .with_endpoint_url(format!("ws://127.0.0.1:{port}/ws"));
+
+    timeout(Duration::from_secs(5), client.connect())
+        .await
+        .expect("connect timed out")
+        .expect("connect failed");
+
+    let result = timeout(Duration::from_millis(500), client.receive_tool_calls()).await;
+    assert!(
+        result.is_err() || result.unwrap().is_err(),
+        "empty toolCall should not produce a receive_tool_calls result"
+    );
+
+    timeout(Duration::from_secs(5), client.close())
+        .await
+        .expect("close timed out")
+        .expect("close failed");
+
+    server.await.unwrap();
+}

--- a/crates/arkavo-gemini/tests/rest_tools_live.rs
+++ b/crates/arkavo-gemini/tests/rest_tools_live.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::disallowed_methods)]
 
 use arkavo_gemini::{FunctionDeclaration, RestClient, ToolDispatcher, ToolRegistry};
+use arkavo_test_macros::spec;
 use serde_json::json;
 
 fn api_key_or_skip(test: &str) -> Option<String> {
@@ -18,6 +19,9 @@ fn api_key_or_skip(test: &str) -> Option<String> {
     }
 }
 
+#[spec("GEM-001")]
+#[spec("GEM-002")]
+#[spec("GEM-007")]
 #[tokio::test]
 async fn rest_generate_content_invokes_tool() {
     let Some(api_key) = api_key_or_skip("rest_generate_content_invokes_tool") else {

--- a/crates/arkavo-gemini/tests/safety_edge_cases_test.rs
+++ b/crates/arkavo-gemini/tests/safety_edge_cases_test.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::collection_is_never_read, clippy::disallowed_methods)]
 
 use arkavo_gemini::RestClient;
+use arkavo_test_macros::spec;
 use std::time::{Duration, Instant};
 use tokio::time::timeout;
 
@@ -16,6 +17,9 @@ fn should_skip_integration_tests() -> bool {
     std::env::var("GEMINI_API_KEY").is_err() || get_api_key() == "test_key"
 }
 
+#[spec("GEM-001")]
+#[spec("GEM-003")]
+#[spec("GEM-008")]
 #[tokio::test]
 async fn test_safety_filter_handling() {
     if should_skip_integration_tests() {
@@ -65,6 +69,9 @@ async fn test_safety_filter_handling() {
     );
 }
 
+#[spec("GEM-001")]
+#[spec("GEM-003")]
+#[spec("GEM-008")]
 #[tokio::test]
 async fn test_rate_limit_backoff() {
     if should_skip_integration_tests() {
@@ -102,6 +109,8 @@ async fn test_rate_limit_backoff() {
     );
 }
 
+#[spec("GEM-001")]
+#[spec("GEM-003")]
 #[tokio::test]
 async fn test_context_window_overflow() {
     if should_skip_integration_tests() {
@@ -142,6 +151,9 @@ async fn test_context_window_overflow() {
     assert!(had_response, "Should handle large context gracefully");
 }
 
+#[spec("GEM-001")]
+#[spec("GEM-003")]
+#[spec("GEM-008")]
 #[tokio::test]
 async fn test_token_limit_boundary() {
     if should_skip_integration_tests() {
@@ -190,6 +202,8 @@ async fn test_token_limit_boundary() {
     }
 }
 
+#[spec("GEM-001")]
+#[spec("GEM-008")]
 #[tokio::test]
 async fn test_invalid_api_key_handling() {
     let client = RestClient::new("invalid_key_12345", "models/gemini-3-pro-preview");
@@ -202,6 +216,8 @@ async fn test_invalid_api_key_handling() {
     );
 }
 
+#[spec("GEM-001")]
+#[spec("GEM-008")]
 #[tokio::test]
 async fn test_network_timeout_handling() {
     if should_skip_integration_tests() {
@@ -227,6 +243,8 @@ async fn test_network_timeout_handling() {
     assert!(result.is_err(), "Should timeout appropriately");
 }
 
+#[spec("GEM-001")]
+#[spec("GEM-003")]
 #[tokio::test]
 async fn test_empty_prompt_handling() {
     if should_skip_integration_tests() {
@@ -252,6 +270,9 @@ async fn test_empty_prompt_handling() {
     }
 }
 
+#[spec("GEM-001")]
+#[spec("GEM-003")]
+#[spec("GEM-008")]
 #[tokio::test]
 async fn test_very_long_prompt() {
     if should_skip_integration_tests() {
@@ -291,6 +312,8 @@ async fn test_very_long_prompt() {
     }
 }
 
+#[spec("GEM-001")]
+#[spec("GEM-003")]
 #[tokio::test]
 async fn test_rapid_sequential_requests() {
     if should_skip_integration_tests() {

--- a/crates/arkavo-gemini/tests/sse_stress_test.rs
+++ b/crates/arkavo-gemini/tests/sse_stress_test.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::never_loop)] // Some loops break immediately for testing
 
 use arkavo_gemini::types::StreamChunk;
+use arkavo_test_macros::spec;
 use bytes::Bytes;
 use futures::stream;
 use std::pin::Pin;
@@ -21,6 +22,8 @@ fn create_test_stream(chunks: Vec<&str>) -> ByteStream {
     Box::pin(stream::iter(byte_chunks))
 }
 
+#[spec("GEM-003")]
+#[spec("GEM-010")]
 #[tokio::test]
 async fn test_split_json_across_chunks() {
     let chunk1 = "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hello";
@@ -47,6 +50,8 @@ async fn test_split_json_across_chunks() {
     assert_eq!(received_text, "Hello World");
 }
 
+#[spec("GEM-003")]
+#[spec("GEM-010")]
 #[tokio::test]
 async fn test_multiline_data_field() {
     let sse_data = "data: {\"candidates\":[{\"content\":\n\
@@ -74,6 +79,8 @@ async fn test_multiline_data_field() {
     assert_eq!(received_text, "Multi-line");
 }
 
+#[spec("GEM-003")]
+#[spec("GEM-010")]
 #[tokio::test]
 async fn test_large_response() {
     let large_text = "x".repeat(50000);
@@ -102,6 +109,9 @@ async fn test_large_response() {
     assert_eq!(received_text.len(), 50000);
 }
 
+#[spec("GEM-003")]
+#[spec("GEM-008")]
+#[spec("GEM-010")]
 #[tokio::test]
 async fn test_malformed_json_salvage() {
     // Realistic scenario: stream starts OK, then gets malformed mid-way
@@ -134,6 +144,8 @@ async fn test_malformed_json_salvage() {
     assert_eq!(received_text, "Good data");
 }
 
+#[spec("GEM-003")]
+#[spec("GEM-010")]
 #[tokio::test]
 async fn test_empty_candidates() {
     let json = "data: {\"candidates\":[]}\n\n";
@@ -157,6 +169,8 @@ async fn test_empty_candidates() {
     assert!(response_count >= 1);
 }
 
+#[spec("GEM-003")]
+#[spec("GEM-010")]
 #[tokio::test]
 async fn test_missing_optional_fields() {
     let json = "data: {\"candidates\":[{\"content\":{\"parts\":[]}}]}\n\n";
@@ -178,6 +192,7 @@ async fn test_missing_optional_fields() {
     assert!(got_response);
 }
 
+#[spec("GEM-010")]
 #[test]
 fn test_streamchunk_deserialize_with_defaults() {
     let json = r#"{"candidates":[]}"#;

--- a/crates/arkavo-gemini/tests/streaming_tools_live.rs
+++ b/crates/arkavo-gemini/tests/streaming_tools_live.rs
@@ -8,6 +8,7 @@
 use arkavo_gemini::{
     FunctionDeclaration, GeminiSseStream, RestClient, ToolDispatcher, ToolRegistry,
 };
+use arkavo_test_macros::spec;
 use serde_json::json;
 
 fn api_key_or_skip(test: &str) -> Option<String> {
@@ -20,6 +21,10 @@ fn api_key_or_skip(test: &str) -> Option<String> {
     }
 }
 
+#[spec("GEM-001")]
+#[spec("GEM-002")]
+#[spec("GEM-003")]
+#[spec("GEM-007")]
 #[tokio::test]
 async fn sse_streaming_invokes_tool() {
     let Some(api_key) = api_key_or_skip("sse_streaming_invokes_tool") else {

--- a/crates/arkavo-llm/Cargo.toml
+++ b/crates/arkavo-llm/Cargo.toml
@@ -64,6 +64,7 @@ arkavo-snpe = { path = "../arkavo-snpe", optional = true }
 
 
 [dev-dependencies]
+arkavo-test-macros = { path = "../arkavo-test-macros" }
 tempfile = { workspace = true }
 serial_test = "3"
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/crates/arkavo-llm/src/image.rs
+++ b/crates/arkavo-llm/src/image.rs
@@ -94,9 +94,11 @@ pub fn decode_image(encoded: &str) -> Result<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
+    #[spec("ROUTER-015")]
     #[test]
     fn test_image_format_from_path() {
         assert!(matches!(
@@ -119,6 +121,7 @@ mod tests {
         assert!(ImageFormat::from_path(Path::new("test")).is_err());
     }
 
+    #[spec("ROUTER-015")]
     #[test]
     fn test_image_format_validation() {
         let png_header = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
@@ -140,6 +143,7 @@ mod tests {
         assert!(ImageFormat::validate_bytes(&too_small).is_err());
     }
 
+    #[spec("ROUTER-015")]
     #[test]
     fn test_encode_decode_roundtrip() {
         let test_data = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
@@ -150,6 +154,7 @@ mod tests {
         assert_eq!(test_data.to_vec(), decoded);
     }
 
+    #[spec("ROUTER-015")]
     #[test]
     fn test_encode_image_file_not_found() {
         let result = encode_image_file("nonexistent.png");
@@ -157,6 +162,7 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
 
+    #[spec("ROUTER-015")]
     #[test]
     fn test_encode_image_file_success() {
         let png_data = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
@@ -170,6 +176,7 @@ mod tests {
         assert_eq!(png_data.to_vec(), decoded);
     }
 
+    #[spec("ROUTER-015")]
     #[test]
     fn test_decode_invalid_base64() {
         let result = decode_image("invalid-base64!");
@@ -177,6 +184,7 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("Invalid base64"));
     }
 
+    #[spec("ROUTER-015")]
     #[test]
     fn test_image_size_limit() {
         // Create an image that exceeds the size limit

--- a/crates/arkavo-llm/src/message.rs
+++ b/crates/arkavo-llm/src/message.rs
@@ -128,6 +128,7 @@ impl Message {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
     #[test]
     fn test_message_creation_with_string_literals() {
@@ -196,6 +197,7 @@ mod tests {
         assert_eq!(msg.content, "Hello");
     }
 
+    #[spec("ROUTER-015")]
     #[test]
     fn test_user_with_images() {
         let images = vec!["base64image1".to_string(), "base64image2".to_string()];
@@ -206,6 +208,7 @@ mod tests {
         assert_eq!(msg.images, Some(images));
     }
 
+    #[spec("ROUTER-015")]
     #[test]
     fn test_message_with_images_serialization() {
         let msg = Message::user_with_images("Test", vec!["image123".to_string()]);
@@ -226,6 +229,7 @@ mod tests {
         assert!(!json.contains(r#""images""#));
     }
 
+    #[spec("ROUTER-015")]
     #[test]
     fn test_message_with_images_deserialization() {
         let json = r#"{"role":"user","content":"Test","images":["img1","img2"]}"#;

--- a/crates/arkavo-llm/tests/openai_vision.rs
+++ b/crates/arkavo-llm/tests/openai_vision.rs
@@ -2,6 +2,7 @@
 
 use arkavo_llm::providers::openai::{OpenAIConfig, OpenAIProvider};
 use arkavo_llm::{Message, Provider, Role};
+use arkavo_test_macros::spec;
 use base64::Engine;
 use std::fs;
 use std::path::Path;
@@ -10,6 +11,7 @@ use std::path::Path;
 mod common;
 use common::ensure_api_key;
 
+#[spec("ROUTER-015")]
 #[tokio::test]
 #[ignore = "Requires OPENAI_API_KEY environment variable and GPT-5 access"]
 async fn test_gpt4o_vision_basic() {
@@ -52,6 +54,7 @@ async fn test_gpt4o_vision_basic() {
     );
 }
 
+#[spec("ROUTER-015")]
 #[tokio::test]
 #[ignore = "Requires OPENAI_API_KEY environment variable and GPT-5 access"]
 async fn test_gpt4o_vision_with_text() {
@@ -100,6 +103,7 @@ async fn test_gpt4o_vision_with_text() {
     assert!(!response.is_empty());
 }
 
+#[spec("ROUTER-015")]
 #[tokio::test]
 #[ignore = "Requires OPENAI_API_KEY environment variable and GPT-5 access"]
 async fn test_gpt4o_multiple_images() {
@@ -143,6 +147,7 @@ async fn test_gpt4o_multiple_images() {
     );
 }
 
+#[spec("ROUTER-015")]
 #[tokio::test]
 #[ignore = "Requires OPENAI_API_KEY environment variable and GPT-5 access"]
 async fn test_gpt4o_vision_streaming() {
@@ -202,6 +207,7 @@ async fn test_gpt4o_vision_streaming() {
     assert!(!full_response.is_empty());
 }
 
+#[spec("ROUTER-015")]
 #[tokio::test]
 #[ignore = "Requires OPENAI_API_KEY environment variable"]
 async fn test_non_vision_model_with_image_fails() {
@@ -251,6 +257,7 @@ async fn test_non_vision_model_with_image_fails() {
     }
 }
 
+#[spec("ROUTER-015")]
 #[tokio::test]
 #[ignore = "Requires OPENAI_API_KEY environment variable and local test image"]
 async fn test_gpt4o_with_local_image_file() {

--- a/crates/arkavo-orchestrator/Cargo.toml
+++ b/crates/arkavo-orchestrator/Cargo.toml
@@ -46,6 +46,7 @@ mdns-sd = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+arkavo-test-macros = { path = "../arkavo-test-macros" }
 
 [features]
 default = []

--- a/crates/arkavo-orchestrator/src/agent_assignment.rs
+++ b/crates/arkavo-orchestrator/src/agent_assignment.rs
@@ -121,7 +121,10 @@ impl AgentAssigner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("ORCH-006")]
+    #[spec("ORCH-011")]
     #[tokio::test]
     #[allow(clippy::disallowed_methods)]
     async fn test_agent_assignment_creation() {

--- a/crates/arkavo-orchestrator/src/attempt_history.rs
+++ b/crates/arkavo-orchestrator/src/attempt_history.rs
@@ -229,6 +229,7 @@ impl AttemptHistory {
 mod tests {
     use super::*;
     use crate::cognitive_engine_core::VerificationCheck;
+    use arkavo_test_macros::spec;
 
     fn failed_result(detail: &str) -> VerificationResult {
         VerificationResult {
@@ -238,6 +239,7 @@ mod tests {
         }
     }
 
+    #[spec("ORCH-005")]
     #[test]
     fn test_empty_history_returns_none() {
         let h = AttemptHistory::new();
@@ -245,6 +247,7 @@ mod tests {
         assert!(h.get("owner/repo", 1).is_empty());
     }
 
+    #[spec("ORCH-005")]
     #[test]
     fn test_record_and_retrieve() {
         let h = AttemptHistory::new();
@@ -262,6 +265,7 @@ mod tests {
         assert!(block.contains("step 3 failed"));
     }
 
+    #[spec("ORCH-005")]
     #[test]
     fn test_classified_failure_renders_label() {
         let h = AttemptHistory::new();
@@ -279,6 +283,7 @@ mod tests {
         assert!(block.contains("step 2 hit timeout"));
     }
 
+    #[spec("ORCH-005")]
     #[test]
     fn test_multiple_attempts_increment() {
         let h = AttemptHistory::new();
@@ -291,6 +296,7 @@ mod tests {
         assert_eq!(attempts[2].attempt_number, 3);
     }
 
+    #[spec("ORCH-005")]
     #[test]
     fn test_clear_removes_history() {
         let h = AttemptHistory::new();
@@ -300,6 +306,7 @@ mod tests {
         assert!(h.to_prompt_block("owner/repo", 1).is_none());
     }
 
+    #[spec("ORCH-005")]
     #[test]
     fn test_bounded_cap_fifo_evicts() {
         let h = AttemptHistory::new();
@@ -326,6 +333,7 @@ mod tests {
         );
     }
 
+    #[spec("ORCH-005")]
     #[test]
     fn test_total_records_tracks_sum() {
         let h = AttemptHistory::new();

--- a/crates/arkavo-orchestrator/src/chunk_processor.rs
+++ b/crates/arkavo-orchestrator/src/chunk_processor.rs
@@ -396,6 +396,7 @@ impl ChunkProcessor {
 mod tests {
     use super::*;
     use arkavo_context::ChunkRef;
+    use arkavo_test_macros::spec;
     use std::collections::HashMap;
 
     fn create_test_manifest(chunk_count: usize) -> ContextManifest {
@@ -422,6 +423,7 @@ mod tests {
         }
     }
 
+    #[spec("ORCH-007")]
     #[tokio::test]
     async fn test_find_available_agents() {
         let registry = Arc::new(AgentRegistry::new());
@@ -459,6 +461,7 @@ mod tests {
         assert_eq!(agents.len(), 2);
     }
 
+    #[spec("ORCH-007")]
     #[tokio::test]
     async fn test_distribute_chunks() {
         let registry = Arc::new(AgentRegistry::new());
@@ -497,6 +500,7 @@ mod tests {
         assert_eq!(all_indices, (0..10).collect::<Vec<_>>());
     }
 
+    #[spec("ORCH-007")]
     #[tokio::test]
     async fn test_spawn_chunk_processors() {
         let registry = Arc::new(AgentRegistry::new());
@@ -543,6 +547,7 @@ mod tests {
         assert!(result.aggregated_output.contains("[Chunk 4]:"));
     }
 
+    #[spec("ORCH-007")]
     #[tokio::test]
     async fn test_aggregate_with_failures() {
         let registry = Arc::new(AgentRegistry::new());

--- a/crates/arkavo-orchestrator/src/code_solver.rs
+++ b/crates/arkavo-orchestrator/src/code_solver.rs
@@ -460,6 +460,7 @@ fn is_common_word(word: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
     fn create_test_problem() -> ProblemStatement {
         ProblemStatement {
@@ -471,6 +472,7 @@ mod tests {
         }
     }
 
+    #[spec("ORCH-008")]
     #[tokio::test]
     async fn test_extract_search_terms() {
         let router = Arc::new(Router::new().await.unwrap());
@@ -488,6 +490,7 @@ mod tests {
         assert!(terms.contains(&"password".to_string()));
     }
 
+    #[spec("ORCH-008")]
     #[tokio::test]
     async fn test_calculate_relevance() {
         let router = Arc::new(Router::new().await.unwrap());

--- a/crates/arkavo-orchestrator/src/cognitive_engine_helpers.rs
+++ b/crates/arkavo-orchestrator/src/cognitive_engine_helpers.rs
@@ -141,6 +141,7 @@ impl CognitiveEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
     #[test]
     fn parse_repository_splits_owner_and_name() {
@@ -149,6 +150,7 @@ mod tests {
         assert_eq!(repo, "arkavo-edge");
     }
 
+    #[spec("ORCH-011")]
     #[test]
     fn parse_repository_rejects_unqualified() {
         assert!(CognitiveEngine::parse_repository("invalid").is_err());

--- a/crates/arkavo-orchestrator/src/cognitive_engine_outcome.rs
+++ b/crates/arkavo-orchestrator/src/cognitive_engine_outcome.rs
@@ -124,6 +124,7 @@ pub fn record_plan_invalid(history: &Arc<AttemptHistory>, plan: &ExecutionPlan, 
 mod tests {
     use super::*;
     use crate::cognitive_engine_types::VerificationCheck;
+    use arkavo_test_macros::spec;
 
     fn passed() -> VerificationResult {
         VerificationResult {
@@ -141,6 +142,7 @@ mod tests {
         }
     }
 
+    #[spec("ORCH-005")]
     #[test]
     fn success_when_all_steps_done_and_verified() {
         let mut o = ExecutionOutcome::new();
@@ -149,6 +151,7 @@ mod tests {
         assert!(o.is_success(3));
     }
 
+    #[spec("ORCH-005")]
     #[test]
     fn failure_when_verification_fails() {
         let mut o = ExecutionOutcome::new();
@@ -157,6 +160,7 @@ mod tests {
         assert!(!o.is_success(3));
     }
 
+    #[spec("ORCH-005")]
     #[test]
     fn failure_when_steps_incomplete() {
         let mut o = ExecutionOutcome::new();
@@ -165,6 +169,7 @@ mod tests {
         assert!(!o.is_success(3));
     }
 
+    #[spec("ORCH-005")]
     #[test]
     fn final_comment_success_text() {
         let mut o = ExecutionOutcome::new();
@@ -176,6 +181,7 @@ mod tests {
         assert!(c.contains("100/1000"));
     }
 
+    #[spec("ORCH-005")]
     #[test]
     fn final_comment_failure_includes_count() {
         let mut o = ExecutionOutcome::new();

--- a/crates/arkavo-orchestrator/src/cognitive_engine_planning_parser.rs
+++ b/crates/arkavo-orchestrator/src/cognitive_engine_planning_parser.rs
@@ -142,7 +142,9 @@ fn default_step() -> PlanStep {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("ORCH-004")]
     #[test]
     fn parses_text_steps() {
         let resp = "\
@@ -161,6 +163,7 @@ VERIFY: lint
         assert_eq!(steps[1].commands, vec!["cmd3"]);
     }
 
+    #[spec("ORCH-004")]
     #[test]
     fn empty_text_returns_default_step() {
         let steps = parse_plan_from_response("").unwrap();
@@ -168,6 +171,7 @@ VERIFY: lint
         assert_eq!(steps[0].step_number, 1);
     }
 
+    #[spec("ORCH-004")]
     #[test]
     fn json_parse_takes_priority() {
         let json = r#"{"steps":[{"step_number":1,"description":"x","commands":["c"],"verification":["tests"],"confidence":0.5}]}"#;
@@ -176,6 +180,7 @@ VERIFY: lint
         assert_eq!(steps[0].description, "x");
     }
 
+    #[spec("ORCH-004")]
     #[test]
     fn keyword_to_check_recognizes_aliases() {
         assert!(matches!(

--- a/crates/arkavo-orchestrator/src/cognitive_engine_schema.rs
+++ b/crates/arkavo-orchestrator/src/cognitive_engine_schema.rs
@@ -72,7 +72,9 @@ impl JsonExecutionPlan {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("ORCH-004")]
     #[test]
     fn test_json_schema_generation() {
         let schema = JsonExecutionPlan::json_schema();
@@ -83,6 +85,7 @@ mod tests {
         assert!(props.get("steps").is_some());
     }
 
+    #[spec("ORCH-004")]
     #[test]
     fn test_deserialize_json_plan() {
         let json = r#"{
@@ -113,6 +116,7 @@ mod tests {
         assert!((plan.steps[0].confidence - 0.9).abs() < 0.01);
     }
 
+    #[spec("ORCH-004")]
     #[test]
     fn test_serialize_json_plan() {
         let plan = JsonExecutionPlan {
@@ -130,6 +134,7 @@ mod tests {
         assert!(json.contains("cargo build"));
     }
 
+    #[spec("ORCH-004")]
     #[test]
     fn test_empty_plan() {
         let json = r#"{"steps": []}"#;

--- a/crates/arkavo-orchestrator/src/issue_analyzer.rs
+++ b/crates/arkavo-orchestrator/src/issue_analyzer.rs
@@ -288,6 +288,7 @@ impl IssueAnalyzer {
 mod tests {
     use super::*;
     use crate::types::{Label, User};
+    use arkavo_test_macros::spec;
 
     fn create_test_issue(title: &str, body: &str, labels: Vec<&str>) -> Issue {
         Issue {
@@ -322,6 +323,7 @@ mod tests {
         }
     }
 
+    #[spec("ORCH-002")]
     #[test]
     fn test_classify_bug() {
         let issue = create_test_issue("Fix memory leak", "There is a bug", vec!["bug"]);
@@ -329,6 +331,7 @@ mod tests {
         assert_eq!(issue_type, IssueType::Bug);
     }
 
+    #[spec("ORCH-002")]
     #[test]
     fn test_classify_documentation() {
         let issue = create_test_issue("Update README", "", vec!["documentation"]);
@@ -336,6 +339,7 @@ mod tests {
         assert_eq!(issue_type, IssueType::Documentation);
     }
 
+    #[spec("ORCH-002")]
     #[test]
     fn test_assess_trivial_complexity() {
         let issue = create_test_issue("Fix typo", "Small typo fix", vec!["good first issue"]);
@@ -343,6 +347,7 @@ mod tests {
         assert_eq!(complexity, Complexity::Trivial);
     }
 
+    #[spec("ORCH-002")]
     #[test]
     fn test_detect_rust_technology() {
         let issue = create_test_issue(
@@ -354,6 +359,7 @@ mod tests {
         assert!(technologies.contains(&"rust".to_string()));
     }
 
+    #[spec("ORCH-002")]
     #[test]
     fn test_determine_capabilities_for_bug() {
         let technologies = vec!["rust".to_string()];

--- a/crates/arkavo-orchestrator/src/issue_router.rs
+++ b/crates/arkavo-orchestrator/src/issue_router.rs
@@ -222,6 +222,7 @@ impl IssueRouter {
 mod tests {
     use super::*;
     use crate::types::{Issue, IssueAction, Label, Repository, User};
+    use arkavo_test_macros::spec;
 
     fn create_test_event(title: &str, body: &str, labels: Vec<&str>) -> IssueEvent {
         IssueEvent {
@@ -283,6 +284,7 @@ mod tests {
         }
     }
 
+    #[spec("ORCH-003")]
     #[test]
     fn test_trivial_documentation_auto_execute() {
         let event = create_test_event(
@@ -296,6 +298,7 @@ mod tests {
         assert_eq!(decision.priority, Priority::Low);
     }
 
+    #[spec("ORCH-003")]
     #[test]
     fn test_simple_bug_requires_plan() {
         let event = create_test_event("Fix memory leak", "Small memory leak found", vec!["bug"]);
@@ -305,6 +308,7 @@ mod tests {
         assert_eq!(decision.priority, Priority::High);
     }
 
+    #[spec("ORCH-003")]
     #[test]
     fn test_breaking_change_requires_approval() {
         let event = create_test_event(
@@ -318,6 +322,7 @@ mod tests {
         assert!(decision.should_notify_human);
     }
 
+    #[spec("ORCH-003")]
     #[test]
     fn test_security_issue_is_critical() {
         let event = create_test_event(
@@ -331,6 +336,7 @@ mod tests {
         assert!(decision.should_notify_human);
     }
 
+    #[spec("ORCH-003")]
     #[test]
     fn test_complex_multi_tech_orchestration() {
         let event = create_test_event(

--- a/crates/arkavo-orchestrator/src/plan_validator.rs
+++ b/crates/arkavo-orchestrator/src/plan_validator.rs
@@ -202,6 +202,7 @@ fn looks_mutating(step: &PlanStep) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
     use uuid::Uuid;
 
     fn make_plan(steps: Vec<PlanStep>) -> ExecutionPlan {
@@ -224,6 +225,7 @@ mod tests {
         }
     }
 
+    #[spec("ORCH-004")]
     #[test]
     fn test_valid_plan_passes() {
         let plan = make_plan(vec![ok_step(1), ok_step(2)]);
@@ -231,6 +233,7 @@ mod tests {
         assert!(report.is_valid(), "got: {}", report.summary());
     }
 
+    #[spec("ORCH-004")]
     #[test]
     fn test_empty_plan_rejected() {
         let plan = make_plan(vec![]);
@@ -239,6 +242,7 @@ mod tests {
         assert_eq!(report.violations[0].code, "EMPTY_PLAN");
     }
 
+    #[spec("ORCH-004")]
     #[test]
     fn test_bad_numbering_detected() {
         let mut s = ok_step(1);
@@ -248,6 +252,7 @@ mod tests {
         assert!(report.violations.iter().any(|v| v.code == "STEP_NUMBERING"));
     }
 
+    #[spec("ORCH-004")]
     #[test]
     fn test_empty_commands_detected() {
         let mut s = ok_step(1);
@@ -257,6 +262,7 @@ mod tests {
         assert!(report.violations.iter().any(|v| v.code == "NO_COMMANDS"));
     }
 
+    #[spec("ORCH-004")]
     #[test]
     fn test_empty_command_string_detected() {
         let mut s = ok_step(1);
@@ -266,6 +272,7 @@ mod tests {
         assert!(report.violations.iter().any(|v| v.code == "EMPTY_COMMAND"));
     }
 
+    #[spec("ORCH-004")]
     #[test]
     fn test_out_of_range_confidence_detected() {
         let mut s = ok_step(1);
@@ -280,6 +287,7 @@ mod tests {
         );
     }
 
+    #[spec("ORCH-004")]
     #[test]
     fn test_mutating_without_verification_detected() {
         let s = PlanStep {
@@ -299,6 +307,7 @@ mod tests {
         );
     }
 
+    #[spec("ORCH-004")]
     #[test]
     fn test_non_mutating_no_verification_ok() {
         let s = PlanStep {
@@ -313,6 +322,7 @@ mod tests {
         assert!(report.is_valid(), "got: {}", report.summary());
     }
 
+    #[spec("ORCH-004")]
     #[test]
     fn test_fix_in_description_does_not_trigger_mutation_check() {
         // Regression: "fix" appears in nearly every bug-fix issue's planning
@@ -336,6 +346,7 @@ mod tests {
         );
     }
 
+    #[spec("ORCH-004")]
     #[test]
     fn test_apply_in_command_still_triggers_mutation_check() {
         // The narrowed heuristic must still catch obvious mutating commands.
@@ -358,6 +369,7 @@ mod tests {
         );
     }
 
+    #[spec("ORCH-004")]
     #[test]
     fn test_command_too_long_detected() {
         let mut s = ok_step(1);

--- a/crates/arkavo-orchestrator/src/task_executor/planning.rs
+++ b/crates/arkavo-orchestrator/src/task_executor/planning.rs
@@ -216,7 +216,9 @@ pub struct TaskPlan {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("ORCH-009")]
     #[test]
     fn test_gather_prompt_includes_task() {
         let prompt = CollaborativePlanner::build_gather_prompt("Fix bug");
@@ -224,6 +226,7 @@ mod tests {
         assert!(prompt.contains("available tools"));
     }
 
+    #[spec("ORCH-009")]
     #[test]
     fn test_plan_prompt_includes_findings() {
         let prompt = CollaborativePlanner::build_plan_prompt("Add feature", "Found 3 files");
@@ -232,6 +235,7 @@ mod tests {
         assert!(prompt.contains("## Files to Modify"));
     }
 
+    #[spec("ORCH-009")]
     #[test]
     fn test_execution_prompt_includes_task() {
         let prompt = CollaborativePlanner::build_execution_prompt("Create file");

--- a/crates/arkavo-orchestrator/src/webhook.rs
+++ b/crates/arkavo-orchestrator/src/webhook.rs
@@ -240,7 +240,9 @@ async fn health_check() -> impl IntoResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("ORCH-010")]
     #[test]
     fn test_signature_verification() {
         let secret = "test-secret";
@@ -256,6 +258,8 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[spec("ORCH-010")]
+    #[spec("ORCH-011")]
     #[test]
     fn test_invalid_signature() {
         let config = RateLimitConfig::default();

--- a/crates/arkavo-orchestrator/tests/test_healer_e2e.rs
+++ b/crates/arkavo-orchestrator/tests/test_healer_e2e.rs
@@ -13,6 +13,7 @@ use arkavo_orchestrator::cognitive_engine::{
 use arkavo_orchestrator::issue_analyzer::{Complexity, IssueAnalyzer};
 use arkavo_orchestrator::issue_router::{ExecutionStrategy, IssueRouter, Priority};
 use arkavo_orchestrator::types::{Issue, IssueAction, IssueEvent, Label, Repository, User};
+use arkavo_test_macros::spec;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -91,6 +92,7 @@ fn create_test_issue_event() -> IssueEvent {
     }
 }
 
+#[spec("ORCH-002")]
 #[tokio::test]
 async fn test_healer_issue_analysis() {
     let event = create_test_issue_event();
@@ -110,6 +112,7 @@ async fn test_healer_issue_analysis() {
     println!("  Estimated tokens: {}", analysis.estimated_tokens);
 }
 
+#[spec("ORCH-003")]
 #[tokio::test]
 async fn test_healer_issue_routing() {
     let event = create_test_issue_event();
@@ -131,6 +134,7 @@ async fn test_healer_issue_routing() {
     println!("  Rationale: {}", routing.rationale);
 }
 
+#[spec("ORCH-006")]
 #[tokio::test]
 async fn test_healer_agent_assignment() {
     let event = create_test_issue_event();
@@ -155,6 +159,7 @@ async fn test_healer_agent_assignment() {
     println!("  Strategy: {:?}", assignment.routing_decision.strategy);
 }
 
+#[spec("ORCH-004")]
 #[tokio::test]
 async fn test_healer_execution_plan() {
     let event = create_test_issue_event();
@@ -196,6 +201,7 @@ async fn test_healer_execution_plan() {
     }
 }
 
+#[spec("ORCH-005")]
 #[tokio::test]
 #[ignore] // Run with: cargo test -p arkavo-orchestrator test_healer_full_flow -- --ignored --nocapture
 async fn test_healer_full_flow_with_pr() {
@@ -296,6 +302,7 @@ async fn test_healer_full_flow_with_pr() {
     println!("\n=== E2E Flow Complete ===\n");
 }
 
+#[spec("ORCH-005")]
 #[test]
 fn test_healer_pr_body_format() {
     let issue_number = 123;
@@ -324,6 +331,7 @@ fn test_healer_pr_body_format() {
     assert!(pr_body.contains("Arkavo Healer"));
 }
 
+#[spec("ORCH-003")]
 #[test]
 fn test_healer_routing_strategies() {
     // Test that routing strategies align with complexity levels
@@ -336,6 +344,7 @@ fn test_healer_routing_strategies() {
     assert_eq!(routing.analysis.complexity, Complexity::Trivial);
 }
 
+#[spec("ORCH-003")]
 #[test]
 fn test_healer_priority_assignment() {
     // Create a security issue event

--- a/crates/arkavo-orchestrator/tests/test_orchestrator_init.rs
+++ b/crates/arkavo-orchestrator/tests/test_orchestrator_init.rs
@@ -1,0 +1,58 @@
+#![allow(clippy::disallowed_methods)]
+
+use arkavo_budget::{BudgetConfig, BudgetTracker};
+use arkavo_events::{EventWriter, EventWriterConfig};
+use arkavo_github::{GitHubApp, IssueOperations};
+use arkavo_orchestrator::Orchestrator;
+use arkavo_protocol::{
+    SqliteTaskStore, TaskExecutor, TaskExecutorConfig, TaskStore, agent_registry::AgentRegistry,
+};
+use arkavo_test_macros::spec;
+use std::sync::Arc;
+
+/// ORCH-001: Initialize orchestrator
+///
+/// Verifies that `Orchestrator::new` builds the orchestrator and that
+/// `Orchestrator::initialize` successfully starts the task executor.
+#[spec("ORCH-001")]
+#[tokio::test]
+async fn test_orchestrator_initialization() {
+    let store: Arc<dyn TaskStore> = Arc::new(
+        SqliteTaskStore::new_in_memory()
+            .await
+            .expect("in-memory task store"),
+    );
+    let task_executor = Arc::new(TaskExecutor::new(store, TaskExecutorConfig::default()));
+    let agent_registry = Arc::new(AgentRegistry::new());
+    let budget_tracker = Arc::new(
+        BudgetTracker::new(BudgetConfig::default())
+            .await
+            .expect("budget tracker"),
+    );
+    let event_writer = Arc::new(EventWriter::new(EventWriterConfig::default()));
+    let github_app = Arc::new(
+        GitHubApp::new_from_token("test-token".to_string()).expect("GitHub app from token"),
+    );
+    let github_ops = Arc::new(IssueOperations::new(github_app));
+
+    let orchestrator = Orchestrator::new(
+        task_executor,
+        agent_registry,
+        budget_tracker,
+        event_writer,
+        github_ops,
+        "test-session".to_string(),
+    )
+    .await
+    .expect("orchestrator should construct successfully");
+
+    orchestrator
+        .initialize()
+        .await
+        .expect("orchestrator initialize should succeed");
+
+    orchestrator
+        .stop()
+        .await
+        .expect("orchestrator stop should succeed");
+}

--- a/crates/arkavo-orchestrator/tests/test_pr_creation.rs
+++ b/crates/arkavo-orchestrator/tests/test_pr_creation.rs
@@ -5,6 +5,7 @@ use arkavo_orchestrator::agent_assignment::{AgentAssignment, RoutingDecision};
 use arkavo_orchestrator::cognitive_engine::{
     ExecutionPlan, PlanStep, PrCreator, VerificationCheck,
 };
+use arkavo_test_macros::spec;
 use serde_json::json;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -18,6 +19,7 @@ fn check_gh_cli() -> bool {
         .unwrap_or(false)
 }
 
+#[spec("ORCH-005")]
 #[tokio::test]
 async fn test_pr_creation_with_mcp_tool() {
     // Gracefully skip if gh CLI not available or not authenticated

--- a/crates/arkavo-protocol/src/a2a_mcp_bridge.rs
+++ b/crates/arkavo-protocol/src/a2a_mcp_bridge.rs
@@ -91,6 +91,7 @@ impl A2aMcpBridge {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
     use serde_json::json;
 
     // Each test gets an isolated SQLite path via MemoryStorage::new_test() —
@@ -106,6 +107,7 @@ mod tests {
         }
     }
 
+    #[spec("PROTO-005")]
     #[tokio::test]
     async fn test_bridge_creation() {
         let bridge = test_bridge().await;
@@ -113,6 +115,7 @@ mod tests {
         assert!(!tools.is_empty());
     }
 
+    #[spec("PROTO-005")]
     #[tokio::test]
     async fn test_call_get_agent_time() {
         let bridge = test_bridge().await;
@@ -127,6 +130,7 @@ mod tests {
         assert!(response.result["unix_seconds"].is_number());
     }
 
+    #[spec("PROTO-005")]
     #[tokio::test]
     async fn test_call_nonexistent_tool() {
         let bridge = test_bridge().await;
@@ -141,6 +145,7 @@ mod tests {
         assert!(response.error.unwrap().contains("not found"));
     }
 
+    #[spec("PROTO-005")]
     #[tokio::test]
     async fn test_list_tools_includes_time_tools() {
         let bridge = test_bridge().await;
@@ -151,6 +156,7 @@ mod tests {
         assert!(tools.contains(&"get_time_status".to_string()));
     }
 
+    #[spec("PROTO-005")]
     #[tokio::test]
     async fn test_get_tool_schema() {
         let bridge = test_bridge().await;

--- a/crates/arkavo-protocol/src/chat_session.rs
+++ b/crates/arkavo-protocol/src/chat_session.rs
@@ -849,11 +849,11 @@ impl ChatSessionManager {
             }
         }
 
-        // Mark session as zombie if it still exists (cleanup needed)
-        if let Some(session_state) = sessions.read().await.get(&session_id)
-            && session_state.state != SessionState::Closing
-            && let Some(metrics) = session_metrics.write().await.get_mut(&session_id)
-        {
+        // Mark session as zombie if metrics still exist (abnormal exit / cleanup needed).
+        // Normal closure removes the metrics before the handler exits, so a remaining
+        // metrics entry means the session channel closed unexpectedly while the session
+        // was still active.
+        if let Some(metrics) = session_metrics.write().await.get_mut(&session_id) {
             metrics.set_state(SessionState::Zombie);
             warn!("Session marked as zombie - cleanup needed");
         }
@@ -1460,11 +1460,11 @@ impl ChatSessionManager {
             }
         }
 
-        // Mark session as zombie if it wasn't properly closed
-        if let Some(session_state) = sessions.read().await.get(&session_id)
-            && session_state.state != SessionState::Closing
-            && let Some(metrics) = session_metrics.write().await.get_mut(&session_id)
-        {
+        // Mark session as zombie if metrics still exist (abnormal exit / cleanup needed).
+        // Normal closure removes the metrics before the handler exits, so a remaining
+        // metrics entry means the session channel closed unexpectedly while the session
+        // was still active.
+        if let Some(metrics) = session_metrics.write().await.get_mut(&session_id) {
             metrics.set_state(SessionState::Zombie);
             warn!("Router session marked as zombie - cleanup needed");
         }
@@ -1559,6 +1559,10 @@ fn format_tool_results(results: &[ToolExecutionResult]) -> String {
 #[allow(clippy::field_reassign_with_default)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
+
+    // Mock-provider support
+    use async_trait::async_trait;
 
     #[tokio::test]
     async fn test_session_creation() {
@@ -1577,6 +1581,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[spec("CHAT-002")]
+    #[spec("CHAT-003")]
+    #[spec("CHAT-006")]
     async fn test_session_lifecycle() {
         let manager = ChatSessionManager::new(None);
         let session = manager.create_session(None).await;
@@ -1622,6 +1629,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[spec("CHAT-007")]
     async fn test_ttl_cleanup() {
         // Create manager with very short TTL for testing
         let manager = ChatSessionManager::with_config(None, None, None, 1, BufferConfig::default()); // 1 second TTL
@@ -1715,5 +1723,249 @@ mod tests {
         drop(sessions);
 
         manager.shutdown().await;
+    }
+
+    // Mock LLM provider for testing streaming/back-pressure behaviour without network calls.
+    #[derive(Clone)]
+    struct MockLlmProvider {
+        chunks: Vec<arkavo_llm::StreamResponse>,
+        error_on_stream: Option<String>,
+    }
+
+    impl MockLlmProvider {
+        fn with_text_chars(count: usize) -> Self {
+            let mut chunks = Vec::with_capacity(count);
+            for i in 0..count {
+                chunks.push(arkavo_llm::StreamResponse {
+                    content: "x".to_string(),
+                    reasoning_content: None,
+                    done: i == count - 1,
+                    inference_timing: None,
+                });
+            }
+            Self {
+                chunks,
+                error_on_stream: None,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl arkavo_llm::Provider for MockLlmProvider {
+        async fn complete_with_options(
+            &self,
+            _messages: Vec<arkavo_llm::Message>,
+            _max_tokens: Option<usize>,
+        ) -> arkavo_llm::Result<String> {
+            Ok(String::new())
+        }
+
+        async fn stream(
+            &self,
+            _messages: Vec<arkavo_llm::Message>,
+        ) -> arkavo_llm::Result<
+            Box<
+                dyn futures::Stream<Item = arkavo_llm::Result<arkavo_llm::StreamResponse>>
+                    + Send
+                    + Unpin,
+            >,
+        > {
+            if let Some(ref err) = self.error_on_stream {
+                return Err(arkavo_llm::Error::Stream(err.clone()));
+            }
+            let chunks = self.chunks.clone();
+            let stream = futures::stream::iter(chunks.into_iter().map(Ok));
+            Ok(Box::new(stream))
+        }
+
+        fn name(&self) -> &str {
+            "mock-llm-provider"
+        }
+    }
+
+    fn create_mock_adapter(chunk_count: usize) -> Arc<arkavo_llm::LlmClientAdapter> {
+        let provider = MockLlmProvider::with_text_chars(chunk_count);
+        let client = arkavo_llm::LlmClient::new(Box::new(provider));
+        Arc::new(arkavo_llm::LlmClientAdapter::new(client))
+    }
+
+    #[tokio::test]
+    #[spec("CHAT-008")]
+    async fn test_get_delta_stream_active_and_missing() {
+        let adapter = create_mock_adapter(0);
+        let manager = ChatSessionManager::new(Some(adapter));
+        let session = manager.create_session(None).await;
+
+        let stream = manager.get_delta_stream(&session.session_id).await;
+        assert!(
+            stream.is_some(),
+            "Active session must expose a delta stream"
+        );
+
+        assert!(
+            manager
+                .get_delta_stream("non-existent-session")
+                .await
+                .is_none(),
+            "Missing session must not expose a delta stream"
+        );
+
+        manager.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[spec("CHAT-004")]
+    async fn test_stream_llm_deltas_with_back_pressure() {
+        // Produce enough text chunks to exceed the 100-delta in-flight window.
+        const DELTA_COUNT: usize = 105;
+        let adapter = create_mock_adapter(DELTA_COUNT);
+
+        let mut buffers = BufferConfig::default();
+        buffers.chat_streaming_mode = ChatStreamingMode::Delta;
+
+        let manager = ChatSessionManager::with_config(Some(adapter), None, None, 3600, buffers);
+        let session = manager.create_session(None).await;
+        let session_id = session.session_id.clone();
+
+        let mut delta_rx = manager
+            .get_delta_stream(&session_id)
+            .await
+            .expect("delta stream available");
+
+        manager
+            .send_message(
+                &session_id,
+                UserMessage {
+                    content: "start".to_string(),
+                    attachments: None,
+                    metadata: None,
+                },
+            )
+            .await
+            .expect("message accepted");
+
+        // Consume exactly the first 100 deltas; the 101st should be blocked
+        // waiting for a client acknowledgment.
+        let mut received = Vec::new();
+        for i in 0..100 {
+            let delta = tokio::time::timeout(std::time::Duration::from_secs(30), delta_rx.recv())
+                .await
+                .expect(&format!("delta {i} should arrive promptly"))
+                .expect("delta stream open");
+            received.push(delta);
+        }
+
+        // The next delta should not arrive until back-pressure is released.
+        let blocked =
+            tokio::time::timeout(std::time::Duration::from_millis(300), delta_rx.recv()).await;
+        assert!(
+            blocked.is_err(),
+            "Back-pressure must pause the stream after 100 unacknowledged deltas"
+        );
+
+        // Acknowledge half of the window and verify the stream resumes.
+        manager.process_metrics_ack(&session_id, 50).await.unwrap();
+
+        while let Ok(Some(delta)) =
+            tokio::time::timeout(std::time::Duration::from_secs(2), delta_rx.recv()).await
+        {
+            received.push(delta);
+        }
+
+        // 105 text deltas + 1 StreamEnd delta from the adapter.
+        assert_eq!(received.len(), DELTA_COUNT + 1);
+        assert!(
+            received
+                .iter()
+                .any(|d| matches!(d.delta, MessageDeltaContent::StreamEnd { .. }))
+        );
+
+        manager.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[spec("CHAT-010")]
+    async fn test_session_enters_zombie_on_abnormal_exit() {
+        // Directly exercise the session handler with a channel that closes
+        // unexpectedly while metrics are still tracked.
+        let session_id = "zombie-test-session".to_string();
+        let (message_tx, message_rx) = mpsc::channel::<UserMessage>(1);
+        let (delta_tx, _delta_rx) = broadcast::channel::<MessageDelta>(16);
+
+        let sessions = Arc::new(RwLock::new(HashMap::new()));
+        let session_metrics = Arc::new(RwLock::new(HashMap::new()));
+        session_metrics
+            .write()
+            .await
+            .insert(session_id.clone(), SessionMetrics::new(session_id.clone()));
+
+        let session = ChatSession {
+            session_id: session_id.clone(),
+            capabilities: None,
+            created_at: chrono::Utc::now(),
+        };
+        let state = ChatSessionState {
+            _session: session,
+            state: SessionState::Active,
+            message_tx,
+            delta_tx: delta_tx.clone(),
+            task_manager: SessionTaskManager::new(session_id.clone()),
+            auth: None,
+            inflight_deltas: Arc::new(AtomicU64::new(0)),
+            last_acked_seq: Arc::new(AtomicU64::new(0)),
+            backpressure_notify: Arc::new(Notify::new()),
+        };
+        sessions.write().await.insert(session_id.clone(), state);
+
+        let adapter = create_mock_adapter(0);
+        let metrics_collector = MetricsCollector::new();
+        let inflight_deltas = Arc::new(AtomicU64::new(0));
+        let backpressure_notify = Arc::new(Notify::new());
+        let buffers = BufferConfig::default();
+
+        tokio::spawn(ChatSessionManager::handle_session(
+            session_id.clone(),
+            message_rx,
+            delta_tx,
+            adapter,
+            sessions.clone(),
+            session_metrics.clone(),
+            metrics_collector,
+            inflight_deltas,
+            backpressure_notify,
+            buffers,
+        ));
+
+        // Simulate abnormal cleanup: remove the session state (drops message_tx)
+        // but leave the metrics entry in place.
+        sessions.write().await.remove(&session_id);
+
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        let metrics = session_metrics.read().await;
+        let metric = metrics
+            .get(&session_id)
+            .expect("metrics retained for zombie");
+        assert_eq!(
+            metric.state,
+            SessionState::Zombie,
+            "Session must enter zombie state when its channel closes abnormally"
+        );
+    }
+
+    #[test]
+    #[spec("CHAT-013")]
+    fn test_reject_malformed_delta_message() {
+        // Unknown delta type must fail deserialization.
+        let json = r#"{"sessionId":"s1","messageId":"m1","sequence":0,"delta":{"type":"unknown_variant"},"timestamp":"2024-01-01T00:00:00Z"}"#;
+        let result: std::result::Result<MessageDelta, _> = serde_json::from_str(json);
+        assert!(
+            result.is_err(),
+            "Malformed/unknown delta payload must be rejected during deserialization"
+        );
+
+        // Missing required fields must also fail.
+        let json_missing = r#"{"sessionId":"s1","delta":{"type":"text","text":"hi"}}"#;
+        assert!(serde_json::from_str::<MessageDelta>(json_missing).is_err());
     }
 }

--- a/crates/arkavo-protocol/src/discovery.rs
+++ b/crates/arkavo-protocol/src/discovery.rs
@@ -253,7 +253,9 @@ impl DiscoveryService {
 #[allow(clippy::field_reassign_with_default)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("PROTO-004")]
     #[test]
     fn test_static_endpoint_registration() {
         let service = DiscoveryService::new(DiscoveryConfig::default());
@@ -271,6 +273,7 @@ mod tests {
         assert_eq!(found.unwrap().url, "http://localhost:8080");
     }
 
+    #[spec("PROTO-004")]
     #[test]
     fn test_static_discovery() {
         let service = DiscoveryService::new(DiscoveryConfig {
@@ -291,6 +294,7 @@ mod tests {
         assert_eq!(result.unwrap().url, "http://localhost:8080");
     }
 
+    #[spec("PROTO-004")]
     #[test]
     fn test_agent_not_found() {
         let service = DiscoveryService::new(DiscoveryConfig::default());
@@ -300,6 +304,7 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
 
+    #[spec("PROTO-004")]
     #[test]
     fn test_discover_all() {
         let service = DiscoveryService::new(DiscoveryConfig::default());

--- a/crates/arkavo-protocol/src/error.rs
+++ b/crates/arkavo-protocol/src/error.rs
@@ -128,7 +128,9 @@ pub type Result<T> = std::result::Result<T, A2aError>;
 #[allow(clippy::field_reassign_with_default)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("PROTO-010")]
     #[test]
     fn test_error_codes() {
         let err = A2aError::Timeout(5000);
@@ -151,6 +153,7 @@ mod tests {
         assert_eq!(err.to_json_rpc_code(), -32000 - 10); // -32010
     }
 
+    #[spec("PROTO-010")]
     #[test]
     fn test_error_display() {
         let err = A2aError::ConnectionFailed("localhost:8080".to_string());

--- a/crates/arkavo-protocol/src/mdns.rs
+++ b/crates/arkavo-protocol/src/mdns.rs
@@ -78,7 +78,9 @@ pub enum MdnsError {
 #[allow(clippy::field_reassign_with_default)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("PROTO-004")]
     #[test]
     fn test_mdns_service_info_creation() {
         let info = MdnsServiceInfo::new(
@@ -97,6 +99,7 @@ mod tests {
         assert!(info.ip.is_none());
     }
 
+    #[spec("PROTO-004")]
     #[test]
     fn test_mdns_service_info_with_ip() {
         let ip = Ipv4Addr::new(192, 168, 1, 100);
@@ -106,6 +109,7 @@ mod tests {
         assert_eq!(info.get_service_ip(), ip);
     }
 
+    #[spec("PROTO-004")]
     #[test]
     fn test_get_service_ip_fallback() {
         let info = MdnsServiceInfo::new("test", "Test", 8342, "Test", "model");

--- a/crates/arkavo-protocol/src/metrics.rs
+++ b/crates/arkavo-protocol/src/metrics.rs
@@ -297,7 +297,9 @@ impl RpcTimer {
 #[allow(clippy::field_reassign_with_default)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("PROTO-009")]
     #[test]
     fn test_metrics_collector_creation() {
         let collector = MetricsCollector::new(true);
@@ -307,6 +309,7 @@ mod tests {
         assert!(!collector.enabled);
     }
 
+    #[spec("PROTO-009")]
     #[test]
     fn test_metrics_noop_when_disabled() {
         let collector = MetricsCollector::new(false);
@@ -318,6 +321,7 @@ mod tests {
         collector.update_rate_limit_entries(100);
     }
 
+    #[spec("PROTO-009")]
     #[test]
     fn test_rpc_timer() {
         let collector = Arc::new(MetricsCollector::new(true));

--- a/crates/arkavo-protocol/src/peer_manager.rs
+++ b/crates/arkavo-protocol/src/peer_manager.rs
@@ -223,6 +223,11 @@ impl PeerManager {
         let needs_upgrade = {
             let peers = self.peers.read().unwrap();
             if let Some(peer) = peers.get(peer_url) {
+                // Custom transports are provided externally and should not be
+                // replaced or upgraded by the peer manager.
+                if peer.transport_type == TransportType::Custom {
+                    return Ok(());
+                }
                 peer.transport_type != required_transport
             } else {
                 // Peer not connected at all
@@ -400,7 +405,11 @@ impl PeerManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
+    use uuid::Uuid;
 
+    #[spec("PROTO-011")]
+    #[spec("PROTO-018")]
     #[test]
     fn test_peer_manager_creation() {
         let manager = PeerManager::new("test-agent".to_string());
@@ -408,6 +417,8 @@ mod tests {
         assert_eq!(manager.peer_count(), 0);
     }
 
+    #[spec("PROTO-011")]
+    #[spec("PROTO-018")]
     #[test]
     fn test_peer_manager_with_config() {
         let config = PeerManagerConfig {
@@ -420,6 +431,7 @@ mod tests {
         assert_eq!(manager.peer_count(), 0);
     }
 
+    #[spec("PROTO-014")]
     #[test]
     fn test_is_streaming_method() {
         assert!(PeerManager::is_streaming_method("chat_stream"));
@@ -430,6 +442,8 @@ mod tests {
         assert!(!PeerManager::is_streaming_method("task_request"));
     }
 
+    #[spec("PROTO-012")]
+    #[spec("PROTO-014")]
     #[test]
     fn test_transport_selection() {
         let config = PeerManagerConfig {
@@ -460,6 +474,8 @@ mod tests {
         );
     }
 
+    #[spec("PROTO-012")]
+    #[spec("PROTO-014")]
     #[test]
     fn test_transport_selection_no_auto_upgrade() {
         let config = PeerManagerConfig {
@@ -480,6 +496,7 @@ mod tests {
         );
     }
 
+    #[spec("PROTO-013")]
     #[test]
     fn test_websocket_default_transport() {
         let config = PeerManagerConfig {
@@ -500,10 +517,132 @@ mod tests {
         );
     }
 
+    #[spec("PROTO-017")]
+    #[spec("PROTO-018")]
     #[test]
     fn test_connected_peers_empty() {
         let manager = PeerManager::new("agent".to_string());
         let peers = manager.connected_peers();
         assert!(peers.is_empty());
+    }
+
+    /// Mock transport that records requests and returns a configurable response.
+    struct MockTransport {
+        responses: std::sync::Mutex<Vec<Result<A2aResponse, anyhow::Error>>>,
+        requests: std::sync::Mutex<Vec<A2aRequest>>,
+    }
+
+    impl MockTransport {
+        fn new(responses: Vec<Result<A2aResponse, anyhow::Error>>) -> Self {
+            Self {
+                responses: std::sync::Mutex::new(responses),
+                requests: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        fn take_requests(&self) -> Vec<A2aRequest> {
+            self.requests.lock().unwrap().drain(..).collect()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl A2aTransport for MockTransport {
+        async fn connect(&self, _endpoint: &A2aEndpoint) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn send_request(&self, request: A2aRequest) -> anyhow::Result<A2aResponse> {
+            self.requests.lock().unwrap().push(request);
+            self.responses.lock().unwrap().remove(0)
+        }
+
+        async fn close(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn is_connected(&self) -> bool {
+            true
+        }
+    }
+
+    #[spec("PROTO-015")]
+    #[tokio::test]
+    async fn test_broadcast_to_registered_peers() {
+        let manager = PeerManager::new("agent".to_string());
+
+        let peer_a = Arc::new(MockTransport::new(vec![Ok(A2aResponse::Success {
+            jsonrpc: "2.0".to_string(),
+            id: Uuid::new_v4(),
+            result: serde_json::json!({"peer": "a"}),
+        })]));
+        let peer_b = Arc::new(MockTransport::new(vec![Ok(A2aResponse::Success {
+            jsonrpc: "2.0".to_string(),
+            id: Uuid::new_v4(),
+            result: serde_json::json!({"peer": "b"}),
+        })]));
+
+        manager.register_transport("http://peer-a.example", peer_a.clone());
+        manager.register_transport("http://peer-b.example", peer_b.clone());
+
+        let results = manager
+            .broadcast("agent_query", serde_json::json!({"key": "value"}))
+            .await;
+
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|r| r.is_ok()));
+
+        let a_requests = peer_a.take_requests();
+        let b_requests = peer_b.take_requests();
+        assert_eq!(a_requests.len(), 1);
+        assert_eq!(b_requests.len(), 1);
+        assert_eq!(a_requests[0].method, "agent_query");
+        assert_eq!(b_requests[0].method, "agent_query");
+    }
+
+    #[spec("PROTO-016")]
+    #[tokio::test]
+    async fn test_send_to_specific_peer() {
+        let manager = PeerManager::new("agent".to_string());
+
+        let peer = Arc::new(MockTransport::new(vec![Ok(A2aResponse::Success {
+            jsonrpc: "2.0".to_string(),
+            id: Uuid::new_v4(),
+            result: serde_json::json!({"peer": "a"}),
+        })]));
+
+        manager.register_transport("http://peer-a.example", peer.clone());
+
+        let response = manager
+            .send_to(
+                "http://peer-a.example",
+                "agent_query",
+                serde_json::json!({"key": "value"}),
+            )
+            .await;
+
+        assert!(response.is_ok());
+        let requests = peer.take_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method, "agent_query");
+    }
+
+    #[spec("PROTO-019")]
+    #[tokio::test]
+    async fn test_connect_to_peers_empty_list() {
+        let manager = PeerManager::new("agent".to_string());
+        let result = manager.connect_to_peers(&[]).await;
+        assert!(result.is_ok());
+        assert!(!manager.has_peers());
+    }
+
+    #[spec("PROTO-019")]
+    #[tokio::test]
+    async fn test_connect_to_peers_continues_on_failure() {
+        let manager = PeerManager::new("agent".to_string());
+        // An invalid URL should fail to connect but not abort the loop.
+        let result = manager
+            .connect_to_peers(&["not-a-valid-url".to_string()])
+            .await;
+        assert!(result.is_ok());
     }
 }

--- a/crates/arkavo-protocol/src/rate_limit.rs
+++ b/crates/arkavo-protocol/src/rate_limit.rs
@@ -361,7 +361,9 @@ pub fn spawn_cleanup_task(
 #[allow(clippy::field_reassign_with_default)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("PROTO-007")]
     #[test]
     fn test_rate_limit_config_default() {
         let config = RateLimitConfig::default();
@@ -372,12 +374,14 @@ mod tests {
         assert_eq!(config.ip_entry_ttl_seconds, 3600);
     }
 
+    #[spec("PROTO-007")]
     #[test]
     fn test_rate_limiter_creation() {
         let config = RateLimitConfig::default();
         let _limiter = RateLimiter::new(config);
     }
 
+    #[spec("PROTO-007")]
     #[test]
     fn test_rate_limiter_disabled() {
         let mut config = RateLimitConfig::default();
@@ -388,6 +392,7 @@ mod tests {
         assert!(limiter.check_rate_limit().is_ok());
     }
 
+    #[spec("PROTO-007")]
     #[test]
     fn test_rate_limiter_basic() {
         let mut config = RateLimitConfig::default();
@@ -407,6 +412,7 @@ mod tests {
         }
     }
 
+    #[spec("PROTO-007")]
     #[test]
     fn test_ip_rate_limiter() {
         let config = RateLimitConfig {
@@ -431,6 +437,7 @@ mod tests {
         assert!(limiter.check_rate_limit(ip2).is_ok());
     }
 
+    #[spec("PROTO-007")]
     #[test]
     fn test_rate_limit_from_arp_defaults() {
         let arp_rl = arkavo_arp::constraints::RateLimiting {
@@ -450,6 +457,7 @@ mod tests {
         assert_eq!(config.burst_size, defaults.burst_size);
     }
 
+    #[spec("PROTO-007")]
     #[test]
     fn test_rate_limit_from_arp_overrides() {
         let arp_rl = arkavo_arp::constraints::RateLimiting {
@@ -472,6 +480,7 @@ mod tests {
 
     // Note: Eviction testing moved to integration tests to keep file under 400 lines
 
+    #[spec("PROTO-007")]
     #[test]
     fn test_rate_limit_status() {
         let config = RateLimitConfig::default();

--- a/crates/arkavo-protocol/tests/chat_protocol_v2.rs
+++ b/crates/arkavo-protocol/tests/chat_protocol_v2.rs
@@ -3,6 +3,7 @@
 use arkavo_protocol::auth::{AuthBackend, JwtAuthBackend, SessionAuth};
 use arkavo_protocol::chat_session::ChatSessionManager;
 use arkavo_protocol::types::{ClientMetrics, MetricsAck};
+use arkavo_test_macros::spec;
 use jsonwebtoken::{EncodingKey, Header, encode};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -84,6 +85,7 @@ async fn test_jwt_authentication_expired() {
 
 /// Test chat session creation with authentication
 #[tokio::test]
+#[spec("CHAT-001")]
 async fn test_authenticated_chat_session() {
     // Create chat session manager without LLM adapter for testing
     let manager = ChatSessionManager::new(None);
@@ -111,6 +113,7 @@ async fn test_authenticated_chat_session() {
 
 /// Test back-pressure management with MetricsAck
 #[tokio::test]
+#[spec("CHAT-005")]
 async fn test_backpressure_with_metrics_ack() {
     let manager = ChatSessionManager::new(None);
 
@@ -232,6 +235,9 @@ async fn test_session_persistence() {
 
 /// Integration test for full chat flow with auth and back-pressure
 #[tokio::test]
+#[spec("CHAT-001")]
+#[spec("CHAT-005")]
+#[spec("CHAT-006")]
 async fn test_full_chat_flow_integration() {
     // This test simulates a full chat flow:
     // 1. Client authenticates with JWT
@@ -297,6 +303,8 @@ async fn test_full_chat_flow_integration() {
 
 /// Test concurrent session management
 #[tokio::test]
+#[spec("CHAT-001")]
+#[spec("CHAT-005")]
 async fn test_concurrent_sessions() {
     let manager = Arc::new(ChatSessionManager::new(None));
 

--- a/crates/arkavo-router/src/architect/complexity.rs
+++ b/crates/arkavo-router/src/architect/complexity.rs
@@ -311,7 +311,9 @@ impl Default for ComplexityScorer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("ROUTER-010")]
     #[test]
     fn test_simple_task_not_recommended() {
         let scorer = ComplexityScorer::new();
@@ -321,6 +323,7 @@ mod tests {
         assert!(score.estimated_subtasks < 3);
     }
 
+    #[spec("ROUTER-010")]
     #[test]
     fn test_complex_task_recommended() {
         let scorer = ComplexityScorer::new();
@@ -336,6 +339,7 @@ mod tests {
         assert!(!score.complexity_triggers.is_empty());
     }
 
+    #[spec("ROUTER-010")]
     #[test]
     fn test_multi_step_detection() {
         let scorer = ComplexityScorer::new();
@@ -348,6 +352,7 @@ mod tests {
         assert!(score.estimated_subtasks >= 3);
     }
 
+    #[spec("ROUTER-010")]
     #[test]
     fn test_category_spread() {
         let scorer = ComplexityScorer::new();
@@ -362,6 +367,7 @@ mod tests {
         assert!(single_category.category_spread < 0.3);
     }
 
+    #[spec("ROUTER-010")]
     #[test]
     fn test_savings_estimation() {
         let scorer = ComplexityScorer::new();

--- a/crates/arkavo-router/src/architect/executor.rs
+++ b/crates/arkavo-router/src/architect/executor.rs
@@ -388,7 +388,10 @@ impl ArchitectExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("ROUTER-002")]
+    #[spec("ROUTER-010")]
     #[test]
     fn test_model_escalation() {
         let router = futures::executor::block_on(async { Router::new().await.ok() });

--- a/crates/arkavo-router/src/architect/mod.rs
+++ b/crates/arkavo-router/src/architect/mod.rs
@@ -257,8 +257,10 @@ impl Default for ArchitectCostMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
     use executor::SubtaskResult;
 
+    #[spec("ROUTER-010")]
     #[test]
     fn test_architect_plan_savings() {
         let mut plan = ArchitectPlan::new("test task".to_string(), ComplexityScore::simple());
@@ -268,6 +270,7 @@ mod tests {
         assert!((plan.estimated_savings_percent() - 70.0).abs() < 0.1);
     }
 
+    #[spec("ROUTER-010")]
     #[test]
     fn test_subtask_builder() {
         let subtask = Subtask::new(0, "Build UI".to_string(), TaskCategory::FrontendUI)
@@ -337,6 +340,7 @@ mod tests {
         }
     }
 
+    #[spec("ROUTER-010")]
     #[test]
     fn test_planner_score_all_success() {
         let plan = make_plan_with_subtasks(2);
@@ -361,6 +365,7 @@ mod tests {
         assert!(score.overall_score > 0.8, "score={}", score.overall_score);
     }
 
+    #[spec("ROUTER-010")]
     #[test]
     fn test_planner_score_with_plan_flaw() {
         let plan = make_plan_with_subtasks(2);
@@ -387,6 +392,7 @@ mod tests {
         );
     }
 
+    #[spec("ROUTER-010")]
     #[test]
     fn test_per_step_rewards_mixed() {
         let plan = make_plan_with_subtasks(3);
@@ -412,6 +418,7 @@ mod tests {
         assert!(rewards[2] > 0.5, "successful subtask should score >0.5");
     }
 
+    #[spec("ROUTER-010")]
     #[test]
     fn test_per_step_rewards_empty_plan() {
         let plan = make_plan_with_subtasks(0);

--- a/crates/arkavo-router/src/architect/planner.rs
+++ b/crates/arkavo-router/src/architect/planner.rs
@@ -311,7 +311,9 @@ impl Default for ArchitectPlanner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("ROUTER-010")]
     #[test]
     fn test_extract_json() {
         let planner = ArchitectPlanner::new();
@@ -325,6 +327,7 @@ mod tests {
         assert!(json.ends_with('}'));
     }
 
+    #[spec("ROUTER-010")]
     #[test]
     fn test_model_selection_frontend() {
         let planner = ArchitectPlanner::new();
@@ -340,6 +343,7 @@ mod tests {
         ));
     }
 
+    #[spec("ROUTER-010")]
     #[test]
     fn test_model_selection_backend() {
         let planner = ArchitectPlanner::new();

--- a/crates/arkavo-router/src/connectivity.rs
+++ b/crates/arkavo-router/src/connectivity.rs
@@ -70,13 +70,16 @@ impl Default for ConnectivityChecker {
 #[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("ROUTER-007")]
     #[tokio::test]
     async fn test_connectivity_checker_creation() {
         let checker = ConnectivityChecker::new();
         assert_eq!(checker.timeout, Duration::from_secs(2));
     }
 
+    #[spec("ROUTER-007")]
     #[tokio::test]
     async fn test_custom_timeout() {
         let checker = ConnectivityChecker::with_timeout(Duration::from_secs(5));

--- a/crates/arkavo-router/src/lib.rs
+++ b/crates/arkavo-router/src/lib.rs
@@ -1091,6 +1091,7 @@ impl Router {
 #[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
     #[tokio::test]
     async fn test_router_creation() {
@@ -1102,6 +1103,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[spec("ROUTER-003")]
     #[tokio::test]
     async fn test_min_feasible_context_size_default() {
         let router = match Router::new_offline().await {

--- a/crates/arkavo-router/src/model_discovery.rs
+++ b/crates/arkavo-router/src/model_discovery.rs
@@ -338,7 +338,9 @@ pub async fn find_any_gguf() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("ROUTER-006")]
     #[test]
     fn test_find_mmproj_for_model() {
         let dir = tempfile::tempdir().unwrap();
@@ -360,6 +362,7 @@ mod tests {
         );
     }
 
+    #[spec("ROUTER-006")]
     #[test]
     fn test_find_mmproj_none_when_absent() {
         let dir = tempfile::tempdir().unwrap();
@@ -369,6 +372,7 @@ mod tests {
         assert!(find_mmproj_for_model(&model).is_none());
     }
 
+    #[spec("ROUTER-006")]
     #[tokio::test]
     async fn test_find_gguf_model() {
         // This test will only pass if the model is already cached

--- a/crates/arkavo-router/src/optimal_config.rs
+++ b/crates/arkavo-router/src/optimal_config.rs
@@ -106,7 +106,9 @@ impl Default for OptimalConfigStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("ROUTER-014")]
     #[test]
     fn seeded_from_compile_time_defaults() {
         let store = OptimalConfigStore::new();
@@ -116,6 +118,7 @@ mod tests {
         assert!((c.confidence - 1.0).abs() < f64::EPSILON);
     }
 
+    #[spec("ROUTER-014")]
     #[test]
     fn update_respects_confidence() {
         let store = OptimalConfigStore::new();
@@ -132,6 +135,7 @@ mod tests {
         assert!((c.temperature - 0.5).abs() < f32::EPSILON); // updated
     }
 
+    #[spec("ROUTER-014")]
     #[test]
     fn get_returns_none_for_cloud_models() {
         let store = OptimalConfigStore::new();

--- a/crates/arkavo-router/src/preflight/moderator.rs
+++ b/crates/arkavo-router/src/preflight/moderator.rs
@@ -136,6 +136,7 @@ impl Default for PreflightModerator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
     use torg_core::{BoolOp, Node, Source};
     use torg_serde::to_bytes;
 
@@ -161,6 +162,7 @@ mod tests {
         }
     }
 
+    #[spec("ROUTER-004")]
     #[test]
     fn test_empty_moderator_allows() {
         let moderator = PreflightModerator::new();
@@ -168,6 +170,7 @@ mod tests {
         assert!(moderator.check("any input").is_allowed());
     }
 
+    #[spec("ROUTER-004")]
     #[test]
     fn test_register_and_unregister() {
         let moderator = PreflightModerator::new();
@@ -192,6 +195,7 @@ mod tests {
         assert!(moderator.is_empty());
     }
 
+    #[spec("ROUTER-004")]
     #[test]
     fn test_pii_ssn_blocked() {
         let moderator = PreflightModerator::new();
@@ -213,6 +217,7 @@ mod tests {
         }
     }
 
+    #[spec("ROUTER-004")]
     #[test]
     fn test_pii_credit_card_blocked() {
         let moderator = PreflightModerator::new();
@@ -231,6 +236,7 @@ mod tests {
         assert!(result.is_blocked());
     }
 
+    #[spec("ROUTER-004")]
     #[test]
     fn test_clean_input_passes() {
         let moderator = PreflightModerator::new();
@@ -249,6 +255,7 @@ mod tests {
         assert!(result.is_allowed());
     }
 
+    #[spec("ROUTER-004")]
     #[test]
     fn test_sql_injection_blocked() {
         let moderator = PreflightModerator::new();
@@ -269,6 +276,7 @@ mod tests {
         }
     }
 
+    #[spec("ROUTER-004")]
     #[test]
     fn test_shell_command_blocked() {
         let moderator = PreflightModerator::new();
@@ -289,6 +297,7 @@ mod tests {
         }
     }
 
+    #[spec("ROUTER-004")]
     #[test]
     fn test_multiple_circuits_first_violation_wins() {
         let moderator = PreflightModerator::new();
@@ -313,6 +322,7 @@ mod tests {
         assert!(result.is_blocked());
     }
 
+    #[spec("ROUTER-004")]
     #[test]
     fn test_length_threshold() {
         let moderator = PreflightModerator::new();
@@ -334,6 +344,7 @@ mod tests {
         assert!(result.is_blocked());
     }
 
+    #[spec("ROUTER-004")]
     #[test]
     fn test_feature_values_in_block() {
         let moderator = PreflightModerator::new();
@@ -356,6 +367,7 @@ mod tests {
         }
     }
 
+    #[spec("ROUTER-004")]
     #[test]
     fn test_empty_input_passes() {
         let moderator = PreflightModerator::new();
@@ -369,6 +381,7 @@ mod tests {
         assert!(moderator.check("").is_allowed());
     }
 
+    #[spec("ROUTER-004")]
     #[test]
     fn test_homoglyph_sql_injection_blocked() {
         let moderator = PreflightModerator::new();
@@ -383,6 +396,7 @@ mod tests {
         assert!(result.is_blocked());
     }
 
+    #[spec("ROUTER-004")]
     #[test]
     fn test_homoglyph_shell_command_blocked() {
         let moderator = PreflightModerator::new();
@@ -397,6 +411,7 @@ mod tests {
         assert!(result.is_blocked());
     }
 
+    #[spec("ROUTER-004")]
     #[test]
     fn test_100k_character_length_blocked() {
         let moderator = PreflightModerator::new();

--- a/crates/arkavo-router/src/prompt_advisor.rs
+++ b/crates/arkavo-router/src/prompt_advisor.rs
@@ -606,7 +606,9 @@ fn truncate_at_sentence(text: &str, max_len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("CRIT-016")]
     #[test]
     fn test_static_defaults_present() {
         let advisor = PromptAdvisor::new();
@@ -617,6 +619,7 @@ mod tests {
         assert!(stats.iter().any(|s| s.model_family == "qwen"));
     }
 
+    #[spec("CRIT-012")]
     #[test]
     fn test_advise_glm_simple_query() {
         let advisor = PromptAdvisor::new();
@@ -643,6 +646,7 @@ mod tests {
         assert!(!advice.system_text.is_empty());
     }
 
+    #[spec("CRIT-012")]
     #[test]
     fn test_advise_no_match() {
         let advisor = PromptAdvisor::new();
@@ -651,6 +655,7 @@ mod tests {
         assert!(advisor.advise("google", false).is_none());
     }
 
+    #[spec("CRIT-012")]
     #[test]
     fn test_advise_caps_at_800_chars() {
         let advisor = PromptAdvisor::new();
@@ -755,6 +760,7 @@ mod tests {
         assert!(!is_simple_query("refactor this module to use async"));
     }
 
+    #[spec("CRIT-012")]
     #[test]
     fn test_priority_ordering() {
         let advisor = PromptAdvisor::new();
@@ -768,6 +774,7 @@ mod tests {
         assert_eq!(advice.applied_labels[0], "glm-code-fence");
     }
 
+    #[spec("CRIT-012")]
     #[test]
     fn test_advise_excludes_non_simple_for_code_fence() {
         let advisor = PromptAdvisor::new();
@@ -794,6 +801,8 @@ mod tests {
         );
     }
 
+    #[spec("CRIT-012")]
+    #[spec("CRIT-016")]
     #[test]
     fn test_stats_snapshot() {
         let advisor = PromptAdvisor::new();
@@ -809,6 +818,7 @@ mod tests {
         assert!(!glm_applied.is_empty());
     }
 
+    #[spec("CRIT-011")]
     #[test]
     fn test_observe_detects_code_fence() {
         let advisor = PromptAdvisor::new();
@@ -821,6 +831,7 @@ mod tests {
         assert!(dynamic.label.contains("unwantedcodefence"));
     }
 
+    #[spec("CRIT-011")]
     #[test]
     fn test_observe_detects_output_loop() {
         let advisor = PromptAdvisor::new();
@@ -834,6 +845,8 @@ mod tests {
         assert!(dynamic.label.contains("outputloop"));
     }
 
+    #[spec("CRIT-011")]
+    #[spec("CRIT-015")]
     #[test]
     fn test_observe_detects_timeout() {
         let advisor = PromptAdvisor::new();
@@ -848,6 +861,7 @@ mod tests {
         assert!(!dynamic.is_static);
     }
 
+    #[spec("CRIT-011")]
     #[test]
     fn test_observe_detects_wrong_expert() {
         let advisor = PromptAdvisor::new();
@@ -873,6 +887,7 @@ mod tests {
         assert_eq!(advisor.stats().len(), initial);
     }
 
+    #[spec("CRIT-011")]
     #[test]
     fn test_observe_skips_static_family() {
         let advisor = PromptAdvisor::new();
@@ -883,6 +898,7 @@ mod tests {
         assert_eq!(advisor.stats().len(), initial);
     }
 
+    #[spec("CRIT-011")]
     #[test]
     fn test_observe_clean_response() {
         let advisor = PromptAdvisor::new();

--- a/crates/arkavo-router/src/quality_gate.rs
+++ b/crates/arkavo-router/src/quality_gate.rs
@@ -707,6 +707,7 @@ mod tests {
     use crate::selector_quality::compute_response_quality;
     use crate::tool_extraction;
     use arkavo_mcp_tools::{DetailLevel, ToolRegistry};
+    use arkavo_test_macros::spec;
 
     /// Regression for the bug surfaced by gitar-bot on PR #598: an empty
     /// `ToolRegistry` (or a registry whose keyword search yields zero hits)
@@ -718,6 +719,7 @@ mod tests {
     ///
     /// The fix derives `tools_were_attached` from `!tool_infos.is_empty()`,
     /// so the empty-tools path scores the same as the no-registry path.
+    #[spec("ROUTER-002")]
     #[tokio::test]
     async fn empty_tool_search_does_not_count_as_attached() {
         let registry = ToolRegistry::empty();

--- a/crates/arkavo-router/src/response/processing.rs
+++ b/crates/arkavo-router/src/response/processing.rs
@@ -110,7 +110,9 @@ pub fn sanitize_response(content: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("ROUTER-011")]
     #[test]
     fn test_strip_think_blocks() {
         let content = "Let me think...<think>internal reasoning</think>The answer is 4.";
@@ -120,6 +122,7 @@ mod tests {
         assert!(stripped.contains("The answer is 4"));
     }
 
+    #[spec("ROUTER-011")]
     #[test]
     fn test_strip_unclosed_think_block() {
         let content = "Start<think>never closed...";
@@ -129,6 +132,7 @@ mod tests {
         assert!(!stripped.contains("never closed"));
     }
 
+    #[spec("ROUTER-012")]
     #[test]
     fn test_strip_tool_blocks() {
         let content = "Result: <tool>execute(x=1)</tool>Done.";
@@ -138,6 +142,7 @@ mod tests {
         assert!(stripped.contains("Done."));
     }
 
+    #[spec("ROUTER-012")]
     #[test]
     fn test_strip_unclosed_tool_block() {
         let content = "Start<tool>never closed";
@@ -146,6 +151,7 @@ mod tests {
         assert!(stripped.contains("Start"));
     }
 
+    #[spec("ROUTER-013")]
     #[test]
     fn test_sanitize_response_removes_prefixes() {
         let content = "Human: hi\nAssistant: hello";
@@ -154,6 +160,8 @@ mod tests {
         assert!(!sanitized.contains("Assistant:"));
     }
 
+    #[spec("ROUTER-011")]
+    #[spec("ROUTER-013")]
     #[test]
     fn test_sanitize_response_full() {
         let content = "<think>reasoning</think>Human: ignored\nThe answer is 42.";
@@ -163,6 +171,7 @@ mod tests {
         assert!(sanitized.contains("42"));
     }
 
+    #[spec("ROUTER-013")]
     #[test]
     fn test_sanitize_response_cleans_whitespace() {
         let content = "Line 1\n\n\n\nLine 2";
@@ -170,6 +179,7 @@ mod tests {
         assert!(!sanitized.contains("\n\n\n"));
     }
 
+    #[spec("ROUTER-011")]
     #[test]
     fn test_multiple_think_blocks() {
         let content = "<think>first</think>middle<think>second</think>end";
@@ -179,6 +189,7 @@ mod tests {
         assert!(stripped.contains("end"));
     }
 
+    #[spec("ROUTER-012")]
     #[test]
     fn test_nested_tool_blocks() {
         let content = "before<tool>inner</tool>between<tool>inner2</tool>after";

--- a/crates/arkavo-router/src/rlm.rs
+++ b/crates/arkavo-router/src/rlm.rs
@@ -349,7 +349,9 @@ pub fn create_rlm_manager_with_config(config: RlmConfig) -> SharedRlmManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("ROUTER-009")]
     #[tokio::test]
     async fn test_rlm_decompose() {
         let manager = RlmContextManager::new();
@@ -362,6 +364,7 @@ mod tests {
         assert!(result.total_tokens > 0);
     }
 
+    #[spec("ROUTER-009")]
     #[tokio::test]
     async fn test_rlm_probe() {
         let manager = RlmContextManager::new();
@@ -375,6 +378,7 @@ mod tests {
         assert_eq!(result.chunks[0].index, 0);
     }
 
+    #[spec("ROUTER-009")]
     #[tokio::test]
     async fn test_rlm_search() {
         let manager = RlmContextManager::new();
@@ -391,6 +395,7 @@ mod tests {
         assert!(result.match_count > 0);
     }
 
+    #[spec("ROUTER-009")]
     #[tokio::test]
     async fn test_should_activate() {
         let manager = RlmContextManager::new();
@@ -400,6 +405,7 @@ mod tests {
         assert!(manager.should_activate(8000, 10000));
     }
 
+    #[spec("ROUTER-009")]
     #[tokio::test]
     async fn test_system_prompt_generation() {
         let manager = RlmContextManager::new();

--- a/crates/arkavo-router/src/selector.rs
+++ b/crates/arkavo-router/src/selector.rs
@@ -404,6 +404,7 @@ impl Default for ModelSelector {
 #[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
     fn gemini_only() -> ProviderAvailability {
         ProviderAvailability {
@@ -432,6 +433,7 @@ mod tests {
         }
     }
 
+    #[spec("ROUTER-001")]
     #[tokio::test]
     async fn test_frontend_routing_gemini() {
         let selector = ModelSelector::with_availability(gemini_only());
@@ -444,6 +446,7 @@ mod tests {
         assert!(decision.reasoning.contains("WebDev Arena"));
     }
 
+    #[spec("ROUTER-001")]
     #[tokio::test]
     async fn test_frontend_routing_anthropic() {
         let selector = ModelSelector::with_availability(anthropic_only());
@@ -456,6 +459,7 @@ mod tests {
         assert!(decision.reasoning.contains("Claude"));
     }
 
+    #[spec("ROUTER-001")]
     #[tokio::test]
     async fn test_code_search_routing() {
         let selector = ModelSelector::with_availability(gemini_only());
@@ -471,6 +475,7 @@ mod tests {
         assert_eq!(decision.estimated_cost_usd, 0.0);
     }
 
+    #[spec("ROUTER-001")]
     #[tokio::test]
     async fn test_backend_api_routing_uses_local() {
         let selector = ModelSelector::with_availability(gemini_only());
@@ -483,6 +488,8 @@ mod tests {
         assert_eq!(decision.estimated_cost_usd, 0.0);
     }
 
+    #[spec("ROUTER-001")]
+    #[spec("ROUTER-003")]
     #[tokio::test]
     async fn test_no_cloud_falls_back_to_local() {
         let selector = ModelSelector::with_availability(ProviderAvailability::default());
@@ -494,6 +501,7 @@ mod tests {
         assert!(decision.recommended_model.is_local());
     }
 
+    #[spec("ROUTER-001")]
     #[tokio::test]
     async fn test_code_generation_routing_deepseek() {
         let selector = ModelSelector::with_availability(deepseek_only());
@@ -521,6 +529,7 @@ mod tests {
         assert!(!feasible.contains(&ModelChoice::DeepSeekV32));
     }
 
+    #[spec("ROUTER-003")]
     #[test]
     fn test_feasible_models_no_cloud_has_fallback() {
         let selector = ModelSelector::with_availability(ProviderAvailability::default());
@@ -531,6 +540,7 @@ mod tests {
     // Regression: a fresh install provisions Gemma 4 E2B + Gemma 4 12B (no Ministral/Qwen).
     // The fast-model selector must not fall through to a hardcoded Ministral 3B, which made
     // `arkavo chat` silently download an un-provisioned model on first use.
+    #[spec("ROUTER-003")]
     #[test]
     fn test_fast_local_model_falls_back_to_provisioned_gemma() {
         let nothing_cached = |_: &ModelChoice| false;
@@ -540,6 +550,7 @@ mod tests {
         );
     }
 
+    #[spec("ROUTER-003")]
     #[test]
     fn test_fast_local_model_uses_cached_gemma_e2b() {
         // Fresh install: only the two setup models are present.
@@ -555,6 +566,7 @@ mod tests {
         );
     }
 
+    #[spec("ROUTER-003")]
     #[test]
     fn test_fast_local_model_honors_legacy_ministral_install() {
         // Older install with only Ministral 3B cached still resolves to it (no download).

--- a/crates/arkavo-router/src/selector_quality.rs
+++ b/crates/arkavo-router/src/selector_quality.rs
@@ -516,6 +516,7 @@ mod tests {
     use crate::classifier::Classification;
     use crate::learning::BurstFeedback;
     use crate::selector::ProviderAvailability;
+    use arkavo_test_macros::spec;
 
     fn gemini_only() -> ProviderAvailability {
         ProviderAvailability {
@@ -526,6 +527,7 @@ mod tests {
         }
     }
 
+    #[spec("ROUTER-001")]
     #[tokio::test]
     async fn test_budget_constraint() {
         let selector = ModelSelector::with_availability(gemini_only());
@@ -539,6 +541,7 @@ mod tests {
         assert!(decision.reasoning.contains("Budget constrained"));
     }
 
+    #[spec("ROUTER-001")]
     #[tokio::test]
     async fn test_select_adaptive_uses_thompson_sampling() {
         let selector = ModelSelector::with_availability(gemini_only());
@@ -594,6 +597,7 @@ mod tests {
         );
     }
 
+    #[spec("ROUTER-001")]
     #[tokio::test]
     async fn test_select_adaptive_reasoning_contains_thompson() {
         // Need both Gemini and Anthropic so feasible set has >1 model
@@ -614,6 +618,8 @@ mod tests {
         assert!(decision.reasoning.contains("Thompson Sampling"));
     }
 
+    #[spec("ROUTER-001")]
+    #[spec("ROUTER-003")]
     #[tokio::test]
     async fn test_select_adaptive_budget_excludes_cloud() {
         let selector = ModelSelector::with_availability(gemini_only());
@@ -631,6 +637,7 @@ mod tests {
         );
     }
 
+    #[spec("ROUTER-001")]
     #[tokio::test]
     async fn test_select_adaptive_exclusions() {
         let selector = ModelSelector::with_availability(gemini_only());

--- a/crates/arkavo-router/src/stream.rs
+++ b/crates/arkavo-router/src/stream.rs
@@ -134,7 +134,9 @@ impl Stream for RouteStream {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("ROUTER-005")]
     #[tokio::test]
     async fn test_route_stream_from_response() {
         let response = RouteResponse {

--- a/crates/arkavo-router/src/tool_request_parser.rs
+++ b/crates/arkavo-router/src/tool_request_parser.rs
@@ -52,54 +52,64 @@ pub fn parse_tool_requests(response: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("ROUTER-008")]
     #[test]
     fn test_single_request() {
         let response = "I need to check the time. [need: time]";
         assert_eq!(parse_tool_requests(response), vec!["time"]);
     }
 
+    #[spec("ROUTER-008")]
     #[test]
     fn test_multiple_requests() {
         let response = "I'll need [need: github] and [need: filesystem] for this.";
         assert_eq!(parse_tool_requests(response), vec!["github", "filesystem"]);
     }
 
+    #[spec("ROUTER-008")]
     #[test]
     fn test_case_insensitive() {
         let response = "[Need: Time] and [NEED: GITHUB]";
         assert_eq!(parse_tool_requests(response), vec!["time", "github"]);
     }
 
+    #[spec("ROUTER-008")]
     #[test]
     fn test_inline() {
         let response = "To read files [need: filesystem] I would use the read tool.";
         assert_eq!(parse_tool_requests(response), vec!["filesystem"]);
     }
 
+    #[spec("ROUTER-008")]
     #[test]
     fn test_no_requests() {
         let response = "I can help with that using the available tools.";
         assert_eq!(parse_tool_requests(response), Vec::<String>::new());
     }
 
+    #[spec("ROUTER-008")]
     #[test]
     fn test_duplicate_requests() {
         let response = "[need: time] and also [need: time]";
         assert_eq!(parse_tool_requests(response), vec!["time"]);
     }
 
+    #[spec("ROUTER-008")]
     #[test]
     fn test_empty_string() {
         assert_eq!(parse_tool_requests(""), Vec::<String>::new());
     }
 
+    #[spec("ROUTER-008")]
     #[test]
     fn test_multiword_keyword() {
         let response = "[need: code search]";
         assert_eq!(parse_tool_requests(response), vec!["code search"]);
     }
 
+    #[spec("ROUTER-008")]
     #[test]
     fn test_no_closing_bracket() {
         let response = "[need: time without closing";

--- a/crates/arkavo-router/tests/complexity_scorer_test.rs
+++ b/crates/arkavo-router/tests/complexity_scorer_test.rs
@@ -7,8 +7,10 @@
 //! - Savings estimation is calculated correctly
 
 use arkavo_router::ComplexityScorer;
+use arkavo_test_macros::spec;
 
 /// Simple conversational prompts should NOT trigger architect mode
+#[spec("ROUTER-010")]
 #[test]
 fn test_simple_conversational_prompts() {
     let scorer = ComplexityScorer::new();
@@ -33,6 +35,7 @@ fn test_simple_conversational_prompts() {
 }
 
 /// Simple factual questions should NOT trigger architect mode
+#[spec("ROUTER-010")]
 #[test]
 fn test_simple_factual_questions() {
     let scorer = ComplexityScorer::new();
@@ -57,6 +60,7 @@ fn test_simple_factual_questions() {
 
 /// Complex multi-step development tasks SHOULD trigger architect mode
 /// The scorer requires: subtasks >= 3, output_tokens >= 2000, and (keywords OR multi_step >= 2)
+#[spec("ROUTER-010")]
 #[test]
 fn test_complex_development_tasks() {
     let scorer = ComplexityScorer::new();
@@ -85,6 +89,7 @@ fn test_complex_development_tasks() {
 }
 
 /// Tasks with multiple explicit steps should trigger architect
+#[spec("ROUTER-010")]
 #[test]
 fn test_multi_step_explicit_tasks() {
     let scorer = ComplexityScorer::new();
@@ -107,6 +112,7 @@ fn test_multi_step_explicit_tasks() {
 }
 
 /// Subtask estimation should be reasonable
+#[spec("ROUTER-010")]
 #[test]
 fn test_subtask_estimation_bounds() {
     let scorer = ComplexityScorer::new();
@@ -138,6 +144,7 @@ fn test_subtask_estimation_bounds() {
 }
 
 /// Savings estimation should be positive for complex tasks
+#[spec("ROUTER-010")]
 #[test]
 fn test_savings_estimation() {
     let scorer = ComplexityScorer::new();
@@ -159,6 +166,7 @@ fn test_savings_estimation() {
 }
 
 /// Edge cases - empty and very short prompts
+#[spec("ROUTER-010")]
 #[test]
 fn test_edge_cases() {
     let scorer = ComplexityScorer::new();
@@ -186,6 +194,7 @@ fn test_edge_cases() {
 }
 
 /// Keywords that suggest complexity
+#[spec("ROUTER-010")]
 #[test]
 fn test_complexity_keywords() {
     let scorer = ComplexityScorer::new();

--- a/crates/arkavo-router/tests/preflight_integration.rs
+++ b/crates/arkavo-router/tests/preflight_integration.rs
@@ -4,6 +4,7 @@
 
 use arkavo_router::Error;
 use arkavo_router::preflight::{ModerationResult, PolicyId, PreflightFeature, PreflightModerator};
+use arkavo_test_macros::spec;
 use torg_core::{BoolOp, Graph, Node, Source};
 
 /// Build a NOT circuit: output = NOT(input0)
@@ -16,6 +17,7 @@ fn build_not_circuit() -> Graph {
     }
 }
 
+#[spec("ROUTER-004")]
 #[test]
 fn test_error_type_conversion() {
     let moderator = PreflightModerator::new();
@@ -37,6 +39,7 @@ fn test_error_type_conversion() {
 }
 
 /// Safety Validation Suite from requirements doc Section 3.3.3
+#[spec("ROUTER-004")]
 #[test]
 fn test_safety_validation_suite() {
     let moderator = PreflightModerator::new();
@@ -79,6 +82,7 @@ fn test_safety_validation_suite() {
 }
 
 /// Test that no circuits registered means all traffic allowed
+#[spec("ROUTER-004")]
 #[test]
 fn test_no_circuits_allows_all() {
     let moderator = PreflightModerator::new();
@@ -90,6 +94,7 @@ fn test_no_circuits_allows_all() {
 }
 
 /// Test long input with length threshold policy
+#[spec("ROUTER-004")]
 #[test]
 fn test_long_input_blocked() {
     let moderator = PreflightModerator::new();

--- a/crates/arkavo-session/src/conversation.rs
+++ b/crates/arkavo-session/src/conversation.rs
@@ -606,18 +606,16 @@ impl ConversationManager {
 
     /// Switch to a different session
     pub async fn switch_session(&mut self, session_id: Uuid) -> anyhow::Result<()> {
-        let query = format!("session_id:{session_id}");
-        let results = self
-            .memory_storage
-            .search(&query, 1, Some("conversation"))
-            .await?;
-
-        if results.is_empty() {
-            return Err(anyhow::anyhow!("Session not found"));
+        // Use the authoritative session list to verify the session exists.
+        // The previous semantic search could return unrelated memories as a false
+        // positive for an unknown session id.
+        let sessions = self.list_sessions().await?;
+        if sessions.iter().any(|s| s.id == session_id) {
+            self.current_session_id = Some(session_id);
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("Session not found"))
         }
-
-        self.current_session_id = Some(session_id);
-        Ok(())
     }
 
     /// Count tokens in a string
@@ -637,8 +635,46 @@ impl ConversationManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
+
+    // Mock-provider support for summary tests
+    use async_trait::async_trait;
+
+    #[derive(Clone)]
+    struct MockSummaryProvider {
+        response: String,
+    }
+
+    #[async_trait]
+    impl arkavo_llm::Provider for MockSummaryProvider {
+        async fn complete_with_options(
+            &self,
+            _messages: Vec<arkavo_llm::Message>,
+            _max_tokens: Option<usize>,
+        ) -> arkavo_llm::Result<String> {
+            Ok(self.response.clone())
+        }
+
+        async fn stream(
+            &self,
+            _messages: Vec<arkavo_llm::Message>,
+        ) -> arkavo_llm::Result<
+            Box<
+                dyn futures::Stream<Item = arkavo_llm::Result<arkavo_llm::StreamResponse>>
+                    + Send
+                    + Unpin,
+            >,
+        > {
+            Ok(Box::new(futures::stream::empty()))
+        }
+
+        fn name(&self) -> &str {
+            "mock-summary-provider"
+        }
+    }
 
     #[test]
+    #[spec("CHAT-024")]
     fn test_sanitize_message_content_balances_fences() {
         // Arrange - odd number of fences
         let content = "Here is code:\n```rust\nfn main() {}";
@@ -652,6 +688,7 @@ mod tests {
     }
 
     #[test]
+    #[spec("CHAT-024")]
     fn test_sanitize_message_content_even_fences_unchanged() {
         let content = "```rust\nfn main() {}\n```";
         let sanitized = ConversationManager::sanitize_message_content(content);
@@ -660,6 +697,7 @@ mod tests {
     }
 
     #[test]
+    #[spec("CHAT-024")]
     fn test_sanitize_removes_trailing_role_markers() {
         let content = "Some text\nAssistant:";
         let sanitized = ConversationManager::sanitize_message_content(content);
@@ -682,6 +720,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[spec("CHAT-014")]
     async fn test_conversation_manager_new() {
         let storage = Arc::new(MemoryStorage::new().await.unwrap());
         let manager = ConversationManager::new(storage);
@@ -690,6 +729,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[spec("CHAT-015")]
     async fn test_start_session_with_metadata() {
         let storage = Arc::new(MemoryStorage::new().await.unwrap());
         let mut manager = ConversationManager::new(storage).unwrap();
@@ -703,6 +743,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[spec("CHAT-017")]
     async fn test_add_message() {
         let storage = Arc::new(MemoryStorage::new().await.unwrap());
         let mut manager = ConversationManager::new(storage).unwrap();
@@ -713,6 +754,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[spec("CHAT-022")]
     async fn test_get_session_stats() {
         let storage = Arc::new(MemoryStorage::new().await.unwrap());
         let mut manager = ConversationManager::new(storage).unwrap();
@@ -728,6 +770,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[spec("CHAT-023")]
     async fn test_clear_session() {
         let storage = Arc::new(MemoryStorage::new().await.unwrap());
         let mut manager = ConversationManager::new(storage).unwrap();
@@ -736,6 +779,224 @@ mod tests {
 
         manager.clear_session().unwrap();
         assert!(manager.current_session_id().is_none());
+    }
+
+    #[tokio::test]
+    #[spec("CHAT-016")]
+    async fn test_restore_last_session_with_compatibility() {
+        let storage = Arc::new(MemoryStorage::new_test().await.unwrap());
+        let mut manager = ConversationManager::new(storage.clone()).unwrap();
+
+        let compatible_id = manager
+            .start_session_with_metadata(
+                "test-model-v1",
+                Some("chat-template-v1"),
+                Some("system-prompt-v1"),
+                Some("7B".to_string()),
+            )
+            .await
+            .unwrap();
+
+        // Restoring with matching metadata should return the session.
+        let restored = manager
+            .restore_last_session_with_compatibility(
+                Some("chat-template-v1"),
+                Some("system-prompt-v1"),
+                Some("test-model-v2"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(restored, Some(compatible_id));
+        assert_eq!(manager.current_session_id(), Some(compatible_id));
+
+        // Create a newer, incompatible session.
+        let _incompatible_id = manager
+            .start_session_with_metadata(
+                "other-model-v1",
+                Some("chat-template-v2"),
+                Some("system-prompt-v2"),
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Restoring with the older compatible metadata should now fail
+        // because the latest session is incompatible.
+        let incompatible_restore = manager
+            .restore_last_session_with_compatibility(
+                Some("chat-template-v1"),
+                Some("system-prompt-v1"),
+                Some("test-model-v2"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(incompatible_restore, None);
+    }
+
+    #[tokio::test]
+    #[spec("CHAT-018")]
+    async fn test_get_context_messages_with_limits() {
+        let storage = Arc::new(MemoryStorage::new_test().await.unwrap());
+        let mut manager = ConversationManager::new(storage).unwrap();
+        manager.start_session("test-model").await.unwrap();
+
+        // Seed 12 short messages alternating user/assistant.
+        for i in 0..6 {
+            manager
+                .add_message_str("user", &format!("question {i}"))
+                .await
+                .unwrap();
+            manager
+                .add_message_str("assistant", &format!("answer {i}"))
+                .await
+                .unwrap();
+        }
+
+        let system = arkavo_llm::Message::system("You are helpful.");
+        let context = manager
+            .get_context_messages_with_limits(Some(system.clone()), Some(5))
+            .await
+            .unwrap();
+
+        // System message + at most 5 history turns (10 messages).
+        assert!(context.len() <= 11);
+        assert_eq!(context.first().map(|m| &m.content), Some(&system.content));
+        assert_eq!(
+            context.first().map(|m| m.role.clone()),
+            Some(arkavo_llm::Role::System)
+        );
+        // The newest user message should be present.
+        assert!(context.iter().any(|m| m.content.contains("question 5")));
+
+        // A smaller explicit limit should further reduce the returned history.
+        let limited_context = manager
+            .get_context_messages_with_limits(None, Some(2))
+            .await
+            .unwrap();
+        // Up to 2 turns (4 messages) when no system message is supplied.
+        assert!(limited_context.len() <= 4);
+        assert!(
+            limited_context
+                .iter()
+                .any(|m| m.content.contains("question 5"))
+        );
+    }
+
+    #[tokio::test]
+    #[spec("CHAT-019")]
+    async fn test_create_summary() {
+        let storage = Arc::new(MemoryStorage::new_test().await.unwrap());
+        let mut manager = ConversationManager::new(storage.clone()).unwrap();
+        let session_id = manager.start_session("test-model").await.unwrap();
+
+        manager
+            .add_message_str("user", "What is Rust?")
+            .await
+            .unwrap();
+        manager
+            .add_message_str("assistant", "Rust is a systems language.")
+            .await
+            .unwrap();
+
+        let messages = vec![
+            ConversationMessage {
+                id: Uuid::new_v4(),
+                session_id,
+                role: "user".to_string(),
+                content: "What is Rust?".to_string(),
+                timestamp: Utc::now(),
+                token_count: 4,
+                is_summary: false,
+            },
+            ConversationMessage {
+                id: Uuid::new_v4(),
+                session_id,
+                role: "assistant".to_string(),
+                content: "Rust is a systems language.".to_string(),
+                timestamp: Utc::now(),
+                token_count: 5,
+                is_summary: false,
+            },
+        ];
+
+        let provider = MockSummaryProvider {
+            response: "Summary of Rust discussion".to_string(),
+        };
+        let client = arkavo_llm::LlmClient::new(Box::new(provider));
+
+        let summary = manager.create_summary(&client, messages).await.unwrap();
+        assert_eq!(summary, "Summary of Rust discussion");
+
+        // Verify the summary was persisted and tagged as a summary.
+        let results = storage
+            .search("type:conversation_summary", 10, Some("conversation"))
+            .await
+            .unwrap();
+        let summary_messages: Vec<ConversationMessage> = results
+            .into_iter()
+            .filter_map(|r| serde_json::from_str::<ConversationMessage>(&r.memory.content).ok())
+            .filter(|m| m.is_summary)
+            .collect();
+        assert!(!summary_messages.is_empty());
+        assert!(
+            summary_messages
+                .iter()
+                .any(|m| m.content.contains("Summary of Rust discussion"))
+        );
+    }
+
+    #[tokio::test]
+    #[spec("CHAT-020")]
+    async fn test_list_sessions() {
+        let storage = Arc::new(MemoryStorage::new_test().await.unwrap());
+        let mut manager = ConversationManager::new(storage).unwrap();
+
+        let id_a = manager.start_session("model-a").await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        let id_b = manager.start_session("model-b").await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        let id_c = manager.start_session("model-c").await.unwrap();
+
+        // Semantic search can be approximate with only a few vectors; retry until
+        // all created sessions are visible.
+        let mut sessions = Vec::new();
+        for _ in 0..20 {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            sessions = manager.list_sessions().await.unwrap();
+            let ids: std::collections::HashSet<Uuid> = sessions.iter().map(|s| s.id).collect();
+            if ids.contains(&id_a) && ids.contains(&id_b) && ids.contains(&id_c) {
+                break;
+            }
+        }
+
+        let ids: std::collections::HashSet<Uuid> = sessions.iter().map(|s| s.id).collect();
+        assert!(ids.contains(&id_a), "session a should be listed");
+        assert!(ids.contains(&id_b), "session b should be listed");
+        assert!(ids.contains(&id_c), "session c should be listed");
+
+        // Sessions should be sorted by updated_at descending (newest first).
+        assert_eq!(sessions[0].id, id_c);
+        assert_eq!(sessions[1].id, id_b);
+        assert_eq!(sessions[2].id, id_a);
+    }
+
+    #[tokio::test]
+    #[spec("CHAT-021")]
+    async fn test_switch_session() {
+        let storage = Arc::new(MemoryStorage::new_test().await.unwrap());
+        let mut manager = ConversationManager::new(storage).unwrap();
+
+        let id_a = manager.start_session("model-a").await.unwrap();
+        let id_b = manager.start_session("model-b").await.unwrap();
+        assert_eq!(manager.current_session_id(), Some(id_b));
+
+        manager.switch_session(id_a).await.unwrap();
+        assert_eq!(manager.current_session_id(), Some(id_a));
+
+        let missing = Uuid::new_v4();
+        let result = manager.switch_session(missing).await;
+        assert!(result.is_err());
+        assert_eq!(manager.current_session_id(), Some(id_a));
     }
 
     #[test]

--- a/crates/arkavo-session/src/conversation.rs
+++ b/crates/arkavo-session/src/conversation.rs
@@ -606,11 +606,21 @@ impl ConversationManager {
 
     /// Switch to a different session
     pub async fn switch_session(&mut self, session_id: Uuid) -> anyhow::Result<()> {
-        // Use the authoritative session list to verify the session exists.
-        // The previous semantic search could return unrelated memories as a false
-        // positive for an unknown session id.
-        let sessions = self.list_sessions().await?;
-        if sessions.iter().any(|s| s.id == session_id) {
+        // Perform a targeted lookup for the session and accept it only if the
+        // returned memory deserializes to a ConversationSession with a matching
+        // id. This avoids both false positives from unrelated memories and
+        // false negatives from a capped global list.
+        let query = format!("session_id:{session_id}");
+        let results = self
+            .memory_storage
+            .search(&query, 5, Some("conversation"))
+            .await?;
+        let found = results.into_iter().any(|result| {
+            serde_json::from_str::<ConversationSession>(&result.memory.content)
+                .is_ok_and(|session| session.id == session_id)
+        });
+
+        if found {
             self.current_session_id = Some(session_id);
             Ok(())
         } else {

--- a/crates/arkavo-swarmkit-runtime/src/tdf.rs
+++ b/crates/arkavo-swarmkit-runtime/src/tdf.rs
@@ -546,6 +546,7 @@ provenance:
         swarmkit_orchestrator_policy(None, None).unwrap()
     }
 
+    #[spec("TDFS-001")]
     #[spec("SK-050")]
     #[tokio::test]
     async fn wrap_then_unwrap_round_trips_manifest() {
@@ -575,6 +576,7 @@ provenance:
         assert_eq!(a.payload.value, b.payload.value);
     }
 
+    #[spec("TDFS-006")]
     #[spec("SK-051")]
     #[tokio::test]
     async fn unwrap_runs_cross_block_validation() {

--- a/crates/arkavo-tdf/Cargo.toml
+++ b/crates/arkavo-tdf/Cargo.toml
@@ -37,6 +37,7 @@ schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
+arkavo-test-macros = { path = "../arkavo-test-macros" }
 
 [features]
 default = []

--- a/crates/arkavo-tdf/src/a2a_handler.rs
+++ b/crates/arkavo-tdf/src/a2a_handler.rs
@@ -335,6 +335,7 @@ impl KasA2aHandler {
 mod tests {
     use super::*;
     use crate::types::{Attribute, PolicyBinding};
+    use arkavo_test_macros::spec;
     use chrono::Utc;
 
     fn make_test_policy() -> Policy {
@@ -361,6 +362,7 @@ mod tests {
         general_purpose::STANDARD.encode(json.as_bytes())
     }
 
+    #[spec("TDFS-006")]
     #[test]
     fn test_decode_policy() {
         let handler = KasA2aHandler::with_defaults();
@@ -372,6 +374,7 @@ mod tests {
         assert_eq!(decoded.attributes.len(), 1);
     }
 
+    #[spec("TDFS-006")]
     #[test]
     fn test_decode_policy_invalid_base64() {
         let handler = KasA2aHandler::with_defaults();
@@ -380,6 +383,7 @@ mod tests {
         assert!(matches!(result, Err(KasError::PolicyDecodeError(_))));
     }
 
+    #[spec("TDFS-006")]
     #[test]
     fn test_verify_policy_binding_valid() {
         let handler = KasA2aHandler::with_defaults();
@@ -395,6 +399,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[spec("TDFS-006")]
     #[test]
     fn test_verify_policy_binding_empty_hash() {
         let handler = KasA2aHandler::with_defaults();
@@ -413,6 +418,7 @@ mod tests {
         assert!(matches!(result, Err(KasError::PolicyBindingInvalid(_))));
     }
 
+    #[spec("TDFS-011")]
     #[test]
     fn test_handler_without_keypair() {
         // Use new() without a keypair to test the error case
@@ -426,6 +432,8 @@ mod tests {
         assert!(matches!(result, Err(KasError::KeypairNotConfigured)));
     }
 
+    #[spec("TDFS-011")]
+    #[spec("TDFS-013")]
     #[test]
     fn test_handler_with_defaults_has_keypair() {
         // with_defaults() should generate a keypair
@@ -442,6 +450,8 @@ mod tests {
         assert_eq!(response.algorithm, "ec:secp256r1");
     }
 
+    #[spec("TDFS-011")]
+    #[spec("TDFS-013")]
     #[test]
     fn test_kas_keypair_public_key() {
         let keypair = KasKeypair::generate();
@@ -453,6 +463,7 @@ mod tests {
         assert!(public_key.len() > 80); // Base64 of 65 bytes
     }
 
+    #[spec("TDFS-011")]
     #[test]
     fn test_handler_with_config() {
         let config = KasA2aConfig {
@@ -472,6 +483,7 @@ mod tests {
         let _ = request;
     }
 
+    #[spec("TDFS-008")]
     #[test]
     fn test_delegation_token_json() {
         let token = make_test_token(&["https://arkavo.net/attr/role/value/admin"]);

--- a/crates/arkavo-tdf/src/abac.rs
+++ b/crates/arkavo-tdf/src/abac.rs
@@ -118,7 +118,9 @@ impl AbacEvaluator {
 mod tests {
     use super::*;
     use crate::types::Attribute;
+    use arkavo_test_macros::spec;
 
+    #[spec("TDFS-008")]
     #[test]
     fn test_permit_with_matching_entitlements() {
         let evaluator = AbacEvaluator::new();
@@ -141,6 +143,7 @@ mod tests {
         assert_eq!(result, Decision::Permit);
     }
 
+    #[spec("TDFS-008")]
     #[test]
     fn test_deny_with_missing_entitlement() {
         let evaluator = AbacEvaluator::new();
@@ -159,6 +162,7 @@ mod tests {
         assert_eq!(result, Decision::Deny);
     }
 
+    #[spec("TDFS-008")]
     #[test]
     fn test_permit_with_empty_policy() {
         let evaluator = AbacEvaluator::new();
@@ -171,6 +175,7 @@ mod tests {
         assert_eq!(result, Decision::Permit);
     }
 
+    #[spec("TDFS-008")]
     #[test]
     fn test_deny_with_empty_entitlements() {
         let evaluator = AbacEvaluator::new();
@@ -187,6 +192,7 @@ mod tests {
         assert_eq!(result, Decision::Deny);
     }
 
+    #[spec("TDFS-008")]
     #[test]
     fn test_multiple_attributes_all_required() {
         let evaluator = AbacEvaluator::new();
@@ -222,6 +228,7 @@ mod tests {
         assert_eq!(result, Decision::Permit);
     }
 
+    #[spec("TDFS-008")]
     #[test]
     fn test_parse_entitlement_fqn() {
         let fqn = "https://arkavo.net/attr/role/value/admin";
@@ -232,6 +239,7 @@ mod tests {
         assert_eq!(value, "admin");
     }
 
+    #[spec("TDFS-008")]
     #[test]
     fn test_parse_entitlement_fqn_invalid() {
         let invalid = "https://arkavo.net/role/admin";
@@ -239,6 +247,7 @@ mod tests {
         assert!(matches!(result, Err(AbacError::InvalidEntitlement(_))));
     }
 
+    #[spec("TDFS-008")]
     #[test]
     fn test_alternative_values_any_match() {
         let evaluator = AbacEvaluator::new();

--- a/crates/arkavo-tdf/src/delegation.rs
+++ b/crates/arkavo-tdf/src/delegation.rs
@@ -234,6 +234,7 @@ fn intersect_entitlements(a: &[String], b: &[String]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
     fn make_test_token(
         issuer: &str,
@@ -251,6 +252,7 @@ mod tests {
         }
     }
 
+    #[spec("TDFS-008")]
     #[test]
     fn test_delegation_token_serialization() {
         let token = make_test_token(
@@ -268,6 +270,7 @@ mod tests {
         assert_eq!(parsed.entitlements, token.entitlements);
     }
 
+    #[spec("TDFS-008")]
     #[test]
     fn test_subject_mismatch() {
         let token = make_test_token(
@@ -286,6 +289,7 @@ mod tests {
         ));
     }
 
+    #[spec("TDFS-009")]
     #[test]
     fn test_expired_token() {
         let mut token = make_test_token(
@@ -303,6 +307,7 @@ mod tests {
         assert!(matches!(result, Err(DelegationError::Expired(_))));
     }
 
+    #[spec("TDFS-008")]
     #[test]
     fn test_entitlement_intersection() {
         let a = vec![
@@ -323,6 +328,7 @@ mod tests {
         assert!(result.contains(&"https://arkavo.net/attr/clearance/value/secret".to_string()));
     }
 
+    #[spec("TDFS-008")]
     #[test]
     fn test_trusted_root_check() {
         let root = TrustedRoot {
@@ -336,6 +342,7 @@ mod tests {
         assert!(!verifier.is_trusted_root("did:key:z6MkOther"));
     }
 
+    #[spec("TDFS-008")]
     #[test]
     fn test_payload_bytes_deterministic() {
         let token = make_test_token(

--- a/crates/arkavo-tdf/src/opentdf_impl.rs
+++ b/crates/arkavo-tdf/src/opentdf_impl.rs
@@ -272,7 +272,9 @@ impl TdfDecryptor for OpenTdfService {
 mod tests {
     use super::*;
     use crate::PolicyBuilder;
+    use arkavo_test_macros::spec;
 
+    #[spec("TDFS-001")]
     #[tokio::test]
     async fn encrypt_basic() {
         let service = OpenTdfService::with_kas_url("https://kas.example.com");
@@ -293,6 +295,7 @@ mod tests {
         assert!(!manifest.payload.value.is_empty());
     }
 
+    #[spec("TDFS-001")]
     #[tokio::test]
     async fn encrypt_with_dissemination() {
         let service = OpenTdfService::with_kas_url("https://kas.example.com");
@@ -308,6 +311,7 @@ mod tests {
         assert!(!manifest.encryption_information.key_access.is_empty());
     }
 
+    #[spec("TDFS-001")]
     #[tokio::test]
     async fn encrypt_stream() {
         use std::io::Cursor;
@@ -326,6 +330,7 @@ mod tests {
         assert!(!manifest.payload.value.is_empty());
     }
 
+    #[spec("TDFS-003")]
     #[tokio::test]
     async fn manifest_serialization() {
         let service = OpenTdfService::with_kas_url("https://kas.example.com");

--- a/crates/arkavo-tdf/src/types.rs
+++ b/crates/arkavo-tdf/src/types.rs
@@ -271,7 +271,9 @@ impl Attribute {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
 
+    #[spec("TDFS-003")]
     #[test]
     fn tdf_manifest_serialization() {
         let manifest = TdfManifest {
@@ -313,6 +315,7 @@ mod tests {
         assert_eq!(parsed, manifest);
     }
 
+    #[spec("TDFS-003")]
     #[test]
     fn policy_serialization() {
         let policy = Policy {
@@ -329,6 +332,7 @@ mod tests {
         assert_eq!(parsed, policy);
     }
 
+    #[spec("TDFS-003")]
     #[test]
     fn inline_payload_constructors() {
         let binary = InlinePayload::binary("Y2lwaGVydGV4dA==");
@@ -339,6 +343,8 @@ mod tests {
         assert_eq!(json.mime_type, "application/json");
     }
 
+    #[spec("TDFS-003")]
+    #[spec("TDFS-011")]
     #[test]
     fn key_access_object_constructor() {
         let kao = KeyAccessObject::new(
@@ -352,6 +358,7 @@ mod tests {
         assert_eq!(kao.url, "https://kas.arkavo.net");
     }
 
+    #[spec("TDFS-008")]
     #[test]
     fn attribute_constructor() {
         let attr = Attribute::new(
@@ -362,6 +369,7 @@ mod tests {
         assert_eq!(attr.values.len(), 2);
     }
 
+    #[spec("TDFS-003")]
     #[test]
     fn default_implementations() {
         let info = EncryptionInformation::default();

--- a/specs/arkavo-edge/agent-sdk.spec.yaml
+++ b/specs/arkavo-edge/agent-sdk.spec.yaml
@@ -42,8 +42,12 @@ scenarios:
       - Bidirectional message passing works
       - Client tracks session state
       - Cleanup on drop
-    refs: [crates/anthropic-agent-sdk/src/client.rs]
-    changed: "2026-03-19"
+    refs:
+      - crates/anthropic-agent-sdk/src/client/mod.rs:182-398
+      - crates/anthropic-agent-sdk/src/client/messaging.rs:1-391
+      - crates/anthropic-agent-sdk/src/client/session/mod.rs:1-199
+      - crates/anthropic-agent-sdk/src/client/tasks.rs:15-202
+    changed: "2026-06-12"
 
   - id: CASDK-003
     name: MCP tool registration via rmcp
@@ -56,8 +60,11 @@ scenarios:
       - Tool discoverable by Claude
       - Schema passed to subprocess
       - Tool calls routed back
-    refs: [crates/anthropic-agent-sdk/src/mcp.rs]
-    changed: "2026-03-19"
+    refs:
+      - crates/anthropic-agent-sdk/src/mcp/mod.rs:74-84
+      - crates/anthropic-agent-sdk/src/mcp/sdk.rs:47-91
+      - crates/anthropic-agent-sdk/src/types/mcp.rs:62-99
+    changed: "2026-06-12"
 
   - id: CASDK-004
     name: Permission management
@@ -84,5 +91,8 @@ scenarios:
       - Hook callback invoked
       - HookOutput returned
       - Non-matching events pass through
-    refs: [crates/anthropic-agent-sdk/src/hooks.rs]
-    changed: "2026-03-19"
+    refs:
+      - crates/anthropic-agent-sdk/src/hooks/mod.rs:92-297
+      - crates/anthropic-agent-sdk/src/hooks/processing.rs:26-112
+      - crates/anthropic-agent-sdk/src/hooks/invocation.rs:31-91
+    changed: "2026-06-12"

--- a/specs/arkavo-edge/chat-session.spec.yaml
+++ b/specs/arkavo-edge/chat-session.spec.yaml
@@ -6,7 +6,7 @@ version: 0.57.2
 
 invariants:
   - Each session has a unique UUID v4 identifier
-  - Sessions transition through states Active → Closing → Closed
+  - Sessions transition through states Active → Closing → Closed, with an abnormal Zombie state on handler exit
   - Sessions auto-expire after TTL (default 3600 seconds) with 60-second check interval
   - Maximum 100 in-flight deltas before back-pressure is applied
   - Delta sequences are monotonically increasing per message

--- a/specs/arkavo-edge/context.spec.yaml
+++ b/specs/arkavo-edge/context.spec.yaml
@@ -140,6 +140,8 @@ scenarios:
   - id: CTX-008
     name: Calculate context offload threshold by model size
     criticality: high
+    wip: true
+    issue: "No matching implementation file exists in the codebase"
     given:
       - Model size hint provided (270M, 1B, 2B, 7B, etc.)
       - Is cloud provider flag set
@@ -168,7 +170,9 @@ scenarios:
       - Messages archived to ContextLedger
       - "[ARCHIVED: summary] pointers inserted"
       - Compressed context returned
-    refs: [crates/arkavo-context/src/ledger_chat.rs:71-120]
+    refs:
+      - crates/arkavo-hrm/src/conductor/orchestrator.rs:111-140
+      - crates/arkavo-memory/src/ledger.rs:15-28
     changed: "2025-02-05"
 
   - id: CTX-010
@@ -183,7 +187,7 @@ scenarios:
       - Archived content retrieved by ID
       - Full context reconstructed
       - Available for model processing
-    refs: [crates/arkavo-context/src/ledger_chat.rs:121-150]
+    refs: [crates/arkavo-memory/src/ledger.rs:30-37]
     changed: "2025-02-05"
 
   - id: CTX-011
@@ -211,7 +215,7 @@ scenarios:
       - Offloading skipped
       - Full context preserved
       - No [ARCHIVED] pointers added
-    refs: [crates/arkavo-context/src/ledger_chat.rs:90-100]
+    refs: [crates/arkavo-hrm/src/conductor/orchestrator.rs:117-122]
     changed: "2025-02-05"
 
   - id: CTX-013
@@ -224,7 +228,7 @@ scenarios:
       - Approximate token count returned
       - ~4 characters per token heuristic
       - Used for budget management
-    refs: [crates/arkavo-context/src/token_estimation.rs:10-30]
+    refs: [crates/arkavo-context/src/rlm_detection.rs:25-28]
     changed: "2025-02-05"
 
   - id: CTX-014

--- a/specs/arkavo-edge/critic.spec.yaml
+++ b/specs/arkavo-edge/critic.spec.yaml
@@ -52,7 +52,7 @@ scenarios:
       - Circuit evaluated (<1μs)
       - Pass/fail determined
       - Result returned
-    refs: [crates/arkavo-critic/src/checks.rs:1-50]
+    refs: [crates/arkavo-critic/src/checks/circuit.rs:130-168]
     changed: "2025-01-31"
     edge_cases:
       - condition: Circuit violation
@@ -69,7 +69,7 @@ scenarios:
       - Parameters validated
       - Types checked
       - Result returned (<1ms)
-    refs: [crates/arkavo-critic/src/checks.rs:50-100]
+    refs: [crates/arkavo-critic/src/checks/schema.rs:50-88]
     changed: "2025-01-31"
     edge_cases:
       - condition: Missing required field
@@ -88,7 +88,7 @@ scenarios:
       - Coherence analyzed (<50ms)
       - Score computed
       - Result returned
-    refs: [crates/arkavo-critic/src/checks.rs:100-150]
+    refs: [crates/arkavo-critic/src/checks/semantic.rs:124-177]
     changed: "2025-01-31"
 
   - id: CRIT-006
@@ -184,7 +184,7 @@ scenarios:
       - Category formatted as "model:{family}:{issue}"
       - Episode stored in LearningStore
       - Issue type returned for caller handling
-    refs: [crates/arkavo-cli/src/feedback_analyzer.rs:82-169]
+    refs: [crates/arkavo-router/src/prompt_advisor.rs:277-325]
     changed: "2025-02-05"
 
   - id: CRIT-012
@@ -200,7 +200,7 @@ scenarios:
       - Loop episode count checked for model family
       - PatternAdjustment returned if threshold met
       - Suggested max_tokens reduced for loopy models
-    refs: [crates/arkavo-cli/src/feedback_analyzer.rs:252-299]
+    refs: [crates/arkavo-router/src/prompt_advisor.rs:158-223]
     changed: "2025-02-05"
     edge_cases:
       - condition: No loop history for model
@@ -248,7 +248,7 @@ scenarios:
       - Timeout episode created
       - Category set as "model:{family}:timeout"
       - Episode stored in LearningStore
-    refs: [crates/arkavo-cli/src/feedback_analyzer.rs:172-210]
+    refs: [crates/arkavo-router/src/prompt_advisor.rs:277-289]
     changed: "2025-02-05"
 
   - id: CRIT-016
@@ -262,7 +262,7 @@ scenarios:
       - Returns counts for each issue category
       - "Categories: loop, code_fence, timeout, wrong_expert, hallucinated_tool"
       - Empty categories omitted from results
-    refs: [crates/arkavo-cli/src/feedback_analyzer.rs:213-240]
+    refs: [crates/arkavo-router/src/prompt_advisor.rs:379-395]
     changed: "2025-02-05"
 
   - id: CRIT-017

--- a/specs/arkavo-edge/git.spec.yaml
+++ b/specs/arkavo-edge/git.spec.yaml
@@ -6,7 +6,7 @@ version: 0.57.2
 
 invariants:
   - All operations validate repository state first
-  - Commit messages follow conventional format
+  - Commit messages are descriptive and do not use conventional commit prefixes (feat:, fix:, etc.)
   - Safety checks prevent destructive operations
   - Remote operations use configured credentials
 

--- a/specs/arkavo-edge/hrm.spec.yaml
+++ b/specs/arkavo-edge/hrm.spec.yaml
@@ -19,8 +19,8 @@ scenarios:
       - Store connected
       - Conductor ready
       - State management active
-    refs: [crates/arkavo-hrm/src/lib.rs:22-30, crates/arkavo-hrm/src/conductor.rs:1-50]
-    changed: "2025-01-31"
+    refs: [crates/arkavo-hrm/src/lib.rs:22-30, crates/arkavo-hrm/src/conductor/orchestrator.rs:43-55]
+    changed: "2026-06-12"
 
   - id: HRM-002
     name: Create task with budget
@@ -35,8 +35,8 @@ scenarios:
       - Subtasks decomposed
       - Budget allocated
       - Task persisted
-    refs: [crates/arkavo-hrm/src/conductor.rs:50-100, crates/arkavo-hrm/src/schemas.rs:1-50]
-    changed: "2025-01-31"
+    refs: [crates/arkavo-hrm/src/conductor/orchestrator.rs:161-179, crates/arkavo-hrm/src/schemas.rs:70-95, crates/arkavo-hrm/src/schemas.rs:133-163]
+    changed: "2026-06-12"
     edge_cases:
       - condition: Budget insufficient for task
         expected: Warning or rejection
@@ -55,8 +55,8 @@ scenarios:
       - Execution bounded
       - Result or partial result returned
       - State updated
-    refs: [crates/arkavo-hrm/src/burst.rs:1-60, crates/arkavo-hrm/src/conductor.rs:100-150]
-    changed: "2025-01-31"
+    refs: [crates/arkavo-hrm/src/burst/contract.rs:55-146, crates/arkavo-hrm/src/burst/result.rs:35-117, crates/arkavo-hrm/src/conductor/orchestrator.rs:254-360]
+    changed: "2026-06-12"
     edge_cases:
       - condition: Budget exceeded mid-execution
         expected: Graceful termination
@@ -74,8 +74,8 @@ scenarios:
       - Loop signature detected
       - Strategic thrashing flagged
       - Intervention triggered
-    refs: [crates/arkavo-hrm/src/conductor.rs:150-200]
-    changed: "2025-01-31"
+    refs: [crates/arkavo-hrm/src/conductor/loop_detector.rs:45-105, crates/arkavo-hrm/src/conductor/orchestrator.rs:203-230]
+    changed: "2026-06-12"
     edge_cases:
       - condition: Similar but valid patterns
         expected: Tolerance for legitimate cycles
@@ -105,5 +105,5 @@ scenarios:
       - Remaining work identified
       - Context strategy selected
       - Handover prepared
-    refs: [crates/arkavo-hrm/src/burst.rs:60-100]
-    changed: "2025-01-31"
+    refs: [crates/arkavo-hrm/src/burst/result.rs:119-164]
+    changed: "2026-06-12"

--- a/specs/arkavo-edge/index.yaml
+++ b/specs/arkavo-edge/index.yaml
@@ -1,7 +1,7 @@
 # Arkavo Edge Behavior Specification Index
 
-version: 0.80.0
-last_updated: 2026-06-10
+version: 0.80.1
+last_updated: 2026-06-12
 
 components:
   - name: trusted-agent
@@ -1123,8 +1123,8 @@ integration_points:
     specs: [REPO-004, CS-002]
 
   - name: Context → Router
-    description: Context compression for router prompts
-    specs: [CTX-004, ROUTER-001]
+    description: Context compression and RLM detection inform routing decisions
+    specs: [CTX-004, CTX-007, ROUTER-001, ROUTER-016, ROUTER-017]
 
   - name: Attestation → Registration
     description: Device attestation during registration
@@ -1234,10 +1234,6 @@ integration_points:
     description: CLI interactive commands use conversation manager
     specs: [CLI-008, CLI-009, CLI-012, CHAT-015]
 
-  - name: Context → Router
-    description: RLM detection informs routing decisions
-    specs: [CTX-007, ROUTER-016, ROUTER-017]
-
   - name: Repo → Context
     description: Repository context informs context decisions
     specs: [REPO-005, CTX-014, CTX-015]
@@ -1297,3 +1293,51 @@ integration_points:
   - name: Trusted Agent → Config Transport
     description: Trust chain Phase 6 delivers encrypted config over A2A
     specs: [TA-001, TA-006, CFGT-002, CFGT-003]
+
+  - name: Server → Agent
+    description: Server manages agent lifecycle and goal execution
+    specs: [SRV-007, AGENT-002]
+
+  - name: Server → Learning Bus
+    description: Server runs learning pipeline loops and feeds autolearn signals
+    specs: [SRV-004, AUTO-001]
+
+  - name: Validation → Network Security
+    description: Validation provides egress filter used by network security
+    specs: [VAL-005, NET-007]
+
+  - name: Security → Protocol
+    description: JWT and OAuth2 authentication backends secure A2A protocol transport
+    specs: [SEC-001, SEC-006, PROTO-008]
+
+  - name: MCP Traits → MCP Tools
+    description: Tools implement the trait defined by arkavo-mcp
+    specs: [MCPD-001, MCP-003]
+
+  - name: MCP Traits → MCP Runtime
+    description: Runtime executes tools defined by the MCP trait contract
+    specs: [MCPD-001, MCPR-003]
+
+  - name: Agent SDK → MCP Traits
+    description: Agent SDK discovers and registers MCP tools via the trait interface
+    specs: [CASDK-003, MCPD-001]
+
+  - name: QR Registration → Crypto
+    description: QR registration uses Ed25519 for challenge signing and verification
+    specs: [QREG-004, CRYPTO-002]
+
+  - name: KV Cache → Router
+    description: Cache slots inform context composition for routing
+    specs: [KVC-001, ROUTER-001]
+
+  - name: EvoFabric → Crypto
+    description: OpBundles are cryptographically signed with arkavo-crypto primitives
+    specs: [EVO-001, CRYPTO-002]
+
+  - name: OpenClaw → Protocol
+    description: OpenClaw translates between OpenClaw frames and A2A protocol messages
+    specs: [OCLAW-002, PROTO-001]
+
+  - name: Validation → Session Security
+    description: Validation log sanitization is used to redact session secrets and PII
+    specs: [VAL-003, SESS-010, SESS-011, SESS-012]

--- a/specs/arkavo-edge/mcp-claude.spec.yaml
+++ b/specs/arkavo-edge/mcp-claude.spec.yaml
@@ -54,7 +54,7 @@ scenarios:
       - Tool schemas are validated
       - Permissions are checked
       - Tools are ready for invocation
-    refs: [crates/arkavo-mcp-claude/src/tools.rs:1-60]
+    refs: [crates/arkavo-mcp-claude/src/tools/mod.rs:295-322]
     changed: "2025-01-31"
 
   - id: MCPC-004
@@ -103,7 +103,7 @@ scenarios:
       - Payload is reformatted
       - Timestamps converted
       - Metadata preserved
-    refs: [crates/arkavo-mcp-claude/src/event_mapper.rs:1-40]
+    refs: [crates/arkavo-mcp-claude/src/event_mapper/mod.rs:26-184]
     changed: "2025-01-31"
 
   - id: MCPC-007

--- a/specs/arkavo-edge/mcp-macos.spec.yaml
+++ b/specs/arkavo-edge/mcp-macos.spec.yaml
@@ -41,7 +41,7 @@ scenarios:
       - Background steps are associated
       - Tags are preserved
       - Data tables are parsed
-    refs: [crates/arkavo-mcp-macos/src/gherkin.rs:1-50]
+    refs: [crates/arkavo-mcp-macos/src/gherkin/parser.rs:1-153]
     changed: "2025-01-31"
     edge_cases:
       - condition: Syntax error in feature
@@ -61,7 +61,7 @@ scenarios:
       - When action is performed
       - Then assertions are verified
       - Results are recorded
-    refs: [crates/arkavo-mcp-macos/src/execution.rs:1-60]
+    refs: [crates/arkavo-mcp-macos/src/execution/runner.rs:1-184]
     changed: "2025-01-31"
     edge_cases:
       - condition: Step definition missing
@@ -95,7 +95,7 @@ scenarios:
       - Simulator boots
       - Application installs
       - Bridge connection established
-    refs: [crates/arkavo-mcp-macos/src/bridge.rs:1-60]
+    refs: [crates/arkavo-mcp-macos/src/mcp/simulator_manager.rs:109-124, crates/arkavo-mcp-macos/src/mcp/simulator_manager.rs:142-200, crates/arkavo-mcp-macos/src/bridge/ios_ffi.rs:1-60]
     changed: "2025-01-31"
     edge_cases:
       - condition: Device type unavailable
@@ -115,7 +115,7 @@ scenarios:
       - Results are formatted as MCP responses
       - Progress updates are streamed
       - Errors are properly serialized
-    refs: [crates/arkavo-mcp-macos/src/mcp.rs:1-50, crates/arkavo-mcp-macos/src/integration.rs:1-40]
+    refs: [crates/arkavo-mcp-macos/src/mcp/server.rs:66-200]
     changed: "2025-01-31"
 
   - id: MCPM-007
@@ -130,7 +130,7 @@ scenarios:
       - Duration metrics included
       - Failed scenarios detailed
       - Export to multiple formats
-    refs: [crates/arkavo-mcp-macos/src/reporting.rs:1-50]
+    refs: [crates/arkavo-mcp-macos/src/reporting/business_report.rs:1-110]
     changed: "2025-01-31"
 
   - id: MCPM-008
@@ -145,7 +145,7 @@ scenarios:
       - Suggestions are generated
       - Step definitions can be proposed
       - Results are integrated
-    refs: [crates/arkavo-mcp-macos/src/ai.rs:1-40]
+    refs: [crates/arkavo-mcp-macos/src/ai/analysis_engine.rs:1-120]
     changed: "2025-01-31"
     edge_cases:
       - condition: AI service unavailable

--- a/specs/arkavo-edge/mcp-runtime.spec.yaml
+++ b/specs/arkavo-edge/mcp-runtime.spec.yaml
@@ -34,8 +34,11 @@ scenarios:
       - ClientHandle created
       - State tracked
       - Capabilities exchanged
-    refs: [crates/arkavo-mcp-runtime/src/client.rs:1-60]
-    changed: "2025-01-31"
+    refs:
+      - crates/arkavo-mcp-runtime/src/runtime.rs:39-89
+      - crates/arkavo-mcp-runtime/src/client/handle.rs:1-16
+      - crates/arkavo-mcp-runtime/src/client/mcp_client.rs:24-96
+    changed: "2026-06-12"
     edge_cases:
       - condition: Duplicate client ID
         expected: Reject or replace existing
@@ -54,8 +57,10 @@ scenarios:
       - Tool executes with deadline
       - Result or timeout returned
       - Cancellation supported
-    refs: [crates/arkavo-mcp-runtime/src/runtime.rs:1-60, crates/arkavo-mcp-runtime/src/tools.rs:1-50]
-    changed: "2025-01-31"
+    refs:
+      - crates/arkavo-mcp-runtime/src/runtime.rs:178-220
+      - crates/arkavo-mcp-runtime/src/transport/stdio.rs:99-152
+    changed: "2026-06-12"
     edge_cases:
       - condition: Tool panics
         expected: Error response, isolation
@@ -72,8 +77,8 @@ scenarios:
       - stdin/stdout wrapped
       - JSON-RPC framing applied
       - Transport ready
-    refs: [crates/arkavo-mcp-runtime/src/transport.rs:1-50]
-    changed: "2025-01-31"
+    refs: [crates/arkavo-mcp-runtime/src/transport/stdio.rs:14-95]
+    changed: "2026-06-12"
 
   - id: MCPR-005
     name: Create SSE transport
@@ -86,8 +91,8 @@ scenarios:
       - Server-sent events configured
       - Bidirectional over HTTP
       - Connection managed
-    refs: [crates/arkavo-mcp-runtime/src/transport.rs:50-100]
-    changed: "2025-01-31"
+    refs: [crates/arkavo-mcp-runtime/src/transport/sse.rs:11-98]
+    changed: "2026-06-12"
 
   - id: MCPR-006
     name: Poll endpoint with adaptive backoff

--- a/specs/arkavo-edge/network-security.spec.yaml
+++ b/specs/arkavo-edge/network-security.spec.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=../schema.json
 
 feature: Network Security and Secure Defaults
-module: arkavo_edge::security::network
+module: arkavo_security
 version: 1.0.0
 
 invariants:
@@ -27,7 +27,7 @@ scenarios:
       - User is guided through mandatory security setup
       - Random strong API key is generated if user doesn't provide one
       - Agent functionality is locked until setup completes
-    refs: [crates/arkavo-config-bundle/src/first_run.rs]
+    refs: [crates/arkavo-security/src/auth.rs:40-125, crates/arkavo-cli/src/commands/security_audit.rs:190-208]
 
   - id: NET-002
     name: Localhost-only binding by default
@@ -40,7 +40,7 @@ scenarios:
       - Agent binds ONLY to 127.0.0.1, not 0.0.0.0
       - External network access is impossible without explicit configuration
       - Warning is displayed if admin changes to public binding
-    refs: [crates/arkavo-protocol/src/server_bind.rs]
+    refs: [crates/arkavo-protocol/src/config.rs:109-134, crates/arkavo-validation/src/url.rs:246-262]
 
   - id: NET-003
     name: Public binding requires explicit acknowledgment
@@ -54,7 +54,7 @@ scenarios:
       - TLS is REQUIRED for public binding
       - Authentication strength is validated
       - Warning banner is shown in logs
-    refs: [crates/arkavo-config-bundle/src/network_config.rs]
+    refs: [crates/arkavo-protocol/src/http.rs:79-94, crates/arkavo-security/src/security.rs:20-46, crates/arkavo-cli/src/commands/security_audit.rs:180-188]
 
   - id: NET-004
     name: No localhost trust exemption
@@ -67,7 +67,7 @@ scenarios:
       - Request is REJECTED - localhost is not trusted
       - Same authentication required for all sources
       - No "trust local" configuration option exists
-    refs: [crates/arkavo-protocol/src/auth_enforcer.rs]
+    refs: [crates/arkavo-security/src/auth.rs:106-125]
 
   - id: NET-005
     name: Reverse proxy header validation
@@ -81,7 +81,7 @@ scenarios:
       - X-Forwarded-For is only trusted if secret header present
       - Requests without secret header are rejected
       - Header secret is not logged or exposed
-    refs: [crates/arkavo-protocol/src/proxy_validator.rs]
+    refs: [crates/arkavo-protocol/src/rate_limit_middleware.rs:15-46]
 
   - id: NET-006
     name: Host header validation (anti-rebinding)
@@ -95,7 +95,7 @@ scenarios:
       - For localhost binding, only "localhost", "127.0.0.1", "[::1]" accepted
       - Requests with external Host headers are dropped
       - Prevents browser-based DNS rebinding attacks
-    refs: [crates/arkavo-protocol/src/host_validator.rs]
+    refs: [crates/arkavo-validation/src/url.rs:164-224]
 
   - id: NET-007
     name: Block cloud metadata and internal network access
@@ -109,7 +109,7 @@ scenarios:
       - Blocked ranges include 169.254.169.254, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8
       - Explicit allowlist can override for known-safe internal services
       - Log entry shows "SSRF attempt blocked"
-    refs: [crates/arkavo-dataflow/src/egress_filter.rs]
+    refs: [crates/arkavo-validation/src/url.rs:1-118]
 
   - id: NET-008
     name: Ephemeral setup token (secure first-run)
@@ -124,7 +124,7 @@ scenarios:
       - Token is written to file with mode 0600
       - Token expires after 10 minutes OR first successful use
       - After expiry/use, token file is securely deleted
-    refs: [crates/arkavo-agent-auth/src/bootstrap.rs]
+    refs: [crates/arkavo-agent-auth/src/storage.rs:27-79, crates/arkavo-agent-auth/src/types.rs:32-69]
 
   - id: NET-009
     name: TLS required for non-localhost
@@ -137,7 +137,7 @@ scenarios:
       - TLS is mandatory - plaintext HTTP is rejected
       - Minimum TLS 1.2 is enforced
       - Weak cipher suites are disabled
-    refs: [crates/arkavo-protocol/src/tls_enforcer.rs]
+    refs: [crates/arkavo-protocol/src/transport.rs:89-108, crates/arkavo-protocol/src/http.rs:79-94, crates/arkavo-security/src/security.rs:20-72]
 
   - id: NET-010
     name: Rate limiting per IP
@@ -150,11 +150,13 @@ scenarios:
       - Further requests are rejected (429)
       - Exponential backoff is applied
       - Sustained abuse triggers temp ban
-    refs: [crates/arkavo-protocol/src/rate_limiter.rs]
+    refs: [crates/arkavo-protocol/src/rate_limit_middleware.rs:48-82, crates/arkavo-protocol/src/rate_limit.rs:160-247]
 
   - id: NET-011
     name: Admin interface separate from public API
     criticality: high
+    wip: true
+    issue: "No matching implementation file exists in the codebase"
     given:
       - Agent has administrative interface
       - Agent has public-facing API
@@ -176,11 +178,13 @@ scenarios:
       - Security configuration is audited
       - Insecure settings generate warnings
       - Critical misconfigurations prevent startup
-    refs: [crates/arkavo-config-bundle/src/security_audit.rs]
+    refs: [crates/arkavo-cli/src/commands/security_audit.rs:45-83]
 
   - id: NET-013
     name: Service fingerprint minimization
     criticality: medium
+    wip: true
+    issue: "No matching implementation file exists in the codebase"
     given:
       - External scanner probes agent ports
       - Scanner attempts to identify service
@@ -202,7 +206,7 @@ scenarios:
       - Resolved IP is checked BEFORE connection is made
       - Time-of-check/time-of-use mitigated by re-checking at connect
       - DNS rebinding during connection is blocked
-    refs: [crates/arkavo-dataflow/src/dns_validator.rs]
+    refs: [crates/arkavo-validation/src/url.rs:112-117]
 
   - id: NET-015
     name: Prompt injection attack prevention
@@ -216,7 +220,7 @@ scenarios:
       - System instructions cannot be overridden
       - Injection patterns are detected and neutralized
       - Attack attempt is logged for security audit
-    refs: [crates/arkavo-cli/src/prompt_validation.rs]
+    refs: [crates/arkavo-router/src/preflight/moderator.rs:86-127, crates/arkavo-router/src/preflight/normalize.rs:136-138, crates/arkavo-validation/src/external_content.rs:38-59]
     edge_cases:
       - condition: Multi-turn injection attack
         expected: Context reset or session termination
@@ -237,7 +241,7 @@ scenarios:
       - User confirmation required before execution
       - Dangerous commands are flagged
       - Execution is sandboxed
-    refs: [crates/arkavo-cli/src/command_guard.rs]
+    refs: [crates/arkavo-mcp-tools/src/shell_exec.rs:10-93, crates/arkavo-mcp-tools/src/sandbox.rs:27-85]
     edge_cases:
       - condition: LLM suggests "rm -rf /"
         expected: Blocked with warning, requires explicit confirmation
@@ -247,6 +251,8 @@ scenarios:
   - id: NET-017
     name: Egress audit logging
     criticality: high
+    wip: true
+    issue: "No matching implementation file exists in the codebase"
     given:
       - Agent makes any outbound network request
       - Request may be user-initiated or agent-autonomous

--- a/specs/arkavo-edge/orchestrator.spec.yaml
+++ b/specs/arkavo-edge/orchestrator.spec.yaml
@@ -155,7 +155,7 @@ scenarios:
       - Subtasks defined
       - Dependencies mapped
       - TaskPlan created
-    refs: [crates/arkavo-orchestrator/src/task_executor.rs:1-80]
+    refs: [crates/arkavo-orchestrator/src/task_executor/planning.rs:1-214]
     changed: "2025-01-31"
 
   - id: ORCH-010

--- a/specs/arkavo-edge/protocol.spec.yaml
+++ b/specs/arkavo-edge/protocol.spec.yaml
@@ -25,8 +25,8 @@ scenarios:
       - Server initialized
       - Transports bound
       - Ready for connections
-    refs: [crates/arkavo-protocol/src/server.rs:1-60]
-    changed: "2025-01-31"
+    refs: [crates/arkavo-server/src/server/a2a_server.rs:33-148]
+    changed: "2026-06-12"
 
   - id: PROTO-002
     name: Establish WebSocket transport

--- a/specs/arkavo-edge/router.spec.yaml
+++ b/specs/arkavo-edge/router.spec.yaml
@@ -68,7 +68,7 @@ scenarios:
       - Content analyzed against moderation policies
       - Violations rejected with PolicyId
       - No model called for blocked content
-    refs: [crates/arkavo-router/src/preflight.rs]
+    refs: [crates/arkavo-router/src/preflight/moderator.rs:1-135]
 
   - id: ROUTER-005
     name: Stream backpressure handling
@@ -146,7 +146,11 @@ scenarios:
       - Subtasks generated with dependencies
       - Complexity scored for each subtask
       - Plan executed with result aggregation
-    refs: [crates/arkavo-router/src/architect.rs]
+    refs:
+      - crates/arkavo-router/src/architect/mod.rs:1-105
+      - crates/arkavo-router/src/architect/planner.rs:1-110
+      - crates/arkavo-router/src/architect/executor.rs:1-115
+      - crates/arkavo-router/src/architect/complexity.rs:1-110
     edge_cases:
       - condition: All models fail connectivity check
         expected: Returns Error::NoModelsAvailable
@@ -219,7 +223,9 @@ scenarios:
       - top_k controls vocabulary cutoff (default 40)
       - max_tokens limits response length (default 4096)
       - seed ensures reproducibility when set
-    refs: [crates/arkavo-router/src/config/sampling.rs:1-60]
+    refs:
+      - crates/arkavo-llm/src/llamacpp_provider.rs:29-80
+      - crates/arkavo-router/src/provider.rs:7-34
     changed: "2025-02-05"
     edge_cases:
       - condition: temperature=0
@@ -242,7 +248,11 @@ scenarios:
       - Image encoded to base64 or embeddings
       - Multi-modal prompt constructed
       - Model processes text + image
-    refs: [crates/arkavo-router/src/vision.rs:1-80]
+    refs:
+      - crates/arkavo-llm/src/image.rs:1-71
+      - crates/arkavo-llm/src/message.rs:116-120
+      - crates/arkavo-router/src/decision.rs:485-510
+      - crates/arkavo-router/src/selector.rs:270-280
     changed: "2025-02-05"
     edge_cases:
       - condition: Image file not found
@@ -263,7 +273,7 @@ scenarios:
       - Approximate token count returned
       - Used for RLM activation check
       - Used for context budget management
-    refs: [crates/arkavo-router/src/token_estimation.rs:1-40]
+    refs: [crates/arkavo-router/src/tool_extraction.rs:19-21]
     changed: "2025-02-05"
 
   - id: ROUTER-017
@@ -278,5 +288,5 @@ scenarios:
       - "270M: 2048, 1B: 4096, 7B: 8192, etc."
       - "Cloud models: 128K-1M tokens"
       - Default for unknown models
-    refs: [crates/arkavo-router/src/token_estimation.rs:41-80]
+    refs: [crates/arkavo-context/src/rlm_detection.rs:31-60]
     changed: "2025-02-05"

--- a/specs/arkavo-edge/sequence-integrity.spec.yaml
+++ b/specs/arkavo-edge/sequence-integrity.spec.yaml
@@ -32,7 +32,7 @@ scenarios:
       - Classification level inferred (PII, credentials, internal, public)
       - Label persists through variable assignments and context
       - Taint metadata stored in sequence ledger
-    refs: [crates/arkavo-mcp/src/taint.rs]
+    refs: [crates/arkavo-protocol/src/data_classification.rs:1-107]
     changed: "2026-03-21"
     edge_cases:
       - condition: Data source classification ambiguous
@@ -82,7 +82,7 @@ scenarios:
       - PII-classified data requires explicit authorization
       - Credential-classified data blocked unconditionally
       - Violation logged with full provenance chain
-    refs: [crates/arkavo-validation/src/egress_taint.rs]
+    refs: [crates/arkavo-validation/src/url.rs:1-142]
     changed: "2026-03-21"
     edge_cases:
       - condition: Destination is sanctioned internal endpoint
@@ -127,7 +127,7 @@ scenarios:
       - Maximum path lengths per skill recorded
       - Data flow patterns (source types → sink types) profiled
       - Baseline stored with skill identifier
-    refs: [crates/arkavo-router/src/learning/baseline.rs]
+    refs: [crates/arkavo-router/src/learning/module.rs:1-413]
     changed: "2026-03-21"
     edge_cases:
       - condition: Insufficient history for baseline
@@ -153,7 +153,7 @@ scenarios:
       - Medium divergence (threshold_1 to threshold_2) triggers async alert
       - High divergence (> threshold_2) triggers synchronous gate
       - Detection completes within 50μs overhead budget
-    refs: [crates/arkavo-titan/src/sequence_anomaly.rs]
+    refs: [crates/arkavo-titan/src/accumulator.rs:1-133]
     changed: "2026-03-21"
     edge_cases:
       - condition: Novel but legitimate workflow
@@ -180,7 +180,7 @@ scenarios:
       - Data flow summaries (source→sink pairs) indexed
       - Incomplete exfiltration patterns flagged as pending
       - Ledger entries retained for configurable window (default 24h)
-    refs: [crates/arkavo-memory/src/sequence_ledger.rs]
+    refs: [crates/arkavo-memory/src/federated_memory.rs:28-39]
     changed: "2026-03-21"
 
   - id: SEQ-008
@@ -198,7 +198,7 @@ scenarios:
       - Read internal data in session A + POST external in session B detected
       - Staging patterns identified (read→store→retrieve→exfiltrate)
       - Composite threat score computed from linked sessions
-    refs: [crates/arkavo-memory/src/decomposition.rs]
+    refs: [crates/arkavo-memory/src/federated_memory.rs:41-51]
     changed: "2026-03-21"
     edge_cases:
       - condition: Legitimate multi-session workflow (e.g., daily report generation)
@@ -223,7 +223,7 @@ scenarios:
       - Composite action graph spans multiple agents
       - No single agent's graph looks anomalous in isolation
       - Combined graph triggers decomposition detection
-    refs: [crates/arkavo-memory/src/cross_agent.rs]
+    refs: [crates/arkavo-memory/src/federated_memory.rs:72-90]
     changed: "2026-03-21"
     edge_cases:
       - condition: Legitimate agent delegation (e.g., summarizer → publisher)
@@ -250,7 +250,7 @@ scenarios:
       - Pass allows action to proceed
       - Fail blocks action with policy violation
       - Evidence includes sequence context for audit
-    refs: [crates/arkavo-critic/src/checks/sequence_circuit.rs]
+    refs: [crates/arkavo-critic/src/checks/circuit.rs:29-170]
     changed: "2026-03-21"
     edge_cases:
       - condition: Circuit not compiled for current agent skill
@@ -273,7 +273,7 @@ scenarios:
       - Taint state of payload assessed
       - Decision returned before action executes
       - Latency budget 100μs for synchronous gate
-    refs: [crates/arkavo-critic/src/checks/sequence_gate.rs]
+    refs: [crates/arkavo-critic/src/pipeline.rs:43-180]
     changed: "2026-03-21"
     edge_cases:
       - condition: Gate evaluation exceeds latency budget
@@ -295,7 +295,7 @@ scenarios:
       - Anomaly score updated asynchronously
       - Threshold breach triggers alert (not retroactive block)
       - Coverage maintained for all actions in session
-    refs: [crates/arkavo-router/src/async_monitor.rs]
+    refs: [crates/arkavo-router/src/metrics.rs:1-151]
     changed: "2026-03-21"
 
   # ============================================================================
@@ -315,7 +315,7 @@ scenarios:
       - DriftDetector identifies gradual behavioral shift
       - BoundaryDetector catches actions outside learned region
       - Anomaly evidence includes sequence context
-    refs: [crates/arkavo-titan/src/sequence_bridge.rs]
+    refs: [crates/arkavo-titan/src/monitor.rs:74-170, crates/arkavo-titan/src/detector.rs:101-166]
     changed: "2026-03-21"
 
   - id: SEQ-014
@@ -334,7 +334,7 @@ scenarios:
       - Legitimate external API calls with public data pass
       - External calls carrying internal-tainted data blocked
       - Decision logged with provenance chain for forensics
-    refs: [crates/arkavo-validation/src/provenance_egress.rs]
+    refs: [crates/arkavo-validation/src/url.rs:1-142]
     changed: "2026-03-21"
     edge_cases:
       - condition: Destination on allowlist but payload tainted
@@ -357,7 +357,7 @@ scenarios:
       - Baseline comparison included (expected vs actual)
       - Correlation ID links to cross-session decomposition if applicable
       - Evidence suitable for forensic reconstruction
-    refs: [crates/arkavo-events/src/sequence_evidence.rs]
+    refs: [crates/arkavo-events/src/event.rs:1-59, crates/arkavo-events/src/payload.rs:1-74]
     changed: "2026-03-21"
 
   # ============================================================================
@@ -378,7 +378,7 @@ scenarios:
       - Gate thresholds applied from config
       - Ledger retention window set
       - Overhead budget enforced
-    refs: [crates/arkavo-protocol/src/sequence_config.rs]
+    refs: [crates/arkavo-protocol/src/agent_config.rs:1-389]
     changed: "2026-03-21"
     edge_cases:
       - condition: Sequence integrity disabled in config
@@ -400,7 +400,7 @@ scenarios:
       - High-consequence actions blocked if tracking unavailable
       - Alert sent to operator
       - Recovery attempted on next action
-    refs: [crates/arkavo-protocol/src/sequence_error.rs]
+    refs: [crates/arkavo-protocol/src/error.rs:1-87]
     changed: "2026-03-21"
     edge_cases:
       - condition: Persistent storage failure

--- a/specs/arkavo-edge/server.spec.yaml
+++ b/specs/arkavo-edge/server.spec.yaml
@@ -27,7 +27,9 @@ scenarios:
       - Transports initialized
       - Startup loops launched
       - Ready to accept connections
-    refs: [crates/arkavo-server/src/server.rs]
+    refs:
+      - crates/arkavo-server/src/server/a2a_server.rs:990-1030
+      - crates/arkavo-server/src/server/a2a_server.rs:1319-1399
     changed: "2026-03-19"
     edge_cases:
       - condition: Port already in use
@@ -46,7 +48,9 @@ scenarios:
       - Method dispatched to handler
       - Response returned with matching id
       - Errors follow JSON-RPC 2.0 format
-    refs: [crates/arkavo-server/src/server.rs]
+    refs:
+      - crates/arkavo-server/src/server/mod.rs:107-350
+      - crates/arkavo-server/src/server/mod.rs:414-1000
     changed: "2026-03-19"
 
   - id: SRV-003
@@ -60,7 +64,7 @@ scenarios:
       - ToolMemoryEntry created
       - Observation persisted
       - Pattern cache updated
-    refs: [crates/arkavo-server/src/server.rs]
+    refs: [crates/arkavo-server/src/server/tool_memory.rs:1-118]
     changed: "2026-03-19"
 
   - id: SRV-004
@@ -74,7 +78,11 @@ scenarios:
       - Episode buffered
       - AutoLearnBridge processes episodes
       - Behavior advice generated
-    refs: [crates/arkavo-server/src/server.rs]
+    refs:
+      - crates/arkavo-server/src/server/episode_buffer.rs:1-174
+      - crates/arkavo-server/src/server/event_loop.rs:215-563
+      - crates/arkavo-server/src/server/learning_bus_synthesis.rs:1-49
+      - crates/arkavo-server/src/server/autolearn_bridge.rs:1-98
     changed: "2026-03-19"
 
   - id: SRV-005
@@ -87,7 +95,9 @@ scenarios:
       - Connections established
       - Messages propagated
       - Peer state tracked
-    refs: [crates/arkavo-server/src/server.rs]
+    refs:
+      - crates/arkavo-server/src/server/gossip_transport.rs:12-47
+      - crates/arkavo-server/src/server/learning_bus.rs:386-527
     changed: "2026-03-19"
 
   - id: SRV-006
@@ -100,7 +110,9 @@ scenarios:
       - State compared with peers
       - Missing data requested
       - Consistency restored
-    refs: [crates/arkavo-server/src/server.rs]
+    refs:
+      - crates/arkavo-server/src/server/gossip_transport.rs:49-68
+      - crates/arkavo-server/src/server/learning_bus_gossip.rs:214-243
     changed: "2026-03-19"
 
   - id: SRV-007
@@ -113,7 +125,10 @@ scenarios:
       - GoalStatus transitions tracked
       - AgentPlan generated
       - Completion or failure recorded
-    refs: [crates/arkavo-server/src/server.rs]
+    refs:
+      - crates/arkavo-server/src/server/startup.rs:7-27
+      - crates/arkavo-server/src/server/startup.rs:167-215
+      - crates/arkavo-server/src/server/agent_loop.rs:81-624
     changed: "2026-03-19"
 
   - id: SRV-008
@@ -126,7 +141,7 @@ scenarios:
       - Agent capabilities returned
       - Version information included
       - State reflects current runtime
-    refs: [crates/arkavo-server/src/server.rs]
+    refs: [crates/arkavo-server/src/server/well_known.rs:1-130]
     changed: "2026-03-19"
 
   - id: SRV-009
@@ -141,7 +156,7 @@ scenarios:
       - Task executed via conductor
       - Learning events emitted
       - Results returned to caller
-    refs: [crates/arkavo-server/src/server.rs]
+    refs: [crates/arkavo-server/src/server/conductor.rs:62-643]
     changed: "2026-03-19"
 
   - id: SRV-010
@@ -154,7 +169,7 @@ scenarios:
       - Stale sessions removed
       - Expired data purged
       - Resources reclaimed
-    refs: [crates/arkavo-server/src/server.rs]
+    refs: [crates/arkavo-server/src/server/gossip_transport.rs:108-136]
     changed: "2026-03-19"
 
   - id: SRV-011

--- a/specs/arkavo-edge/session-security.spec.yaml
+++ b/specs/arkavo-edge/session-security.spec.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=../schema.json
 
 feature: Session Security Hardening
-module: arkavo_session::security
+module: arkavo_session
 version: 1.0.0
 
 invariants:
@@ -287,7 +287,7 @@ scenarios:
       - Arbitrary inputs are generated
       - Memory safety is verified (no crashes, use-after-free)
       - Return values are validated
-    refs: [crates/arkavo-session/fuzz/ffi_fuzz.rs]
+    refs: [crates/arkavo-session/tests/ffi_fuzz_test.rs:104-150, crates/arkavo-session/tests/ffi_fuzz_test.rs:185-255]
 
 
   - id: SESS-020
@@ -300,7 +300,7 @@ scenarios:
       - Seed corpus is generated from valid inputs
       - Edge cases are included (empty, max size, boundary values)
       - Mutation strategies target session-specific fields
-    refs: [crates/arkavo-session/fuzz/ffi_fuzz.rs]
+    refs: [crates/arkavo-session/tests/ffi_fuzz_test.rs:152-176, crates/arkavo-session/tests/ffi_fuzz_test.rs:257-300]
 
 
   - id: SESS-021
@@ -313,5 +313,5 @@ scenarios:
       - Fuzzing runs for minimum duration (5 minutes)
       - New crashes are reported immediately
       - Coverage reports are generated
-    refs: [crates/arkavo-session/fuzz/ffi_fuzz.rs]
+    refs: [crates/arkavo-session/tests/ffi_fuzz_test.rs:302-365]
 

--- a/specs/arkavo-edge/swarmkit.spec.yaml
+++ b/specs/arkavo-edge/swarmkit.spec.yaml
@@ -794,8 +794,8 @@ scenarios:
       - On hit, ResolvedSkill returned with verified=true
       - On miss (id not in cache), ResolveError::RegistryMiss returned with cache_path
     refs:
-      - crates/arkavo-swarmkit-runtime/src/skill_resolver/mod.rs (t8_registry_cache_hit, t9_registry_cache_miss)
-    changed: "2026-05-08"
+      - crates/arkavo-swarmkit-runtime/src/skill_resolver/mod.rs:209-235
+    changed: "2026-06-12"
 
   # --- Plane governance and flight proposal apply ---------------------------
 

--- a/specs/arkavo-edge/task-orchestration.spec.yaml
+++ b/specs/arkavo-edge/task-orchestration.spec.yaml
@@ -24,7 +24,7 @@ scenarios:
       - Subtasks generated if needed
       - Dependencies identified
       - Execution plan created
-    refs: [crates/arkavo-protocol/src/task_planner.rs]
+    refs: [crates/arkavo-tasks/src/task_planner.rs:74-129]
 
   - id: ORCH-002
     name: Execute task with executor
@@ -80,7 +80,7 @@ scenarios:
       - Human notified
       - Task paused
       - Resumes after response
-    refs: [crates/arkavo-hrm/src/conductor.rs]
+    refs: [crates/arkavo-orchestrator/src/issue_router.rs:7-12, crates/arkavo-orchestrator/src/issue_router.rs:51-131, crates/arkavo-orchestrator/src/orchestrator.rs:391-397, crates/arkavo-orchestrator/src/orchestrator.rs:431-436]
 
   - id: ORCH-006
     name: Parallel subtask execution

--- a/specs/arkavo-edge/tdf-iroh.spec.yaml
+++ b/specs/arkavo-edge/tdf-iroh.spec.yaml
@@ -3,7 +3,7 @@ module: crate::tdf_iroh
 version: 0.57.2
 
 invariants:
-  - Transport handles raw bytes only, no encryption
+  - Transport handles raw bytes; encryption occurs before handoff to Iroh
   - Tickets are self-contained and transferable
   - Embedded Iroh node lifecycle managed automatically
   - Content-addressed storage ensures data integrity

--- a/specs/arkavo-edge/tdf-security.spec.yaml
+++ b/specs/arkavo-edge/tdf-security.spec.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=../schema.json
 
 feature: TDF Security and Control Plane Protection
-module: arkavo_tdf::security
+module: arkavo_tdf
 version: 1.0.0
 
 invariants:
@@ -25,7 +25,10 @@ scenarios:
       - Only authorized agents can decrypt
       - Command integrity verified via policy binding
       - Unauthorized decryption attempts logged and rejected
-    refs: [crates/arkavo-tdf/src/control_plane.rs]
+    refs:
+      - crates/arkavo-swarmkit-runtime/src/tdf.rs:88-98
+      - crates/arkavo-swarmkit-runtime/src/tdf.rs:371-403
+      - crates/arkavo-tdf/src/opentdf_impl.rs:114-174
 
   - id: TDFS-002
     name: Configuration bundle TDF encryption
@@ -39,7 +42,10 @@ scenarios:
       - Policy restricts decryption to specific agent identities
       - Dissemination controls enforce geographic restrictions
       - Bundle integrity protected by policy binding
-    refs: [crates/arkavo-config-bundle/src/encryption.rs]
+    refs:
+      - crates/arkavo-config-encryption/src/lib.rs:35-98
+      - crates/arkavo-config-encryption/src/lib.rs:101-162
+      - crates/arkavo-config-encryption/src/policy.rs:1-11
 
   - id: TDFS-003
     name: TDF-JSON format for API compatibility
@@ -53,11 +59,16 @@ scenarios:
       - EncryptionInformation embedded in JSON structure
       - Payload base64-encoded in JSON field
       - Same security properties as binary TDF
-    refs: [crates/arkavo-tdf/src/formats/json.rs]
+    refs:
+      - crates/arkavo-tdf/src/types.rs:12-23
+      - crates/arkavo-tdf/src/types.rs:158-201
+      - crates/arkavo-tdf/src/opentdf_impl.rs:114-174
 
   - id: TDFS-004
     name: TDF-CBOR format for efficiency
     criticality: high
+    wip: true
+    issue: "No matching implementation file exists in the codebase"
     given:
       - Bandwidth-constrained environment
       - Binary efficiency preferred over JSON
@@ -72,6 +83,8 @@ scenarios:
   - id: TDFS-005
     name: Format negotiation between agents
     criticality: medium
+    wip: true
+    issue: "No matching implementation file exists in the codebase"
     given:
       - Two agents communicating via A2A
       - Each supports different TDF formats
@@ -95,11 +108,15 @@ scenarios:
       - Modified policy fails integrity check
       - Decryption refused if binding invalid
       - Tampering attempt logged with forensic details
-    refs: [crates/arkavo-tdf/src/policy_binding.rs]
+    refs:
+      - crates/arkavo-tdf/src/types.rs:102-123
+      - crates/arkavo-tdf/src/a2a_handler.rs:305-331
 
   - id: TDFS-007
     name: Key escrow for data recovery
     criticality: high
+    wip: true
+    issue: "No matching implementation file exists in the codebase"
     given:
       - Organization requires data recovery capability
       - User loses access to their keys
@@ -123,7 +140,10 @@ scenarios:
       - Attribute certificates checked for expiration
       - Revoked attributes rejected
       - Attribute provenance logged
-    refs: [crates/arkavo-tdf/src/attribute_authority.rs]
+    refs:
+      - crates/arkavo-tdf/src/abac.rs:31-115
+      - crates/arkavo-tdf/src/delegation.rs:96-227
+      - crates/arkavo-config-encryption/src/policy.rs:1-11
 
   - id: TDFS-009
     name: Time-based policy enforcement
@@ -137,11 +157,15 @@ scenarios:
       - Access denied outside permitted hours
       - Time window validation cryptographically bound
       - Policy engine uses tamper-evident time source
-    refs: [crates/arkavo-tdf/src/temporal_policy.rs]
+    refs:
+      - crates/arkavo-tdf/src/delegation.rs:160-164
+      - crates/arkavo-policy-cache/src/lib.rs:97-121
 
   - id: TDFS-010
     name: Data residency enforcement
     criticality: high
+    wip: true
+    issue: "No matching implementation file exists in the codebase"
     given:
       - Policy requires data stay in specific jurisdiction
       - KAS servers available in multiple regions
@@ -165,11 +189,15 @@ scenarios:
       - Intermediate KEKs rotated regularly
       - DEKs never stored in plaintext
       - Key derivation uses approved algorithms
-    refs: [crates/arkavo-tdf/src/key_hierarchy.rs]
+    refs:
+      - crates/arkavo-tdf/src/a2a_handler.rs:73-171
+      - crates/arkavo-config-encryption/src/keys.rs:61-78
 
   - id: TDFS-012
     name: Offline policy evaluation
     criticality: medium
+    wip: true
+    issue: "No matching implementation file exists in the codebase"
     given:
       - Agent lacks network connectivity
       - Policy decision needed for cached data
@@ -193,11 +221,15 @@ scenarios:
       - Session keys derived from ephemeral exchange
       - Compromise of long-term key doesn't expose past sessions
       - Ephemeral keys destroyed after use
-    refs: [crates/arkavo-tdf/src/forward_secrecy.rs]
+    refs:
+      - crates/arkavo-tdf/src/a2a_handler.rs:120-171
+      - crates/arkavo-tdf/src/kas_client.rs:236-259
 
   - id: TDFS-014
     name: Policy update propagation
     criticality: high
+    wip: true
+    issue: "No matching implementation file exists in the codebase"
     given:
       - Policy is updated for existing encrypted data
       - Data owners need to reflect new policy
@@ -212,6 +244,8 @@ scenarios:
   - id: TDFS-015
     name: TDF payload obfuscation
     criticality: medium
+    wip: true
+    issue: "No matching implementation file exists in the codebase"
     given:
       - Encrypted payload may leak metadata via size
       - Traffic analysis could reveal patterns

--- a/specs/arkavo-edge/terminal.spec.yaml
+++ b/specs/arkavo-edge/terminal.spec.yaml
@@ -111,7 +111,7 @@ scenarios:
     then:
       - Key bindings loaded
       - Modal editing active
-    refs: [crates/arkavo-terminal/src/vim.rs:1-50]
+    refs: [crates/arkavo-terminal/src/vim/mod.rs:1-12, crates/arkavo-terminal/src/vim/keybindings.rs:1-60, crates/arkavo-terminal/src/vim/mode.rs:1-80, crates/arkavo-terminal/src/ui/widgets/vim_input.rs:1-40]
     changed: "2025-01-31"
 
   - id: TERM-008
@@ -123,5 +123,5 @@ scenarios:
     then:
       - Tree-sitter highlighting
       - Selection model active
-    refs: [crates/arkavo-terminal/src/helix.rs:1-50]
+    refs: [crates/arkavo-terminal/src/helix/mod.rs:1-90]
     changed: "2025-01-31"

--- a/specs/arkavo-edge/ucp.spec.yaml
+++ b/specs/arkavo-edge/ucp.spec.yaml
@@ -56,7 +56,7 @@ scenarios:
       - Budget deducted
       - Payment recorded
       - Result returned
-    refs: [crates/arkavo-ucp/src/handlers.rs:1-50, crates/arkavo-ucp/src/lib.rs:40-62]
+    refs: [crates/arkavo-ucp/src/handlers/budget.rs:49-72, crates/arkavo-ucp/src/lib.rs:40-62]
     changed: "2025-01-31"
 
   - id: UCP-004
@@ -71,7 +71,7 @@ scenarios:
       - Transaction built
       - Signed offline
       - Result with signed_tx returned
-    refs: [crates/arkavo-ucp/src/handlers.rs:50-100, crates/arkavo-ucp/src/lib.rs:64-80]
+    refs: [crates/arkavo-ucp/src/handlers/evm.rs:64-101, crates/arkavo-ucp/src/lib.rs:64-80]
     changed: "2025-01-31"
     edge_cases:
       - condition: Insufficient balance (check)
@@ -118,7 +118,7 @@ scenarios:
       - ExecutePaymentTool registered
       - GetPaymentStatusTool registered
       - ListPaymentsTool registered
-    refs: [crates/arkavo-ucp/src/tools.rs:1-60]
+    refs: [crates/arkavo-ucp/src/tools/mod.rs:80-95]
     changed: "2025-01-31"
 
   - id: UCP-008

--- a/specs/arkavo-edge/ui-core.spec.yaml
+++ b/specs/arkavo-edge/ui-core.spec.yaml
@@ -65,5 +65,8 @@ scenarios:
       - Backend-specific rendering
       - Content formatted
       - Display updated
-    refs: [crates/arkavo-ui-core/src/adapters.rs:1-50]
-    changed: "2025-01-31"
+    refs:
+      - crates/arkavo-ui-core/src/adapters/mod.rs:1-11
+      - crates/arkavo-ui-core/src/adapters/cef.rs:15-75
+      - crates/arkavo-ui-core/src/adapters/web.rs:5-67
+    changed: "2026-06-12"


### PR DESCRIPTION
This PR brings the behavior specifications and traceability tooling back into sync with the codebase.

## Summary

- **Fixed stale index stats**: 75 specs, 680 scenarios, 177 critical (was 73/621/160).
- **Resolved documented spec conflicts** from `specs/spec-analysis.md`:
  - Git commit convention contradiction
  - Chat session Zombie state
  - Token estimation / model context size refs
  - Incorrect module paths for network/session/TDF security specs
  - TDF-Iroh raw-bytes invariant wording
- **Added 12 missing cross-component integration points** to `index.yaml` and merged a duplicate Context → Router entry.
- **Updated 105 stale scenario refs** across 20 specs to point to existing source files.
- **Marked 13 unimplemented scenarios as wip** with issue notes (no matching source files exist).
- **Added `cargo xtask spec-test validate-refs --skip-wip`** and wired it into `.github/workflows/feature.yaml`.

## Validation

- `cargo test -p xtask` — 12 passed
- `cargo fmt -- --check` — clean
- `cargo clippy -p xtask -- -D warnings` — clean
- `cargo xtask spec-test validate-refs --skip-wip` — **All spec refs resolve to existing files**
- `cargo xtask spec-test coverage` — 680 scenarios, 21.8% covered
- Index consistency check — passed

## Stale refs

Before: 118 stale refs across specs.  
After: 13 stale refs, all on scenarios explicitly marked `wip: true`.
