### PR TITLE
GLM-5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,6 +1162,7 @@ name = "arkavo-llm"
 version = "0.82.0"
 dependencies = [
  "anyhow",
+ "arkavo-budget",
  "arkavo-deepseek",
  "arkavo-gemini",
  "arkavo-gossip",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui-protocol"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-test-macros",
  "serde",
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "chrono",
  "serde",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-test-macros",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "git2",
  "tempfile",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1135,11 +1135,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-lesson-synthesis"
-version = "0.81.1"
+version = "0.82.0"
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1213,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1633,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "lru 0.16.4",
  "serde",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1756,7 +1756,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1869,7 +1869,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-shadow-consolidation"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-lesson-synthesis",
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -2000,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2035,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.81.1"
+version = "0.82.0"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.81.1"
+version = "0.82.0"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-budget/src/cost.rs
+++ b/crates/arkavo-budget/src/cost.rs
@@ -20,6 +20,11 @@ impl TokenCost {
         }
     }
 
+    /// Cost of `tokens` priced **per 1K tokens**. Prefer
+    /// [`Self::from_tokens_per_million`] for cloud rates: `ProviderPricing`
+    /// stores cents-per-MTok, and feeding a per-MTok rate here (or vice versa)
+    /// is a silent 1000x error. This per-1K form remains only for the legacy
+    /// `TokenUsage::calculate_cost` path.
     pub fn from_tokens(tokens: u32, cost_per_thousand: TokenCost) -> Self {
         let total_cents = (tokens as u64 * cost_per_thousand.cents) / 1000;
         Self { cents: total_cents }

--- a/crates/arkavo-budget/src/cost.rs
+++ b/crates/arkavo-budget/src/cost.rs
@@ -25,6 +25,16 @@ impl TokenCost {
         Self { cents: total_cents }
     }
 
+    /// Cost of `tokens` priced at `cost_per_million` (cents per 1M tokens).
+    ///
+    /// Modern cloud rates are quoted per-MTok and are routinely sub-cent per
+    /// 1K (GLM-5.2 input is $1.40/MTok = 0.14c/1K), which floors to zero in the
+    /// per-1K integer unit. Pricing the rate per-MTok keeps it representable.
+    pub fn from_tokens_per_million(tokens: u32, cost_per_million: TokenCost) -> Self {
+        let total_cents = (tokens as u64 * cost_per_million.cents) / 1_000_000;
+        Self { cents: total_cents }
+    }
+
     pub fn as_cents(&self) -> u64 {
         self.cents
     }
@@ -214,6 +224,16 @@ mod tests {
         let cost_per_thousand = TokenCost::from_cents(30); // $0.30 per 1K tokens
         let cost = TokenCost::from_tokens(1500, cost_per_thousand);
         assert_eq!(cost.as_cents(), 45); // 1.5 * 30 = 45 cents
+    }
+
+    #[test]
+    fn test_token_cost_from_tokens_per_million() {
+        // Per-MTok is the unit modern cloud rates are quoted in, and the only
+        // resolution that survives sub-cent-per-1K rates. GLM-5.2 input is
+        // $1.40/MTok = 140 cents/MTok; a 200K-token prompt costs $0.28 = 28c.
+        let rate_per_mtok = TokenCost::from_cents(140);
+        let cost = TokenCost::from_tokens_per_million(200_000, rate_per_mtok);
+        assert_eq!(cost.as_cents(), 28);
     }
 
     #[test]

--- a/crates/arkavo-budget/src/policy.rs
+++ b/crates/arkavo-budget/src/policy.rs
@@ -102,10 +102,12 @@ impl ModelSelectionPolicy {
                 let pricing = crate::provider_costs::ModelPricing {
                     model_id: model.model_id.clone(),
                     provider: model.provider_name.clone(),
-                    input_cost_per_thousand: input_cost,
-                    output_cost_per_thousand: output_cost,
-                    cached_input_cost_per_thousand: None,
-                    cache_write_cost_per_thousand: None,
+                    // Source rates are per-1K cents; ProviderPricing is per-MTok
+                    // (1000x) — convert so the stored entry's unit is consistent.
+                    input_cost_per_mtok: input_cost * 1000,
+                    output_cost_per_mtok: output_cost * 1000,
+                    cached_input_cost_per_mtok: None,
+                    cache_write_cost_per_mtok: None,
                     context_window: model.context_window,
                     max_output_tokens: model.max_output_tokens,
                     effective_date: model_pricing.effective_date,

--- a/crates/arkavo-budget/src/provider_costs.rs
+++ b/crates/arkavo-budget/src/provider_costs.rs
@@ -8,12 +8,12 @@ use tokio::sync::RwLock;
 pub struct ModelPricing {
     pub model_id: String,
     pub provider: String,
-    pub input_cost_per_thousand: TokenCost,
-    pub output_cost_per_thousand: TokenCost,
+    pub input_cost_per_mtok: TokenCost,
+    pub output_cost_per_mtok: TokenCost,
     /// Discounted rate for tokens read from prompt cache (None = no caching support)
-    pub cached_input_cost_per_thousand: Option<TokenCost>,
+    pub cached_input_cost_per_mtok: Option<TokenCost>,
     /// Surcharge rate for writing tokens into prompt cache (None = no write surcharge)
-    pub cache_write_cost_per_thousand: Option<TokenCost>,
+    pub cache_write_cost_per_mtok: Option<TokenCost>,
     pub context_window: Option<u32>,
     pub max_output_tokens: Option<u32>,
     pub effective_date: chrono::DateTime<chrono::Utc>,
@@ -22,21 +22,23 @@ pub struct ModelPricing {
 /// JSON-serializable pricing entry for runtime loading.
 ///
 /// Agents fetch pricing from an API endpoint and deserialize into this format.
-/// All cost fields are in cents per 1K tokens.
+/// All cost fields are in cents per 1M (million) tokens — the unit cloud
+/// rates are published in, and the only one that keeps sub-cent-per-1K rates
+/// (e.g. GLM-5.2's $1.40/MTok = 0.14c/1K) from flooring to zero.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PricingEntry {
     pub model_id: String,
     pub provider: String,
-    /// Input cost in cents per 1K tokens
-    pub input_cents_per_1k: u64,
-    /// Output cost in cents per 1K tokens
-    pub output_cents_per_1k: u64,
-    /// Cached input cost in cents per 1K tokens (None = no caching)
+    /// Input cost in cents per 1M tokens
+    pub input_cents_per_mtok: u64,
+    /// Output cost in cents per 1M tokens
+    pub output_cents_per_mtok: u64,
+    /// Cached input cost in cents per 1M tokens (None = no caching)
     #[serde(default)]
-    pub cached_input_cents_per_1k: Option<u64>,
-    /// Cache write cost in cents per 1K tokens (None = no write surcharge)
+    pub cached_input_cents_per_mtok: Option<u64>,
+    /// Cache write cost in cents per 1M tokens (None = no write surcharge)
     #[serde(default)]
-    pub cache_write_cents_per_1k: Option<u64>,
+    pub cache_write_cents_per_mtok: Option<u64>,
     #[serde(default)]
     pub context_window: Option<u32>,
     #[serde(default)]
@@ -48,12 +50,10 @@ impl PricingEntry {
         ModelPricing {
             model_id: self.model_id.clone(),
             provider: self.provider.clone(),
-            input_cost_per_thousand: TokenCost::from_cents(self.input_cents_per_1k),
-            output_cost_per_thousand: TokenCost::from_cents(self.output_cents_per_1k),
-            cached_input_cost_per_thousand: self
-                .cached_input_cents_per_1k
-                .map(TokenCost::from_cents),
-            cache_write_cost_per_thousand: self.cache_write_cents_per_1k.map(TokenCost::from_cents),
+            input_cost_per_mtok: TokenCost::from_cents(self.input_cents_per_mtok),
+            output_cost_per_mtok: TokenCost::from_cents(self.output_cents_per_mtok),
+            cached_input_cost_per_mtok: self.cached_input_cents_per_mtok.map(TokenCost::from_cents),
+            cache_write_cost_per_mtok: self.cache_write_cents_per_mtok.map(TokenCost::from_cents),
             context_window: self.context_window,
             max_output_tokens: self.max_output_tokens,
             effective_date: chrono::Utc::now(),
@@ -121,10 +121,10 @@ impl ProviderPricing {
             .map(|m| PricingEntry {
                 model_id: m.model_id.clone(),
                 provider: m.provider.clone(),
-                input_cents_per_1k: m.input_cost_per_thousand.as_cents(),
-                output_cents_per_1k: m.output_cost_per_thousand.as_cents(),
-                cached_input_cents_per_1k: m.cached_input_cost_per_thousand.map(|c| c.as_cents()),
-                cache_write_cents_per_1k: m.cache_write_cost_per_thousand.map(|c| c.as_cents()),
+                input_cents_per_mtok: m.input_cost_per_mtok.as_cents(),
+                output_cents_per_mtok: m.output_cost_per_mtok.as_cents(),
+                cached_input_cents_per_mtok: m.cached_input_cost_per_mtok.map(|c| c.as_cents()),
+                cache_write_cents_per_mtok: m.cache_write_cost_per_mtok.map(|c| c.as_cents()),
                 context_window: m.context_window,
                 max_output_tokens: m.max_output_tokens,
             })
@@ -143,10 +143,14 @@ impl ProviderPricing {
         estimated_output_tokens: u32,
     ) -> Option<TokenCost> {
         self.get_model_pricing(provider, model).map(|pricing| {
-            let input_cost =
-                TokenCost::from_tokens(estimated_input_tokens, pricing.input_cost_per_thousand);
-            let output_cost =
-                TokenCost::from_tokens(estimated_output_tokens, pricing.output_cost_per_thousand);
+            let input_cost = TokenCost::from_tokens_per_million(
+                estimated_input_tokens,
+                pricing.input_cost_per_mtok,
+            );
+            let output_cost = TokenCost::from_tokens_per_million(
+                estimated_output_tokens,
+                pricing.output_cost_per_mtok,
+            );
             input_cost + output_cost
         })
     }
@@ -160,21 +164,23 @@ impl ProviderPricing {
     ) -> Option<TokenCost> {
         self.get_model_pricing(provider, model).map(|pricing| {
             let input_cost =
-                TokenCost::from_tokens(usage.input_tokens, pricing.input_cost_per_thousand);
+                TokenCost::from_tokens_per_million(usage.input_tokens, pricing.input_cost_per_mtok);
             // Thinking tokens bill at the output rate (Gemini pricing rule).
             let billable_output = usage.output_tokens.saturating_add(usage.thinking_tokens);
             let output_cost =
-                TokenCost::from_tokens(billable_output, pricing.output_cost_per_thousand);
+                TokenCost::from_tokens_per_million(billable_output, pricing.output_cost_per_mtok);
 
             let cached_rate = pricing
-                .cached_input_cost_per_thousand
-                .unwrap_or(pricing.input_cost_per_thousand);
-            let cached_cost = TokenCost::from_tokens(usage.cached_input_tokens, cached_rate);
+                .cached_input_cost_per_mtok
+                .unwrap_or(pricing.input_cost_per_mtok);
+            let cached_cost =
+                TokenCost::from_tokens_per_million(usage.cached_input_tokens, cached_rate);
 
             let write_rate = pricing
-                .cache_write_cost_per_thousand
-                .unwrap_or(pricing.input_cost_per_thousand);
-            let write_cost = TokenCost::from_tokens(usage.cache_write_tokens, write_rate);
+                .cache_write_cost_per_mtok
+                .unwrap_or(pricing.input_cost_per_mtok);
+            let write_cost =
+                TokenCost::from_tokens_per_million(usage.cache_write_tokens, write_rate);
 
             input_cost + output_cost + cached_cost + write_cost
         })
@@ -233,34 +239,35 @@ mod tests {
             PricingEntry {
                 model_id: "gpt-4o".into(),
                 provider: "openai".into(),
-                input_cents_per_1k: 250,
-                output_cents_per_1k: 1000,
-                cached_input_cents_per_1k: Some(125),
-                cache_write_cents_per_1k: None,
+                input_cents_per_mtok: 250,
+                output_cents_per_mtok: 1000,
+                cached_input_cents_per_mtok: Some(125),
+                cache_write_cents_per_mtok: None,
                 context_window: Some(128000),
                 max_output_tokens: Some(16384),
             },
             PricingEntry {
                 model_id: "gemini-3.5-flash".into(),
                 provider: "google".into(),
-                // Gemini 3.5 Flash (May 2026): $1.50/M input → 0.15¢/1K rounded up to 1¢ resolution.
-                // Sample data lives in integer cents per 1K — real registry overrides via API.
-                input_cents_per_1k: 150,
-                output_cents_per_1k: 900,
-                cached_input_cents_per_1k: Some(15),
-                cache_write_cents_per_1k: None,
+                // Gemini 3.5 Flash (May 2026): $1.50/MTok input = 150 cents/MTok.
+                // Per-MTok integer cents represents this exactly; the real
+                // registry overrides via the budget.pricing API.
+                input_cents_per_mtok: 150,
+                output_cents_per_mtok: 900,
+                cached_input_cents_per_mtok: Some(15),
+                cache_write_cents_per_mtok: None,
                 context_window: Some(1_048_576),
                 max_output_tokens: Some(8192),
             },
             PricingEntry {
                 model_id: "local".into(),
                 provider: "local".into(),
-                input_cents_per_1k: 0,
-                output_cents_per_1k: 0,
-                cached_input_cents_per_1k: None,
-                cache_write_cents_per_1k: None,
-                context_window: Some(2048),
-                max_output_tokens: Some(512),
+                input_cents_per_mtok: 0,
+                output_cents_per_mtok: 0,
+                cached_input_cents_per_mtok: None,
+                cache_write_cents_per_mtok: None,
+                context_window: Some(1_048_576),
+                max_output_tokens: Some(16384),
             },
         ]
     }
@@ -279,11 +286,8 @@ mod tests {
         assert_eq!(pricing.model_count(), 3);
 
         let gpt4o = pricing.get_model_pricing("openai", "gpt-4o").unwrap();
-        assert_eq!(gpt4o.input_cost_per_thousand.as_cents(), 250);
-        assert_eq!(
-            gpt4o.cached_input_cost_per_thousand.unwrap().as_cents(),
-            125
-        );
+        assert_eq!(gpt4o.input_cost_per_mtok.as_cents(), 250);
+        assert_eq!(gpt4o.cached_input_cost_per_mtok.unwrap().as_cents(), 125);
     }
 
     #[test]
@@ -311,7 +315,7 @@ mod tests {
         assert_eq!(pricing.model_count(), pricing2.model_count());
         let p1 = pricing.get_model_pricing("openai", "gpt-4o").unwrap();
         let p2 = pricing2.get_model_pricing("openai", "gpt-4o").unwrap();
-        assert_eq!(p1.input_cost_per_thousand, p2.input_cost_per_thousand);
+        assert_eq!(p1.input_cost_per_mtok, p2.input_cost_per_mtok);
     }
 
     #[test]
@@ -319,11 +323,35 @@ mod tests {
         let mut pricing = ProviderPricing::new();
         pricing.load_from_entries(&sample_entries());
 
+        // gpt-4o at $2.50/MTok in, $10/MTok out: 1M in + 0.5M out =
+        // 1_000_000*250/1e6 + 500_000*1000/1e6 = 250 + 500 = 750 cents.
         let cost = pricing
-            .estimate_cost("openai", "gpt-4o", 1000, 500)
+            .estimate_cost("openai", "gpt-4o", 1_000_000, 500_000)
             .unwrap();
-        // 1000 * 250/1000 + 500 * 1000/1000 = 250 + 500 = 750
         assert_eq!(cost.as_cents(), 750);
+    }
+
+    #[test]
+    fn test_glm52_priced_at_per_mtok_resolution() {
+        // GLM-5.2 is $1.40/$4.40 per MTok. In the old per-1K-cents unit these
+        // rounded to 0 (the bug this migration fixes); per-MTok they are
+        // 140/440 cents and a realistic call prices correctly.
+        let mut pricing = ProviderPricing::new();
+        pricing.register(&PricingEntry {
+            model_id: "glm-5.2".into(),
+            provider: "zhipu".into(),
+            input_cents_per_mtok: 140,
+            output_cents_per_mtok: 440,
+            cached_input_cents_per_mtok: Some(26),
+            cache_write_cents_per_mtok: None,
+            context_window: Some(1_000_000),
+            max_output_tokens: Some(131_072),
+        });
+        // 200K in + 100K out = 200_000*140/1e6 + 100_000*440/1e6 = 28 + 44 = 72c.
+        let cost = pricing
+            .estimate_cost("zhipu", "glm-5.2", 200_000, 100_000)
+            .unwrap();
+        assert_eq!(cost.as_cents(), 72);
     }
 
     #[test]
@@ -331,8 +359,11 @@ mod tests {
         let mut pricing = ProviderPricing::new();
         pricing.load_from_entries(&sample_entries());
 
-        let standard = pricing.estimate_cost("openai", "gpt-4o", 1000, 0).unwrap();
-        let usage = TokenUsage::with_cache(0, 0, 1000, 0);
+        // 1M tokens so per-MTok rates produce non-zero, comparable cents.
+        let standard = pricing
+            .estimate_cost("openai", "gpt-4o", 1_000_000, 0)
+            .unwrap();
+        let usage = TokenUsage::with_cache(0, 0, 1_000_000, 0);
         let cached = pricing
             .estimate_cost_with_cache("openai", "gpt-4o", &usage)
             .unwrap();
@@ -359,16 +390,16 @@ mod tests {
         pricing.register(&PricingEntry {
             model_id: "gpt-4o".into(),
             provider: "openai".into(),
-            input_cents_per_1k: 200,
-            output_cents_per_1k: 800,
-            cached_input_cents_per_1k: Some(100),
-            cache_write_cents_per_1k: None,
+            input_cents_per_mtok: 200,
+            output_cents_per_mtok: 800,
+            cached_input_cents_per_mtok: Some(100),
+            cache_write_cents_per_mtok: None,
             context_window: Some(128000),
             max_output_tokens: Some(16384),
         });
 
         let gpt4o = pricing.get_model_pricing("openai", "gpt-4o").unwrap();
-        assert_eq!(gpt4o.input_cost_per_thousand.as_cents(), 200);
+        assert_eq!(gpt4o.input_cost_per_mtok.as_cents(), 200);
     }
 
     #[test]
@@ -376,7 +407,12 @@ mod tests {
         let mut pricing = ProviderPricing::new();
         pricing.load_from_entries(&sample_entries());
 
-        let cheapest = pricing.find_cheapest_model_for_tokens(1000, 500).unwrap();
+        // Large token requirements so per-MTok costs differentiate (small
+        // counts all floor to 0c). gpt-4o is filtered out by context window;
+        // the free local model beats paid gemini.
+        let cheapest = pricing
+            .find_cheapest_model_for_tokens(500_000, 4_000)
+            .unwrap();
         assert_eq!(cheapest.model_id, "local");
     }
 }

--- a/crates/arkavo-budget/src/tracker_tests.rs
+++ b/crates/arkavo-budget/src/tracker_tests.rs
@@ -274,31 +274,31 @@ mod tests {
             PricingEntry {
                 model_id: "gpt-3.5-turbo".into(),
                 provider: "openai".into(),
-                input_cents_per_1k: 50,
-                output_cents_per_1k: 150,
-                cached_input_cents_per_1k: None,
-                cache_write_cents_per_1k: None,
+                input_cents_per_mtok: 50,
+                output_cents_per_mtok: 150,
+                cached_input_cents_per_mtok: None,
+                cache_write_cents_per_mtok: None,
                 context_window: Some(16385),
                 max_output_tokens: Some(4096),
             },
             PricingEntry {
                 model_id: "llama3.2:latest".into(),
                 provider: "ollama".into(),
-                input_cents_per_1k: 0,
-                output_cents_per_1k: 0,
-                cached_input_cents_per_1k: None,
-                cache_write_cents_per_1k: None,
+                input_cents_per_mtok: 0,
+                output_cents_per_mtok: 0,
+                cached_input_cents_per_mtok: None,
+                cache_write_cents_per_mtok: None,
                 context_window: Some(8192),
                 max_output_tokens: Some(4096),
             },
         ]);
 
-        // Test OpenAI GPT-3.5-turbo pricing
+        // Test OpenAI GPT-3.5-turbo pricing (rates are per-MTok now).
         let cost = pricing
-            .estimate_cost("openai", "gpt-3.5-turbo", 1000, 500)
+            .estimate_cost("openai", "gpt-3.5-turbo", 1_000_000, 500_000)
             .expect("Should have pricing for GPT-3.5-turbo");
 
-        // 1000 * 50/1000 + 500 * 150/1000 = 50 + 75 = 125
+        // 1M * 50/1M + 0.5M * 150/1M = 50 + 75 = 125
         assert_eq!(cost.as_cents(), 125);
 
         // Test free models

--- a/crates/arkavo-cli/Cargo.toml
+++ b/crates/arkavo-cli/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["command-line-utilities", "development-tools"]
 
 [features]
 # Full defaults with all providers (cross-platform)
-default = ["memory", "mdns", "mcp-tools", "llm-remote", "llama-cpp", "gemini", "deepseek", "kimi", "web-ui", "claude-agent", "kas", "iroh"]
+default = ["memory", "mdns", "mcp-tools", "llm-remote", "llama-cpp", "gemini", "deepseek", "kimi", "glm", "web-ui", "claude-agent", "kas", "iroh"]
 # Minimal feature set for non-typical use cases
 minimal = ["memory", "mdns", "mcp-tools"]
 # Default features for Windows (no C++ dependencies)
@@ -30,6 +30,7 @@ mdns = ["mdns-sd", "arkavo-agui/mdns", "arkavo-protocol/mdns", "arkavo-orchestra
 llm-remote = ["arkavo-llm/llm-remote", "arkavo-dataflow/llm-remote", "arkavo-terminal/llm-remote", "arkavo-router/llm-remote"]
 kimi = ["arkavo-llm/kimi"]
 deepseek = ["arkavo-llm/deepseek"]
+glm = ["arkavo-llm/llm-remote", "arkavo-router/glm", "arkavo-ui-core/glm"]
 gemini = ["arkavo-llm/gemini", "arkavo-router/gemini"]
 llama-cpp = ["arkavo-llm/llama-cpp", "arkavo-agui/llama-cpp", "arkavo-ui-core/llama-cpp", "arkavo-router/llama-cpp", "arkavo-context/llama-cpp", "arkavo-server/llama-cpp"]
 snpe = ["arkavo-llm/snpe"]

--- a/crates/arkavo-cli/src/commands/ui.rs
+++ b/crates/arkavo-cli/src/commands/ui.rs
@@ -1066,6 +1066,28 @@ async fn create_client_from_routing(
                 Err("Kimi support requires kimi feature".into())
             }
         }
+        ModelChoice::Glm52 => {
+            #[cfg(feature = "glm")]
+            {
+                use arkavo_llm::providers::openai::{OpenAIConfig, OpenAIProvider};
+                let api_key = std::env::var("GLM_API_KEY")?;
+                let base_url = std::env::var("GLM_BASE_URL")
+                    .unwrap_or_else(|_| "https://api.z.ai/api/paas/v4".to_string());
+                let provider = Box::new(OpenAIProvider::new(OpenAIConfig {
+                    api_key,
+                    base_url,
+                    model: decision.recommended_model.name().to_string(),
+                    organization_id: None,
+                    api_version: None,
+                    is_azure: false,
+                })?);
+                Ok(LlmClient::new(provider))
+            }
+            #[cfg(not(feature = "glm"))]
+            {
+                Err("GLM support requires glm feature".into())
+            }
+        }
     }
 }
 

--- a/crates/arkavo-cli/tests/e2e_kimi_budget_test.rs
+++ b/crates/arkavo-cli/tests/e2e_kimi_budget_test.rs
@@ -83,10 +83,10 @@ async fn test_kimi_budget_tracking() -> Result<(), Box<dyn std::error::Error>> {
     pricing.load_from_entries(&[PricingEntry {
         model_id: "moonshot-v1-32k".into(),
         provider: "kimi".into(),
-        input_cents_per_1k: 200,
-        output_cents_per_1k: 600,
-        cached_input_cents_per_1k: None,
-        cache_write_cents_per_1k: None,
+        input_cents_per_mtok: 200,
+        output_cents_per_mtok: 600,
+        cached_input_cents_per_mtok: None,
+        cache_write_cents_per_mtok: None,
         context_window: Some(32000),
         max_output_tokens: Some(8192),
     }]);

--- a/crates/arkavo-llm/Cargo.toml
+++ b/crates/arkavo-llm/Cargo.toml
@@ -69,6 +69,8 @@ tempfile = { workspace = true }
 serial_test = "3"
 criterion = { version = "0.5", features = ["async_tokio"] }
 arkavo-gossip = { path = "../arkavo-gossip" }
+# Used only by the gated GLM cost e2e to reconcile real usage -> cost -> budget.
+arkavo-budget = { path = "../arkavo-budget" }
 
 [[bench]]
 name = "concurrent_inference_benchmark"

--- a/crates/arkavo-llm/src/providers/openai.rs
+++ b/crates/arkavo-llm/src/providers/openai.rs
@@ -221,7 +221,7 @@ impl OpenAIProvider {
                     role,
                     content,
                     tool_calls,
-                    tool_call_id: msg.tool_call_id.clone(),
+                    tool_call_id: msg.tool_call_id,
                 }
             })
             .collect()

--- a/crates/arkavo-llm/src/providers/openai.rs
+++ b/crates/arkavo-llm/src/providers/openai.rs
@@ -1,6 +1,6 @@
 use crate::common::{HttpClientBuilder, HttpClientConfig, RetryableHttpClient};
 use crate::common::{ProviderError, ProviderResult};
-use crate::provider::ProviderResponse;
+use crate::provider::{InferenceTiming, ProviderResponse};
 use crate::tool_parser::ParsedToolCall;
 use crate::{Message, Provider, Role, StreamResponse};
 use async_trait::async_trait;
@@ -278,6 +278,17 @@ impl OpenAIProvider {
             .unwrap_or_default()
     }
 
+    /// Map the response `usage` block (prompt/completion tokens) onto
+    /// `InferenceTiming` so the cost path can reconcile against real spend.
+    /// Cloud usage carries no wall-clock timing, only token counts.
+    fn timing_from_usage(usage: &Usage) -> InferenceTiming {
+        InferenceTiming {
+            n_prompt_eval: usage.prompt_tokens,
+            n_eval: usage.completion_tokens,
+            ..Default::default()
+        }
+    }
+
     /// Build the API endpoint URL
     fn build_url(&self, endpoint: &str) -> String {
         if self.config.is_azure {
@@ -467,7 +478,7 @@ impl Provider for OpenAIProvider {
 
         let url = self.build_url("chat/completions");
 
-        let (content, tool_calls, finish_reason) = self
+        let (content, tool_calls, finish_reason, inference_timing) = self
             .client
             .execute_with_retry(|client| {
                 let config = self.config.clone();
@@ -491,7 +502,12 @@ impl Provider for OpenAIProvider {
                             .ok_or_else(|| anyhow::anyhow!("No response from OpenAI"))?;
                         let content = choice.message.content.clone().unwrap_or_default();
                         let tool_calls = OpenAIProvider::parse_tool_calls(&choice.message);
-                        Ok((content, tool_calls, choice.finish_reason.clone()))
+                        let finish_reason = choice.finish_reason.clone();
+                        let timing = completion
+                            .usage
+                            .as_ref()
+                            .map(OpenAIProvider::timing_from_usage);
+                        Ok((content, tool_calls, finish_reason, timing))
                     } else {
                         let status = response.status();
                         let error_text = response
@@ -510,7 +526,7 @@ impl Provider for OpenAIProvider {
             reasoning_content: None,
             tool_calls,
             finish_reason,
-            inference_timing: None,
+            inference_timing,
             quality_gate_retries: 0,
         })
     }
@@ -795,5 +811,17 @@ mod tests {
         assert_eq!(api[1].role, "tool");
         assert_eq!(api[1].content.as_deref(), Some("12:00 UTC"));
         assert_eq!(api[1].tool_call_id.as_deref(), Some("call_1"));
+    }
+
+    #[test]
+    fn usage_maps_to_inference_timing() {
+        let usage = Usage {
+            prompt_tokens: 120,
+            completion_tokens: 45,
+            total_tokens: 165,
+        };
+        let timing = OpenAIProvider::timing_from_usage(&usage);
+        assert_eq!(timing.n_prompt_eval, 120);
+        assert_eq!(timing.n_eval, 45);
     }
 }

--- a/crates/arkavo-llm/src/providers/openai.rs
+++ b/crates/arkavo-llm/src/providers/openai.rs
@@ -1,9 +1,12 @@
 use crate::common::{HttpClientBuilder, HttpClientConfig, RetryableHttpClient};
 use crate::common::{ProviderError, ProviderResult};
+use crate::provider::ProviderResponse;
+use crate::tool_parser::ParsedToolCall;
 use crate::{Message, Provider, Role, StreamResponse};
 use async_trait::async_trait;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
 use std::sync::Arc;
 
 /// OpenAI API configuration
@@ -49,12 +52,47 @@ struct ChatCompletionRequest {
     stream: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     n: Option<u32>,
+    /// OpenAI function-calling tool list. Omitted entirely when the caller
+    /// passes no tools, so plain chat requests are unchanged on the wire.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<Value>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct ApiMessage {
+    role: String,
+    /// Null for an assistant turn that is purely tool calls; otherwise the text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
+    /// Tool calls the assistant issued (response) or is replaying (request).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tool_calls: Option<Vec<ToolCallJson>>,
+    /// Set on `role:"tool"` result messages, pairing the result to its call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tool_call_id: Option<String>,
+}
+
+/// OpenAI tool-call wire shape: `{id, type:"function", function:{name, arguments}}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ToolCallJson {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    id: Option<String>,
+    #[serde(rename = "type", default = "function_call_type")]
+    call_type: String,
+    function: FunctionCallJson,
+}
+
+fn function_call_type() -> String {
+    "function".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct ApiMessage {
-    role: String,
-    content: String,
+struct FunctionCallJson {
+    name: String,
+    /// Arguments as a JSON string (OpenAI sends them stringified).
+    arguments: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -143,20 +181,101 @@ impl OpenAIProvider {
         Ok(Self { config, client })
     }
 
-    /// Convert internal messages to API format
+    /// Convert internal messages to API format, including assistant tool calls
+    /// and `role:"tool"` results so a multi-turn tool loop replays correctly.
     fn convert_messages(&self, messages: Vec<Message>) -> Vec<ApiMessage> {
         messages
             .into_iter()
-            .map(|msg| ApiMessage {
-                role: match msg.role {
-                    Role::System => "system".to_string(),
-                    Role::User => "user".to_string(),
-                    Role::Assistant => "assistant".to_string(),
-                    Role::Tool => "tool".to_string(),
-                },
-                content: msg.content,
+            .map(|msg| {
+                let role = match msg.role {
+                    Role::System => "system",
+                    Role::User => "user",
+                    Role::Assistant => "assistant",
+                    Role::Tool => "tool",
+                }
+                .to_string();
+
+                let tool_calls = (!msg.tool_calls.is_empty()).then(|| {
+                    msg.tool_calls
+                        .iter()
+                        .map(|tc| ToolCallJson {
+                            id: tc.id.clone(),
+                            call_type: "function".to_string(),
+                            function: FunctionCallJson {
+                                name: tc.name.clone(),
+                                arguments: tc.arguments.clone(),
+                            },
+                        })
+                        .collect()
+                });
+
+                // OpenAI requires `content: null` (not "") on an assistant turn
+                // that only carries tool calls.
+                let content = if msg.content.is_empty() && tool_calls.is_some() {
+                    None
+                } else {
+                    Some(msg.content)
+                };
+
+                ApiMessage {
+                    role,
+                    content,
+                    tool_calls,
+                    tool_call_id: msg.tool_call_id.clone(),
+                }
             })
             .collect()
+    }
+
+    /// Convert the router's generic tool list (`[{name, description,
+    /// parameters|input_schema}]`) into OpenAI's `tools` array.
+    fn convert_tools_to_openai(tools_json: &Value) -> Vec<Value> {
+        let Some(arr) = tools_json.as_array() else {
+            return Vec::new();
+        };
+        arr.iter()
+            .filter_map(|tool| {
+                let name = tool.get("name")?.as_str()?;
+                let description = tool
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                let parameters = tool
+                    .get("parameters")
+                    .or_else(|| tool.get("input_schema"))
+                    .cloned()
+                    .unwrap_or_else(|| json!({"type": "object", "properties": {}}));
+                Some(json!({
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "description": description,
+                        "parameters": parameters,
+                    }
+                }))
+            })
+            .collect()
+    }
+
+    /// Parse a response message's `tool_calls` into the unified representation.
+    fn parse_tool_calls(message: &ApiMessage) -> Vec<ParsedToolCall> {
+        message
+            .tool_calls
+            .as_ref()
+            .map(|calls| {
+                calls
+                    .iter()
+                    .map(|tc| ParsedToolCall {
+                        tool_name: tc.function.name.clone(),
+                        // Arguments arrive as a JSON string; parse to a value,
+                        // falling back to an empty object on malformed JSON.
+                        arguments: serde_json::from_str(&tc.function.arguments)
+                            .unwrap_or_else(|_| json!({})),
+                        call_id: tc.id.clone(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     /// Build the API endpoint URL
@@ -257,6 +376,8 @@ impl Provider for OpenAIProvider {
             max_tokens: None,
             stream: Some(false),
             n: Some(1),
+            tools: None,
+            tool_choice: None,
         };
 
         let url = self.build_url("chat/completions");
@@ -288,7 +409,7 @@ impl Provider for OpenAIProvider {
                         completion
                             .choices
                             .first()
-                            .map(|choice| choice.message.content.clone())
+                            .map(|choice| choice.message.content.clone().unwrap_or_default())
                             .ok_or_else(|| anyhow::anyhow!("No response from OpenAI"))
                     } else {
                         // Need to handle error here without self reference
@@ -305,6 +426,93 @@ impl Provider for OpenAIProvider {
             .map_err(|e| crate::Error::Provider(e.to_string()))?;
 
         Ok(response)
+    }
+
+    fn supports_tools(&self) -> bool {
+        true
+    }
+
+    async fn complete_with_tools(
+        &self,
+        messages: Vec<Message>,
+        tools: Option<Value>,
+        max_tokens: Option<usize>,
+    ) -> Result<ProviderResponse, crate::Error> {
+        let api_messages = self.convert_messages(messages);
+
+        let temperature = if self.config.model == "gpt-5" {
+            None
+        } else {
+            Some(0.7)
+        };
+
+        // Attach tools only when the caller passed a non-empty set; otherwise
+        // the field stays off the wire and this is an ordinary completion.
+        let openai_tools = tools
+            .as_ref()
+            .map(Self::convert_tools_to_openai)
+            .filter(|t| !t.is_empty());
+        let tool_choice = openai_tools.as_ref().map(|_| json!("auto"));
+
+        let request = ChatCompletionRequest {
+            model: self.config.model.clone(),
+            messages: api_messages,
+            temperature,
+            max_tokens: max_tokens.and_then(|m| u32::try_from(m).ok()),
+            stream: Some(false),
+            n: Some(1),
+            tools: openai_tools,
+            tool_choice,
+        };
+
+        let url = self.build_url("chat/completions");
+
+        let (content, tool_calls, finish_reason) = self
+            .client
+            .execute_with_retry(|client| {
+                let config = self.config.clone();
+                let url = url.clone();
+                let request = request.clone();
+                Box::pin(async move {
+                    let mut req = client.post(&url).json(&request);
+                    if config.is_azure {
+                        req = req.header("api-key", &config.api_key);
+                    }
+                    if let Some(ref org_id) = config.organization_id {
+                        req = req.header("OpenAI-Organization", org_id);
+                    }
+
+                    let response = req.send().await?;
+                    if response.status().is_success() {
+                        let completion: ChatCompletionResponse = response.json().await?;
+                        let choice = completion
+                            .choices
+                            .first()
+                            .ok_or_else(|| anyhow::anyhow!("No response from OpenAI"))?;
+                        let content = choice.message.content.clone().unwrap_or_default();
+                        let tool_calls = OpenAIProvider::parse_tool_calls(&choice.message);
+                        Ok((content, tool_calls, choice.finish_reason.clone()))
+                    } else {
+                        let status = response.status();
+                        let error_text = response
+                            .text()
+                            .await
+                            .unwrap_or_else(|_| "Failed to read error response".to_string());
+                        Err(anyhow::anyhow!("OpenAI API error {status}: {error_text}"))
+                    }
+                })
+            })
+            .await
+            .map_err(|e| crate::Error::Provider(e.to_string()))?;
+
+        Ok(ProviderResponse {
+            content,
+            reasoning_content: None,
+            tool_calls,
+            finish_reason,
+            inference_timing: None,
+            quality_gate_retries: 0,
+        })
     }
 
     async fn stream(
@@ -330,6 +538,8 @@ impl Provider for OpenAIProvider {
             max_tokens: None,
             stream: Some(true),
             n: Some(1),
+            tools: None,
+            tool_choice: None,
         };
 
         let url = self.build_url("chat/completions");
@@ -485,5 +695,105 @@ mod tests {
         assert_eq!(api_messages.len(), 2);
         assert_eq!(api_messages[0].role, "system");
         assert_eq!(api_messages[1].role, "user");
+    }
+
+    #[test]
+    fn provider_advertises_tool_support() {
+        let provider = OpenAIProvider::new(OpenAIConfig::default()).unwrap();
+        assert!(
+            provider.supports_tools(),
+            "OpenAI-compatible providers (incl. GLM) must advertise tool support"
+        );
+    }
+
+    #[test]
+    fn convert_tools_wraps_in_openai_function_shape() {
+        let tools = json!([{
+            "name": "get_time",
+            "description": "Get the current time",
+            "parameters": {"type": "object", "properties": {}}
+        }]);
+        let out = OpenAIProvider::convert_tools_to_openai(&tools);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["type"], "function");
+        assert_eq!(out[0]["function"]["name"], "get_time");
+        assert_eq!(out[0]["function"]["description"], "Get the current time");
+        assert!(out[0]["function"]["parameters"].is_object());
+    }
+
+    #[test]
+    fn convert_tools_accepts_input_schema_alias() {
+        // Anthropic-style `input_schema` maps onto OpenAI's `parameters`.
+        let tools = json!([{"name": "t", "input_schema": {"type": "object"}}]);
+        let out = OpenAIProvider::convert_tools_to_openai(&tools);
+        assert_eq!(out[0]["function"]["parameters"]["type"], "object");
+    }
+
+    #[test]
+    fn parse_tool_calls_extracts_name_args_and_id() {
+        let msg = ApiMessage {
+            role: "assistant".to_string(),
+            content: None,
+            tool_calls: Some(vec![ToolCallJson {
+                id: Some("call_1".to_string()),
+                call_type: "function".to_string(),
+                function: FunctionCallJson {
+                    name: "get_time".to_string(),
+                    arguments: r#"{"tz":"UTC"}"#.to_string(),
+                },
+            }]),
+            tool_call_id: None,
+        };
+        let parsed = OpenAIProvider::parse_tool_calls(&msg);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].tool_name, "get_time");
+        assert_eq!(parsed[0].call_id.as_deref(), Some("call_1"));
+        assert_eq!(parsed[0].arguments["tz"], "UTC");
+    }
+
+    #[test]
+    fn parse_tool_calls_empty_for_plain_text() {
+        let msg = ApiMessage {
+            role: "assistant".to_string(),
+            content: Some("hi".to_string()),
+            tool_calls: None,
+            tool_call_id: None,
+        };
+        assert!(OpenAIProvider::parse_tool_calls(&msg).is_empty());
+    }
+
+    #[test]
+    fn convert_messages_round_trips_call_and_result() {
+        let provider = OpenAIProvider::new(OpenAIConfig::default()).unwrap();
+        let messages = vec![
+            Message {
+                role: Role::Assistant,
+                tool_calls: vec![crate::ToolCall {
+                    name: "get_time".to_string(),
+                    arguments: "{}".to_string(),
+                    id: Some("call_1".to_string()),
+                }],
+                ..Default::default()
+            },
+            Message {
+                role: Role::Tool,
+                content: "12:00 UTC".to_string(),
+                tool_call_id: Some("call_1".to_string()),
+                tool_name: Some("get_time".to_string()),
+                ..Default::default()
+            },
+        ];
+        let api = provider.convert_messages(messages);
+        // Assistant turn: null content + tool_calls (OpenAI requires null, not "").
+        assert_eq!(api[0].role, "assistant");
+        assert!(api[0].content.is_none());
+        assert_eq!(
+            api[0].tool_calls.as_ref().unwrap()[0].function.name,
+            "get_time"
+        );
+        // Tool result: role=tool + paired tool_call_id + content.
+        assert_eq!(api[1].role, "tool");
+        assert_eq!(api[1].content.as_deref(), Some("12:00 UTC"));
+        assert_eq!(api[1].tool_call_id.as_deref(), Some("call_1"));
     }
 }

--- a/crates/arkavo-llm/tests/e2e_glm.rs
+++ b/crates/arkavo-llm/tests/e2e_glm.rs
@@ -1,0 +1,71 @@
+//! End-to-end test against the **live GLM-5.2** (Zhipu AI / Z.ai) endpoint.
+//!
+//! Exercises the exact path the router uses for `ModelChoice::Glm52`: the
+//! generic OpenAI-compatible [`OpenAIProvider`] pointed at Z.ai's `paas/v4`
+//! API, wrapped in [`LlmClient`] (identical to the CLI's GLM construction in
+//! `arkavo-cli/src/commands/ui.rs`). GLM-5.2 speaks the OpenAI chat-completions
+//! wire format, so no bespoke client is needed.
+//!
+//! This is the one thing a real key proves that CI can't: that a GLM-5.2 call
+//! actually round-trips through our provider. It is `#[ignore]`-d and skips
+//! cleanly when `GLM_API_KEY` is unset, so it never runs (or fails) in CI.
+//!
+//! ## Running it
+//!
+//! Put the token in the **environment** — never in code, args, or commits:
+//!
+//! ```sh
+//! export GLM_API_KEY=<your z.ai api key>
+//! # optional: mainland host
+//! # export GLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4
+//! cargo test -p arkavo-llm --test e2e_glm -- --ignored --nocapture
+//! ```
+
+use arkavo_llm::providers::openai::{OpenAIConfig, OpenAIProvider};
+use arkavo_llm::{LlmClient, Message};
+
+/// Build the GLM-5.2 client from the environment, or `None` if the key is
+/// absent (so the test skips rather than fails on a machine without a token).
+fn glm_client() -> Option<LlmClient> {
+    let api_key = std::env::var("GLM_API_KEY").ok()?;
+    let base_url = std::env::var("GLM_BASE_URL")
+        .unwrap_or_else(|_| "https://api.z.ai/api/paas/v4".to_string());
+    let provider = OpenAIProvider::new(OpenAIConfig {
+        api_key,
+        base_url,
+        model: "glm-5.2".to_string(),
+        organization_id: None,
+        api_version: None,
+        is_azure: false,
+    })
+    .expect("OpenAIProvider construction should not fail with a valid config");
+    Some(LlmClient::new(Box::new(provider)))
+}
+
+#[tokio::test]
+#[ignore = "Requires GLM_API_KEY — makes a live GLM-5.2 call to Z.ai"]
+async fn glm52_round_trips_a_prompt() {
+    let Some(client) = glm_client() else {
+        eprintln!("GLM_API_KEY not set — skipping live GLM-5.2 e2e");
+        return;
+    };
+
+    let messages = vec![Message::user(
+        "What is 2 + 2? Respond with only the digit and nothing else.",
+    )];
+
+    let response = client
+        .complete(messages)
+        .await
+        .expect("live GLM-5.2 completion should succeed");
+
+    eprintln!("--- GLM-5.2 raw response ---\n{response}\n---------------------------");
+    assert!(
+        !response.trim().is_empty(),
+        "GLM-5.2 returned empty content — the endpoint responded but produced no text"
+    );
+    assert!(
+        response.contains('4'),
+        "GLM-5.2 should answer 2+2 with a '4'; got: {response:?}"
+    );
+}

--- a/crates/arkavo-llm/tests/e2e_glm.rs
+++ b/crates/arkavo-llm/tests/e2e_glm.rs
@@ -21,6 +21,10 @@
 //! cargo test -p arkavo-llm --test e2e_glm -- --ignored --nocapture
 //! ```
 
+// `#[tokio::test]` expands to `Runtime::block_on`, which the workspace's
+// disallowed-methods lint flags; allowed here as in the other e2e tests.
+#![allow(clippy::disallowed_methods)]
+
 use arkavo_budget::BudgetConfig;
 use arkavo_budget::cost::TokenUsage;
 use arkavo_budget::provider_costs::{PricingEntry, ProviderPricing};

--- a/crates/arkavo-llm/tests/e2e_glm.rs
+++ b/crates/arkavo-llm/tests/e2e_glm.rs
@@ -21,25 +21,34 @@
 //! cargo test -p arkavo-llm --test e2e_glm -- --ignored --nocapture
 //! ```
 
+use arkavo_budget::BudgetConfig;
+use arkavo_budget::cost::TokenUsage;
+use arkavo_budget::provider_costs::{PricingEntry, ProviderPricing};
+use arkavo_budget::tracker::BudgetTracker;
 use arkavo_llm::providers::openai::{OpenAIConfig, OpenAIProvider};
-use arkavo_llm::{LlmClient, Message};
+use arkavo_llm::{LlmClient, Message, Provider};
 
 /// Build the GLM-5.2 client from the environment, or `None` if the key is
 /// absent (so the test skips rather than fails on a machine without a token).
-fn glm_client() -> Option<LlmClient> {
+fn glm_provider() -> Option<OpenAIProvider> {
     let api_key = std::env::var("GLM_API_KEY").ok()?;
     let base_url = std::env::var("GLM_BASE_URL")
         .unwrap_or_else(|_| "https://api.z.ai/api/paas/v4".to_string());
-    let provider = OpenAIProvider::new(OpenAIConfig {
-        api_key,
-        base_url,
-        model: "glm-5.2".to_string(),
-        organization_id: None,
-        api_version: None,
-        is_azure: false,
-    })
-    .expect("OpenAIProvider construction should not fail with a valid config");
-    Some(LlmClient::new(Box::new(provider)))
+    Some(
+        OpenAIProvider::new(OpenAIConfig {
+            api_key,
+            base_url,
+            model: "glm-5.2".to_string(),
+            organization_id: None,
+            api_version: None,
+            is_azure: false,
+        })
+        .expect("OpenAIProvider construction should not fail with a valid config"),
+    )
+}
+
+fn glm_client() -> Option<LlmClient> {
+    Some(LlmClient::new(Box::new(glm_provider()?)))
 }
 
 #[tokio::test]
@@ -67,5 +76,74 @@ async fn glm52_round_trips_a_prompt() {
     assert!(
         response.contains('4'),
         "GLM-5.2 should answer 2+2 with a '4'; got: {response:?}"
+    );
+}
+
+/// Real GLM-5.2 call -> real `usage` tokens -> cost at the published per-MTok
+/// rate -> through the budget gate. Validates the cost model against *actual*
+/// spend (not a fixed category estimate), end to end.
+#[tokio::test]
+#[ignore = "Requires GLM_API_KEY — live GLM-5.2 call + cost reconciliation"]
+async fn glm52_usage_reconciles_to_cost_and_budget() {
+    let Some(provider) = glm_provider() else {
+        eprintln!("GLM_API_KEY not set — skipping GLM-5.2 cost e2e");
+        return;
+    };
+
+    let messages = vec![Message::user("Write a short haiku about budgets.")];
+    let response = provider
+        .complete_with_tools(messages, None, Some(128))
+        .await
+        .expect("live GLM-5.2 completion should succeed");
+
+    // The new capability: real prompt/completion token counts surfaced from
+    // Z.ai's `usage` block (previously dropped).
+    let timing = response
+        .inference_timing
+        .expect("GLM-5.2 should surface token usage");
+    assert!(
+        timing.n_prompt_eval > 0 && timing.n_eval > 0,
+        "expected real prompt+completion token counts, got {timing:?}"
+    );
+
+    // Price the real usage with the per-MTok table (published GLM-5.2 rate).
+    let mut pricing = ProviderPricing::new();
+    pricing.register(&PricingEntry {
+        model_id: "glm-5.2".to_string(),
+        provider: "zhipu".to_string(),
+        input_cents_per_mtok: 140,
+        output_cents_per_mtok: 440,
+        cached_input_cents_per_mtok: Some(26),
+        cache_write_cents_per_mtok: None,
+        context_window: Some(1_000_000),
+        max_output_tokens: Some(131_072),
+    });
+    let cost = pricing
+        .estimate_cost("zhipu", "glm-5.2", timing.n_prompt_eval, timing.n_eval)
+        .expect("GLM-5.2 must be priced from the per-MTok table");
+
+    // Run the real spend through the budget gate and confirm it's tracked.
+    let tracker = BudgetTracker::new(BudgetConfig::default()).await.unwrap();
+    assert!(
+        tracker.can_afford("glm-agent", cost).await.unwrap(),
+        "a single GLM call must fit the default budget"
+    );
+    tracker
+        .record_spending(
+            "glm-agent".to_string(),
+            "zhipu".to_string(),
+            "glm-5.2".to_string(),
+            TokenUsage::new(timing.n_prompt_eval, timing.n_eval),
+            cost,
+        )
+        .await
+        .unwrap();
+    assert_eq!(tracker.get_status().await.session_spent, cost);
+
+    eprintln!(
+        "GLM-5.2 real spend: {} in + {} out tokens = {cost} ({} total)",
+        timing.n_prompt_eval,
+        timing.n_eval,
+        timing.n_prompt_eval + timing.n_eval
     );
 }

--- a/crates/arkavo-mcp-workspace/src/workspace.rs
+++ b/crates/arkavo-mcp-workspace/src/workspace.rs
@@ -12,11 +12,10 @@ pub struct WorkspaceTool {
 
 impl WorkspaceTool {
     pub fn new() -> Self {
-        if Self::detect_runtime().is_err() {
-            eprintln!(
-                "Warning: Neither Docker nor Podman found. Install Docker Desktop (macOS/Windows) or podman"
-            );
-        }
+        // No container-runtime probe here: the workspace tool is registered on
+        // every run, but most sessions never touch it. Surfacing the missing
+        // runtime is deferred to actual use (`create_workspace` returns a typed
+        // `ContainerRuntime` error), so we don't spam unrelated runs.
         Self {
             schema: ToolSchema {
                 name: "workspace_container".to_string(),

--- a/crates/arkavo-router/Cargo.toml
+++ b/crates/arkavo-router/Cargo.toml
@@ -47,18 +47,21 @@ arkavo-tdf = { path = "../arkavo-tdf", optional = true, features = ["opentdf"] }
 uuid = { version = "1.18.1", features = ["v4"] }
 
 [features]
-default = ["llama-cpp", "gemini", "deepseek", "kimi"]
+default = ["llama-cpp", "gemini", "deepseek", "kimi", "glm"]
 critic = []
 advisor-persistence = ["dep:arkavo-memory"]
 llama-cpp = ["arkavo-llm/llama-cpp"]
 gemini = ["arkavo-llm/gemini", "arkavo-gemini"]
 deepseek = ["arkavo-llm/deepseek"]
 kimi = ["arkavo-llm/kimi"]
+# GLM-5.2 routes through the generic OpenAI-compatible provider, which lives
+# behind arkavo-llm's `llm-remote` feature.
+glm = ["arkavo-llm/llm-remote"]
 llm-remote = ["arkavo-llm/llm-remote", "arkavo-context/llm-remote"]
 tdf-encrypt = ["dep:arkavo-tdf", "dep:arkavo-memory"]
 persistence = ["sqlx"]
 # Windows compatible features (no C++ dependencies)
-windows = ["gemini", "llm-remote", "deepseek", "kimi"]
+windows = ["gemini", "llm-remote", "deepseek", "kimi", "glm"]
 
 [dev-dependencies]
 arkavo-test-macros = { path = "../arkavo-test-macros" }

--- a/crates/arkavo-router/src/architect/executor.rs
+++ b/crates/arkavo-router/src/architect/executor.rs
@@ -303,6 +303,9 @@ impl ArchitectExecutor {
             ModelChoice::ClaudeOpus => ModelChoice::ClaudeFable5,
             ModelChoice::ClaudeFable5 => ModelChoice::ClaudeFable5,
             ModelChoice::KimiK2 => ModelChoice::ClaudeSonnet,
+            // GLM-5.2 is a low-cost cloud arm; escalate to a stronger tier
+            // when it underperforms on a task.
+            ModelChoice::Glm52 => ModelChoice::ClaudeSonnet,
         }
     }
 

--- a/crates/arkavo-router/src/decision.rs
+++ b/crates/arkavo-router/src/decision.rs
@@ -1108,6 +1108,11 @@ mod tests {
         assert!(model.is_cloud());
         assert!(!model.is_local());
         assert_eq!(model.capability(), PlannerTier::Large);
+        // Contract (docs.z.ai): GLM-5.2 is text-only — the vision sibling is a
+        // separate model (glm-5v-turbo). Pinning this catches an accidental add
+        // to the supports_vision allow-list, which would send image parts the
+        // model can't accept.
+        assert!(!model.supports_vision(), "GLM-5.2 is text-only");
     }
 
     #[test]
@@ -1148,6 +1153,34 @@ mod tests {
         assert!(glm < opus, "GLM-5.2 should be cheaper than Opus");
     }
 
+    // BUDGET-001 (track token cost): pin the EXACT cost math, not just an
+    // inequality. The "cheaper than Opus" check above was too weak to catch the
+    // $0.60/$2.20 (GLM-4.6) vs $1.40/$4.40 (GLM-5.2) error — a ~2x under-count
+    // that still passed "< Opus". This asserts the published GLM-5.2 rate so a
+    // future stale-price edit fails CI: CodeGeneration estimates 800 in / 3000
+    // out, so cost = 800/1e6*$1.40 + 3000/1e6*$4.40 = $0.00112 + $0.0132.
+    #[spec("BUDGET-001")]
+    #[test]
+    fn test_glm52_cost_math_matches_published_rate() {
+        let cost =
+            RoutingDecision::estimate_cost(&ModelChoice::Glm52, TaskCategory::CodeGeneration);
+        // Mirror estimate_cost's term structure (separate input/output costs) so
+        // this matches bit-for-bit and avoids a fused mul-add (suboptimal_flops).
+        let input_cost = 800.0 / 1_000_000.0 * 1.40;
+        let output_cost = 3000.0 / 1_000_000.0 * 4.40;
+        let expected = input_cost + output_cost;
+        assert!(
+            (cost - expected).abs() < 1e-9,
+            "GLM-5.2 cost {cost} must equal {expected} at the published $1.40/$4.40 rate"
+        );
+        // Guard the absolute figure too, so a refactor of `estimated_tokens()`
+        // that also drifts the rate can't keep this green by coincidence.
+        assert!(
+            (cost - 0.01432).abs() < 1e-9,
+            "expected $0.01432 for a CodeGeneration-sized GLM-5.2 call, got {cost}"
+        );
+    }
+
     #[test]
     fn test_glm52_fallback_chain_has_local_safety_net() {
         let decision = RoutingDecision::new(
@@ -1156,15 +1189,35 @@ mod tests {
             0.9,
             "Test".to_string(),
         );
-        assert!(decision.fallback_chain.iter().any(ModelChoice::is_local));
+        let chain = &decision.fallback_chain;
+        assert!(!chain.is_empty(), "GLM-5.2 must have a fallback chain");
+        // "A missing GLM key never strands a task" requires more than *a* local
+        // model somewhere in the chain — the chain must TERMINATE on a local
+        // model, so that even with every cloud key absent the walk reaches a
+        // runnable model instead of dead-ending on an unavailable cloud arm.
+        assert!(
+            chain.last().is_some_and(ModelChoice::is_local),
+            "GLM-5.2 fallback chain must end on a local model: {chain:?}"
+        );
+        // The chain steps down through the cheaper cloud arms first (cost
+        // discipline), then to the local net — order is part of the contract.
+        assert_eq!(
+            chain,
+            &vec![
+                ModelChoice::DeepSeekV32,
+                ModelChoice::GeminiFlash,
+                ModelChoice::LocalMinistral8B,
+            ]
+        );
     }
 
     // A realistic GLM-5.2 call (200K input + 100K output) priced at the
     // `ModelChoice::Glm52` arm's published rates ($1.40 / $4.40 per 1M). Kept in
     // one place so these budget tests track the cost arm above.
     fn glm52_call_cost() -> TokenCost {
-        let usd = (200_000.0 / 1_000_000.0) * 1.40 + (100_000.0 / 1_000_000.0) * 4.40;
-        TokenCost::from_dollars(usd)
+        let input_cost = 200_000.0 / 1_000_000.0 * 1.40;
+        let output_cost = 100_000.0 / 1_000_000.0 * 4.40;
+        TokenCost::from_dollars(input_cost + output_cost)
     }
 
     // BUDGET-001 (track token cost): a real routed GLM call accrues non-zero,

--- a/crates/arkavo-router/src/decision.rs
+++ b/crates/arkavo-router/src/decision.rs
@@ -78,6 +78,12 @@ pub enum ModelChoice {
     DeepSeekV32Speciale,
     /// Kimi K2.5 - 256K context, thinking mode support
     KimiK2,
+    /// GLM-5.2 (Zhipu AI / Z.ai) - OpenAI-compatible cloud reasoning model.
+    /// Routed through the generic OpenAI-compatible adapter (base URL +
+    /// model string + `GLM_API_KEY`). Introduced as a single Thompson
+    /// Sampling arm to respect the cold-start exploration cap; a thinking-tier
+    /// (High/Max) split can follow once this base arm graduates probation.
+    Glm52,
 }
 
 impl ModelChoice {
@@ -118,6 +124,7 @@ impl ModelChoice {
             Self::LocalDeepSeekCoder => "deepseek-coder-v2-lite-instruct",
             Self::DeepSeekV32 | Self::DeepSeekV32Speciale => "deepseek-chat",
             Self::KimiK2 => "kimi-k2.5",
+            Self::Glm52 => "glm-5.2",
         }
     }
 
@@ -129,7 +136,7 @@ impl ModelChoice {
             | Self::LocalQwen35_27B
             | Self::LocalQwen36A3B => "qwen",
             Self::LocalMinistral3B | Self::LocalMinistral8B => "mistral",
-            Self::LocalGlm47Flash => "glm",
+            Self::LocalGlm47Flash | Self::Glm52 => "glm",
             Self::LocalGemma4E2B
             | Self::LocalGemma4E4B
             | Self::LocalGemma4_26B
@@ -162,6 +169,7 @@ impl ModelChoice {
             "qwen3.5-27b" => Some(Self::LocalQwen35_27B),
             "qwen3.6-35b-a3b" | "qwen3.6" | "qwen36" => Some(Self::LocalQwen36A3B),
             "glm-4.7-flash" => Some(Self::LocalGlm47Flash),
+            "glm-5.2" | "glm5.2" | "glm-5" | "glm52" => Some(Self::Glm52),
             "gemma-4-e2b" => Some(Self::LocalGemma4E2B),
             "gemma-4-e4b" => Some(Self::LocalGemma4E4B),
             "gemma-4-26b-a4b" => Some(Self::LocalGemma4_26B),
@@ -304,6 +312,12 @@ impl ModelChoice {
         matches!(self, Self::KimiK2)
     }
 
+    /// Cloud GLM (Zhipu AI / Z.ai) arm, reached via the OpenAI-compatible
+    /// adapter. Distinct from the local `LocalGlm47Flash` GGUF model.
+    pub fn is_glm(&self) -> bool {
+        matches!(self, Self::Glm52)
+    }
+
     pub fn provider(&self) -> &str {
         match self {
             Self::GeminiFlash
@@ -330,6 +344,7 @@ impl ModelChoice {
             Self::LocalDeepSeekCoder => "local-deepseek",
             Self::DeepSeekV32 | Self::DeepSeekV32Speciale => "deepseek",
             Self::KimiK2 => "kimi",
+            Self::Glm52 => "zhipu",
         }
     }
 
@@ -365,7 +380,8 @@ impl ModelChoice {
             | Self::ClaudeFable5
             | Self::DeepSeekV32
             | Self::DeepSeekV32Speciale
-            | Self::KimiK2 => PlannerTier::Large,
+            | Self::KimiK2
+            | Self::Glm52 => PlannerTier::Large,
         }
     }
 
@@ -565,6 +581,7 @@ impl ModelChoice {
             Self::DeepSeekV32 => "DeepSeek V3.2",
             Self::DeepSeekV32Speciale => "DeepSeek V3.2 Speciale",
             Self::KimiK2 => "Kimi K2.5",
+            Self::Glm52 => "GLM-5.2",
         }
     }
 }
@@ -727,6 +744,15 @@ impl RoutingDecision {
                     ModelChoice::GeminiPro,
                 ]
             }
+            // GLM-5.2 steps down to the other low-cost cloud arms, then a
+            // capable local model, so a missing GLM key never strands a task.
+            (ModelChoice::Glm52, _) => {
+                vec![
+                    ModelChoice::DeepSeekV32,
+                    ModelChoice::GeminiFlash,
+                    ModelChoice::LocalMinistral8B,
+                ]
+            }
             _ => vec![ModelChoice::GeminiFlash],
         }
     }
@@ -808,6 +834,17 @@ impl RoutingDecision {
                 let output_cost = (token_estimate.output as f64 / 1_000_000.0) * 2.20;
                 input_cost + output_cost
             }
+            ModelChoice::Glm52 => {
+                // GLM-5.2 (Zhipu AI / Z.ai), GLM-4.6-class published rates:
+                // $0.60/1M input, $2.20/1M output. Cheap relative to the
+                // Anthropic/Gemini tiers, so budget enforcement keeps it
+                // routable where DeepSeek/Kimi sit. Update when Z.ai confirms
+                // GLM-5.2-specific pricing; real spend should come from the
+                // response `usage` block once surfaced.
+                let input_cost = (token_estimate.input as f64 / 1_000_000.0) * 0.60;
+                let output_cost = (token_estimate.output as f64 / 1_000_000.0) * 2.20;
+                input_cost + output_cost
+            }
             // All local models are free
             ModelChoice::LocalQwen3
             | ModelChoice::LocalMinistral3B
@@ -862,6 +899,9 @@ impl RoutingDecision {
             ModelChoice::LocalDeepSeekCoder => Duration::from_secs(4),
             ModelChoice::DeepSeekV32 | ModelChoice::DeepSeekV32Speciale => Duration::from_secs(5),
             ModelChoice::KimiK2 => Duration::from_secs(5),
+            // GLM-5.2 reasons before answering; budget extra wall-clock on
+            // hard tasks, in line with the other thinking cloud arms.
+            ModelChoice::Glm52 => Duration::from_secs(8),
         }
     }
 }
@@ -1046,6 +1086,65 @@ mod tests {
         );
 
         assert_eq!(decision.estimated_cost_usd, 0.0);
+    }
+
+    #[test]
+    fn test_glm52_properties() {
+        let model = ModelChoice::Glm52;
+        assert_eq!(model.name(), "glm-5.2");
+        assert_eq!(model.provider(), "zhipu");
+        assert_eq!(model.family(), "glm");
+        assert_eq!(model.display_name(), "GLM-5.2");
+        assert!(model.is_glm());
+        assert!(model.is_cloud());
+        assert!(!model.is_local());
+        assert_eq!(model.capability(), PlannerTier::Large);
+    }
+
+    #[test]
+    fn test_glm52_name_resolution() {
+        for alias in ["glm-5.2", "glm5.2", "glm-5", "glm52", "GLM-5.2"] {
+            assert_eq!(
+                ModelChoice::from_name(alias),
+                Some(ModelChoice::Glm52),
+                "alias {alias} should resolve to Glm52"
+            );
+        }
+        assert_eq!(
+            ModelChoice::from_name(ModelChoice::Glm52.name()),
+            Some(ModelChoice::Glm52),
+            "round-trip via primary name"
+        );
+        // GLM-5.2 (cloud) must not collide with the local GLM-4.7-Flash GGUF.
+        assert_eq!(
+            ModelChoice::from_name("glm-4.7-flash"),
+            Some(ModelChoice::LocalGlm47Flash)
+        );
+    }
+
+    #[test]
+    fn test_glm52_cost_is_priced_below_anthropic() {
+        // Budget enforcement only engages if GLM has a real, non-zero cost
+        // model. GLM-5.2 must be priced (cloud) yet sit well under Opus.
+        let glm = RoutingDecision::estimate_cost(&ModelChoice::Glm52, TaskCategory::CodeGeneration);
+        let opus =
+            RoutingDecision::estimate_cost(&ModelChoice::ClaudeOpus, TaskCategory::CodeGeneration);
+        assert!(
+            glm > 0.0,
+            "GLM-5.2 must carry a real cost for budget gating"
+        );
+        assert!(glm < opus, "GLM-5.2 should be cheaper than Opus");
+    }
+
+    #[test]
+    fn test_glm52_fallback_chain_has_local_safety_net() {
+        let decision = RoutingDecision::new(
+            ModelChoice::Glm52,
+            TaskCategory::CodeGeneration,
+            0.9,
+            "Test".to_string(),
+        );
+        assert!(decision.fallback_chain.iter().any(ModelChoice::is_local));
     }
 
     #[test]

--- a/crates/arkavo-router/src/decision.rs
+++ b/crates/arkavo-router/src/decision.rs
@@ -835,14 +835,18 @@ impl RoutingDecision {
                 input_cost + output_cost
             }
             ModelChoice::Glm52 => {
-                // GLM-5.2 (Zhipu AI / Z.ai), GLM-4.6-class published rates:
-                // $0.60/1M input, $2.20/1M output. Cheap relative to the
-                // Anthropic/Gemini tiers, so budget enforcement keeps it
-                // routable where DeepSeek/Kimi sit. Update when Z.ai confirms
-                // GLM-5.2-specific pricing; real spend should come from the
-                // response `usage` block once surfaced.
-                let input_cost = (token_estimate.input as f64 / 1_000_000.0) * 0.60;
-                let output_cost = (token_estimate.output as f64 / 1_000_000.0) * 2.20;
+                // GLM-5.2 (Zhipu AI / Z.ai) published list rates:
+                // $1.40/1M input, $4.40/1M output (docs.z.ai/guides/overview/pricing,
+                // cross-checked on OpenRouter). The earlier $0.60/$2.20 placeholder
+                // was GLM-4.6's rate and undercounted spend ~2x — enough that a
+                // single category-sized call rounded to $0.00 in the integer-cent
+                // `TokenCost`, so the budget gate treated GLM calls as free. At the
+                // real rate a call carries non-zero cost and enforcement engages.
+                // Cheap relative to the Anthropic/Gemini tiers, so it stays routable
+                // where DeepSeek/Kimi sit. Real spend should come from the response
+                // `usage` block once surfaced.
+                let input_cost = (token_estimate.input as f64 / 1_000_000.0) * 1.40;
+                let output_cost = (token_estimate.output as f64 / 1_000_000.0) * 4.40;
                 input_cost + output_cost
             }
             // All local models are free
@@ -917,6 +921,11 @@ pub struct TokenEstimate {
 #[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
+    use arkavo_budget::TokenCost;
+    use arkavo_budget::config::{BudgetConfig, BudgetLimits};
+    use arkavo_budget::cost::TokenUsage;
+    use arkavo_budget::tracker::BudgetTracker;
+    use arkavo_test_macros::spec;
 
     #[test]
     fn test_model_choice_name() {
@@ -1122,6 +1131,9 @@ mod tests {
         );
     }
 
+    // BUDGET-001 (track token cost): the cost-calculation half — a GLM call is
+    // priced from real provider rates, the precondition for any budget tracking.
+    #[spec("BUDGET-001")]
     #[test]
     fn test_glm52_cost_is_priced_below_anthropic() {
         // Budget enforcement only engages if GLM has a real, non-zero cost
@@ -1145,6 +1157,131 @@ mod tests {
             "Test".to_string(),
         );
         assert!(decision.fallback_chain.iter().any(ModelChoice::is_local));
+    }
+
+    // A realistic GLM-5.2 call (200K input + 100K output) priced at the
+    // `ModelChoice::Glm52` arm's published rates ($1.40 / $4.40 per 1M). Kept in
+    // one place so these budget tests track the cost arm above.
+    fn glm52_call_cost() -> TokenCost {
+        let usd = (200_000.0 / 1_000_000.0) * 1.40 + (100_000.0 / 1_000_000.0) * 4.40;
+        TokenCost::from_dollars(usd)
+    }
+
+    // BUDGET-001 (track token cost): a real routed GLM call accrues non-zero,
+    // tracked spend. This exercises the exact orchestrator conversion
+    // (`TokenCost::from_dollars(decision.estimated_cost_usd)`), so it also guards
+    // the integer-cent flooring regression — under the old $0.60/$2.20 placeholder
+    // a category-sized call rounded to $0.00 and escaped tracking entirely.
+    #[spec("BUDGET-001")]
+    #[tokio::test]
+    async fn test_glm52_call_accrues_tracked_cost() {
+        let decision = RoutingDecision::new(
+            ModelChoice::Glm52,
+            TaskCategory::CodeGeneration,
+            0.9,
+            "Generate code via GLM".to_string(),
+        );
+        let cost = TokenCost::from_dollars(decision.estimated_cost_usd);
+        assert!(
+            cost > TokenCost::ZERO,
+            "a routed GLM call must price above zero cents or budget tracking is a no-op"
+        );
+
+        let tracker = BudgetTracker::new(BudgetConfig::default()).await.unwrap();
+        tracker
+            .record_spending(
+                "agent-glm".to_string(),
+                ModelChoice::Glm52.provider().to_string(),
+                ModelChoice::Glm52.name().to_string(),
+                TokenUsage::new(800, 3000),
+                cost,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            tracker.get_status().await.session_spent,
+            cost,
+            "running total must reflect the GLM call's cost"
+        );
+    }
+
+    // BUDGET-002 (enforce budget limit before call): with spend near the cap, a
+    // GLM call is rejected and nothing is recorded — proving the paid arm is
+    // bounded.
+    #[spec("BUDGET-002")]
+    #[tokio::test]
+    async fn test_glm52_call_blocked_when_over_budget() {
+        let config = BudgetConfig {
+            limits: BudgetLimits {
+                session_limit: Some(TokenCost::from_dollars(1.00)),
+                hourly_limit: None,
+                daily_limit: None,
+                monthly_limit: None,
+                total_limit: None,
+            },
+            ..Default::default()
+        };
+        let tracker = BudgetTracker::new(config).await.unwrap();
+        // Current spend near the $1.00 session cap.
+        tracker
+            .record_spending(
+                "agent-glm".to_string(),
+                ModelChoice::Glm52.provider().to_string(),
+                ModelChoice::Glm52.name().to_string(),
+                TokenUsage::new(0, 0),
+                TokenCost::from_dollars(0.99),
+            )
+            .await
+            .unwrap();
+
+        let call = glm52_call_cost();
+        assert!(
+            !tracker.can_afford("agent-glm", call).await.unwrap(),
+            "GLM call that overruns the cap must not be affordable"
+        );
+        assert!(
+            tracker
+                .try_spend(
+                    "agent-glm".to_string(),
+                    ModelChoice::Glm52.provider().to_string(),
+                    ModelChoice::Glm52.name().to_string(),
+                    TokenUsage::new(200_000, 100_000),
+                    call,
+                )
+                .await
+                .is_err(),
+            "try_spend must error rather than dispatch an over-budget GLM call"
+        );
+        assert_eq!(
+            tracker.get_status().await.session_spent,
+            TokenCost::from_dollars(0.99),
+            "a blocked GLM call must not accrue spend"
+        );
+    }
+
+    // BUDGET-002 (enforce budget limit before call): the gate is bidirectional —
+    // the same GLM call clears and records when it fits under the budget.
+    #[spec("BUDGET-002")]
+    #[tokio::test]
+    async fn test_glm52_call_allowed_within_budget() {
+        let tracker = BudgetTracker::new(BudgetConfig::default()).await.unwrap();
+        let call = glm52_call_cost();
+        assert!(
+            tracker.can_afford("agent-glm", call).await.unwrap(),
+            "GLM call within the default budget must be affordable"
+        );
+        tracker
+            .try_spend(
+                "agent-glm".to_string(),
+                ModelChoice::Glm52.provider().to_string(),
+                ModelChoice::Glm52.name().to_string(),
+                TokenUsage::new(200_000, 100_000),
+                call,
+            )
+            .await
+            .expect("an affordable GLM call must record spend");
+        assert_eq!(tracker.get_status().await.session_spent, call);
     }
 
     #[test]

--- a/crates/arkavo-router/src/orchestrator.rs
+++ b/crates/arkavo-router/src/orchestrator.rs
@@ -5,6 +5,7 @@ use crate::metrics::RoutingMetrics;
 use crate::selector::ModelSelector;
 use crate::{Error, Result, Router};
 use arkavo_budget::TokenCost;
+use arkavo_budget::provider_costs::ProviderPricing;
 use arkavo_budget::tracker::{ArchitectCostMetadata, BudgetTracker, SpendingRecord};
 use arkavo_llm::Message;
 use arkavo_mcp_tools::ToolRegistry;
@@ -81,6 +82,22 @@ impl OrchestratorMetrics {
     }
 }
 
+/// Resolve the budget cost of a routing decision. Manifest-authored pricing is
+/// authoritative when the model is in the table; otherwise the model's built-in
+/// static estimate is used. This is the seam that makes editing a rate in the
+/// manifest move the live budget gate (no code change, no runtime fetch).
+fn estimate_decision_cost(pricing: &ProviderPricing, decision: &RoutingDecision) -> TokenCost {
+    let est = decision.task_category.estimated_tokens();
+    pricing
+        .estimate_cost(
+            decision.recommended_model.provider(),
+            decision.recommended_model.name(),
+            est.input,
+            est.output,
+        )
+        .unwrap_or_else(|| TokenCost::from_dollars(decision.estimated_cost_usd))
+}
+
 pub struct CostOrchestrator {
     classifier: Arc<TaskClassifier>,
     selector: Arc<ModelSelector>,
@@ -88,10 +105,25 @@ pub struct CostOrchestrator {
     routing_metrics: Arc<RwLock<RoutingMetrics>>,
     orchestrator_metrics: Arc<RwLock<OrchestratorMetrics>>,
     budget_threshold: f64,
+    /// Manifest-authored per-model pricing (cents per MTok). Empty by default;
+    /// when a model is present it is the cost source of truth and overrides the
+    /// model's built-in static estimate. Populated from the SwarmKit manifest
+    /// at authoring time — never fetched from a vendor endpoint at runtime.
+    pricing: ProviderPricing,
 }
 
 impl CostOrchestrator {
     pub async fn new(budget_tracker: Arc<BudgetTracker>) -> Result<Self> {
+        Self::new_with_pricing(budget_tracker, ProviderPricing::new()).await
+    }
+
+    /// Construct with an authored pricing table (e.g. derived from a SwarmKit
+    /// manifest's `pricing` block). Models present in the table are priced from
+    /// it; everything else falls back to the built-in static estimate.
+    pub async fn new_with_pricing(
+        budget_tracker: Arc<BudgetTracker>,
+        pricing: ProviderPricing,
+    ) -> Result<Self> {
         let classifier = Arc::new(TaskClassifier::new().await?);
         let selector = Arc::new(ModelSelector::new());
 
@@ -102,6 +134,7 @@ impl CostOrchestrator {
             routing_metrics: Arc::new(RwLock::new(RoutingMetrics::new())),
             orchestrator_metrics: Arc::new(RwLock::new(OrchestratorMetrics::new())),
             budget_threshold: 0.80,
+            pricing,
         })
     }
 
@@ -125,7 +158,7 @@ impl CostOrchestrator {
             self.selector.select(&classification, task)?
         };
 
-        let estimated_token_cost = TokenCost::from_dollars(decision.estimated_cost_usd);
+        let estimated_token_cost = estimate_decision_cost(&self.pricing, &decision);
 
         let can_afford = self
             .budget_tracker
@@ -495,6 +528,55 @@ impl ArchitectRoutingResult {
 mod tests {
     use super::*;
     use arkavo_budget::{BudgetConfig, BudgetManager};
+
+    #[test]
+    fn manifest_pricing_is_authoritative_over_static_estimate() {
+        use crate::classifier::TaskCategory;
+        use crate::decision::ModelChoice;
+        use arkavo_budget::provider_costs::PricingEntry;
+
+        // Author GLM-5.2 at a deliberately inflated rate so the table-driven
+        // cost is clearly distinct from the built-in static estimate.
+        let mut pricing = ProviderPricing::new();
+        pricing.register(&PricingEntry {
+            model_id: "glm-5.2".to_string(),
+            provider: "zhipu".to_string(),
+            input_cents_per_mtok: 1400,
+            output_cents_per_mtok: 4400,
+            cached_input_cents_per_mtok: None,
+            cache_write_cents_per_mtok: None,
+            context_window: Some(1_000_000),
+            max_output_tokens: Some(131_072),
+        });
+        let decision = RoutingDecision::new(
+            ModelChoice::Glm52,
+            TaskCategory::CodeGeneration,
+            0.9,
+            "task".to_string(),
+        );
+        // CodeGeneration estimates 800 in / 3000 out:
+        // (800*1400 + 3000*4400)/1e6 = 1 + 13 = 14 cents.
+        let cost = estimate_decision_cost(&pricing, &decision);
+        assert_eq!(cost.as_cents(), 14, "authored table rate must drive cost");
+        // And it must differ from the static estimate, proving the override.
+        assert_ne!(cost, TokenCost::from_dollars(decision.estimated_cost_usd));
+    }
+
+    #[test]
+    fn empty_pricing_falls_back_to_static_estimate() {
+        use crate::classifier::TaskCategory;
+        use crate::decision::ModelChoice;
+
+        let pricing = ProviderPricing::new(); // no authored rates
+        let decision = RoutingDecision::new(
+            ModelChoice::Glm52,
+            TaskCategory::CodeGeneration,
+            0.9,
+            "task".to_string(),
+        );
+        let cost = estimate_decision_cost(&pricing, &decision);
+        assert_eq!(cost, TokenCost::from_dollars(decision.estimated_cost_usd));
+    }
 
     #[tokio::test]
     async fn test_cost_orchestrator_creation() {

--- a/crates/arkavo-router/src/provider.rs
+++ b/crates/arkavo-router/src/provider.rs
@@ -62,7 +62,11 @@ impl super::Router {
     }
 
     pub fn is_glm_available(&self) -> bool {
-        std::env::var("GLM_API_KEY").is_ok()
+        // Only "available" when the arm can actually be built: instantiation is
+        // `#[cfg(feature = "glm")]`, so gate availability the same way. Without
+        // this, a no-`glm` build with GLM_API_KEY set marks Glm52 feasible and
+        // then dead-ends on the catch-all.
+        cfg!(feature = "glm") && std::env::var("GLM_API_KEY").is_ok()
     }
 
     pub fn get_anthropic_provider(
@@ -100,7 +104,7 @@ impl super::Router {
                 std::env::var("DEEPSEEK_API_KEY").is_ok()
             }
             ModelChoice::KimiK2 => std::env::var("MOONSHOT_API_KEY").is_ok(),
-            ModelChoice::Glm52 => std::env::var("GLM_API_KEY").is_ok(),
+            ModelChoice::Glm52 => cfg!(feature = "glm") && std::env::var("GLM_API_KEY").is_ok(),
             m if m.is_local() => match (m.repo_id(), m.gguf_filename()) {
                 (Some(repo), Some(file)) => model_discovery::is_model_cached(repo, file),
                 _ => false,

--- a/crates/arkavo-router/src/provider.rs
+++ b/crates/arkavo-router/src/provider.rs
@@ -61,6 +61,10 @@ impl super::Router {
         std::env::var("MOONSHOT_API_KEY").is_ok()
     }
 
+    pub fn is_glm_available(&self) -> bool {
+        std::env::var("GLM_API_KEY").is_ok()
+    }
+
     pub fn get_anthropic_provider(
         &self,
     ) -> Option<arkavo_llm::providers::anthropic::AnthropicProvider> {
@@ -96,6 +100,7 @@ impl super::Router {
                 std::env::var("DEEPSEEK_API_KEY").is_ok()
             }
             ModelChoice::KimiK2 => std::env::var("MOONSHOT_API_KEY").is_ok(),
+            ModelChoice::Glm52 => std::env::var("GLM_API_KEY").is_ok(),
             m if m.is_local() => match (m.repo_id(), m.gguf_filename()) {
                 (Some(repo), Some(file)) => model_discovery::is_model_cached(repo, file),
                 _ => false,
@@ -372,6 +377,33 @@ impl super::Router {
 
                 let provider = AnthropicProvider::new(config).map_err(|e| {
                     Error::ModelExecution(format!("Failed to create Kimi provider: {e}"))
+                })?;
+                Ok(Box::new(provider))
+            }
+            #[cfg(feature = "glm")]
+            ModelChoice::Glm52 => {
+                // GLM-5.2 speaks the OpenAI chat-completions wire format, so it
+                // routes through the generic OpenAI-compatible provider rather
+                // than a bespoke crate. Base URL defaults to Z.ai's v4 endpoint
+                // and is overridable for the mainland (open.bigmodel.cn) host.
+                use arkavo_llm::providers::openai::{OpenAIConfig, OpenAIProvider};
+
+                let api_key = std::env::var("GLM_API_KEY")
+                    .map_err(|_| Error::ModelExecution("GLM_API_KEY not set".to_string()))?;
+                let base_url = std::env::var("GLM_BASE_URL")
+                    .unwrap_or_else(|_| "https://api.z.ai/api/paas/v4".to_string());
+
+                let config = OpenAIConfig {
+                    api_key,
+                    base_url,
+                    model: model.name().to_string(),
+                    organization_id: None,
+                    api_version: None,
+                    is_azure: false,
+                };
+
+                let provider = OpenAIProvider::new(config).map_err(|e| {
+                    Error::ModelExecution(format!("Failed to create GLM provider: {e}"))
                 })?;
                 Ok(Box::new(provider))
             }

--- a/crates/arkavo-router/src/selector.rs
+++ b/crates/arkavo-router/src/selector.rs
@@ -11,6 +11,7 @@ pub struct ProviderAvailability {
     pub anthropic: bool,
     pub deepseek: bool,
     pub kimi: bool,
+    pub glm: bool,
 }
 
 impl ProviderAvailability {
@@ -21,12 +22,13 @@ impl ProviderAvailability {
             anthropic: std::env::var("ANTHROPIC_API_KEY").is_ok(),
             deepseek: std::env::var("DEEPSEEK_API_KEY").is_ok(),
             kimi: std::env::var("MOONSHOT_API_KEY").is_ok(),
+            glm: std::env::var("GLM_API_KEY").is_ok(),
         }
     }
 
     /// Check if any cloud provider is available
     pub fn has_cloud(&self) -> bool {
-        self.gemini || self.anthropic || self.deepseek || self.kimi
+        self.gemini || self.anthropic || self.deepseek || self.kimi || self.glm
     }
 }
 
@@ -384,6 +386,12 @@ impl ModelSelector {
         if self.availability.kimi {
             models.push(ModelChoice::KimiK2);
         }
+        if self.availability.glm {
+            // GLM-5.2 enters as a single Thompson Sampling arm (cold-start
+            // cap). The learning module decides where its quality/cost point
+            // beats the other low-cost cloud arms (DeepSeek, Gemini Flash).
+            models.push(ModelChoice::Glm52);
+        }
 
         // Fallback: always include Qwen3 as baseline
         if models.is_empty() {
@@ -412,6 +420,7 @@ mod tests {
             anthropic: false,
             deepseek: false,
             kimi: false,
+            glm: false,
         }
     }
 
@@ -421,6 +430,7 @@ mod tests {
             anthropic: true,
             deepseek: false,
             kimi: false,
+            glm: false,
         }
     }
 
@@ -430,6 +440,17 @@ mod tests {
             anthropic: false,
             deepseek: true,
             kimi: false,
+            glm: false,
+        }
+    }
+
+    fn glm_only() -> ProviderAvailability {
+        ProviderAvailability {
+            gemini: false,
+            anthropic: false,
+            deepseek: false,
+            kimi: false,
+            glm: true,
         }
     }
 
@@ -527,6 +548,20 @@ mod tests {
         assert!(!feasible.contains(&ModelChoice::GeminiPro));
         assert!(!feasible.contains(&ModelChoice::ClaudeSonnet));
         assert!(!feasible.contains(&ModelChoice::DeepSeekV32));
+    }
+
+    #[test]
+    fn test_feasible_models_glm_only() {
+        let selector = ModelSelector::with_availability(glm_only());
+        let feasible = selector.feasible_models();
+        assert!(feasible.contains(&ModelChoice::Glm52));
+        assert!(!feasible.contains(&ModelChoice::DeepSeekV32));
+        assert!(!feasible.contains(&ModelChoice::ClaudeSonnet));
+    }
+
+    #[test]
+    fn test_provider_availability_glm_counts_as_cloud() {
+        assert!(glm_only().has_cloud());
     }
 
     #[spec("ROUTER-003")]

--- a/crates/arkavo-router/src/selector.rs
+++ b/crates/arkavo-router/src/selector.rs
@@ -22,7 +22,9 @@ impl ProviderAvailability {
             anthropic: std::env::var("ANTHROPIC_API_KEY").is_ok(),
             deepseek: std::env::var("DEEPSEEK_API_KEY").is_ok(),
             kimi: std::env::var("MOONSHOT_API_KEY").is_ok(),
-            glm: std::env::var("GLM_API_KEY").is_ok(),
+            // Gated on the `glm` feature so the arm isn't marked feasible in a
+            // build that can't instantiate it (instantiation is cfg(glm)).
+            glm: cfg!(feature = "glm") && std::env::var("GLM_API_KEY").is_ok(),
         }
     }
 

--- a/crates/arkavo-router/src/selector_quality.rs
+++ b/crates/arkavo-router/src/selector_quality.rs
@@ -105,6 +105,7 @@ impl ModelSelector {
             ModelChoice::DeepSeekV32 => "Fast (5s), cost-effective ($0.001), excellent for code",
             ModelChoice::DeepSeekV32Speciale => "Planning-optimized (5s), reasoning-only, no tools",
             ModelChoice::KimiK2 => "Fast (5s), 256K context, thinking mode support",
+            ModelChoice::Glm52 => "GLM-5.2 (8s), low-cost cloud reasoning, OpenAI-compatible",
         };
 
         format!(
@@ -524,6 +525,7 @@ mod tests {
             anthropic: false,
             deepseek: false,
             kimi: false,
+            glm: false,
         }
     }
 
@@ -607,6 +609,7 @@ mod tests {
             anthropic: true,
             deepseek: false,
             kimi: false,
+            glm: false,
         });
         let learning = LearningModule::new();
         let classification =

--- a/crates/arkavo-router/src/tool_extraction.rs
+++ b/crates/arkavo-router/src/tool_extraction.rs
@@ -54,7 +54,8 @@ pub(crate) fn detail_level_for_model(
         | ModelChoice::ClaudeFable5
         | ModelChoice::DeepSeekV32
         | ModelChoice::DeepSeekV32Speciale
-        | ModelChoice::KimiK2 => arkavo_mcp_tools::DetailLevel::FullSchema,
+        | ModelChoice::KimiK2
+        | ModelChoice::Glm52 => arkavo_mcp_tools::DetailLevel::FullSchema,
     }
 }
 

--- a/crates/arkavo-server/Cargo.toml
+++ b/crates/arkavo-server/Cargo.toml
@@ -123,7 +123,12 @@ mdns = ["if-addrs"]
 metrics = ["dep:metrics", "metrics-exporter-prometheus"]
 kas = ["dep:arkavo-tdf", "arkavo-router/tdf-encrypt", "arkavo-protocol/kas"]
 iroh = ["dep:arkavo-tdf-iroh"]
-llama-cpp = ["arkavo-llm/llama-cpp", "dep:arkavo-llama-cpp"]
+# The real LlamaTokenEstimator in agent_loop.rs is gated on this feature and
+# calls Router::any_loaded_model() / min_feasible_context_size(), which only
+# exist under arkavo-router's own llama-cpp feature. Propagate it here so the
+# real tokenizer compiles and budget/window trimming stops falling back to the
+# chars/4 MockEstimator.
+llama-cpp = ["arkavo-llm/llama-cpp", "arkavo-router/llama-cpp", "dep:arkavo-llama-cpp"]
 claude-agent = ["dep:arkavo-mcp-claude"]
 
 [dev-dependencies]

--- a/crates/arkavo-swarmkit/src/lib.rs
+++ b/crates/arkavo-swarmkit/src/lib.rs
@@ -13,6 +13,7 @@ pub mod canonical;
 pub mod coordination;
 pub mod governance;
 pub mod manifest;
+pub mod pricing;
 pub mod role;
 pub mod skill_content;
 pub mod validate;
@@ -28,6 +29,7 @@ pub use governance::{
     RoleProposalCeiling,
 };
 pub use manifest::{Author, DeliverableSpec, InputSpec, KitMetadata, Manifest, Objective};
+pub use pricing::ModelPricingEntry;
 #[allow(deprecated)]
 pub use role::ArpRule;
 pub use role::{

--- a/crates/arkavo-swarmkit/src/manifest.rs
+++ b/crates/arkavo-swarmkit/src/manifest.rs
@@ -21,6 +21,12 @@ pub struct Manifest {
     pub roles: Vec<RoleSpec>,
     pub coordination: CoordinationSpec,
     pub constraints: ConstraintsSpec,
+    /// Manifest-level model pricing table (cents per 1M tokens), authored at
+    /// SwarmKit authoring time. Read at runtime to populate the budget cost
+    /// model; never fetched from a vendor endpoint. Optional and skipped when
+    /// empty, so a manifest without prices keeps its existing `kit.id`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pricing: Vec<crate::pricing::ModelPricingEntry>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub evaluation: Option<EvaluationSpec>,
     /// Kit-level tightening-proposal governance. Optional: absent means no

--- a/crates/arkavo-swarmkit/src/pricing.rs
+++ b/crates/arkavo-swarmkit/src/pricing.rs
@@ -1,0 +1,65 @@
+//! Manifest-level model pricing table.
+//!
+//! Authored at SwarmKit authoring time (and, later, via the UI) and read at
+//! runtime to populate the budget cost model. Prices are dynamic but **never
+//! fetched from a vendor endpoint at runtime** — they are curated config that
+//! travels inside the signed manifest. Rates are cents per 1M (million) tokens,
+//! matching `arkavo_budget::PricingEntry` so the runtime conversion is direct.
+
+use serde::{Deserialize, Serialize};
+
+/// One model's published rates, in cents per 1M tokens.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelPricingEntry {
+    pub model_id: String,
+    pub provider: String,
+    /// Input cost, cents per 1M tokens.
+    pub input_cents_per_mtok: u64,
+    /// Output cost, cents per 1M tokens.
+    pub output_cents_per_mtok: u64,
+    /// Cached-input read cost, cents per 1M tokens (None = no cache discount).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cached_input_cents_per_mtok: Option<u64>,
+    /// Cache-write surcharge, cents per 1M tokens (None = no surcharge).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_write_cents_per_mtok: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pricing_entry_parses_glm_rates() {
+        let json = r#"{
+            "model_id": "glm-5.2",
+            "provider": "zhipu",
+            "input_cents_per_mtok": 140,
+            "output_cents_per_mtok": 440,
+            "cached_input_cents_per_mtok": 26
+        }"#;
+        let entry: ModelPricingEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.model_id, "glm-5.2");
+        assert_eq!(entry.provider, "zhipu");
+        assert_eq!(entry.input_cents_per_mtok, 140);
+        assert_eq!(entry.output_cents_per_mtok, 440);
+        assert_eq!(entry.cached_input_cents_per_mtok, Some(26));
+        assert_eq!(entry.cache_write_cents_per_mtok, None);
+    }
+
+    #[test]
+    fn pricing_entry_cache_fields_optional() {
+        // Minimal entry (no cache rates) must parse — cache discount is optional.
+        let json = r#"{
+            "model_id": "claude-opus-4-8",
+            "provider": "anthropic",
+            "input_cents_per_mtok": 500,
+            "output_cents_per_mtok": 2500
+        }"#;
+        let entry: ModelPricingEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.cached_input_cents_per_mtok, None);
+        // Absent optional rates are skipped on re-serialize (canonical-form stable).
+        let round = serde_json::to_string(&entry).unwrap();
+        assert!(!round.contains("cached_input_cents_per_mtok"));
+    }
+}

--- a/crates/arkavo-swarmkit/src/validate.rs
+++ b/crates/arkavo-swarmkit/src/validate.rs
@@ -381,6 +381,7 @@ mod tests {
                     egress_allowlist: vec![],
                 },
             },
+            pricing: vec![],
             evaluation: None,
             proposal_governance: None,
             completion: CompletionSpec {

--- a/crates/arkavo-ui-core/Cargo.toml
+++ b/crates/arkavo-ui-core/Cargo.toml
@@ -15,6 +15,7 @@ llama-cpp = ["arkavo-llm/llama-cpp"]
 gemini = ["arkavo-llm/gemini"]
 deepseek = ["arkavo-llm/deepseek"]
 kimi = ["arkavo-llm/kimi"]
+glm = ["arkavo-llm/llm-remote"]
 
 [dependencies]
 # Core async runtime

--- a/crates/arkavo-ui-core/src/llm_integration.rs
+++ b/crates/arkavo-ui-core/src/llm_integration.rs
@@ -95,6 +95,30 @@ impl LlmIntegration {
                     anyhow::bail!("Kimi feature not enabled")
                 }
             }
+            ModelChoice::Glm52 => {
+                #[cfg(feature = "glm")]
+                {
+                    use arkavo_llm::providers::openai::{OpenAIConfig, OpenAIProvider};
+                    let Ok(api_key) = std::env::var("GLM_API_KEY") else {
+                        anyhow::bail!("GLM_API_KEY not set")
+                    };
+                    let base_url = std::env::var("GLM_BASE_URL")
+                        .unwrap_or_else(|_| "https://api.z.ai/api/paas/v4".to_string());
+                    let provider = OpenAIProvider::new(OpenAIConfig {
+                        api_key,
+                        base_url,
+                        model: decision.recommended_model.name().to_string(),
+                        organization_id: None,
+                        api_version: None,
+                        is_azure: false,
+                    })?;
+                    Ok(LlmClient::new(Box::new(provider)))
+                }
+                #[cfg(not(feature = "glm"))]
+                {
+                    anyhow::bail!("GLM feature not enabled")
+                }
+            }
             ModelChoice::LocalQwen3
             | ModelChoice::LocalMinistral3B
             | ModelChoice::LocalMinistral8B

--- a/crates/arkavo/Cargo.toml
+++ b/crates/arkavo/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities", "development-tools"]
 
 [features]
 # Full defaults with all LLM providers
-default = ["memory", "mdns", "mcp-tools", "llm-remote", "llama-cpp", "gemini", "deepseek", "kimi", "web-ui", "claude-agent"]
+default = ["memory", "mdns", "mcp-tools", "llm-remote", "llama-cpp", "gemini", "deepseek", "kimi", "glm", "web-ui", "claude-agent"]
 # Minimal feature set for non-typical use cases
 minimal = ["memory", "mdns", "mcp-tools"]
 # Default features for Windows
@@ -23,6 +23,7 @@ mdns = ["arkavo-cli/mdns"]
 llm-remote = ["arkavo-cli/llm-remote"]
 kimi = ["arkavo-cli/kimi"]
 deepseek = ["arkavo-cli/deepseek"]
+glm = ["arkavo-cli/glm"]
 gemini = ["arkavo-cli/gemini"]
 llama-cpp = ["arkavo-cli/llama-cpp"]
 snpe = ["arkavo-cli/snpe"]


### PR DESCRIPTION
## Summary

Integrates **GLM-5.2** (Zhipu AI / Z.ai) end to end — from a routable Thompson-Sampling arm through to a **tool-using agent** — and hardens the cost/budget model it runs under. Validated against the live Z.ai endpoint (gated tests + a real example run). GLM speaks the OpenAI chat-completions wire format, so it routes through the generic `OpenAIProvider` rather than a bespoke crate.

This branch is the omnibus for the GLM effort; it also carries a few tangential fixes the work surfaced (budget-table resolution, binary feature wiring, a startup-warning cleanup).

## What's included

**GLM-5.2 as a routable arm**
- `ModelChoice::Glm52` + full method fan-out; `GLM_API_KEY`-gated; added to `feasible_models()`.
- Runtime instantiation via `OpenAIProvider` (Z.ai `paas/v4`, model `glm-5.2`) across router / CLI / ui-core, behind a `glm` feature.
- Fallback chain ends on a **local** model (never strands a task); architect escalation runs **GLM-5.2 → ClaudeSonnet → GeminiPro → ClaudeOpus → ClaudeFable5**.

**Correct, load-bearing pricing**
- GLM-5.2 priced at its **published Z.ai rate $1.40 / $4.40 per MTok** (cached input $0.26). The earlier `$0.60/$2.20` was GLM-4.6's rate; at that figure a normal call floored to **$0.00** in the integer-cent gate (the same bug class as the prior 2× under-count), so this fix is load-bearing for enforcement, not cosmetic.
- An **exact cost-math** regression test pins the rate (the old "cheaper than Opus" check was too weak to catch a 2× drift).
- Contract pinned: model id `glm-5.2`, **text-only** (`supports_vision == false`; `glm-5.2[1m]` is a coding-plan routing suffix, not a chat-API id).

**Tool-using agent (OpenAI function calling)**
- `OpenAIProvider` was text-only — no tools on the wire, `supports_tools()` false. Implemented OpenAI function calling: `tools`/`tool_choice` on the request, assistant `tool_calls` + `role:"tool"` results, `convert_tools_to_openai`, `parse_tool_calls → ParsedToolCall`, `supports_tools() → true`, `complete_with_tools`.
- Result: `arkavo chat --model glm-5.2 --prompt "What time is it?"` now **calls the time tool** and answers with the real clock time (previously "I can't access the time"). Benefits any OpenAI-compatible model.

**Cost model + budget**
- `arkavo-budget::ProviderPricing` rate unit migrated **cents-per-1K → cents-per-MTok** so modern sub-$10/MTok rates are representable (the per-1K unit floored GLM to $0).
- `OpenAIProvider` now surfaces the response `usage` block (real prompt/completion tokens) for cost reconciliation.
- **BUDGET-001 / BUDGET-002** spec coverage added against the GLM arm (budget coverage **0/7 → 2/7**, both critical).

**Pricing as authored config (Deliverable 2)**
- SwarmKit **manifest-level `pricing` table** (`ModelPricingEntry`, per-MTok) — authored at SwarmKit authoring time, read at runtime, **never fetched** from a vendor endpoint. Optional + `skip_serializing_if`, so existing manifests' `kit.id` is unchanged.
- `CostOrchestrator` reads an authored `ProviderPricing` table as the **cost source of truth** (`new_with_pricing`), overriding the static estimate when a model is present. The runtime connection from a loaded manifest to the live gate crosses a subsystem seam — tracked in **#635**.

**Fixes surfaced by running real things**
- The `arkavo` **binary had no `glm` feature** (gemini/deepseek/kimi were wired, glm wasn't) — so the shipped binary couldn't reach GLM at all. Fixed; verified by the example run.
- Removed an unconditional Docker/Podman startup warning (the actionable error still fires at use time).

## Verification (live, against a real `GLM_API_KEY`)

- **Direct e2e** (`arkavo-llm/tests/e2e_glm.rs`, `#[ignore]`-gated): GLM-5.2 answers "2+2" → `4`; a second test does real call → real `usage` → per-MTok cost → budget gate.
- **Full example**: `examples/01-hello-world` with `--model glm-5.2` ran through the binary → router → provider → live Z.ai; GLM answered as the agent.
- **Tool call**: "what time is it?" → real tool call → real clock time.
- Router lib tests **369+ pass**; `arkavo-llm` **222 pass** + new provider tests; budget tests green; `fmt`/`clippy` clean on changed code.
- Workspace version bumped `0.81.1 → 0.82.0`.

## Out of scope / follow-ups (filed)

- **#633** — CLI `kimi`/`deepseek` features don't propagate to `arkavo-router` (GLM is wired correctly).
- **#634** — reduced-feature router builds don't compile; pin the `health::tests` feature subset.
- **#635** — wire authored manifest pricing into the *live* cost gate (mechanism done; runtime hookup crosses the `arkavo-budget` ↔ `arkavo-arp` seam; A/B decision noted).
- GLM as signed learning-plane artifacts, and any autonomous self-merge — explicitly **not** built; the gate stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
