### PR TITLE
Feasibility, quality, and spend planes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui-protocol"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-test-macros",
  "serde",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "chrono",
  "serde",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-test-macros",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "git2",
  "tempfile",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1144,11 +1144,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-lesson-synthesis"
-version = "0.84.0"
+version = "0.85.0"
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1383,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1632,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "lru 0.16.4",
  "serde",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1740,7 +1740,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1883,7 +1883,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-shadow-consolidation"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-lesson-synthesis",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1929,7 +1929,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.84.0"
+version = "0.85.0"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-agui/src/gateway.rs
+++ b/crates/arkavo-agui/src/gateway.rs
@@ -515,6 +515,13 @@ fn load_budget_config_from_agents_md() -> arkavo_budget::BudgetConfig {
                 config.limits.daily_limit =
                     Some(arkavo_budget::TokenCost::from_dollars(daily_cost));
             }
+            if let Some(policy) = budget_yaml
+                .cloud_policy
+                .as_deref()
+                .and_then(arkavo_budget::CloudPolicy::parse)
+            {
+                config.cloud_policy = policy;
+            }
             tracing::info!(
                 "AG-UI: Budget config loaded from AGENTS.md (session={:?}, daily={:?})",
                 budget_yaml.max_cost_per_session,

--- a/crates/arkavo-agui/src/gateway_monitors.rs
+++ b/crates/arkavo-agui/src/gateway_monitors.rs
@@ -138,8 +138,17 @@ pub fn spawn_status_broadcaster(connections: Arc<RwLock<HashMap<String, Connecti
                     health: health_data,
                     timestamp: chrono::Utc::now().to_rfc3339(),
                 };
+                // Router telemetry from the process-wide event counters (the
+                // real serving router increments these at emit time, so this
+                // needs no router handle and never double-drains).
+                let router_telemetry = AgUiEvent::RouterTelemetry {
+                    counters: arkavo_observability::event_counters::global_event_counters()
+                        .snapshot(),
+                    timestamp: chrono::Utc::now().to_rfc3339(),
+                };
                 for (_, conn_info) in conns.iter() {
                     let _ = conn_info._ws_tx.send(status_event.clone()).await;
+                    let _ = conn_info._ws_tx.send(router_telemetry.clone()).await;
                 }
             }
         }

--- a/crates/arkavo-agui/src/types.rs
+++ b/crates/arkavo-agui/src/types.rs
@@ -377,6 +377,15 @@ pub enum AgUiEvent {
         failed: u32,
     },
 
+    /// Router telemetry: process-wide counts of structured `RouterEvent`s
+    /// (e.g. `cloud_escalation_blocked`, `local_feasibility`,
+    /// `spec_decoding_disabled`), read from the global event counters. Lets the
+    /// UI surface how often local-first held and feasibility degraded.
+    RouterTelemetry {
+        counters: std::collections::HashMap<String, u64>,
+        timestamp: String,
+    },
+
     // Security / TDF audit events
     GetSecurityStatus,
     SecurityStatusUpdate {

--- a/crates/arkavo-budget/src/cloud_policy.rs
+++ b/crates/arkavo-budget/src/cloud_policy.rs
@@ -1,0 +1,263 @@
+//! Cloud spend permission policy — the **spend plane** authority.
+//!
+//! Architectural rule:
+//!   Availability changes what is *possible*.
+//!   Quality changes what is *advisable*.
+//!   Budget policy changes what is *allowed*.
+//!
+//! Only this module authorizes cloud spend. Feasibility/availability signals
+//! (slow laptop, timeout, low tokens/sec, OOM) are deliberately NOT inputs
+//! here: a busy local runtime is not a budget-authorization event. Quality
+//! inadequacy may *request* cloud spend; only budget policy may *authorize* it.
+
+use crate::cost::TokenCost;
+use serde::{Deserialize, Serialize};
+
+/// User-chosen posture for cloud spending.
+///
+/// The safe v1 default is [`CloudPolicy::AskBeforeCloud`]. `CloudWithinCap`
+/// should only become a default after the adequacy gate is validated against
+/// real user outcomes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CloudPolicy {
+    /// Never call a paid cloud model. Stay local even if the local answer
+    /// visibly collapses.
+    LocalOnly,
+    /// Cloud allowed only after explicit per-request user confirmation.
+    #[default]
+    AskBeforeCloud,
+    /// Cloud allowed automatically while projected spend stays within the cap.
+    /// Reserved for after the adequacy gate is validated.
+    CloudWithinCap,
+}
+
+/// Why a cloud upgrade is being requested.
+///
+/// A request is a *question*, never an authorization. There is deliberately no
+/// `LocalSlow` / `LocalUnavailable` variant: feasibility failures may not
+/// request spend. A slow laptop or a timeout is not a reason to spend money.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CloudSpendReason {
+    /// The user explicitly asked to use cloud.
+    UserRequested,
+    /// The local answer visibly collapsed (empty/truncated/loop/...).
+    LocalCollapsed,
+    /// The task class is high-risk and warrants a stronger model.
+    HighRiskTask,
+}
+
+/// A request to spend cloud budget. Carries the projected per-request cost and
+/// whether the user has confirmed this specific spend.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CloudSpendRequest {
+    pub reason: CloudSpendReason,
+    /// Projected cost of the cloud call (the per-request reservation amount).
+    pub projected_cost: TokenCost,
+    /// Whether the user has confirmed this specific spend.
+    pub user_confirmed: bool,
+}
+
+/// Spend-plane caps that bound a single cloud call.
+#[derive(Debug, Clone, Copy)]
+pub struct SpendCaps {
+    /// Cloud budget still available in the binding window.
+    pub remaining_cap: TokenCost,
+    /// Maximum a single request may cost. `None` = no per-request cap.
+    pub per_request_max: Option<TokenCost>,
+}
+
+/// Why a cloud spend was denied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DenyReason {
+    /// Policy forbids cloud entirely.
+    LocalOnlyPolicy,
+    /// Projected cost exceeds the remaining budget cap.
+    BudgetExhausted,
+    /// Projected cost exceeds the per-request maximum.
+    PerRequestCapExceeded,
+}
+
+/// The spend plane's verdict on a cloud spend request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CloudSpendDecision {
+    /// Spend is authorized; reserve `cost`.
+    Authorized { cost: TokenCost },
+    /// Spend is permitted by budget but requires explicit user confirmation.
+    NeedsUserConfirmation { projected_cost: TokenCost },
+    /// Spend is denied.
+    Denied(DenyReason),
+}
+
+impl CloudSpendDecision {
+    pub fn is_authorized(&self) -> bool {
+        matches!(self, Self::Authorized { .. })
+    }
+}
+
+/// Authorize (or refuse) a cloud spend request — the sole spend authority.
+///
+/// The evaluation order encodes the architectural rule: a hardware/feasibility
+/// signal never appears here, so it can never authorize spend. The decision is
+/// a pure function of policy, the request, and the budget caps.
+pub fn authorize_cloud_spend(
+    policy: CloudPolicy,
+    request: &CloudSpendRequest,
+    caps: SpendCaps,
+) -> CloudSpendDecision {
+    // 1. Policy gate. LocalOnly forbids cloud regardless of everything else.
+    if policy == CloudPolicy::LocalOnly {
+        return CloudSpendDecision::Denied(DenyReason::LocalOnlyPolicy);
+    }
+
+    // 2. Per-request cap.
+    if let Some(max) = caps.per_request_max
+        && request.projected_cost > max
+    {
+        return CloudSpendDecision::Denied(DenyReason::PerRequestCapExceeded);
+    }
+
+    // 3. Remaining budget cap. Budget is the sole authority on "allowed".
+    if request.projected_cost > caps.remaining_cap {
+        return CloudSpendDecision::Denied(DenyReason::BudgetExhausted);
+    }
+
+    // 4. Confirmation gate. AskBeforeCloud needs explicit confirmation;
+    //    CloudWithinCap authorizes silently within the cap.
+    match policy {
+        CloudPolicy::AskBeforeCloud => {
+            if request.user_confirmed {
+                CloudSpendDecision::Authorized {
+                    cost: request.projected_cost,
+                }
+            } else {
+                CloudSpendDecision::NeedsUserConfirmation {
+                    projected_cost: request.projected_cost,
+                }
+            }
+        }
+        CloudPolicy::CloudWithinCap => CloudSpendDecision::Authorized {
+            cost: request.projected_cost,
+        },
+        // Handled by the policy gate above.
+        CloudPolicy::LocalOnly => CloudSpendDecision::Denied(DenyReason::LocalOnlyPolicy),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn caps(remaining_dollars: f64, per_request_dollars: Option<f64>) -> SpendCaps {
+        SpendCaps {
+            remaining_cap: TokenCost::from_dollars(remaining_dollars),
+            per_request_max: per_request_dollars.map(TokenCost::from_dollars),
+        }
+    }
+
+    fn request(confirmed: bool) -> CloudSpendRequest {
+        CloudSpendRequest {
+            reason: CloudSpendReason::LocalCollapsed,
+            projected_cost: TokenCost::from_dollars(0.10),
+            user_confirmed: confirmed,
+        }
+    }
+
+    #[test]
+    fn default_policy_is_ask_before_cloud() {
+        assert_eq!(CloudPolicy::default(), CloudPolicy::AskBeforeCloud);
+    }
+
+    #[test]
+    fn local_only_always_denies_even_when_confirmed_and_within_budget() {
+        let decision =
+            authorize_cloud_spend(CloudPolicy::LocalOnly, &request(true), caps(100.0, None));
+        assert_eq!(
+            decision,
+            CloudSpendDecision::Denied(DenyReason::LocalOnlyPolicy)
+        );
+    }
+
+    #[test]
+    fn ask_before_cloud_needs_confirmation_even_with_budget() {
+        let decision = authorize_cloud_spend(
+            CloudPolicy::AskBeforeCloud,
+            &request(false),
+            caps(100.0, None),
+        );
+        assert_eq!(
+            decision,
+            CloudSpendDecision::NeedsUserConfirmation {
+                projected_cost: TokenCost::from_dollars(0.10)
+            }
+        );
+    }
+
+    #[test]
+    fn ask_before_cloud_authorizes_once_confirmed() {
+        let decision = authorize_cloud_spend(
+            CloudPolicy::AskBeforeCloud,
+            &request(true),
+            caps(100.0, None),
+        );
+        assert_eq!(
+            decision,
+            CloudSpendDecision::Authorized {
+                cost: TokenCost::from_dollars(0.10)
+            }
+        );
+    }
+
+    #[test]
+    fn cloud_within_cap_authorizes_without_confirmation() {
+        let decision = authorize_cloud_spend(
+            CloudPolicy::CloudWithinCap,
+            &request(false),
+            caps(100.0, None),
+        );
+        assert!(decision.is_authorized());
+    }
+
+    // Regression: budget is the sole authority. An exhausted cap denies even
+    // CloudWithinCap, and even an explicitly confirmed AskBeforeCloud request.
+    #[test]
+    fn exhausted_budget_denies_regardless_of_policy() {
+        for policy in [CloudPolicy::AskBeforeCloud, CloudPolicy::CloudWithinCap] {
+            let decision = authorize_cloud_spend(policy, &request(true), caps(0.05, None));
+            assert_eq!(
+                decision,
+                CloudSpendDecision::Denied(DenyReason::BudgetExhausted),
+                "policy {policy:?} must defer to the budget cap"
+            );
+        }
+    }
+
+    #[test]
+    fn per_request_cap_denies_oversized_call() {
+        let decision = authorize_cloud_spend(
+            CloudPolicy::CloudWithinCap,
+            &request(true),
+            caps(100.0, Some(0.05)),
+        );
+        assert_eq!(
+            decision,
+            CloudSpendDecision::Denied(DenyReason::PerRequestCapExceeded)
+        );
+    }
+
+    // Regression: the per-request cap is checked before the remaining cap so
+    // the most specific limit wins the denial reason.
+    #[test]
+    fn per_request_cap_takes_precedence_over_remaining_cap() {
+        let decision = authorize_cloud_spend(
+            CloudPolicy::AskBeforeCloud,
+            &request(true),
+            caps(0.01, Some(0.05)),
+        );
+        assert_eq!(
+            decision,
+            CloudSpendDecision::Denied(DenyReason::PerRequestCapExceeded)
+        );
+    }
+}

--- a/crates/arkavo-budget/src/cloud_policy.rs
+++ b/crates/arkavo-budget/src/cloud_policy.rs
@@ -33,6 +33,23 @@ pub enum CloudPolicy {
 }
 
 impl CloudPolicy {
+    /// Parse a policy from a config/AGENTS.md string. Accepts snake_case,
+    /// kebab-case, and a few natural aliases. Returns `None` for unknown input
+    /// so the caller can keep the safe default.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s
+            .trim()
+            .to_ascii_lowercase()
+            .replace(['-', ' '], "_")
+            .as_str()
+        {
+            "local_only" | "local" | "offline" => Some(Self::LocalOnly),
+            "ask_before_cloud" | "ask" | "prompt" => Some(Self::AskBeforeCloud),
+            "cloud_within_cap" | "cloud" | "auto" | "within_cap" => Some(Self::CloudWithinCap),
+            _ => None,
+        }
+    }
+
     /// Whether the router may route to a paid cloud model *without first asking*
     /// the user. Only `CloudWithinCap` permits silent cloud spend; `LocalOnly`
     /// and `AskBeforeCloud` require staying local (or an explicit confirmation
@@ -177,6 +194,31 @@ mod tests {
     #[test]
     fn default_policy_is_ask_before_cloud() {
         assert_eq!(CloudPolicy::default(), CloudPolicy::AskBeforeCloud);
+    }
+
+    #[test]
+    fn parse_accepts_aliases_and_rejects_unknown() {
+        assert_eq!(
+            CloudPolicy::parse("local_only"),
+            Some(CloudPolicy::LocalOnly)
+        );
+        assert_eq!(
+            CloudPolicy::parse("Local-Only"),
+            Some(CloudPolicy::LocalOnly)
+        );
+        assert_eq!(
+            CloudPolicy::parse("ask before cloud"),
+            Some(CloudPolicy::AskBeforeCloud)
+        );
+        assert_eq!(
+            CloudPolicy::parse("cloud_within_cap"),
+            Some(CloudPolicy::CloudWithinCap)
+        );
+        assert_eq!(
+            CloudPolicy::parse("auto"),
+            Some(CloudPolicy::CloudWithinCap)
+        );
+        assert_eq!(CloudPolicy::parse("nonsense"), None);
     }
 
     #[test]

--- a/crates/arkavo-budget/src/cloud_policy.rs
+++ b/crates/arkavo-budget/src/cloud_policy.rs
@@ -32,6 +32,16 @@ pub enum CloudPolicy {
     CloudWithinCap,
 }
 
+impl CloudPolicy {
+    /// Whether the router may route to a paid cloud model *without first asking*
+    /// the user. Only `CloudWithinCap` permits silent cloud spend; `LocalOnly`
+    /// and `AskBeforeCloud` require staying local (or an explicit confirmation
+    /// step) so a feasibility/quality signal can never silently spend.
+    pub fn permits_silent_cloud(self) -> bool {
+        matches!(self, Self::CloudWithinCap)
+    }
+}
+
 /// Why a cloud upgrade is being requested.
 ///
 /// A request is a *question*, never an authorization. There is deliberately no
@@ -167,6 +177,13 @@ mod tests {
     #[test]
     fn default_policy_is_ask_before_cloud() {
         assert_eq!(CloudPolicy::default(), CloudPolicy::AskBeforeCloud);
+    }
+
+    #[test]
+    fn only_cloud_within_cap_permits_silent_cloud() {
+        assert!(!CloudPolicy::LocalOnly.permits_silent_cloud());
+        assert!(!CloudPolicy::AskBeforeCloud.permits_silent_cloud());
+        assert!(CloudPolicy::CloudWithinCap.permits_silent_cloud());
     }
 
     #[test]

--- a/crates/arkavo-budget/src/config.rs
+++ b/crates/arkavo-budget/src/config.rs
@@ -1,3 +1,4 @@
+use crate::cloud_policy::CloudPolicy;
 use crate::cost::TokenCost;
 use chrono::{DateTime, Datelike, Duration, Utc};
 use serde::{Deserialize, Serialize};
@@ -9,6 +10,10 @@ pub struct BudgetConfig {
     pub thresholds: BudgetThresholds,
     pub time_windows: TimeWindows,
     pub agent_budgets: HashMap<String, AgentBudget>,
+    /// Cloud spend posture. Defaults to `AskBeforeCloud` — the safe v1 default
+    /// that never lets availability or quality signals spend silently.
+    #[serde(default)]
+    pub cloud_policy: CloudPolicy,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/arkavo-budget/src/lib.rs
+++ b/crates/arkavo-budget/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod cloud_policy;
 pub mod compute_budget;
 pub mod config;
 pub mod cost;
@@ -7,6 +8,10 @@ pub mod policy;
 pub mod provider_costs;
 pub mod tracker;
 
+pub use cloud_policy::{
+    CloudPolicy, CloudSpendDecision, CloudSpendReason, CloudSpendRequest, DenyReason, SpendCaps,
+    authorize_cloud_spend,
+};
 pub use compute_budget::{
     AgentAllocationSummary, AgentComputeBudget, BudgetAllocation, BudgetPolicy,
     ComputeBudgetSnapshot, SharedComputeBudget, UrgencyLevel, new_shared_compute_budget,

--- a/crates/arkavo-cli/src/tool_integration.rs
+++ b/crates/arkavo-cli/src/tool_integration.rs
@@ -92,15 +92,10 @@ pub async fn process_with_tools(
         arkavo_router::preflight::PreflightModerator::new()
     });
 
-    // Spend plane: adopt the AGENTS.md cloud policy and share one budget
-    // tracker between the router (live-cap enforcement) and UCP below.
-    let cloud_policy = arkavo_router::load_agent_config()
-        .unwrap_or_default()
-        .budget
-        .as_ref()
-        .and_then(|b| b.cloud_policy.as_deref())
-        .and_then(arkavo_budget::CloudPolicy::parse)
-        .unwrap_or_default();
+    // Spend plane: adopt the AGENTS.md cloud policy (resolved by the shared
+    // server-crate helper) and share one budget tracker between the router
+    // (live-cap enforcement) and UCP below.
+    let cloud_policy = arkavo_server::cloud_policy_from_agents_md();
     let ucp_budget_tracker = std::sync::Arc::new(
         arkavo_budget::BudgetTracker::new(arkavo_budget::BudgetConfig::default())
             .await

--- a/crates/arkavo-cli/src/tool_integration.rs
+++ b/crates/arkavo-cli/src/tool_integration.rs
@@ -92,7 +92,27 @@ pub async fn process_with_tools(
         arkavo_router::preflight::PreflightModerator::new()
     });
 
-    let router = Arc::new(Router::new().await?.with_preflight(moderator));
+    // Spend plane: adopt the AGENTS.md cloud policy and share one budget
+    // tracker between the router (live-cap enforcement) and UCP below.
+    let cloud_policy = arkavo_router::load_agent_config()
+        .unwrap_or_default()
+        .budget
+        .as_ref()
+        .and_then(|b| b.cloud_policy.as_deref())
+        .and_then(arkavo_budget::CloudPolicy::parse)
+        .unwrap_or_default();
+    let ucp_budget_tracker = std::sync::Arc::new(
+        arkavo_budget::BudgetTracker::new(arkavo_budget::BudgetConfig::default())
+            .await
+            .map_err(|e| format!("Failed to create budget tracker: {e}"))?,
+    );
+    let router = Arc::new(
+        Router::new()
+            .await?
+            .with_preflight(moderator)
+            .with_cloud_policy(cloud_policy)
+            .with_budget_tracker(ucp_budget_tracker.clone()),
+    );
 
     // Create critic pipeline for post-LLM validation
     let critic = arkavo_critic::default_pipeline();
@@ -113,13 +133,9 @@ pub async fn process_with_tools(
     ));
     arkavo_hrm::tools::register_tools(&mut tool_registry, hrm_state);
 
-    // Register UCP payment tools for AI agent commerce
-    // Uses the same budget tracker infrastructure for spending limits
-    let ucp_budget_tracker = std::sync::Arc::new(
-        arkavo_budget::BudgetTracker::new(arkavo_budget::BudgetConfig::default())
-            .await
-            .map_err(|e| format!("Failed to create UCP budget tracker: {e}"))?,
-    );
+    // Register UCP payment tools for AI agent commerce.
+    // Reuses the same budget tracker wired into the router above so spend
+    // accounting is unified.
     let ucp_state = std::sync::Arc::new(tokio::sync::RwLock::new(arkavo_ucp::UcpState::new(
         ucp_budget_tracker,
     )));

--- a/crates/arkavo-llama-cpp/src/lib.rs
+++ b/crates/arkavo-llama-cpp/src/lib.rs
@@ -315,6 +315,14 @@ impl LlamaModel {
         unsafe { ffi::llama_model_get_vocab(self.ptr) }
     }
 
+    /// Number of tokens in the model's vocabulary — the length of one row of
+    /// logits from `get_logits_ith`. Used to read per-token logprobs.
+    pub fn n_vocab(&self) -> i32 {
+        // SAFETY: get_vocab returns the model's vocab pointer (non-null for a
+        // loaded model); llama_vocab_n_tokens reads its token count.
+        unsafe { ffi::llama_vocab_n_tokens(self.get_vocab()) }
+    }
+
     pub fn get_eos_token(&self) -> i32 {
         let vocab = self.get_vocab();
         // SAFETY: Batch/sampler pointers originate from llama.cpp allocation and remain valid for the struct's lifetime

--- a/crates/arkavo-llm/src/gemini_adapter.rs
+++ b/crates/arkavo-llm/src/gemini_adapter.rs
@@ -349,6 +349,7 @@ fn timing_from_usage(usage: &UsageMetadata) -> InferenceTiming {
         n_draft: None,
         n_accepted: None,
         spec_bypassed: None,
+        avg_logprob: None,
     }
 }
 

--- a/crates/arkavo-llm/src/llamacpp_streaming/mod.rs
+++ b/crates/arkavo-llm/src/llamacpp_streaming/mod.rs
@@ -371,6 +371,11 @@ async fn generate_tokens_pooled_baseline(
 
         let mut pos = start_pos;
         let end_pos = start_pos.saturating_add(i32::try_from(max_generation).unwrap_or(i32::MAX));
+        // Per-token confidence accumulation for the quality plane's
+        // LowConfidence signal: mean log-probability of the sampled tokens.
+        let n_vocab = model.n_vocab().max(0) as usize;
+        let mut logprob_sum = 0.0f64;
+        let mut logprob_count = 0u32;
         while pos < end_pos {
             validate_logits(&ctx)?;
             let token = sampler.sample(&ctx, -1);
@@ -424,6 +429,21 @@ async fn generate_tokens_pooled_baseline(
             }
             tokens_generated += 1;
 
+            // Accumulate the sampled token's log-probability from the logits
+            // that produced it (still valid until the next decode_batch below).
+            if n_vocab > 0 && token >= 0 {
+                let logits_ptr = ctx.get_logits_ith(-1);
+                if !logits_ptr.is_null() {
+                    // SAFETY: get_logits_ith(-1) returns a row of n_vocab f32s
+                    // for the just-sampled position; valid before the next decode.
+                    let logits = unsafe { std::slice::from_raw_parts(logits_ptr, n_vocab) };
+                    if let Some(lp) = token_logprob(logits, token as usize) {
+                        logprob_sum += f64::from(lp);
+                        logprob_count += 1;
+                    }
+                }
+            }
+
             if !piece.is_empty()
                 && tx
                     .send(Ok(StreamResponse {
@@ -474,6 +494,8 @@ async fn generate_tokens_pooled_baseline(
             n_draft: None,
             n_accepted: None,
             spec_bypassed: spec_bypass_reason.map(|s| s.to_string()),
+            avg_logprob: (logprob_count > 0)
+                .then(|| (logprob_sum / f64::from(logprob_count)) as f32),
         };
         Ok::<(u32, Option<Instant>, InferenceTiming), Error>((
             tokens_generated,
@@ -859,6 +881,8 @@ async fn generate_tokens_baseline(
             n_draft: None,
             n_accepted: None,
             spec_bypassed: spec_bypass_reason.map(|s| s.to_string()),
+            // This path does not accumulate per-token logprobs.
+            avg_logprob: None,
         };
 
         Ok::<(u32, Option<Instant>, InferenceTiming), Error>((tokens_generated, first_token_time, timing))
@@ -931,6 +955,55 @@ fn process_input_tokens(ctx: &LlamaContext, input_tokens: &[i32]) -> Result<()> 
     }
 
     Ok(())
+}
+
+/// Log-probability of `token` under `logits` (length n_vocab): the log-softmax
+/// value, computed stably as `logits[token] - logsumexp(logits)`. Returns
+/// `None` if the token is out of range or the distribution is degenerate.
+#[cfg(all(feature = "llama-cpp", not(target_env = "musl")))]
+fn token_logprob(logits: &[f32], token: usize) -> Option<f32> {
+    let chosen = *logits.get(token)?;
+    if !chosen.is_finite() {
+        return None;
+    }
+    let max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    if !max.is_finite() {
+        return None;
+    }
+    let sum_exp: f64 = logits.iter().map(|&l| f64::from(l - max).exp()).sum();
+    if sum_exp <= 0.0 {
+        return None;
+    }
+    let logsumexp = f64::from(max) + sum_exp.ln();
+    Some((f64::from(chosen) - logsumexp) as f32)
+}
+
+#[cfg(all(test, feature = "llama-cpp", not(target_env = "musl")))]
+mod logprob_tests {
+    use super::token_logprob;
+
+    #[test]
+    fn two_equal_logits_give_ln_half() {
+        let lp = token_logprob(&[1.0, 1.0], 0).unwrap();
+        assert!((lp - 0.5f32.ln()).abs() < 1e-4, "got {lp}");
+    }
+
+    #[test]
+    fn dominant_token_is_high_confidence() {
+        let lp = token_logprob(&[20.0, 0.0, 0.0], 0).unwrap();
+        assert!(lp > -0.01, "dominant token ≈ 0 logprob, got {lp}");
+    }
+
+    #[test]
+    fn unlikely_token_is_low_confidence() {
+        let lp = token_logprob(&[20.0, 0.0, 0.0], 1).unwrap();
+        assert!(lp < -10.0, "unlikely token very negative, got {lp}");
+    }
+
+    #[test]
+    fn out_of_range_token_is_none() {
+        assert!(token_logprob(&[1.0, 2.0], 5).is_none());
+    }
 }
 
 #[cfg(all(feature = "llama-cpp", not(target_env = "musl")))]

--- a/crates/arkavo-llm/src/llamacpp_streaming/spec.rs
+++ b/crates/arkavo-llm/src/llamacpp_streaming/spec.rs
@@ -403,6 +403,7 @@ pub(super) async fn generate_tokens_pooled_with_spec(
             n_draft: Some(n_draft_total),
             n_accepted: Some(n_accepted_total),
             spec_bypassed: None,
+            avg_logprob: None,
         };
 
         Ok::<(u32, Option<Instant>, InferenceTiming), Error>((
@@ -748,6 +749,7 @@ pub(super) async fn generate_tokens_with_spec(
             n_draft: Some(n_draft_total),
             n_accepted: Some(n_accepted_total),
             spec_bypassed: None,
+            avg_logprob: None,
         };
 
         Ok::<(u32, Option<Instant>, InferenceTiming), Error>((

--- a/crates/arkavo-llm/src/provider.rs
+++ b/crates/arkavo-llm/src/provider.rs
@@ -58,6 +58,12 @@ pub struct InferenceTiming {
     /// requested, or spec ran (in which case n_draft/n_accepted are Some).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub spec_bypassed: Option<String>,
+    /// Mean per-token log-probability of the generated answer, when the engine
+    /// computes it. Near `0` is confident; very negative means the model was
+    /// guessing. Feeds the quality plane's `LowConfidence` adequacy signal.
+    /// `None` for providers/paths that don't surface logprobs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub avg_logprob: Option<f32>,
 }
 
 /// Per-request completion options that the router populates and the

--- a/crates/arkavo-observability/src/event_counters.rs
+++ b/crates/arkavo-observability/src/event_counters.rs
@@ -1,0 +1,71 @@
+//! Global named-event counters for router / telemetry events.
+//!
+//! Components increment a counter by event kind at emit time; a metrics
+//! snapshot reads the totals. This is the backend sink for `RouterEvent`s
+//! (`cloud_escalation_blocked`, `local_feasibility`, …) so they are observable
+//! without a polling consumer. Cheap (one `RwLock<HashMap>` behind a global)
+//! and pull-based, mirroring [`crate::subsystem_timing`].
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, RwLock};
+
+/// Monotonic counters keyed by event kind.
+#[derive(Debug, Default)]
+pub struct EventCounters {
+    counts: RwLock<HashMap<String, u64>>,
+}
+
+impl EventCounters {
+    /// Increment the counter for `kind` by one.
+    pub fn increment(&self, kind: &str) {
+        if let Ok(mut counts) = self.counts.write() {
+            *counts.entry(kind.to_string()).or_insert(0) += 1;
+        }
+    }
+
+    /// Current total for `kind` (0 if never incremented).
+    pub fn count(&self, kind: &str) -> u64 {
+        self.counts
+            .read()
+            .ok()
+            .and_then(|c| c.get(kind).copied())
+            .unwrap_or(0)
+    }
+
+    /// Snapshot of all counters for a metrics export.
+    pub fn snapshot(&self) -> HashMap<String, u64> {
+        self.counts.read().map(|c| c.clone()).unwrap_or_default()
+    }
+}
+
+static GLOBAL: LazyLock<EventCounters> = LazyLock::new(EventCounters::default);
+
+/// Process-wide event counters.
+pub fn global_event_counters() -> &'static EventCounters {
+    &GLOBAL
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn increment_and_read() {
+        let c = EventCounters::default();
+        assert_eq!(c.count("x"), 0);
+        c.increment("x");
+        c.increment("x");
+        c.increment("y");
+        assert_eq!(c.count("x"), 2);
+        assert_eq!(c.count("y"), 1);
+        let snap = c.snapshot();
+        assert_eq!(snap.get("x"), Some(&2));
+        assert_eq!(snap.get("y"), Some(&1));
+    }
+
+    #[test]
+    fn global_is_shared() {
+        global_event_counters().increment("global_test_kind");
+        assert!(global_event_counters().count("global_test_kind") >= 1);
+    }
+}

--- a/crates/arkavo-observability/src/lib.rs
+++ b/crates/arkavo-observability/src/lib.rs
@@ -5,6 +5,7 @@ use tracing_subscriber::{Layer, filter::EnvFilter, layer::SubscriberExt};
 pub mod agent_detection;
 pub mod config;
 pub mod decision_trace;
+pub mod event_counters;
 pub mod gpu_scheduler;
 pub mod health_reporter;
 pub mod metrics;

--- a/crates/arkavo-orchestrator/src/token_estimator.rs
+++ b/crates/arkavo-orchestrator/src/token_estimator.rs
@@ -97,6 +97,7 @@ mod tests {
                 n_draft: None,
                 n_accepted: None,
                 spec_bypassed: None,
+                avg_logprob: None,
             }),
             quality_gate_retries: 0,
         };

--- a/crates/arkavo-router/src/decision.rs
+++ b/crates/arkavo-router/src/decision.rs
@@ -776,7 +776,7 @@ impl RoutingDecision {
         }
     }
 
-    fn estimate_cost(model: &ModelChoice, category: TaskCategory) -> f64 {
+    pub(crate) fn estimate_cost(model: &ModelChoice, category: TaskCategory) -> f64 {
         let token_estimate = category.estimated_tokens();
 
         match model {

--- a/crates/arkavo-router/src/decision.rs
+++ b/crates/arkavo-router/src/decision.rs
@@ -252,6 +252,25 @@ impl ModelChoice {
         Self::LocalQwen35_27B,
     ];
 
+    /// All paid cloud model variants. Used by the spend plane to exclude cloud
+    /// arms from a feasibility/quality re-route when the cloud policy does not
+    /// authorize silent spend. Every entry satisfies `is_cloud()`.
+    pub const ALL_CLOUD: &[Self] = &[
+        Self::GeminiFlash,
+        Self::Gemini35Flash,
+        Self::Gemini35FlashMinimal,
+        Self::Gemini35FlashMedium,
+        Self::Gemini35FlashHigh,
+        Self::GeminiPro,
+        Self::ClaudeSonnet,
+        Self::ClaudeOpus,
+        Self::ClaudeFable5,
+        Self::DeepSeekV32,
+        Self::DeepSeekV32Speciale,
+        Self::KimiK2,
+        Self::Glm52,
+    ];
+
     pub fn is_anthropic(&self) -> bool {
         matches!(
             self,
@@ -1083,6 +1102,23 @@ mod tests {
     fn test_model_choice_is_local() {
         assert!(ModelChoice::LocalGemma4B.is_local());
         assert!(!ModelChoice::GeminiFlash.is_local());
+    }
+
+    // Regression: the spend plane excludes ALL_CLOUD on a feasibility/quality
+    // re-route, so every listed arm must actually be a cloud arm — a local arm
+    // slipping in would wrongly block a free local model.
+    #[test]
+    fn all_cloud_entries_are_cloud_and_disjoint_from_local() {
+        for m in ModelChoice::ALL_CLOUD {
+            assert!(m.is_cloud(), "{m:?} is in ALL_CLOUD but is not cloud");
+        }
+        for m in ModelChoice::ALL_LOCAL {
+            assert!(m.is_local(), "{m:?} is in ALL_LOCAL but is not local");
+            assert!(
+                !ModelChoice::ALL_CLOUD.contains(m),
+                "{m:?} appears in both ALL_LOCAL and ALL_CLOUD"
+            );
+        }
     }
 
     #[test]

--- a/crates/arkavo-router/src/lib.rs
+++ b/crates/arkavo-router/src/lib.rs
@@ -131,6 +131,17 @@ pub enum RouterEvent {
         /// structural check, `Some` for the post-dispatch throughput sample.
         tokens_per_sec: Option<f32>,
     },
+    /// A local answer collapsed and the cloud policy *permits* cloud but
+    /// requires confirmation (`AskBeforeCloud`). The router stayed local and
+    /// surfaced this offer so the caller (CLI / UI) can prompt the user, then
+    /// `confirm_next_cloud_upgrade()` + re-dispatch to escalate. This is the
+    /// "ask before cloud" handshake made observable.
+    CloudUpgradeOffered {
+        /// Why the upgrade is offered, e.g. `LocalCollapsed`.
+        reason: String,
+        /// Projected cloud cost in cents.
+        projected_cost_cents: u64,
+    },
 }
 
 impl RouterEvent {
@@ -140,6 +151,7 @@ impl RouterEvent {
             Self::SpecDecodingDisabled { .. } => "spec_decoding_disabled",
             Self::CloudEscalationBlocked { .. } => "cloud_escalation_blocked",
             Self::LocalFeasibility { .. } => "local_feasibility",
+            Self::CloudUpgradeOffered { .. } => "cloud_upgrade_offered",
         }
     }
 }
@@ -236,6 +248,11 @@ pub struct Router {
     /// cloud-escalation decision consults the real remaining cap via
     /// `authorize_cloud_spend`; when absent there is no cap to enforce.
     budget_tracker: Option<Arc<arkavo_budget::BudgetTracker>>,
+    /// One-shot user confirmation for the next cloud upgrade under
+    /// `AskBeforeCloud`. The caller sets it via `confirm_next_cloud_upgrade()`
+    /// after the user approves a `CloudUpgradeOffered`; the loop consumes it
+    /// when authorizing spend.
+    cloud_confirmation: std::sync::atomic::AtomicBool,
 }
 
 impl Router {
@@ -287,6 +304,7 @@ impl Router {
                     .unwrap_or_default(),
             ),
             budget_tracker: None,
+            cloud_confirmation: std::sync::atomic::AtomicBool::new(false),
         })
     }
 
@@ -338,6 +356,7 @@ impl Router {
                     .unwrap_or_default(),
             ),
             budget_tracker: None,
+            cloud_confirmation: std::sync::atomic::AtomicBool::new(false),
         })
     }
 
@@ -366,6 +385,23 @@ impl Router {
     /// The configured spend-plane cloud policy.
     pub fn cloud_policy(&self) -> arkavo_budget::CloudPolicy {
         self.cloud_policy
+    }
+
+    /// Grant one-shot user confirmation for the next cloud upgrade.
+    ///
+    /// Call this after the user approves a `CloudUpgradeOffered` event, then
+    /// re-dispatch the request: under `AskBeforeCloud` the next collapse-driven
+    /// escalation will be authorized (within the budget cap). The flag is
+    /// consumed by the first routing decision that consults it.
+    pub fn confirm_next_cloud_upgrade(&self) {
+        self.cloud_confirmation
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Consume the one-shot cloud confirmation (read-and-clear).
+    fn consume_cloud_confirmation(&self) -> bool {
+        self.cloud_confirmation
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
     }
 
     /// Attach a live budget tracker so the loop's cloud-escalation decision
@@ -1323,6 +1359,7 @@ impl Router {
             cloud_policy: self.cloud_policy,
             feasibility_baseline: self.feasibility_baseline.clone(),
             budget_tracker: self.budget_tracker.clone(),
+            cloud_confirmation: std::sync::atomic::AtomicBool::new(false),
         })
     }
 

--- a/crates/arkavo-router/src/lib.rs
+++ b/crates/arkavo-router/src/lib.rs
@@ -220,6 +220,10 @@ pub struct Router {
     /// model+context's decode throughput from real `InferenceTiming` so "slow"
     /// is judged relative to that configuration, not an absolute threshold.
     feasibility_baseline: Arc<planes::FeasibilityBaseline>,
+    /// Optional live budget tracker (spend plane). When present, the loop's
+    /// cloud-escalation decision consults the real remaining cap via
+    /// `authorize_cloud_spend`; when absent there is no cap to enforce.
+    budget_tracker: Option<Arc<arkavo_budget::BudgetTracker>>,
 }
 
 impl Router {
@@ -266,6 +270,7 @@ impl Router {
             pending_events: Arc::new(std::sync::Mutex::new(Vec::new())),
             cloud_policy: arkavo_budget::CloudPolicy::default(),
             feasibility_baseline: Arc::new(planes::FeasibilityBaseline::new()),
+            budget_tracker: None,
         })
     }
 
@@ -312,6 +317,7 @@ impl Router {
             pending_events: Arc::new(std::sync::Mutex::new(Vec::new())),
             cloud_policy: arkavo_budget::CloudPolicy::default(),
             feasibility_baseline: Arc::new(planes::FeasibilityBaseline::new()),
+            budget_tracker: None,
         })
     }
 
@@ -340,6 +346,57 @@ impl Router {
     /// The configured spend-plane cloud policy.
     pub fn cloud_policy(&self) -> arkavo_budget::CloudPolicy {
         self.cloud_policy
+    }
+
+    /// Attach a live budget tracker so the loop's cloud-escalation decision
+    /// enforces the real remaining cap (spend plane), not just the policy gate.
+    #[must_use]
+    pub fn with_budget_tracker(mut self, tracker: Arc<arkavo_budget::BudgetTracker>) -> Self {
+        self.budget_tracker = Some(tracker);
+        self
+    }
+
+    /// Spend caps for a cloud-escalation decision, read from the live budget
+    /// tracker. Without a tracker (or a session limit) there is no cap to
+    /// enforce, so the remaining cap is reported as effectively unbounded — the
+    /// policy gate in `authorize_cloud_spend` still applies.
+    async fn cloud_spend_caps(&self) -> arkavo_budget::SpendCaps {
+        let unbounded = arkavo_budget::TokenCost::from_dollars(f64::from(u32::MAX));
+        let remaining_cap = match &self.budget_tracker {
+            Some(tracker) => {
+                let status = tracker.get_status().await;
+                status
+                    .session_limit
+                    .map(|limit| {
+                        limit
+                            .checked_sub(status.session_spent)
+                            .unwrap_or(arkavo_budget::TokenCost::ZERO)
+                    })
+                    .unwrap_or(unbounded)
+            }
+            None => unbounded,
+        };
+        arkavo_budget::SpendCaps {
+            remaining_cap,
+            per_request_max: None,
+        }
+    }
+
+    /// Projected cost of escalating this decision to cloud, used by the spend
+    /// plane's cap check. Estimates against the first cloud arm in the decision's
+    /// fallback chain (or a cheap default), since the concrete arm is only
+    /// chosen after the spend gate passes.
+    fn projected_cloud_cost(&self, decision: &RoutingDecision) -> arkavo_budget::TokenCost {
+        let arm = decision
+            .fallback_chain
+            .iter()
+            .find(|m| m.is_cloud())
+            .cloned()
+            .unwrap_or(ModelChoice::GeminiFlash);
+        arkavo_budget::TokenCost::from_dollars(RoutingDecision::estimate_cost(
+            &arm,
+            decision.task_category,
+        ))
     }
 
     /// Exclusion set for a feasibility/quality-driven re-route.
@@ -1251,6 +1308,7 @@ impl Router {
             pending_events: self.pending_events.clone(),
             cloud_policy: self.cloud_policy,
             feasibility_baseline: self.feasibility_baseline.clone(),
+            budget_tracker: self.budget_tracker.clone(),
         })
     }
 

--- a/crates/arkavo-router/src/lib.rs
+++ b/crates/arkavo-router/src/lib.rs
@@ -50,9 +50,9 @@ pub use orchestrator::{
     ScalingDecision,
 };
 pub use planes::{
-    AnswerObservation, CollapseSignal, CollapseVerdict, FeasibilityVerdict, LocalPlan,
-    RuntimeStats, UpgradeContext, UpgradeOffer, assess_feasibility, augment_exclusions_for_policy,
-    authorize_upgrade, detect_collapse, plan_local, upgrade_offer,
+    AnswerObservation, CollapseSignal, CollapseVerdict, FeasibilityBaseline, FeasibilityVerdict,
+    LocalPlan, RuntimeStats, UpgradeContext, UpgradeOffer, assess_feasibility,
+    augment_exclusions_for_policy, authorize_upgrade, detect_collapse, plan_local, upgrade_offer,
 };
 pub use prediction::{BudgetRunway, WorkflowCostPrediction, WorkflowCostPredictor};
 pub use preflight::{
@@ -112,6 +112,23 @@ pub enum RouterEvent {
         reason: String,
         /// The cloud policy that refused, e.g. `AskBeforeCloud`.
         policy: String,
+    },
+    /// The feasibility plane reported a non-nominal local runtime condition.
+    ///
+    /// Pre-dispatch this surfaces a reshape need (prompt does not fit the
+    /// context) or unavailability; post-dispatch it surfaces degraded
+    /// throughput for the model+context configuration. It is a *cost/feasibility*
+    /// signal only — it never authorizes cloud spend. Consumers (UI, the RLM
+    /// chunking layer) decide what to do with it.
+    LocalFeasibility {
+        model: String,
+        /// The `FeasibilityVerdict` as a debug string, e.g. `LocalNeedsChunking`.
+        verdict: String,
+        prompt_tokens: u32,
+        n_ctx: u32,
+        /// Observed decode throughput (tokens/sec); `None` for the pre-dispatch
+        /// structural check, `Some` for the post-dispatch throughput sample.
+        tokens_per_sec: Option<f32>,
     },
 }
 
@@ -199,6 +216,10 @@ pub struct Router {
     /// cross into paid cloud. Defaults to `AskBeforeCloud`, so an availability
     /// failure or a quality collapse never silently spends — it stays local.
     cloud_policy: arkavo_budget::CloudPolicy,
+    /// Per-config runtime-cost baseline for the feasibility plane. Learns each
+    /// model+context's decode throughput from real `InferenceTiming` so "slow"
+    /// is judged relative to that configuration, not an absolute threshold.
+    feasibility_baseline: Arc<planes::FeasibilityBaseline>,
 }
 
 impl Router {
@@ -244,6 +265,7 @@ impl Router {
             spec_stats: Arc::new(spec_stats::SpecStats::default()),
             pending_events: Arc::new(std::sync::Mutex::new(Vec::new())),
             cloud_policy: arkavo_budget::CloudPolicy::default(),
+            feasibility_baseline: Arc::new(planes::FeasibilityBaseline::new()),
         })
     }
 
@@ -289,6 +311,7 @@ impl Router {
             spec_stats: Arc::new(spec_stats::SpecStats::default()),
             pending_events: Arc::new(std::sync::Mutex::new(Vec::new())),
             cloud_policy: arkavo_budget::CloudPolicy::default(),
+            feasibility_baseline: Arc::new(planes::FeasibilityBaseline::new()),
         })
     }
 
@@ -328,6 +351,89 @@ impl Router {
     async fn reroute_exclusions(&self) -> Vec<String> {
         let excluded = self.get_excluded_models().await;
         planes::augment_exclusions_for_policy(excluded, self.cloud_policy)
+    }
+
+    /// Free KV-cache slots for a local model, read from the live context pool.
+    /// Defaults to 1 ("assume placeable") when the pool has no entry or on
+    /// builds without the local engine — an honest fallback, not a fake count.
+    #[cfg(all(feature = "llama-cpp", not(target_env = "musl")))]
+    fn kv_slots_free(&self, model_name: &str) -> usize {
+        self.model_registry
+            .context_pool()
+            .stats(model_name)
+            .map(|s| s.available)
+            .unwrap_or(1)
+    }
+
+    #[cfg(not(all(feature = "llama-cpp", not(target_env = "musl"))))]
+    fn kv_slots_free(&self, _model_name: &str) -> usize {
+        1
+    }
+
+    /// Pre-dispatch feasibility check for a local model (the feasibility plane).
+    ///
+    /// Assembles live `RuntimeStats` (prompt estimate, model context window,
+    /// KV-cache availability) and classifies. When the prompt does not fit
+    /// (reshape) or local cannot run, it emits a `LocalFeasibility` event so the
+    /// UI / RLM chunking layer can react. Cloud models are skipped, and this
+    /// never authorizes spend — it only surfaces a cost/feasibility signal.
+    fn check_local_feasibility(&self, model: &ModelChoice, prompt_tokens: u32) {
+        if !model.is_local() {
+            return;
+        }
+        let n_ctx =
+            arkavo_context::rlm_detection::model_context_size(Some(model.name()), false) as u32;
+        let stats = RuntimeStats {
+            prompt_tokens,
+            n_ctx,
+            local_model_available: self.is_model_available(model),
+            kv_cache_slots_free: self.kv_slots_free(model.name()),
+            tokens_per_sec: None,
+            context_overflow: false,
+        };
+        let key = FeasibilityBaseline::key(model.name(), n_ctx);
+        let verdict = self.feasibility_baseline.classify(&stats, &key);
+        if verdict.needs_reshape() || verdict == FeasibilityVerdict::LocalCannotRun {
+            self.emit_event(RouterEvent::LocalFeasibility {
+                model: model.name().to_string(),
+                verdict: format!("{verdict:?}"),
+                prompt_tokens,
+                n_ctx,
+                tokens_per_sec: None,
+            });
+        }
+    }
+
+    /// Post-dispatch: record observed decode throughput for a local model into
+    /// the per-config baseline, and emit a `LocalFeasibility` event when the
+    /// sample is slow *for that configuration*. Feasibility telemetry only —
+    /// it learns "slow" per model+context rather than from an absolute floor,
+    /// and never authorizes spend.
+    fn record_local_throughput(
+        &self,
+        model: &ModelChoice,
+        timing: &arkavo_llm::InferenceTiming,
+        prompt_tokens: u32,
+    ) {
+        if !model.is_local() || timing.generation_ms <= 0.0 || timing.n_eval == 0 {
+            return;
+        }
+        let tps = (f64::from(timing.n_eval) / (timing.generation_ms / 1000.0)) as f32;
+        let n_ctx =
+            arkavo_context::rlm_detection::model_context_size(Some(model.name()), false) as u32;
+        let key = FeasibilityBaseline::key(model.name(), n_ctx);
+        // Judge against prior history before folding this sample in.
+        let slow = self.feasibility_baseline.is_slow(&key, tps) == Some(true);
+        self.feasibility_baseline.record(&key, tps);
+        if slow {
+            self.emit_event(RouterEvent::LocalFeasibility {
+                model: model.name().to_string(),
+                verdict: format!("{:?}", FeasibilityVerdict::LocalCanRunSlowly),
+                prompt_tokens,
+                n_ctx,
+                tokens_per_sec: Some(tps),
+            });
+        }
     }
 
     /// Run preflight moderation check without full classification.
@@ -1144,6 +1250,7 @@ impl Router {
             spec_stats: self.spec_stats.clone(),
             pending_events: self.pending_events.clone(),
             cloud_policy: self.cloud_policy,
+            feasibility_baseline: self.feasibility_baseline.clone(),
         })
     }
 

--- a/crates/arkavo-router/src/lib.rs
+++ b/crates/arkavo-router/src/lib.rs
@@ -133,6 +133,17 @@ pub enum RouterEvent {
     },
 }
 
+impl RouterEvent {
+    /// Stable snake_case kind, used as the observability counter key.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::SpecDecodingDisabled { .. } => "spec_decoding_disabled",
+            Self::CloudEscalationBlocked { .. } => "cloud_escalation_blocked",
+            Self::LocalFeasibility { .. } => "local_feasibility",
+        }
+    }
+}
+
 #[cfg(feature = "llama-cpp")]
 use arkavo_llm::ModelRegistry;
 use arkavo_llm::{Message, Role};
@@ -610,20 +621,11 @@ impl Router {
         let decision = self.spec_stats.decide(model_name);
         if let Some(rate_pct) = decision.crossed_below_threshold {
             let sample_size = self.spec_stats.window();
-            if let Ok(mut g) = self.pending_events.lock() {
-                // Cap to prevent unbounded growth in the absence of a
-                // drain_events() consumer. In practice the queue fires
-                // at most once per model per threshold crossing, but a
-                // long-running process with many models flapping above
-                // and below threshold would accumulate otherwise.
-                if g.len() < 1024 {
-                    g.push(RouterEvent::SpecDecodingDisabled {
-                        model: model_name.to_string(),
-                        accept_rate_pct: rate_pct,
-                        sample_size,
-                    });
-                }
-            }
+            self.emit_event(RouterEvent::SpecDecodingDisabled {
+                model: model_name.to_string(),
+                accept_rate_pct: rate_pct,
+                sample_size,
+            });
         }
         decision.use_spec
     }
@@ -633,6 +635,9 @@ impl Router {
     /// Capped at 1024 pending events to bound growth when no `drain_events()`
     /// consumer is polling.
     pub(crate) fn emit_event(&self, event: RouterEvent) {
+        // Backend sink: count by kind at emit time so events are observable
+        // even when no `drain_events()` consumer (e.g. the AG-UI gateway) runs.
+        arkavo_observability::event_counters::global_event_counters().increment(event.kind());
         if let Ok(mut g) = self.pending_events.lock()
             && g.len() < 1024
         {

--- a/crates/arkavo-router/src/lib.rs
+++ b/crates/arkavo-router/src/lib.rs
@@ -50,9 +50,10 @@ pub use orchestrator::{
     ScalingDecision,
 };
 pub use planes::{
-    AnswerObservation, CollapseSignal, CollapseVerdict, FeasibilityBaseline, FeasibilityVerdict,
-    LocalPlan, RuntimeStats, UpgradeContext, UpgradeOffer, assess_feasibility,
-    augment_exclusions_for_policy, authorize_upgrade, detect_collapse, plan_local, upgrade_offer,
+    AnswerObservation, CollapseSignal, CollapseVerdict, FeasibilityBaseline,
+    FeasibilityBaselineSnapshot, FeasibilityVerdict, LocalPlan, RuntimeStats, UpgradeContext,
+    UpgradeOffer, assess_feasibility, augment_exclusions_for_policy, authorize_upgrade,
+    detect_collapse, plan_local, upgrade_offer,
 };
 pub use prediction::{BudgetRunway, WorkflowCostPrediction, WorkflowCostPredictor};
 pub use preflight::{
@@ -269,7 +270,11 @@ impl Router {
             spec_stats: Arc::new(spec_stats::SpecStats::default()),
             pending_events: Arc::new(std::sync::Mutex::new(Vec::new())),
             cloud_policy: arkavo_budget::CloudPolicy::default(),
-            feasibility_baseline: Arc::new(planes::FeasibilityBaseline::new()),
+            feasibility_baseline: Arc::new(
+                planes::FeasibilityBaseline::default_path()
+                    .map(planes::FeasibilityBaseline::load)
+                    .unwrap_or_default(),
+            ),
             budget_tracker: None,
         })
     }
@@ -316,7 +321,11 @@ impl Router {
             spec_stats: Arc::new(spec_stats::SpecStats::default()),
             pending_events: Arc::new(std::sync::Mutex::new(Vec::new())),
             cloud_policy: arkavo_budget::CloudPolicy::default(),
-            feasibility_baseline: Arc::new(planes::FeasibilityBaseline::new()),
+            feasibility_baseline: Arc::new(
+                planes::FeasibilityBaseline::default_path()
+                    .map(planes::FeasibilityBaseline::load)
+                    .unwrap_or_default(),
+            ),
             budget_tracker: None,
         })
     }

--- a/crates/arkavo-router/src/lib.rs
+++ b/crates/arkavo-router/src/lib.rs
@@ -14,6 +14,7 @@ pub mod metrics;
 pub mod model_discovery;
 pub mod optimal_config;
 pub mod orchestrator;
+pub mod planes;
 pub mod prediction;
 pub mod preflight;
 pub mod prompt_advisor;
@@ -47,6 +48,11 @@ pub use metrics::RoutingMetrics;
 pub use orchestrator::{
     ArchitectRoutingResult, CostOrchestrator, CostRecommendation, OrchestratorMetrics,
     ScalingDecision,
+};
+pub use planes::{
+    AnswerObservation, CollapseSignal, CollapseVerdict, FeasibilityVerdict, LocalPlan,
+    RuntimeStats, UpgradeContext, UpgradeOffer, assess_feasibility, authorize_upgrade,
+    detect_collapse, plan_local, upgrade_offer,
 };
 pub use prediction::{BudgetRunway, WorkflowCostPrediction, WorkflowCostPredictor};
 pub use preflight::{

--- a/crates/arkavo-router/src/lib.rs
+++ b/crates/arkavo-router/src/lib.rs
@@ -51,8 +51,8 @@ pub use orchestrator::{
 };
 pub use planes::{
     AnswerObservation, CollapseSignal, CollapseVerdict, FeasibilityVerdict, LocalPlan,
-    RuntimeStats, UpgradeContext, UpgradeOffer, assess_feasibility, authorize_upgrade,
-    detect_collapse, plan_local, upgrade_offer,
+    RuntimeStats, UpgradeContext, UpgradeOffer, assess_feasibility, augment_exclusions_for_policy,
+    authorize_upgrade, detect_collapse, plan_local, upgrade_offer,
 };
 pub use prediction::{BudgetRunway, WorkflowCostPrediction, WorkflowCostPredictor};
 pub use preflight::{
@@ -100,6 +100,18 @@ pub enum RouterEvent {
         model: String,
         accept_rate_pct: u32,
         sample_size: u32,
+    },
+    /// A local answer visibly collapsed and a cloud upgrade was offered, but the
+    /// cloud policy did not authorize silent spend, so the router stayed local.
+    ///
+    /// This is the quality→spend boundary made observable: the collapse (a
+    /// quality signal) requested an upgrade, and the spend plane refused to
+    /// spend without asking. Operators see how often local-first holds.
+    CloudEscalationBlocked {
+        /// What triggered the refused escalation, e.g. `collapse:RepetitionLoop`.
+        reason: String,
+        /// The cloud policy that refused, e.g. `AskBeforeCloud`.
+        policy: String,
     },
 }
 
@@ -183,6 +195,10 @@ pub struct Router {
     /// Structured router events waiting to be consumed by the caller.
     /// Callers drain these via `drain_events()` instead of scraping log lines.
     pending_events: Arc<std::sync::Mutex<Vec<RouterEvent>>>,
+    /// Spend-plane posture. Decides whether a feasibility/quality re-route may
+    /// cross into paid cloud. Defaults to `AskBeforeCloud`, so an availability
+    /// failure or a quality collapse never silently spends — it stays local.
+    cloud_policy: arkavo_budget::CloudPolicy,
 }
 
 impl Router {
@@ -227,6 +243,7 @@ impl Router {
             )),
             spec_stats: Arc::new(spec_stats::SpecStats::default()),
             pending_events: Arc::new(std::sync::Mutex::new(Vec::new())),
+            cloud_policy: arkavo_budget::CloudPolicy::default(),
         })
     }
 
@@ -271,6 +288,7 @@ impl Router {
             )),
             spec_stats: Arc::new(spec_stats::SpecStats::default()),
             pending_events: Arc::new(std::sync::Mutex::new(Vec::new())),
+            cloud_policy: arkavo_budget::CloudPolicy::default(),
         })
     }
 
@@ -282,6 +300,34 @@ impl Router {
     pub fn with_preflight(mut self, moderator: preflight::PreflightModerator) -> Self {
         self.preflight = Some(Arc::new(moderator));
         self
+    }
+
+    /// Set the spend-plane cloud policy (default `AskBeforeCloud`).
+    ///
+    /// Governs whether a feasibility/quality re-route may cross into paid
+    /// cloud. Only `CloudWithinCap` permits silent cloud spend; the other
+    /// postures keep an availability failure or quality collapse on a local
+    /// model.
+    #[must_use]
+    pub fn with_cloud_policy(mut self, policy: arkavo_budget::CloudPolicy) -> Self {
+        self.cloud_policy = policy;
+        self
+    }
+
+    /// The configured spend-plane cloud policy.
+    pub fn cloud_policy(&self) -> arkavo_budget::CloudPolicy {
+        self.cloud_policy
+    }
+
+    /// Exclusion set for a feasibility/quality-driven re-route.
+    ///
+    /// Starts from the cooldown-excluded models, then applies the spend plane:
+    /// unless the cloud policy authorizes silent spend, all cloud arms are
+    /// excluded so re-selection stays local. This is how the routing loop keeps
+    /// an availability failure or a quality collapse from silently spending.
+    async fn reroute_exclusions(&self) -> Vec<String> {
+        let excluded = self.get_excluded_models().await;
+        planes::augment_exclusions_for_policy(excluded, self.cloud_policy)
     }
 
     /// Run preflight moderation check without full classification.
@@ -408,6 +454,18 @@ impl Router {
             }
         }
         decision.use_spec
+    }
+
+    /// Enqueue a structured router event for telemetry consumers.
+    ///
+    /// Capped at 1024 pending events to bound growth when no `drain_events()`
+    /// consumer is polling.
+    pub(crate) fn emit_event(&self, event: RouterEvent) {
+        if let Ok(mut g) = self.pending_events.lock()
+            && g.len() < 1024
+        {
+            g.push(event);
+        }
     }
 
     /// Drain all pending structured router events.
@@ -1085,6 +1143,7 @@ impl Router {
             reward_failure_counts: self.reward_failure_counts.clone(),
             spec_stats: self.spec_stats.clone(),
             pending_events: self.pending_events.clone(),
+            cloud_policy: self.cloud_policy,
         })
     }
 

--- a/crates/arkavo-router/src/orchestrator.rs
+++ b/crates/arkavo-router/src/orchestrator.rs
@@ -106,6 +106,10 @@ pub struct CostOrchestrator {
     routing_metrics: Arc<RwLock<RoutingMetrics>>,
     orchestrator_metrics: Arc<RwLock<OrchestratorMetrics>>,
     budget_threshold: f64,
+    /// Spend-plane posture. A cloud arm must pass `authorize_cloud_spend`
+    /// (policy + live cap) — the same authority the route loop uses — so this
+    /// path and the loop share one spend gate rather than two heuristics.
+    cloud_policy: arkavo_budget::CloudPolicy,
     /// Manifest-authored per-model pricing (cents per MTok). Empty by default;
     /// when a model is present it is the cost source of truth and overrides the
     /// model's built-in static estimate. Populated from the SwarmKit manifest
@@ -135,6 +139,7 @@ impl CostOrchestrator {
             routing_metrics: Arc::new(RwLock::new(RoutingMetrics::new())),
             orchestrator_metrics: Arc::new(RwLock::new(OrchestratorMetrics::new())),
             budget_threshold: 0.80,
+            cloud_policy: arkavo_budget::CloudPolicy::default(),
             pricing,
         })
     }
@@ -157,6 +162,33 @@ impl CostOrchestrator {
             switched_decision
         } else {
             self.selector.select(&classification, task)?
+        };
+
+        // Spend plane: a cloud arm must clear the same authority the route loop
+        // uses — policy AND live cap — not just the budget-usage heuristic. If
+        // the spend plane denies (AskBeforeCloud without confirmation, or over
+        // cap), fall back to a budget-constrained local model.
+        let decision = if decision.recommended_model.is_cloud() {
+            let caps = self.cloud_spend_caps().await;
+            let request = arkavo_budget::CloudSpendRequest {
+                reason: arkavo_budget::CloudSpendReason::UserRequested,
+                projected_cost: estimate_decision_cost(&self.pricing, &decision),
+                user_confirmed: false,
+            };
+            if arkavo_budget::authorize_cloud_spend(self.cloud_policy, &request, caps)
+                .is_authorized()
+            {
+                decision
+            } else {
+                let mut metrics = self.orchestrator_metrics.write().await;
+                metrics.budget_switches += 1;
+                drop(metrics);
+                self.selector
+                    .select_with_budget_constraint(&classification, task, 1.0)
+                    .await?
+            }
+        } else {
+            decision
         };
 
         let estimated_token_cost = estimate_decision_cost(&self.pricing, &decision);
@@ -356,6 +388,32 @@ impl CostOrchestrator {
     pub fn with_budget_threshold(mut self, threshold: f64) -> Self {
         self.budget_threshold = threshold.clamp(0.0, 1.0);
         self
+    }
+
+    /// Set the spend-plane cloud policy (default `AskBeforeCloud`).
+    pub fn with_cloud_policy(mut self, policy: arkavo_budget::CloudPolicy) -> Self {
+        self.cloud_policy = policy;
+        self
+    }
+
+    /// Spend caps from the live budget tracker (session remaining). Without a
+    /// session limit the cap is effectively unbounded; the policy gate still
+    /// applies.
+    async fn cloud_spend_caps(&self) -> arkavo_budget::SpendCaps {
+        let unbounded = TokenCost::from_dollars(f64::from(u32::MAX));
+        let status = self.budget_tracker.get_status().await;
+        let remaining_cap = status
+            .session_limit
+            .map(|limit| {
+                limit
+                    .checked_sub(status.session_spent)
+                    .unwrap_or(TokenCost::ZERO)
+            })
+            .unwrap_or(unbounded);
+        arkavo_budget::SpendCaps {
+            remaining_cap,
+            per_request_max: None,
+        }
     }
 
     /// Check if a task should use architect mode based on complexity

--- a/crates/arkavo-router/src/planes/collapse.rs
+++ b/crates/arkavo-router/src/planes/collapse.rs
@@ -108,6 +108,14 @@ pub fn detect(obs: &AnswerObservation<'_>) -> CollapseVerdict {
 
 /// Conservative repetition-loop check: flags an answer whose tail is a short
 /// phrase (1–4 words) repeated many times — the classic local-model collapse.
+///
+/// Known blind spots, acceptable for a v1 collapse detector that must not
+/// over-fire: it only inspects the final `cycle * MIN_REPEATS` words with cycle
+/// length ≤ 4, so a longer-period loop (5+ word phrase), a mid-answer loop that
+/// recovers with a non-repeating tail, or a loop shorter than `MIN_REPEATS`
+/// reads as `NoVisibleCollapse`. It can also false-positive on a naturally
+/// emphatic repeated tail. A clean verdict means "did not visibly collapse",
+/// not "the answer is good" — callers must not over-trust it.
 fn has_repetition_loop(text: &str) -> bool {
     const MIN_REPEATS: usize = 6;
     let words: Vec<&str> = text.split_whitespace().collect();

--- a/crates/arkavo-router/src/planes/collapse.rs
+++ b/crates/arkavo-router/src/planes/collapse.rs
@@ -1,0 +1,245 @@
+//! Answer adequacy gate — a hard, unsolved product problem.
+//!
+//! This module is deliberately NOT named a "quality gate". v1 cannot judge
+//! whether an answer is *good*; it can only catch visible *collapse*. It is a
+//! collapse detector. A [`CollapseVerdict::NoVisibleCollapse`] result means the
+//! output "did not visibly fall apart" — it is **not** a guarantee of adequacy.
+//!
+//! A detected collapse may *request* a cloud upgrade offer. It may never
+//! authorize cloud spend; that is the budget (spend) plane's sole job. The
+//! honest v1 policy is: local answer completed, cloud upgrade available, ask
+//! the user before spending — never "local answer seems bad, auto-spend cloud".
+
+use serde::{Deserialize, Serialize};
+
+/// A visible collapse mode. These are the only failures v1 can reliably detect;
+/// they are signs of breakdown, not a measure of answer quality.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CollapseSignal {
+    /// No usable output was produced.
+    EmptyOutput,
+    /// Generation was cut off by the output-token cap.
+    TruncatedOutput,
+    /// Output degenerated into a repeating loop.
+    RepetitionLoop,
+    /// Output was expected to match a structured format and did not.
+    FormatFailure,
+    /// A tool call was emitted but failed schema validation.
+    ToolCallSchemaFailure,
+    /// The model refused although the task is allowed.
+    DisallowedRefusal,
+    /// The model plainly ignored the instructions (e.g. produced neither the
+    /// required tool call nor any answer).
+    InstructionNoncompliance,
+}
+
+/// The collapse detector's verdict on a completed local answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CollapseVerdict {
+    /// No visible collapse. NOT a guarantee that the answer is adequate.
+    NoVisibleCollapse,
+    /// The output visibly collapsed in the named way.
+    Collapsed(CollapseSignal),
+}
+
+impl CollapseVerdict {
+    pub fn collapsed(&self) -> bool {
+        matches!(self, Self::Collapsed(_))
+    }
+
+    pub fn signal(&self) -> Option<CollapseSignal> {
+        match self {
+            Self::Collapsed(s) => Some(*s),
+            Self::NoVisibleCollapse => None,
+        }
+    }
+}
+
+/// Observations about a completed local answer.
+///
+/// The collapse modes the detector cannot derive from raw text — tool-schema
+/// validity, structured-format match, refusal-vs-allowed — are computed by the
+/// routing loop and passed in via [`AnswerObservation::precomputed`].
+#[derive(Debug, Clone, Default)]
+pub struct AnswerObservation<'a> {
+    /// The visible answer text (tool/think blocks already stripped).
+    pub text: &'a str,
+    /// Generation stopped because it hit the output-token cap.
+    pub hit_output_cap: bool,
+    /// The task required a tool call (function-calling) to proceed.
+    pub tool_call_required: bool,
+    /// A collapse the caller already detected from context the detector cannot
+    /// see (e.g. [`CollapseSignal::ToolCallSchemaFailure`],
+    /// [`CollapseSignal::FormatFailure`], [`CollapseSignal::DisallowedRefusal`]).
+    pub precomputed: Option<CollapseSignal>,
+}
+
+/// Detect visible collapse in a completed local answer.
+///
+/// The first matching signal wins. A caller-supplied `precomputed` signal takes
+/// priority, since it reflects context the text alone cannot reveal.
+pub fn detect(obs: &AnswerObservation<'_>) -> CollapseVerdict {
+    if let Some(signal) = obs.precomputed {
+        return CollapseVerdict::Collapsed(signal);
+    }
+
+    let trimmed = obs.text.trim();
+
+    if trimmed.is_empty() {
+        // Tool-required tasks that produced neither a valid tool call nor text
+        // ignored the instruction; a plain chat turn just came back empty.
+        return if obs.tool_call_required {
+            CollapseVerdict::Collapsed(CollapseSignal::InstructionNoncompliance)
+        } else {
+            CollapseVerdict::Collapsed(CollapseSignal::EmptyOutput)
+        };
+    }
+
+    if obs.hit_output_cap {
+        return CollapseVerdict::Collapsed(CollapseSignal::TruncatedOutput);
+    }
+
+    if has_repetition_loop(trimmed) {
+        return CollapseVerdict::Collapsed(CollapseSignal::RepetitionLoop);
+    }
+
+    CollapseVerdict::NoVisibleCollapse
+}
+
+/// Conservative repetition-loop check: flags an answer whose tail is a short
+/// phrase (1–4 words) repeated many times — the classic local-model collapse.
+fn has_repetition_loop(text: &str) -> bool {
+    const MIN_REPEATS: usize = 6;
+    let words: Vec<&str> = text.split_whitespace().collect();
+    if words.len() < MIN_REPEATS {
+        return false;
+    }
+    for cycle in 1..=4 {
+        if words.len() < cycle * MIN_REPEATS {
+            continue;
+        }
+        let tail = &words[words.len() - cycle * MIN_REPEATS..];
+        let pattern = &tail[..cycle];
+        if tail.chunks(cycle).all(|chunk| chunk == pattern) {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn answer(text: &str) -> AnswerObservation<'_> {
+        AnswerObservation {
+            text,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn healthy_answer_has_no_visible_collapse() {
+        let verdict = detect(&answer("The capital of France is Paris."));
+        assert_eq!(verdict, CollapseVerdict::NoVisibleCollapse);
+        assert!(!verdict.collapsed());
+    }
+
+    #[test]
+    fn empty_chat_answer_is_empty_output() {
+        assert_eq!(
+            detect(&answer("   ")),
+            CollapseVerdict::Collapsed(CollapseSignal::EmptyOutput)
+        );
+    }
+
+    #[test]
+    fn empty_when_tool_required_is_noncompliance() {
+        let obs = AnswerObservation {
+            text: "",
+            tool_call_required: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            detect(&obs),
+            CollapseVerdict::Collapsed(CollapseSignal::InstructionNoncompliance)
+        );
+    }
+
+    #[test]
+    fn refusal_on_allowed_task_collapses() {
+        let obs = AnswerObservation {
+            text: "I cannot help with that.",
+            precomputed: Some(CollapseSignal::DisallowedRefusal),
+            ..Default::default()
+        };
+        assert_eq!(
+            detect(&obs),
+            CollapseVerdict::Collapsed(CollapseSignal::DisallowedRefusal)
+        );
+    }
+
+    #[test]
+    fn invalid_tool_schema_collapses() {
+        let obs = AnswerObservation {
+            text: "{\"tool\": ...}",
+            precomputed: Some(CollapseSignal::ToolCallSchemaFailure),
+            ..Default::default()
+        };
+        assert_eq!(
+            detect(&obs),
+            CollapseVerdict::Collapsed(CollapseSignal::ToolCallSchemaFailure)
+        );
+    }
+
+    #[test]
+    fn format_failure_collapses() {
+        let obs = AnswerObservation {
+            text: "not json",
+            precomputed: Some(CollapseSignal::FormatFailure),
+            ..Default::default()
+        };
+        assert_eq!(
+            detect(&obs),
+            CollapseVerdict::Collapsed(CollapseSignal::FormatFailure)
+        );
+    }
+
+    #[test]
+    fn output_cap_truncation_collapses() {
+        let obs = AnswerObservation {
+            text: "A long answer that ran out of room",
+            hit_output_cap: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            detect(&obs),
+            CollapseVerdict::Collapsed(CollapseSignal::TruncatedOutput)
+        );
+    }
+
+    #[test]
+    fn repetition_loop_collapses() {
+        let obs = answer("ok the answer is yes yes yes yes yes yes yes yes");
+        assert_eq!(
+            detect(&obs),
+            CollapseVerdict::Collapsed(CollapseSignal::RepetitionLoop)
+        );
+    }
+
+    #[test]
+    fn multiword_repetition_loop_collapses() {
+        let obs = answer("go on go on go on go on go on go on go on");
+        assert_eq!(
+            detect(&obs),
+            CollapseVerdict::Collapsed(CollapseSignal::RepetitionLoop)
+        );
+    }
+
+    #[test]
+    fn ordinary_repetition_is_not_a_loop() {
+        // A few natural repeats must not trip the detector.
+        let obs = answer("very very good work overall, nicely done and complete");
+        assert_eq!(detect(&obs), CollapseVerdict::NoVisibleCollapse);
+    }
+}

--- a/crates/arkavo-router/src/planes/collapse.rs
+++ b/crates/arkavo-router/src/planes/collapse.rs
@@ -31,6 +31,11 @@ pub enum CollapseSignal {
     /// The model plainly ignored the instructions (e.g. produced neither the
     /// required tool call nor any answer).
     InstructionNoncompliance,
+    /// The model generated this answer with low token-level confidence (mean
+    /// log-probability well below the confident range). This is the closest v1
+    /// has to an *adequacy* signal — uncertainty, not visible breakdown — and
+    /// is weaker than the structural collapses above.
+    LowConfidence,
 }
 
 /// The collapse detector's verdict on a completed local answer.
@@ -72,7 +77,17 @@ pub struct AnswerObservation<'a> {
     /// see (e.g. [`CollapseSignal::ToolCallSchemaFailure`],
     /// [`CollapseSignal::FormatFailure`], [`CollapseSignal::DisallowedRefusal`]).
     pub precomputed: Option<CollapseSignal>,
+    /// Mean per-token log-probability of the generated answer, when the local
+    /// engine reported it (`InferenceTiming.avg_logprob`). `None` for providers
+    /// that don't surface logprobs. Values near `0` are confident; very negative
+    /// values mean the model was guessing.
+    pub avg_logprob: Option<f32>,
 }
+
+/// Mean log-probability below which the answer is flagged as low-confidence.
+/// −3.0 nats ≈ an average chosen-token probability of ~5%, i.e. the model was
+/// consistently unsure. Conservative so a confident answer never trips it.
+const LOW_CONFIDENCE_LOGPROB: f32 = -3.0;
 
 /// Detect visible collapse in a completed local answer.
 ///
@@ -101,6 +116,15 @@ pub fn detect(obs: &AnswerObservation<'_>) -> CollapseVerdict {
 
     if has_repetition_loop(trimmed) {
         return CollapseVerdict::Collapsed(CollapseSignal::RepetitionLoop);
+    }
+
+    // Weakest signal, checked last so it never masks a structural collapse: the
+    // model produced fluent text but with consistently low token confidence.
+    if obs
+        .avg_logprob
+        .is_some_and(|lp| lp.is_finite() && lp < LOW_CONFIDENCE_LOGPROB)
+    {
+        return CollapseVerdict::Collapsed(CollapseSignal::LowConfidence);
     }
 
     CollapseVerdict::NoVisibleCollapse
@@ -248,6 +272,49 @@ mod tests {
     fn ordinary_repetition_is_not_a_loop() {
         // A few natural repeats must not trip the detector.
         let obs = answer("very very good work overall, nicely done and complete");
+        assert_eq!(detect(&obs), CollapseVerdict::NoVisibleCollapse);
+    }
+
+    #[test]
+    fn low_token_confidence_flags_collapse() {
+        let obs = AnswerObservation {
+            text: "A fluent but low-confidence guess.",
+            avg_logprob: Some(-3.5),
+            ..Default::default()
+        };
+        assert_eq!(
+            detect(&obs),
+            CollapseVerdict::Collapsed(CollapseSignal::LowConfidence)
+        );
+    }
+
+    #[test]
+    fn confident_answer_is_not_low_confidence() {
+        let obs = AnswerObservation {
+            text: "The capital of France is Paris.",
+            avg_logprob: Some(-0.4),
+            ..Default::default()
+        };
+        assert_eq!(detect(&obs), CollapseVerdict::NoVisibleCollapse);
+    }
+
+    #[test]
+    fn low_confidence_never_masks_a_structural_collapse() {
+        // Empty output wins over low confidence (structural beats uncertainty).
+        let obs = AnswerObservation {
+            text: "   ",
+            avg_logprob: Some(-9.0),
+            ..Default::default()
+        };
+        assert_eq!(
+            detect(&obs),
+            CollapseVerdict::Collapsed(CollapseSignal::EmptyOutput)
+        );
+    }
+
+    #[test]
+    fn missing_logprob_is_not_low_confidence() {
+        let obs = answer("No logprob reported by this provider.");
         assert_eq!(detect(&obs), CollapseVerdict::NoVisibleCollapse);
     }
 }

--- a/crates/arkavo-router/src/planes/feasibility.rs
+++ b/crates/arkavo-router/src/planes/feasibility.rs
@@ -1,0 +1,235 @@
+//! Feasibility plane — "can the local model run this *now*?"
+//!
+//! This plane consumes llama.cpp / runtime statistics ONLY. It answers what is
+//! *possible*, never what is *advisable* or *allowed*. There is deliberately no
+//! "use cloud" conclusion in [`FeasibilityVerdict`]: a slow laptop is not a
+//! budget-authorization event.
+//!
+//! Allowed conclusions: local can run now, local can run slowly, local cannot
+//! run, local needs chunking, local needs a smaller context. A feasibility
+//! failure may make the router ask the user, queue, retry locally, or return a
+//! partial answer — it may **never** silently spend cloud dollars.
+
+use serde::{Deserialize, Serialize};
+
+/// Runtime telemetry sampled from the local llama.cpp engine for one request.
+///
+/// Every field is a measurement of *cost/feasibility*, not answer quality.
+#[derive(Debug, Clone)]
+pub struct RuntimeStats {
+    /// Prompt token count for this request.
+    pub prompt_tokens: u32,
+    /// Context window of the loaded model (`0` if unknown).
+    pub n_ctx: u32,
+    /// Whether a local model is loaded and ready to serve.
+    pub local_model_available: bool,
+    /// Free KV-cache slots in the context pool (`0` = saturated).
+    pub kv_cache_slots_free: usize,
+    /// Requests queued ahead of this one.
+    pub queue_depth: usize,
+    /// Recent decode throughput (tokens/sec). `None` if not yet measured.
+    pub tokens_per_sec: Option<f32>,
+    /// Device is thermally throttled or under heavy load.
+    pub thermal_throttling: bool,
+    /// The previous attempt hit OOM / context overflow.
+    pub context_overflow: bool,
+}
+
+impl RuntimeStats {
+    /// Below this decode rate the experience is "slow but working".
+    const SLOW_TOKENS_PER_SEC: f32 = 8.0;
+    /// More than this many requests queued ahead makes the wait noticeable.
+    const SLOW_QUEUE_DEPTH: usize = 2;
+    /// Once the prompt crosses this fraction of context, too little headroom
+    /// remains for a useful completion.
+    const CONTEXT_PRESSURE: f32 = 0.9;
+}
+
+/// What the feasibility plane concluded about local execution.
+///
+/// None of these variants name the cloud. Mapping a verdict to a *cloud* action
+/// is not this plane's job — and in particular `LocalCannotRun` is not a spend
+/// authorization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FeasibilityVerdict {
+    /// Local can run this request now at an acceptable speed.
+    LocalCanRunNow,
+    /// Local can run, but slowly (queue depth, low tok/s, thermal throttle).
+    LocalCanRunSlowly,
+    /// The prompt alone exceeds the context window; it must be chunked first.
+    LocalNeedsChunking,
+    /// The prompt is near the context limit; retry with a smaller context.
+    LocalNeedsSmallerContext,
+    /// Local cannot run right now (no model, KV saturated, OOM/overflow).
+    LocalCannotRun,
+}
+
+impl FeasibilityVerdict {
+    /// Whether local execution can proceed (now or slowly) without reshaping.
+    pub fn can_run_local(self) -> bool {
+        matches!(self, Self::LocalCanRunNow | Self::LocalCanRunSlowly)
+    }
+
+    /// Whether the request must be reshaped (chunk / smaller context) before
+    /// local can run.
+    pub fn needs_reshape(self) -> bool {
+        matches!(
+            self,
+            Self::LocalNeedsChunking | Self::LocalNeedsSmallerContext
+        )
+    }
+}
+
+/// Assess local feasibility from runtime statistics.
+///
+/// The check order is deliberate: a request that does not *fit* is infeasible
+/// until reshaped (not merely "slow"), so context sizing is decided before
+/// throughput.
+pub fn assess(stats: &RuntimeStats) -> FeasibilityVerdict {
+    // No engine to run on at all.
+    if !stats.local_model_available {
+        return FeasibilityVerdict::LocalCannotRun;
+    }
+
+    // Context sizing comes before throughput.
+    if stats.n_ctx > 0 {
+        if stats.prompt_tokens >= stats.n_ctx {
+            // The prompt alone does not fit — it must be split.
+            return FeasibilityVerdict::LocalNeedsChunking;
+        }
+        let pressure = stats.prompt_tokens as f32 / stats.n_ctx as f32;
+        if pressure >= RuntimeStats::CONTEXT_PRESSURE || stats.context_overflow {
+            // Fits, but leaves too little room for output (or just overflowed).
+            return FeasibilityVerdict::LocalNeedsSmallerContext;
+        }
+    } else if stats.context_overflow {
+        return FeasibilityVerdict::LocalNeedsSmallerContext;
+    }
+
+    // KV cache fully saturated: the request cannot be placed right now.
+    if stats.kv_cache_slots_free == 0 {
+        return FeasibilityVerdict::LocalCannotRun;
+    }
+
+    // Feasible. Is it fast enough to be pleasant?
+    let throttled = stats.thermal_throttling
+        || stats.queue_depth > RuntimeStats::SLOW_QUEUE_DEPTH
+        || stats
+            .tokens_per_sec
+            .is_some_and(|t| t < RuntimeStats::SLOW_TOKENS_PER_SEC);
+
+    if throttled {
+        FeasibilityVerdict::LocalCanRunSlowly
+    } else {
+        FeasibilityVerdict::LocalCanRunNow
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A healthy, idle runtime with plenty of headroom.
+    fn healthy() -> RuntimeStats {
+        RuntimeStats {
+            prompt_tokens: 1_000,
+            n_ctx: 8_192,
+            local_model_available: true,
+            kv_cache_slots_free: 4,
+            queue_depth: 0,
+            tokens_per_sec: Some(40.0),
+            thermal_throttling: false,
+            context_overflow: false,
+        }
+    }
+
+    #[test]
+    fn healthy_runtime_runs_now() {
+        assert_eq!(assess(&healthy()), FeasibilityVerdict::LocalCanRunNow);
+    }
+
+    #[test]
+    fn no_local_model_cannot_run() {
+        let stats = RuntimeStats {
+            local_model_available: false,
+            ..healthy()
+        };
+        assert_eq!(assess(&stats), FeasibilityVerdict::LocalCannotRun);
+    }
+
+    #[test]
+    fn oversized_prompt_needs_chunking() {
+        let stats = RuntimeStats {
+            prompt_tokens: 9_000,
+            n_ctx: 8_192,
+            ..healthy()
+        };
+        assert_eq!(assess(&stats), FeasibilityVerdict::LocalNeedsChunking);
+    }
+
+    #[test]
+    fn near_full_context_needs_smaller_context() {
+        let stats = RuntimeStats {
+            prompt_tokens: 7_900, // ~96% of 8192
+            n_ctx: 8_192,
+            ..healthy()
+        };
+        assert_eq!(assess(&stats), FeasibilityVerdict::LocalNeedsSmallerContext);
+    }
+
+    #[test]
+    fn overflow_flag_needs_smaller_context() {
+        let stats = RuntimeStats {
+            context_overflow: true,
+            ..healthy()
+        };
+        assert_eq!(assess(&stats), FeasibilityVerdict::LocalNeedsSmallerContext);
+    }
+
+    #[test]
+    fn saturated_kv_cache_cannot_run() {
+        let stats = RuntimeStats {
+            kv_cache_slots_free: 0,
+            ..healthy()
+        };
+        assert_eq!(assess(&stats), FeasibilityVerdict::LocalCannotRun);
+    }
+
+    // Each of these is a *feasibility* degradation, not a quality degradation:
+    // the request still runs, just slowly. None may authorize cloud spend.
+    #[test]
+    fn low_throughput_runs_slowly() {
+        let stats = RuntimeStats {
+            tokens_per_sec: Some(3.0),
+            ..healthy()
+        };
+        assert_eq!(assess(&stats), FeasibilityVerdict::LocalCanRunSlowly);
+    }
+
+    #[test]
+    fn deep_queue_runs_slowly() {
+        let stats = RuntimeStats {
+            queue_depth: 5,
+            ..healthy()
+        };
+        assert_eq!(assess(&stats), FeasibilityVerdict::LocalCanRunSlowly);
+    }
+
+    #[test]
+    fn thermal_throttle_runs_slowly() {
+        let stats = RuntimeStats {
+            thermal_throttling: true,
+            ..healthy()
+        };
+        assert_eq!(assess(&stats), FeasibilityVerdict::LocalCanRunSlowly);
+    }
+
+    #[test]
+    fn verdict_helpers() {
+        assert!(FeasibilityVerdict::LocalCanRunNow.can_run_local());
+        assert!(FeasibilityVerdict::LocalCanRunSlowly.can_run_local());
+        assert!(!FeasibilityVerdict::LocalCannotRun.can_run_local());
+        assert!(FeasibilityVerdict::LocalNeedsChunking.needs_reshape());
+        assert!(!FeasibilityVerdict::LocalCanRunNow.needs_reshape());
+    }
+}

--- a/crates/arkavo-router/src/planes/feasibility.rs
+++ b/crates/arkavo-router/src/planes/feasibility.rs
@@ -14,7 +14,15 @@ use serde::{Deserialize, Serialize};
 
 /// Runtime telemetry sampled from the local llama.cpp engine for one request.
 ///
-/// Every field is a measurement of *cost/feasibility*, not answer quality.
+/// Every field is a measurement of *cost/feasibility*, not answer quality, and
+/// every field is fed from a real source: `prompt_tokens` from the tokenizer
+/// estimate (or `InferenceTiming.n_prompt_eval`), `n_ctx` from
+/// `model_context_size`, `kv_cache_slots_free` from the context pool's
+/// `PoolStats`, and `tokens_per_sec` from `InferenceTiming` (or the learned
+/// per-config baseline). Signals with no honest local source — thermal/SMC
+/// temperature, OS scheduler queue depth — are deliberately absent rather than
+/// stubbed: "local busy" is represented by KV-cache saturation and a degraded
+/// `tokens_per_sec`.
 #[derive(Debug, Clone)]
 pub struct RuntimeStats {
     /// Prompt token count for this request.
@@ -25,21 +33,18 @@ pub struct RuntimeStats {
     pub local_model_available: bool,
     /// Free KV-cache slots in the context pool (`0` = saturated).
     pub kv_cache_slots_free: usize,
-    /// Requests queued ahead of this one.
-    pub queue_depth: usize,
     /// Recent decode throughput (tokens/sec). `None` if not yet measured.
     pub tokens_per_sec: Option<f32>,
-    /// Device is thermally throttled or under heavy load.
-    pub thermal_throttling: bool,
     /// The previous attempt hit OOM / context overflow.
     pub context_overflow: bool,
 }
 
 impl RuntimeStats {
-    /// Below this decode rate the experience is "slow but working".
-    const SLOW_TOKENS_PER_SEC: f32 = 8.0;
-    /// More than this many requests queued ahead makes the wait noticeable.
-    const SLOW_QUEUE_DEPTH: usize = 2;
+    /// Below this absolute decode rate the experience is "slow but working".
+    /// This is the cold-start floor; once a per-config baseline has enough
+    /// samples, [`super::FeasibilityBaseline`] refines "slow" relative to that
+    /// model+context's own learned distribution.
+    pub(crate) const SLOW_TOKENS_PER_SEC: f32 = 8.0;
     /// Once the prompt crosses this fraction of context, too little headroom
     /// remains for a useful completion.
     const CONTEXT_PRESSURE: f32 = 0.9;
@@ -54,7 +59,7 @@ impl RuntimeStats {
 pub enum FeasibilityVerdict {
     /// Local can run this request now at an acceptable speed.
     LocalCanRunNow,
-    /// Local can run, but slowly (queue depth, low tok/s, thermal throttle).
+    /// Local can run, but slowly (low tok/s for this model+context).
     LocalCanRunSlowly,
     /// The prompt alone exceeds the context window; it must be chunked first.
     LocalNeedsChunking,
@@ -111,14 +116,13 @@ pub fn assess(stats: &RuntimeStats) -> FeasibilityVerdict {
         return FeasibilityVerdict::LocalCannotRun;
     }
 
-    // Feasible. Is it fast enough to be pleasant?
-    let throttled = stats.thermal_throttling
-        || stats.queue_depth > RuntimeStats::SLOW_QUEUE_DEPTH
-        || stats
-            .tokens_per_sec
-            .is_some_and(|t| t < RuntimeStats::SLOW_TOKENS_PER_SEC);
+    // Feasible. Is it fast enough to be pleasant? This is the absolute
+    // cold-start floor; the per-config baseline refines it once it has samples.
+    let slow = stats
+        .tokens_per_sec
+        .is_some_and(|t| t < RuntimeStats::SLOW_TOKENS_PER_SEC);
 
-    if throttled {
+    if slow {
         FeasibilityVerdict::LocalCanRunSlowly
     } else {
         FeasibilityVerdict::LocalCanRunNow
@@ -136,9 +140,7 @@ mod tests {
             n_ctx: 8_192,
             local_model_available: true,
             kv_cache_slots_free: 4,
-            queue_depth: 0,
             tokens_per_sec: Some(40.0),
-            thermal_throttling: false,
             context_overflow: false,
         }
     }
@@ -195,30 +197,12 @@ mod tests {
         assert_eq!(assess(&stats), FeasibilityVerdict::LocalCannotRun);
     }
 
-    // Each of these is a *feasibility* degradation, not a quality degradation:
-    // the request still runs, just slowly. None may authorize cloud spend.
+    // A throughput degradation is a *feasibility* degradation, not a quality
+    // one: the request still runs, just slowly. It may not authorize cloud spend.
     #[test]
     fn low_throughput_runs_slowly() {
         let stats = RuntimeStats {
             tokens_per_sec: Some(3.0),
-            ..healthy()
-        };
-        assert_eq!(assess(&stats), FeasibilityVerdict::LocalCanRunSlowly);
-    }
-
-    #[test]
-    fn deep_queue_runs_slowly() {
-        let stats = RuntimeStats {
-            queue_depth: 5,
-            ..healthy()
-        };
-        assert_eq!(assess(&stats), FeasibilityVerdict::LocalCanRunSlowly);
-    }
-
-    #[test]
-    fn thermal_throttle_runs_slowly() {
-        let stats = RuntimeStats {
-            thermal_throttling: true,
             ..healthy()
         };
         assert_eq!(assess(&stats), FeasibilityVerdict::LocalCanRunSlowly);

--- a/crates/arkavo-router/src/planes/feasibility_baseline.rs
+++ b/crates/arkavo-router/src/planes/feasibility_baseline.rs
@@ -120,17 +120,26 @@ fn median(sorted: &[f32]) -> f32 {
 }
 
 /// Robust z-score: `(x - median) / (1.4826 * MAD)`. The 1.4826 scales MAD to a
-/// standard-deviation-equivalent for normal data; a small epsilon avoids a
-/// divide-by-zero when every sample is identical.
+/// standard-deviation-equivalent for normal data.
+///
+/// When a config's history has little spread the MAD collapses to ~0 (common
+/// once more than half the retained samples are near-identical), and a bare
+/// `1.4826 * MAD` denominator would amplify a marginal dip into an enormous
+/// z-score — flagging a 79.9 tok/s sample against an all-80 history as "slow".
+/// To keep the scale meaningful, floor it at a small fraction of the median so
+/// only a *materially* lower throughput trips the threshold.
 fn robust_z(x: f32, samples: &[f32]) -> f32 {
     const EPS: f32 = 1e-6;
+    /// Minimum scale as a fraction of the median, used when MAD is ~0.
+    const MIN_SCALE_FRAC: f32 = 0.05;
     let mut sorted: Vec<f32> = samples.to_vec();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let med = median(&sorted);
     let mut deviations: Vec<f32> = sorted.iter().map(|v| (v - med).abs()).collect();
     deviations.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let mad = median(&deviations);
-    (x - med) / 1.4826f32.mul_add(mad, EPS)
+    let scale = (1.4826 * mad).max(med.abs() * MIN_SCALE_FRAC).max(EPS);
+    (x - med) / scale
 }
 
 #[cfg(test)]
@@ -236,6 +245,28 @@ mod tests {
     fn robust_z_is_zero_at_median() {
         let samples = vec![10.0, 20.0, 30.0, 40.0, 50.0];
         assert_eq!(robust_z(30.0, &samples), 0.0);
+    }
+
+    // Regression (gitar-bot): a near-zero MAD must not amplify a marginal dip
+    // into a "slow" verdict. A perfectly stable 80 tok/s history has MAD 0, so
+    // without the scale floor a 79.9 sample produced a huge negative z and
+    // spurious LocalCanRunSlowly. A *material* drop must still register.
+    #[test]
+    fn stable_config_does_not_overflag_marginal_dip() {
+        let b = FeasibilityBaseline::new();
+        for _ in 0..16 {
+            b.record("stable@8192", 80.0);
+        }
+        assert_eq!(
+            b.is_slow("stable@8192", 79.9),
+            Some(false),
+            "a 0.1 tok/s dip on a stable config must not read as slow"
+        );
+        assert_eq!(
+            b.is_slow("stable@8192", 30.0),
+            Some(true),
+            "a material drop must still read as slow"
+        );
     }
 
     #[test]

--- a/crates/arkavo-router/src/planes/feasibility_baseline.rs
+++ b/crates/arkavo-router/src/planes/feasibility_baseline.rs
@@ -14,14 +14,28 @@
 //! nothing here can authorize cloud spend.
 
 use super::feasibility::{FeasibilityVerdict, RuntimeStats, assess};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::collections::VecDeque;
+use std::path::PathBuf;
 use std::sync::RwLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Serializable form of the baseline for persistence across restarts.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FeasibilityBaselineSnapshot {
+    /// Config key (`model@n_ctx`) → recent throughput samples.
+    pub windows: HashMap<String, Vec<f32>>,
+}
 
 /// Rolling per-config throughput baseline.
 #[derive(Debug, Default)]
 pub struct FeasibilityBaseline {
     windows: RwLock<HashMap<String, VecDeque<f32>>>,
+    /// Where the baseline autosaves, if persistence is enabled.
+    path: Option<PathBuf>,
+    /// Records observed since the last autosave.
+    writes_since_save: AtomicU64,
 }
 
 impl FeasibilityBaseline {
@@ -34,9 +48,69 @@ impl FeasibilityBaseline {
     /// A sample this many robust-sigma below the config median is "slow for
     /// this config", even if it clears the absolute floor.
     const SLOW_Z: f32 = 1.5;
+    /// Autosave cadence (records). A few-KB JSON write every N inferences is
+    /// negligible next to an LLM call.
+    const SAVE_EVERY: u64 = 16;
 
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Default persistence path (`<cache>/arkavo/feasibility_baseline.json`),
+    /// or `None` if no cache dir is available.
+    pub fn default_path() -> Option<PathBuf> {
+        dirs::cache_dir().map(|d| d.join("arkavo").join("feasibility_baseline.json"))
+    }
+
+    /// Load a persisted baseline from `path` (if present and valid) and retain
+    /// `path` for autosave. A missing or corrupt file yields an empty baseline.
+    pub fn load(path: PathBuf) -> Self {
+        let snapshot = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|s| serde_json::from_str::<FeasibilityBaselineSnapshot>(&s).ok())
+            .unwrap_or_default();
+        Self {
+            windows: RwLock::new(snapshot_to_windows(snapshot)),
+            path: Some(path),
+            writes_since_save: AtomicU64::new(0),
+        }
+    }
+
+    /// Restore from an in-memory snapshot (no autosave path attached).
+    pub fn restore(snapshot: FeasibilityBaselineSnapshot) -> Self {
+        Self {
+            windows: RwLock::new(snapshot_to_windows(snapshot)),
+            path: None,
+            writes_since_save: AtomicU64::new(0),
+        }
+    }
+
+    /// Serializable snapshot of the current state.
+    pub fn snapshot(&self) -> FeasibilityBaselineSnapshot {
+        let windows = self
+            .windows
+            .read()
+            .ok()
+            .map(|w| {
+                w.iter()
+                    .map(|(k, v)| (k.clone(), v.iter().copied().collect()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        FeasibilityBaselineSnapshot { windows }
+    }
+
+    /// Write the snapshot to the autosave path. No-op when no path is set.
+    pub fn save(&self) -> std::io::Result<()> {
+        let Some(path) = &self.path else {
+            return Ok(());
+        };
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_string(&self.snapshot())
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        std::fs::write(path, json)
     }
 
     /// Canonical config key. Throughput is comparable only within a
@@ -45,7 +119,8 @@ impl FeasibilityBaseline {
         format!("{model_name}@{n_ctx}")
     }
 
-    /// Record an observed decode throughput for a config.
+    /// Record an observed decode throughput for a config, autosaving every
+    /// [`Self::SAVE_EVERY`] records when persistence is enabled.
     pub fn record(&self, key: &str, tokens_per_sec: f32) {
         if !tokens_per_sec.is_finite() || tokens_per_sec <= 0.0 {
             return;
@@ -56,6 +131,13 @@ impl FeasibilityBaseline {
             while window.len() > Self::WINDOW {
                 window.pop_front();
             }
+        }
+        // Autosave outside the write lock (`save` takes the read lock).
+        if self.path.is_some()
+            && self.writes_since_save.fetch_add(1, Ordering::Relaxed) + 1 >= Self::SAVE_EVERY
+        {
+            self.writes_since_save.store(0, Ordering::Relaxed);
+            let _ = self.save();
         }
     }
 
@@ -107,6 +189,25 @@ impl FeasibilityBaseline {
             None => structural,
         }
     }
+}
+
+/// Rebuild the bounded windows from a snapshot, dropping non-positive samples
+/// and capping each window to [`FeasibilityBaseline::WINDOW`].
+fn snapshot_to_windows(snapshot: FeasibilityBaselineSnapshot) -> HashMap<String, VecDeque<f32>> {
+    snapshot
+        .windows
+        .into_iter()
+        .map(|(key, samples)| {
+            let mut window: VecDeque<f32> = samples
+                .into_iter()
+                .filter(|x| x.is_finite() && *x > 0.0)
+                .collect();
+            while window.len() > FeasibilityBaseline::WINDOW {
+                window.pop_front();
+            }
+            (key, window)
+        })
+        .collect()
 }
 
 /// Median of a non-empty slice. Caller guarantees non-empty.
@@ -276,5 +377,52 @@ mod tests {
         b.record("m@8192", -5.0);
         b.record("m@8192", f32::NAN);
         assert_eq!(b.sample_count("m@8192"), 0);
+    }
+
+    // Regression: per-config learning must survive a restart. A snapshot
+    // round-trip preserves the windows and the resulting slow/fast verdict.
+    #[test]
+    fn snapshot_round_trip_preserves_learning() {
+        let b = FeasibilityBaseline::new();
+        for _ in 0..16 {
+            b.record("m3@8192", 80.0);
+        }
+        let restored = FeasibilityBaseline::restore(b.snapshot());
+        assert_eq!(restored.sample_count("m3@8192"), 16);
+        // The learned distribution carries over: 30 tok/s is still slow here.
+        assert_eq!(restored.is_slow("m3@8192", 30.0), Some(true));
+        assert_eq!(restored.is_slow("m3@8192", 79.0), Some(false));
+    }
+
+    #[test]
+    fn snapshot_drops_non_positive_and_caps_window() {
+        let mut snapshot = FeasibilityBaselineSnapshot::default();
+        let mut samples = vec![0.0, -1.0, f32::NAN];
+        samples.extend(std::iter::repeat_n(50.0, FeasibilityBaseline::WINDOW + 10));
+        snapshot.windows.insert("m@8192".to_string(), samples);
+        let restored = FeasibilityBaseline::restore(snapshot);
+        assert_eq!(
+            restored.sample_count("m@8192"),
+            FeasibilityBaseline::WINDOW,
+            "non-positive samples dropped and window capped on restore"
+        );
+    }
+
+    #[test]
+    fn save_and_load_via_disk_round_trip() {
+        let dir =
+            std::env::temp_dir().join(format!("arkavo_feasibility_test_{}", std::process::id()));
+        let path = dir.join("baseline.json");
+        let _ = std::fs::remove_file(&path);
+        {
+            let b = FeasibilityBaseline::load(path.clone());
+            for _ in 0..20 {
+                b.record("disk@8192", 60.0);
+            }
+            b.save().unwrap();
+        }
+        let reloaded = FeasibilityBaseline::load(path.clone());
+        assert_eq!(reloaded.sample_count("disk@8192"), 20);
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/crates/arkavo-router/src/planes/feasibility_baseline.rs
+++ b/crates/arkavo-router/src/planes/feasibility_baseline.rs
@@ -1,0 +1,249 @@
+//! Per-configuration runtime-cost baseline for the feasibility plane.
+//!
+//! llama.cpp statistics measure *observed computational cost*, and that cost is
+//! only comparable within one `(model, quantization, context, hardware)`
+//! configuration — the same prompt looks "fast" on an M3 and "slow" on a Pi 5.
+//! So a single absolute tokens/sec threshold (the cold-start floor in
+//! [`super::feasibility::assess`]) is wrong for at least one of them.
+//!
+//! This store keeps a rolling window of observed decode throughput per config
+//! and classifies a new sample with a robust z-score (median / MAD, not
+//! mean / stddev, because LLM latency is heavy-tailed). It only ever refines the
+//! *running* verdict (`LocalCanRunNow` ↔ `LocalCanRunSlowly`); structural
+//! verdicts — chunking, smaller-context, cannot-run — stay with `assess`, and
+//! nothing here can authorize cloud spend.
+
+use super::feasibility::{FeasibilityVerdict, RuntimeStats, assess};
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::sync::RwLock;
+
+/// Rolling per-config throughput baseline.
+#[derive(Debug, Default)]
+pub struct FeasibilityBaseline {
+    windows: RwLock<HashMap<String, VecDeque<f32>>>,
+}
+
+impl FeasibilityBaseline {
+    /// Samples retained per config. Small enough to track recent hardware/load
+    /// state, large enough for a stable median/MAD.
+    const WINDOW: usize = 32;
+    /// Minimum samples before the baseline has an opinion; below this the
+    /// absolute cold-start floor is used instead.
+    const MIN_SAMPLES: usize = 8;
+    /// A sample this many robust-sigma below the config median is "slow for
+    /// this config", even if it clears the absolute floor.
+    const SLOW_Z: f32 = 1.5;
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Canonical config key. Throughput is comparable only within a
+    /// `(model, context-window)` pair on a given host, so both are in the key.
+    pub fn key(model_name: &str, n_ctx: u32) -> String {
+        format!("{model_name}@{n_ctx}")
+    }
+
+    /// Record an observed decode throughput for a config.
+    pub fn record(&self, key: &str, tokens_per_sec: f32) {
+        if !tokens_per_sec.is_finite() || tokens_per_sec <= 0.0 {
+            return;
+        }
+        if let Ok(mut windows) = self.windows.write() {
+            let window = windows.entry(key.to_string()).or_default();
+            window.push_back(tokens_per_sec);
+            while window.len() > Self::WINDOW {
+                window.pop_front();
+            }
+        }
+    }
+
+    /// Number of samples held for a config (for telemetry / tests).
+    pub fn sample_count(&self, key: &str) -> usize {
+        self.windows
+            .read()
+            .ok()
+            .and_then(|w| w.get(key).map(VecDeque::len))
+            .unwrap_or(0)
+    }
+
+    /// Whether `tokens_per_sec` is slow *relative to this config's own history*.
+    ///
+    /// Returns `None` until the window has [`Self::MIN_SAMPLES`] samples, so the
+    /// caller falls back to the absolute floor during cold start.
+    pub fn is_slow(&self, key: &str, tokens_per_sec: f32) -> Option<bool> {
+        let windows = self.windows.read().ok()?;
+        let window = windows.get(key)?;
+        if window.len() < Self::MIN_SAMPLES {
+            return None;
+        }
+        let samples: Vec<f32> = window.iter().copied().collect();
+        let z = robust_z(tokens_per_sec, &samples);
+        // Negative z = below the config median (slower than usual).
+        Some(z <= -Self::SLOW_Z)
+    }
+
+    /// Classify feasibility, refining the running verdict with the per-config
+    /// baseline.
+    ///
+    /// Structural verdicts (`assess` decided chunking / smaller-context /
+    /// cannot-run) pass through untouched. For a *running* verdict the baseline
+    /// can both downgrade (`Now` → `Slowly`, when throughput is far below this
+    /// config's median) and upgrade (`Slowly` → `Now`, when a normally-slow
+    /// device is running at its usual rate and the absolute floor mislabeled
+    /// it). With no baseline opinion the absolute-floor verdict stands.
+    pub fn classify(&self, stats: &RuntimeStats, key: &str) -> FeasibilityVerdict {
+        let structural = assess(stats);
+        if !structural.can_run_local() {
+            return structural;
+        }
+        let Some(tps) = stats.tokens_per_sec else {
+            return structural;
+        };
+        match self.is_slow(key, tps) {
+            Some(true) => FeasibilityVerdict::LocalCanRunSlowly,
+            Some(false) => FeasibilityVerdict::LocalCanRunNow,
+            None => structural,
+        }
+    }
+}
+
+/// Median of a non-empty slice. Caller guarantees non-empty.
+fn median(sorted: &[f32]) -> f32 {
+    let n = sorted.len();
+    if n % 2 == 1 {
+        sorted[n / 2]
+    } else {
+        f32::midpoint(sorted[n / 2 - 1], sorted[n / 2])
+    }
+}
+
+/// Robust z-score: `(x - median) / (1.4826 * MAD)`. The 1.4826 scales MAD to a
+/// standard-deviation-equivalent for normal data; a small epsilon avoids a
+/// divide-by-zero when every sample is identical.
+fn robust_z(x: f32, samples: &[f32]) -> f32 {
+    const EPS: f32 = 1e-6;
+    let mut sorted: Vec<f32> = samples.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let med = median(&sorted);
+    let mut deviations: Vec<f32> = sorted.iter().map(|v| (v - med).abs()).collect();
+    deviations.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mad = median(&deviations);
+    (x - med) / 1.4826f32.mul_add(mad, EPS)
+}
+
+#[cfg(test)]
+#[allow(clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    fn stats_with_tps(tps: f32) -> RuntimeStats {
+        RuntimeStats {
+            prompt_tokens: 500,
+            n_ctx: 8_192,
+            local_model_available: true,
+            kv_cache_slots_free: 4,
+            tokens_per_sec: Some(tps),
+            context_overflow: false,
+        }
+    }
+
+    #[test]
+    fn key_includes_model_and_context() {
+        assert_eq!(
+            FeasibilityBaseline::key("qwen3.5-9b", 8192),
+            "qwen3.5-9b@8192"
+        );
+    }
+
+    #[test]
+    fn no_opinion_until_min_samples() {
+        let b = FeasibilityBaseline::new();
+        for _ in 0..(FeasibilityBaseline::MIN_SAMPLES - 1) {
+            b.record("m@8192", 80.0);
+        }
+        assert_eq!(b.is_slow("m@8192", 5.0), None);
+        // With no opinion, classify falls back to the absolute floor: 5 tok/s
+        // is below the 8 tok/s floor, so it reads as slow.
+        assert_eq!(
+            b.classify(&stats_with_tps(5.0), "m@8192"),
+            FeasibilityVerdict::LocalCanRunSlowly
+        );
+    }
+
+    #[test]
+    fn downgrades_fast_config_when_throughput_collapses() {
+        let b = FeasibilityBaseline::new();
+        // An M3-class config that normally sustains ~80 tok/s.
+        for _ in 0..16 {
+            b.record("m3@8192", 80.0);
+        }
+        // 30 tok/s clears the absolute 8 tok/s floor but is far below this
+        // config's own median, so it is "slow for this config".
+        assert_eq!(b.is_slow("m3@8192", 30.0), Some(true));
+        assert_eq!(
+            b.classify(&stats_with_tps(30.0), "m3@8192"),
+            FeasibilityVerdict::LocalCanRunSlowly
+        );
+    }
+
+    #[test]
+    fn upgrades_slow_device_running_at_its_normal_rate() {
+        let b = FeasibilityBaseline::new();
+        // A Pi-5-class config whose normal rate is ~5 tok/s (below the floor).
+        for _ in 0..16 {
+            b.record("pi5@4096", 5.0);
+        }
+        // 5 tok/s is normal here, so it must NOT be flagged slow even though it
+        // is under the absolute cold-start floor.
+        assert_eq!(b.is_slow("pi5@4096", 5.0), Some(false));
+        assert_eq!(
+            b.classify(&stats_with_tps(5.0), "pi5@4096"),
+            FeasibilityVerdict::LocalCanRunNow
+        );
+    }
+
+    #[test]
+    fn baseline_never_overrides_structural_verdict() {
+        let b = FeasibilityBaseline::new();
+        for _ in 0..16 {
+            b.record("m@8192", 80.0);
+        }
+        // Oversized prompt is structural — chunking wins regardless of the
+        // throughput baseline.
+        let oversized = RuntimeStats {
+            prompt_tokens: 9_000,
+            n_ctx: 8_192,
+            ..stats_with_tps(80.0)
+        };
+        assert_eq!(
+            b.classify(&oversized, "m@8192"),
+            FeasibilityVerdict::LocalNeedsChunking
+        );
+    }
+
+    #[test]
+    fn window_is_bounded() {
+        let b = FeasibilityBaseline::new();
+        for i in 0..(FeasibilityBaseline::WINDOW + 20) {
+            b.record("m@8192", 10.0 + i as f32);
+        }
+        assert_eq!(b.sample_count("m@8192"), FeasibilityBaseline::WINDOW);
+    }
+
+    #[test]
+    fn robust_z_is_zero_at_median() {
+        let samples = vec![10.0, 20.0, 30.0, 40.0, 50.0];
+        assert_eq!(robust_z(30.0, &samples), 0.0);
+    }
+
+    #[test]
+    fn non_positive_samples_are_ignored() {
+        let b = FeasibilityBaseline::new();
+        b.record("m@8192", 0.0);
+        b.record("m@8192", -5.0);
+        b.record("m@8192", f32::NAN);
+        assert_eq!(b.sample_count("m@8192"), 0);
+    }
+}

--- a/crates/arkavo-router/src/planes/mod.rs
+++ b/crates/arkavo-router/src/planes/mod.rs
@@ -1,0 +1,262 @@
+//! Three-plane router separation.
+//!
+//! ```text
+//! Availability changes what is *possible*  -> feasibility plane
+//! Quality changes what is *advisable*       -> collapse plane (adequacy v1)
+//! Budget policy changes what is *allowed*   -> spend plane (arkavo-budget)
+//! ```
+//!
+//! The planes are kept strictly separate so a feasibility/availability failure
+//! can never silently authorize cloud spend. The flow this module encodes:
+//!
+//! 1. Check local feasibility.
+//! 2. If local can run, run local.
+//! 3. If local visibly collapses, mark it as collapse.
+//! 4. If local completes, show the answer.
+//! 5. Offer a cloud upgrade when: the user asks, a collapse occurred, the task
+//!    class is high-risk, and the user policy allows asking.
+//! 6. Before any cloud call, check budget.
+//! 7. If budget is exhausted, stay local.
+//!
+//! The key distinction: a collapse can trigger an upgrade *offer*; it does not
+//! trigger automatic spend by default.
+
+pub mod collapse;
+pub mod feasibility;
+
+pub use collapse::{AnswerObservation, CollapseSignal, CollapseVerdict, detect as detect_collapse};
+pub use feasibility::{FeasibilityVerdict, RuntimeStats, assess as assess_feasibility};
+
+use arkavo_budget::TokenCost;
+use arkavo_budget::cloud_policy::{
+    CloudPolicy, CloudSpendDecision, CloudSpendReason, CloudSpendRequest, SpendCaps,
+    authorize_cloud_spend,
+};
+
+/// What to do with the request given only the feasibility plane's verdict.
+///
+/// [`LocalPlan::Unavailable`] is **not** a spend authorization: the caller must
+/// ask the user, queue, retry locally, or return a partial answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LocalPlan {
+    /// Run the request on the local model.
+    RunLocal,
+    /// Run locally, but tell the user it will be slow (busy/throttled).
+    RunLocalSlow,
+    /// Reshape the request first (chunk or shrink context), then run local.
+    Reshape(FeasibilityVerdict),
+    /// Local cannot run right now. Availability failure — never silent spend.
+    Unavailable,
+}
+
+/// Map the feasibility verdict to a local execution plan. The feasibility plane
+/// alone decides this; no cloud action is reachable from here.
+pub fn plan_local(stats: &RuntimeStats) -> LocalPlan {
+    match assess_feasibility(stats) {
+        FeasibilityVerdict::LocalCanRunNow => LocalPlan::RunLocal,
+        FeasibilityVerdict::LocalCanRunSlowly => LocalPlan::RunLocalSlow,
+        reshape @ (FeasibilityVerdict::LocalNeedsChunking
+        | FeasibilityVerdict::LocalNeedsSmallerContext) => LocalPlan::Reshape(reshape),
+        FeasibilityVerdict::LocalCannotRun => LocalPlan::Unavailable,
+    }
+}
+
+/// Conditions, independent of feasibility, under which a cloud upgrade may be
+/// *offered* after a local answer.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UpgradeContext {
+    /// The user explicitly asked for a cloud / higher-quality answer.
+    pub user_requested: bool,
+    /// The task class is high-risk (e.g. security-sensitive, irreversible).
+    pub high_risk_task: bool,
+}
+
+/// Whether — and why — to offer a cloud upgrade. Presenting an offer never
+/// spends; the offer must still pass the spend plane.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpgradeOffer {
+    /// Do not offer cloud; keep the local answer.
+    None,
+    /// Offer the user a cloud upgrade for the stated reason.
+    Offer(CloudSpendReason),
+}
+
+/// Decide whether to offer a cloud upgrade after a completed local answer.
+///
+/// Only quality (collapse) and user/task context drive an offer — never a
+/// feasibility signal. `LocalOnly` policy never offers.
+pub fn upgrade_offer(
+    policy: CloudPolicy,
+    collapse: &CollapseVerdict,
+    ctx: UpgradeContext,
+) -> UpgradeOffer {
+    if policy == CloudPolicy::LocalOnly {
+        return UpgradeOffer::None;
+    }
+    if ctx.user_requested {
+        return UpgradeOffer::Offer(CloudSpendReason::UserRequested);
+    }
+    if collapse.collapsed() {
+        return UpgradeOffer::Offer(CloudSpendReason::LocalCollapsed);
+    }
+    if ctx.high_risk_task {
+        return UpgradeOffer::Offer(CloudSpendReason::HighRiskTask);
+    }
+    UpgradeOffer::None
+}
+
+/// Authorize cloud spend for an offered upgrade.
+///
+/// This is the ONLY path from a collapse/offer to actual spend, and it
+/// delegates the allow/deny decision to the budget (spend) plane. Feasibility
+/// signals never reach this function.
+pub fn authorize_upgrade(
+    policy: CloudPolicy,
+    reason: CloudSpendReason,
+    projected_cost: TokenCost,
+    caps: SpendCaps,
+    user_confirmed: bool,
+) -> CloudSpendDecision {
+    let request = CloudSpendRequest {
+        reason,
+        projected_cost,
+        user_confirmed,
+    };
+    authorize_cloud_spend(policy, &request, caps)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn healthy_stats() -> RuntimeStats {
+        RuntimeStats {
+            prompt_tokens: 500,
+            n_ctx: 8_192,
+            local_model_available: true,
+            kv_cache_slots_free: 4,
+            queue_depth: 0,
+            tokens_per_sec: Some(40.0),
+            thermal_throttling: false,
+            context_overflow: false,
+        }
+    }
+
+    #[test]
+    fn healthy_runtime_runs_local() {
+        assert_eq!(plan_local(&healthy_stats()), LocalPlan::RunLocal);
+    }
+
+    #[test]
+    fn slow_runtime_runs_local_slow_not_cloud() {
+        let stats = RuntimeStats {
+            thermal_throttling: true,
+            ..healthy_stats()
+        };
+        // A slow laptop stays local. There is no cloud variant in LocalPlan.
+        assert_eq!(plan_local(&stats), LocalPlan::RunLocalSlow);
+    }
+
+    #[test]
+    fn unavailable_local_is_not_a_spend_event() {
+        let stats = RuntimeStats {
+            local_model_available: false,
+            ..healthy_stats()
+        };
+        assert_eq!(plan_local(&stats), LocalPlan::Unavailable);
+    }
+
+    // Corrected escalation behavior: a feasibility degradation produces no
+    // upgrade offer on its own. Only collapse / user-ask / high-risk do.
+    #[test]
+    fn slow_local_alone_does_not_offer_cloud() {
+        let offer = upgrade_offer(
+            CloudPolicy::AskBeforeCloud,
+            &CollapseVerdict::NoVisibleCollapse,
+            UpgradeContext::default(),
+        );
+        assert_eq!(offer, UpgradeOffer::None);
+    }
+
+    #[test]
+    fn collapse_offers_cloud_upgrade() {
+        let offer = upgrade_offer(
+            CloudPolicy::AskBeforeCloud,
+            &CollapseVerdict::Collapsed(CollapseSignal::RepetitionLoop),
+            UpgradeContext::default(),
+        );
+        assert_eq!(offer, UpgradeOffer::Offer(CloudSpendReason::LocalCollapsed));
+    }
+
+    #[test]
+    fn user_request_offers_cloud_upgrade() {
+        let offer = upgrade_offer(
+            CloudPolicy::AskBeforeCloud,
+            &CollapseVerdict::NoVisibleCollapse,
+            UpgradeContext {
+                user_requested: true,
+                ..Default::default()
+            },
+        );
+        assert_eq!(offer, UpgradeOffer::Offer(CloudSpendReason::UserRequested));
+    }
+
+    #[test]
+    fn local_only_never_offers_even_on_collapse() {
+        let offer = upgrade_offer(
+            CloudPolicy::LocalOnly,
+            &CollapseVerdict::Collapsed(CollapseSignal::EmptyOutput),
+            UpgradeContext {
+                user_requested: true,
+                high_risk_task: true,
+            },
+        );
+        assert_eq!(offer, UpgradeOffer::None);
+    }
+
+    // End-to-end of the corrected logic: collapse -> offer -> the spend plane
+    // still gates the actual call. Under the default policy that means asking.
+    #[test]
+    fn collapse_offer_then_spend_plane_asks_before_spending() {
+        let policy = CloudPolicy::AskBeforeCloud;
+        let collapse = CollapseVerdict::Collapsed(CollapseSignal::TruncatedOutput);
+        let UpgradeOffer::Offer(reason) =
+            upgrade_offer(policy, &collapse, UpgradeContext::default())
+        else {
+            panic!("collapse should produce an offer");
+        };
+
+        let caps = SpendCaps {
+            remaining_cap: TokenCost::from_dollars(10.0),
+            per_request_max: None,
+        };
+        // Not yet confirmed → the spend plane asks, it does not auto-spend.
+        let decision = authorize_upgrade(policy, reason, TokenCost::from_dollars(0.2), caps, false);
+        assert!(matches!(
+            decision,
+            CloudSpendDecision::NeedsUserConfirmation { .. }
+        ));
+
+        // After the user confirms, the same request is authorized.
+        let confirmed = authorize_upgrade(policy, reason, TokenCost::from_dollars(0.2), caps, true);
+        assert!(confirmed.is_authorized());
+    }
+
+    // Regression: budget exhaustion keeps us local even when the user confirmed
+    // and a collapse occurred. Budget is the sole spend authority.
+    #[test]
+    fn exhausted_budget_stays_local() {
+        let caps = SpendCaps {
+            remaining_cap: TokenCost::from_cents(1),
+            per_request_max: None,
+        };
+        let decision = authorize_upgrade(
+            CloudPolicy::CloudWithinCap,
+            CloudSpendReason::LocalCollapsed,
+            TokenCost::from_dollars(0.5),
+            caps,
+            true,
+        );
+        assert!(!decision.is_authorized());
+    }
+}

--- a/crates/arkavo-router/src/planes/mod.rs
+++ b/crates/arkavo-router/src/planes/mod.rs
@@ -27,7 +27,7 @@ pub mod feasibility_baseline;
 
 pub use collapse::{AnswerObservation, CollapseSignal, CollapseVerdict, detect as detect_collapse};
 pub use feasibility::{FeasibilityVerdict, RuntimeStats, assess as assess_feasibility};
-pub use feasibility_baseline::FeasibilityBaseline;
+pub use feasibility_baseline::{FeasibilityBaseline, FeasibilityBaselineSnapshot};
 
 use arkavo_budget::TokenCost;
 use arkavo_budget::cloud_policy::{

--- a/crates/arkavo-router/src/planes/mod.rs
+++ b/crates/arkavo-router/src/planes/mod.rs
@@ -125,6 +125,30 @@ pub fn authorize_upgrade(
     authorize_cloud_spend(policy, &request, caps)
 }
 
+/// Augment a re-route exclusion set per the plane separation.
+///
+/// A retry triggered by a feasibility failure (timeout/OOM) or a quality
+/// collapse may not silently cross into paid cloud spend. Unless the cloud
+/// policy authorizes spending without asking
+/// ([`CloudPolicy::permits_silent_cloud`]), every cloud arm is added to the
+/// `excluded` set so re-selection stays local. This is the single place the
+/// "availability/quality may not silently spend" rule is enforced in the
+/// routing loop, and it is pure so it can be unit-tested without a model.
+pub fn augment_exclusions_for_policy(
+    mut excluded: Vec<String>,
+    policy: CloudPolicy,
+) -> Vec<String> {
+    if !policy.permits_silent_cloud() {
+        for model in crate::decision::ModelChoice::ALL_CLOUD {
+            let name = model.name().to_string();
+            if !excluded.iter().any(|e| e == &name) {
+                excluded.push(name);
+            }
+        }
+    }
+    excluded
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -240,6 +264,51 @@ mod tests {
         // After the user confirms, the same request is authorized.
         let confirmed = authorize_upgrade(policy, reason, TokenCost::from_dollars(0.2), caps, true);
         assert!(confirmed.is_authorized());
+    }
+
+    // The plane separation in the routing loop: a feasibility/quality re-route
+    // excludes all cloud arms unless the policy permits silent cloud.
+    #[test]
+    fn reroute_excludes_cloud_unless_policy_permits() {
+        use crate::decision::ModelChoice;
+
+        for policy in [CloudPolicy::LocalOnly, CloudPolicy::AskBeforeCloud] {
+            let excluded = augment_exclusions_for_policy(Vec::new(), policy);
+            for cloud in ModelChoice::ALL_CLOUD {
+                assert!(
+                    excluded.iter().any(|e| e == cloud.name()),
+                    "{policy:?} must exclude cloud arm {}",
+                    cloud.name()
+                );
+            }
+            // Local arms must remain selectable.
+            assert!(
+                !excluded.iter().any(|e| e == ModelChoice::LocalQwen3.name()),
+                "local arms must not be excluded"
+            );
+        }
+
+        // CloudWithinCap leaves the set untouched — cloud stays selectable.
+        let excluded = augment_exclusions_for_policy(Vec::new(), CloudPolicy::CloudWithinCap);
+        assert!(excluded.is_empty());
+    }
+
+    #[test]
+    fn augment_preserves_existing_exclusions_without_duplicating() {
+        use crate::decision::ModelChoice;
+        let seed = vec![
+            ModelChoice::LocalQwen3.name().to_string(),
+            ModelChoice::Glm52.name().to_string(),
+        ];
+        let excluded = augment_exclusions_for_policy(seed, CloudPolicy::AskBeforeCloud);
+        // Glm52 was already present; it must appear exactly once.
+        let glm_count = excluded
+            .iter()
+            .filter(|e| *e == ModelChoice::Glm52.name())
+            .count();
+        assert_eq!(glm_count, 1, "existing cloud exclusion must not duplicate");
+        // The seeded local exclusion is preserved.
+        assert!(excluded.iter().any(|e| e == ModelChoice::LocalQwen3.name()));
     }
 
     // Regression: budget exhaustion keeps us local even when the user confirmed

--- a/crates/arkavo-router/src/planes/mod.rs
+++ b/crates/arkavo-router/src/planes/mod.rs
@@ -23,9 +23,11 @@
 
 pub mod collapse;
 pub mod feasibility;
+pub mod feasibility_baseline;
 
 pub use collapse::{AnswerObservation, CollapseSignal, CollapseVerdict, detect as detect_collapse};
 pub use feasibility::{FeasibilityVerdict, RuntimeStats, assess as assess_feasibility};
+pub use feasibility_baseline::FeasibilityBaseline;
 
 use arkavo_budget::TokenCost;
 use arkavo_budget::cloud_policy::{
@@ -159,9 +161,7 @@ mod tests {
             n_ctx: 8_192,
             local_model_available: true,
             kv_cache_slots_free: 4,
-            queue_depth: 0,
             tokens_per_sec: Some(40.0),
-            thermal_throttling: false,
             context_overflow: false,
         }
     }
@@ -174,7 +174,7 @@ mod tests {
     #[test]
     fn slow_runtime_runs_local_slow_not_cloud() {
         let stats = RuntimeStats {
-            thermal_throttling: true,
+            tokens_per_sec: Some(3.0),
             ..healthy_stats()
         };
         // A slow laptop stays local. There is no cloud variant in LocalPlan.

--- a/crates/arkavo-router/src/preflight/config.rs
+++ b/crates/arkavo-router/src/preflight/config.rs
@@ -175,6 +175,10 @@ pub struct BudgetYamlConfig {
     pub max_cost_per_session: Option<f64>,
     /// Maximum token cost per day in dollars
     pub max_cost_per_day: Option<f64>,
+    /// Cloud spend posture: `local_only` | `ask_before_cloud` | `cloud_within_cap`.
+    /// Omitted → the safe default `ask_before_cloud`.
+    #[serde(default)]
+    pub cloud_policy: Option<String>,
 }
 
 /// KAS section in AGENTS.md YAML frontmatter

--- a/crates/arkavo-router/src/quality_gate.rs
+++ b/crates/arkavo-router/src/quality_gate.rs
@@ -648,11 +648,19 @@ impl super::Router {
                     hit_output_cap: response.finish_reason.as_deref() == Some("length"),
                     tool_call_required: false,
                     precomputed: None,
+                    avg_logprob: response
+                        .inference_timing
+                        .as_ref()
+                        .and_then(|t| t.avg_logprob),
                 });
-                // Retry only on breakdowns where a fresh attempt clearly helps;
-                // a truncated-but-coherent long answer is not re-rolled.
+                // Retry/offer on breakdowns where a fresh attempt or a stronger
+                // model helps: empty/repetition (local re-roll) and low token
+                // confidence (the adequacy signal — a stronger model may be
+                // surer). A truncated-but-coherent long answer is not re-rolled.
                 if let CollapseVerdict::Collapsed(
-                    signal @ (CollapseSignal::EmptyOutput | CollapseSignal::RepetitionLoop),
+                    signal @ (CollapseSignal::EmptyOutput
+                    | CollapseSignal::RepetitionLoop
+                    | CollapseSignal::LowConfidence),
                 ) = collapse
                 {
                     let offer = planes::upgrade_offer(
@@ -662,35 +670,47 @@ impl super::Router {
                     );
                     // Spend plane: a collapse only *requests* cloud. Authorize
                     // it through the budget plane — policy AND the live remaining
-                    // cap — never on the quality signal alone. No user
-                    // confirmation channel here yet, so `user_confirmed=false`:
-                    // AskBeforeCloud stays local, CloudWithinCap escalates only
-                    // within cap.
+                    // cap — never on the quality signal alone. A one-shot user
+                    // confirmation (set via confirm_next_cloud_upgrade after a
+                    // CloudUpgradeOffered) satisfies AskBeforeCloud; otherwise the
+                    // decision tells us whether to offer (ask) or refuse.
                     let allow_cloud = if let UpgradeOffer::Offer(reason) = offer {
                         let caps = self.cloud_spend_caps().await;
                         let projected = self.projected_cloud_cost(&current_decision);
-                        planes::authorize_upgrade(
+                        let confirmed = self.consume_cloud_confirmation();
+                        match planes::authorize_upgrade(
                             self.cloud_policy(),
                             reason,
                             projected,
                             caps,
-                            false,
-                        )
-                        .is_authorized()
+                            confirmed,
+                        ) {
+                            arkavo_budget::CloudSpendDecision::Authorized { .. } => true,
+                            arkavo_budget::CloudSpendDecision::NeedsUserConfirmation {
+                                projected_cost,
+                            } => {
+                                // Policy permits cloud but needs the user's OK:
+                                // surface the offer and stay local this turn.
+                                self.emit_event(crate::RouterEvent::CloudUpgradeOffered {
+                                    reason: format!("{reason:?}"),
+                                    projected_cost_cents: projected_cost.as_cents(),
+                                });
+                                false
+                            }
+                            arkavo_budget::CloudSpendDecision::Denied(_) => {
+                                self.emit_event(crate::RouterEvent::CloudEscalationBlocked {
+                                    reason: format!("collapse:{signal:?}"),
+                                    policy: format!("{:?}", self.cloud_policy()),
+                                });
+                                false
+                            }
+                        }
                     } else {
                         false
                     };
                     let mut excluded = if allow_cloud {
                         self.get_excluded_models().await
                     } else {
-                        // Quality collapse, but the spend plane won't authorize
-                        // silent cloud — stay local and surface the boundary.
-                        if matches!(offer, UpgradeOffer::Offer(_)) {
-                            self.emit_event(crate::RouterEvent::CloudEscalationBlocked {
-                                reason: format!("collapse:{signal:?}"),
-                                policy: format!("{:?}", self.cloud_policy()),
-                            });
-                        }
                         self.reroute_exclusions().await
                     };
                     // Exclude the model that just collapsed so re-selection

--- a/crates/arkavo-router/src/quality_gate.rs
+++ b/crates/arkavo-router/src/quality_gate.rs
@@ -662,7 +662,7 @@ impl super::Router {
                     );
                     let allow_cloud = matches!(offer, UpgradeOffer::Offer(_))
                         && self.cloud_policy().permits_silent_cloud();
-                    let excluded = if allow_cloud {
+                    let mut excluded = if allow_cloud {
                         self.get_excluded_models().await
                     } else {
                         // Quality collapse, but the spend plane won't authorize
@@ -675,6 +675,13 @@ impl super::Router {
                         }
                         self.reroute_exclusions().await
                     };
+                    // Exclude the model that just collapsed so re-selection
+                    // actually rotates the arm instead of reproducing the same
+                    // collapse and burning a retry.
+                    let collapsed_name = current_decision.recommended_model.name().to_string();
+                    if !excluded.iter().any(|e| e == &collapsed_name) {
+                        excluded.push(collapsed_name);
+                    }
                     let re_class = classifier::Classification::new(
                         current_decision.task_category,
                         current_decision.confidence,
@@ -685,6 +692,20 @@ impl super::Router {
                         .select_adaptive(&self.model_learning, &re_class, 0.0, &excluded)
                         .await
                     {
+                        // Steer Thompson Sampling away from the collapsing
+                        // model before rotating off it, mirroring the
+                        // Judge-rejection path — otherwise the retry doesn't
+                        // learn from the collapse.
+                        self.model_learning
+                            .immediate_update(
+                                current_decision.recommended_model.name(),
+                                &BurstFeedback::failure(
+                                    uuid::Uuid::new_v4(),
+                                    current_decision.task_category.as_str().to_string(),
+                                    inference_start.elapsed().as_millis() as u64,
+                                ),
+                            )
+                            .await;
                         tracing::info!(
                             signal = ?signal,
                             from = %current_decision.recommended_model.name(),

--- a/crates/arkavo-router/src/quality_gate.rs
+++ b/crates/arkavo-router/src/quality_gate.rs
@@ -419,7 +419,14 @@ impl super::Router {
                         .await;
 
                     if attempt + 1 < MAX_RETRIES {
-                        let excluded = self.get_excluded_models().await;
+                        // Feasibility plane: a provider error (timeout / OOM /
+                        // crash) is an *availability* failure, not a quality
+                        // one. Per the plane separation it may not silently
+                        // cross into paid cloud — `reroute_exclusions` drops the
+                        // cloud arms unless the cloud policy authorizes silent
+                        // spend, so the retry stays local under the default
+                        // `AskBeforeCloud` posture.
+                        let excluded = self.reroute_exclusions().await;
                         let re_class = classifier::Classification::new(
                             current_decision.task_category,
                             current_decision.confidence,
@@ -431,6 +438,8 @@ impl super::Router {
                             .await?;
                         tracing::info!(
                             model = %current_decision.recommended_model.name(),
+                            cloud_policy = ?self.cloud_policy(),
+                            stayed_local = current_decision.recommended_model.is_local(),
                             "Re-routed after availability failure: {e}"
                         );
                         continue;
@@ -617,6 +626,68 @@ impl super::Router {
                         Err(e) => {
                             tracing::debug!("Judge validation skipped (model unavailable): {}", e);
                         }
+                    }
+                }
+            }
+
+            // Collapse plane (adequacy v1): catch visible breakdowns the
+            // validator and Judge miss — empty output and repetition loops on a
+            // final-answer turn. A collapse may trigger a retry/offer, but per
+            // the plane separation it never silently spends: cloud becomes a
+            // retry candidate only when the policy authorizes silent spend.
+            if !execution_mode && response.tool_calls.is_empty() && attempt + 1 < MAX_RETRIES {
+                use crate::planes::{self, CollapseSignal, CollapseVerdict, UpgradeOffer};
+                let collapse = planes::detect_collapse(&planes::AnswerObservation {
+                    text: &response.content,
+                    hit_output_cap: response.finish_reason.as_deref() == Some("length"),
+                    tool_call_required: false,
+                    precomputed: None,
+                });
+                // Retry only on breakdowns where a fresh attempt clearly helps;
+                // a truncated-but-coherent long answer is not re-rolled.
+                if let CollapseVerdict::Collapsed(
+                    signal @ (CollapseSignal::EmptyOutput | CollapseSignal::RepetitionLoop),
+                ) = collapse
+                {
+                    let offer = planes::upgrade_offer(
+                        self.cloud_policy(),
+                        &collapse,
+                        planes::UpgradeContext::default(),
+                    );
+                    let allow_cloud = matches!(offer, UpgradeOffer::Offer(_))
+                        && self.cloud_policy().permits_silent_cloud();
+                    let excluded = if allow_cloud {
+                        self.get_excluded_models().await
+                    } else {
+                        // Quality collapse, but the spend plane won't authorize
+                        // silent cloud — stay local and surface the boundary.
+                        if matches!(offer, UpgradeOffer::Offer(_)) {
+                            self.emit_event(crate::RouterEvent::CloudEscalationBlocked {
+                                reason: format!("collapse:{signal:?}"),
+                                policy: format!("{:?}", self.cloud_policy()),
+                            });
+                        }
+                        self.reroute_exclusions().await
+                    };
+                    let re_class = classifier::Classification::new(
+                        current_decision.task_category,
+                        current_decision.confidence,
+                        format!("Re-routed after local collapse ({signal:?})"),
+                    );
+                    if let Ok(next) = self
+                        .selector
+                        .select_adaptive(&self.model_learning, &re_class, 0.0, &excluded)
+                        .await
+                    {
+                        tracing::info!(
+                            signal = ?signal,
+                            from = %current_decision.recommended_model.name(),
+                            to = %next.recommended_model.name(),
+                            cloud_allowed = allow_cloud,
+                            "Re-routed after local collapse"
+                        );
+                        current_decision = next;
+                        continue;
                     }
                 }
             }

--- a/crates/arkavo-router/src/quality_gate.rs
+++ b/crates/arkavo-router/src/quality_gate.rs
@@ -438,17 +438,35 @@ impl super::Router {
                             current_decision.confidence,
                             "Re-routed after availability failure".to_string(),
                         );
-                        current_decision = self
+                        match self
                             .selector
                             .select_adaptive(&self.model_learning, &re_class, 0.0, &excluded)
-                            .await?;
-                        tracing::info!(
-                            model = %current_decision.recommended_model.name(),
-                            cloud_policy = ?self.cloud_policy(),
-                            stayed_local = current_decision.recommended_model.is_local(),
-                            "Re-routed after availability failure: {e}"
-                        );
-                        continue;
+                            .await
+                        {
+                            Ok(next) => {
+                                current_decision = next;
+                                tracing::info!(
+                                    model = %current_decision.recommended_model.name(),
+                                    cloud_policy = ?self.cloud_policy(),
+                                    stayed_local = current_decision.recommended_model.is_local(),
+                                    "Re-routed after availability failure: {e}"
+                                );
+                                continue;
+                            }
+                            Err(reroute_err) => {
+                                // No local model could be selected and the cloud
+                                // policy bars a silent paid fallback. Surface the
+                                // quality→spend boundary so callers can tell
+                                // "local unavailable, cloud blocked by policy"
+                                // from a generic provider failure, then propagate
+                                // the more specific re-route error.
+                                self.emit_event(crate::RouterEvent::CloudEscalationBlocked {
+                                    reason: format!("availability:{e}"),
+                                    policy: format!("{:?}", self.cloud_policy()),
+                                });
+                                return Err(reroute_err);
+                            }
+                        }
                     }
                     return Err(Error::ModelExecution(format!("Provider error: {e}")));
                 }

--- a/crates/arkavo-router/src/quality_gate.rs
+++ b/crates/arkavo-router/src/quality_gate.rs
@@ -660,8 +660,26 @@ impl super::Router {
                         &collapse,
                         planes::UpgradeContext::default(),
                     );
-                    let allow_cloud = matches!(offer, UpgradeOffer::Offer(_))
-                        && self.cloud_policy().permits_silent_cloud();
+                    // Spend plane: a collapse only *requests* cloud. Authorize
+                    // it through the budget plane — policy AND the live remaining
+                    // cap — never on the quality signal alone. No user
+                    // confirmation channel here yet, so `user_confirmed=false`:
+                    // AskBeforeCloud stays local, CloudWithinCap escalates only
+                    // within cap.
+                    let allow_cloud = if let UpgradeOffer::Offer(reason) = offer {
+                        let caps = self.cloud_spend_caps().await;
+                        let projected = self.projected_cloud_cost(&current_decision);
+                        planes::authorize_upgrade(
+                            self.cloud_policy(),
+                            reason,
+                            projected,
+                            caps,
+                            false,
+                        )
+                        .is_authorized()
+                    } else {
+                        false
+                    };
                     let mut excluded = if allow_cloud {
                         self.get_excluded_models().await
                     } else {

--- a/crates/arkavo-router/src/quality_gate.rs
+++ b/crates/arkavo-router/src/quality_gate.rs
@@ -408,6 +408,12 @@ impl super::Router {
                 "Semaphore acquired"
             );
 
+            // Feasibility plane (pre-dispatch): assess whether the local model
+            // can run this prompt now, surfacing a reshape/unavailable signal
+            // before we spend an inference on a doomed call. Local-only; never
+            // spends.
+            self.check_local_feasibility(&current_decision.recommended_model, input_tokens as u32);
+
             let max_tokens = if execution_mode { Some(200usize) } else { None };
             let mut response = match provider
                 .complete_with_tools(advised_messages, tools_json, max_tokens)
@@ -737,6 +743,18 @@ impl super::Router {
                     .with_usage(current_decision.estimated_cost_usd, 0),
                 )
                 .await;
+
+            // Feasibility plane (post-dispatch): fold this call's real decode
+            // throughput into the per-config baseline so "slow" is learned per
+            // model+context, and surface a degraded-throughput signal when this
+            // sample is slow for that configuration.
+            if let Some(timing) = response.inference_timing.as_ref() {
+                self.record_local_throughput(
+                    &current_decision.recommended_model,
+                    timing,
+                    input_tokens as u32,
+                );
+            }
 
             // Record which model was selected so the conductor can attribute
             // reward-based corrective feedback to the right Thompson Sampling prior.

--- a/crates/arkavo-server/src/lib.rs
+++ b/crates/arkavo-server/src/lib.rs
@@ -9,6 +9,9 @@
 //! for A2A protocol communication.
 
 pub mod server;
+pub mod spend_plane;
+
+pub use spend_plane::{cloud_policy_from_agents_md, cloud_policy_from_config};
 
 // Re-export commonly used types
 pub use server::{

--- a/crates/arkavo-server/src/server/a2a_server.rs
+++ b/crates/arkavo-server/src/server/a2a_server.rs
@@ -456,6 +456,27 @@ impl A2aServer {
         // Use cached AGENTS.md config for preflight, budget, KAS
         let agent_config = self.agent_config.read().await.clone();
 
+        // Build the budget manager up front so the router can both enforce the
+        // live remaining cap (spend plane) and adopt the configured cloud policy.
+        let budget_manager = if let Some(ref budget_yaml) = agent_config.budget {
+            let budget_config = build_budget_config(budget_yaml);
+            match arkavo_budget::BudgetManager::new(budget_config).await {
+                Ok(manager) => Some(Arc::new(manager)),
+                Err(e) => {
+                    warn!("Failed to initialize budget manager: {}", e);
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        let cloud_policy = agent_config
+            .budget
+            .as_ref()
+            .and_then(|b| b.cloud_policy.as_deref())
+            .and_then(arkavo_budget::CloudPolicy::parse)
+            .unwrap_or_default();
+
         let router_result = if offline_mode {
             arkavo_router::Router::new_offline().await
         } else {
@@ -464,6 +485,15 @@ impl A2aServer {
 
         match router_result {
             Ok(router) => {
+                // Spend plane: adopt the configured cloud policy and the live
+                // budget tracker so cloud escalation honors policy + cap.
+                let router = router.with_cloud_policy(cloud_policy);
+                let router = if let Some(ref manager) = budget_manager {
+                    router.with_budget_tracker(manager.tracker())
+                } else {
+                    router
+                };
+
                 // Wire preflight from AGENTS.md
                 let router = if let Some(ref pf) = agent_config.preflight {
                     let moderator = arkavo_router::build_moderator_from_config(pf);
@@ -548,18 +578,11 @@ impl A2aServer {
                     offline_mode
                 );
 
-                // Wire budget from AGENTS.md
-                if let Some(ref budget_yaml) = agent_config.budget {
-                    let budget_config = build_budget_config(budget_yaml);
-                    match arkavo_budget::BudgetManager::new(budget_config).await {
-                        Ok(manager) => {
-                            *self.budget_manager.write().await = Some(Arc::new(manager));
-                            info!("Budget enforcement loaded from AGENTS.md");
-                        }
-                        Err(e) => {
-                            warn!("Failed to initialize budget manager: {}", e);
-                        }
-                    }
+                // Store the budget manager built up front (also wired into the
+                // router above for live-cap spend enforcement).
+                if let Some(manager) = budget_manager {
+                    *self.budget_manager.write().await = Some(manager);
+                    info!("Budget enforcement loaded from AGENTS.md");
                 }
 
                 // Set router on learning bus for LLM-based synthesis
@@ -1476,6 +1499,13 @@ fn build_budget_config(yaml: &arkavo_router::BudgetYamlConfig) -> arkavo_budget:
     }
     if let Some(daily_cost) = yaml.max_cost_per_day {
         config.limits.daily_limit = Some(arkavo_budget::TokenCost::from_dollars(daily_cost));
+    }
+    if let Some(policy) = yaml
+        .cloud_policy
+        .as_deref()
+        .and_then(arkavo_budget::CloudPolicy::parse)
+    {
+        config.cloud_policy = policy;
     }
 
     config

--- a/crates/arkavo-server/src/server/local_engine.rs
+++ b/crates/arkavo-server/src/server/local_engine.rs
@@ -36,14 +36,10 @@ impl LocalEngine {
             router
         };
 
-        // Spend plane: adopt the configured cloud policy, and share one budget
-        // tracker between the router (live-cap enforcement) and UCP.
-        let cloud_policy = agent_config
-            .budget
-            .as_ref()
-            .and_then(|b| b.cloud_policy.as_deref())
-            .and_then(arkavo_budget::CloudPolicy::parse)
-            .unwrap_or_default();
+        // Spend plane: adopt the configured cloud policy (shared resolver), and
+        // share one budget tracker between the router (live-cap enforcement) and
+        // UCP.
+        let cloud_policy = crate::spend_plane::cloud_policy_from_config(&agent_config);
         let budget_tracker =
             arkavo_budget::BudgetTracker::new(arkavo_budget::BudgetConfig::default())
                 .await

--- a/crates/arkavo-server/src/server/local_engine.rs
+++ b/crates/arkavo-server/src/server/local_engine.rs
@@ -36,8 +36,27 @@ impl LocalEngine {
             router
         };
 
+        // Spend plane: adopt the configured cloud policy, and share one budget
+        // tracker between the router (live-cap enforcement) and UCP.
+        let cloud_policy = agent_config
+            .budget
+            .as_ref()
+            .and_then(|b| b.cloud_policy.as_deref())
+            .and_then(arkavo_budget::CloudPolicy::parse)
+            .unwrap_or_default();
+        let budget_tracker =
+            arkavo_budget::BudgetTracker::new(arkavo_budget::BudgetConfig::default())
+                .await
+                .ok()
+                .map(Arc::new);
+        let router = router.with_cloud_policy(cloud_policy);
+        let router = match budget_tracker {
+            Some(ref tracker) => router.with_budget_tracker(tracker.clone()),
+            None => router,
+        };
+
         let router = Arc::new(router);
-        let tool_registry = Arc::new(Self::build_tool_registry(&router).await);
+        let tool_registry = Arc::new(Self::build_tool_registry(&router, budget_tracker).await);
 
         Ok(Self {
             router,
@@ -56,7 +75,10 @@ impl LocalEngine {
     }
 
     /// Build a ToolRegistry with all available tool sets.
-    async fn build_tool_registry(router: &Arc<Router>) -> ToolRegistry {
+    async fn build_tool_registry(
+        router: &Arc<Router>,
+        budget_tracker: Option<Arc<arkavo_budget::BudgetTracker>>,
+    ) -> ToolRegistry {
         // Start with built-in tools (time, filesystem, etc.)
         let storage = match arkavo_memory::storage::MemoryStorage::new().await {
             Ok(s) => Arc::new(s),
@@ -80,18 +102,19 @@ impl LocalEngine {
         ));
         arkavo_hrm::tools::register_tools(&mut registry, hrm_state);
 
-        // UCP payment tools
-        match arkavo_budget::BudgetTracker::new(arkavo_budget::BudgetConfig::default()).await {
-            Ok(tracker) => {
-                let ucp_budget_tracker = Arc::new(tracker);
-                let ucp_state = Arc::new(tokio::sync::RwLock::new(arkavo_ucp::UcpState::new(
-                    ucp_budget_tracker,
-                )));
-                arkavo_ucp::register_tools(&mut registry, ucp_state);
-            }
-            Err(e) => {
-                warn!("UCP tools disabled: {e}");
-            }
+        // UCP payment tools — reuse the router's budget tracker so spend
+        // accounting is unified; fall back to a fresh default tracker.
+        let ucp_budget_tracker = match budget_tracker {
+            Some(tracker) => Some(tracker),
+            None => arkavo_budget::BudgetTracker::new(arkavo_budget::BudgetConfig::default())
+                .await
+                .map(Arc::new)
+                .map_err(|e| warn!("UCP tools disabled: {e}"))
+                .ok(),
+        };
+        if let Some(tracker) = ucp_budget_tracker {
+            let ucp_state = Arc::new(tokio::sync::RwLock::new(arkavo_ucp::UcpState::new(tracker)));
+            arkavo_ucp::register_tools(&mut registry, ucp_state);
         }
 
         // Claude Agent SDK tools (feature-gated)

--- a/crates/arkavo-server/src/spend_plane.rs
+++ b/crates/arkavo-server/src/spend_plane.rs
@@ -1,0 +1,72 @@
+//! Spend-plane wiring shared across the server and CLI entry points.
+//!
+//! Resolving the cloud-spend policy from an agent's AGENTS.md was duplicated in
+//! every place that builds a Router (the A2A server, `LocalEngine`, and the CLI
+//! tool integration). It lives here so all entry points share one source of
+//! truth and the safe default is applied consistently.
+
+use arkavo_budget::CloudPolicy;
+use arkavo_router::AgentConfig;
+
+/// Resolve the cloud-spend policy from an agent's AGENTS.md budget block,
+/// falling back to the safe `AskBeforeCloud` default when it is absent or
+/// unparseable.
+pub fn cloud_policy_from_config(config: &AgentConfig) -> CloudPolicy {
+    config
+        .budget
+        .as_ref()
+        .and_then(|b| b.cloud_policy.as_deref())
+        .and_then(CloudPolicy::parse)
+        .unwrap_or_default()
+}
+
+/// Resolve the cloud-spend policy from the AGENTS.md discovered in the current
+/// directory tree (or the default when none is found / it does not parse).
+pub fn cloud_policy_from_agents_md() -> CloudPolicy {
+    cloud_policy_from_config(&arkavo_router::load_agent_config().unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arkavo_router::BudgetYamlConfig;
+
+    fn config_with_policy(policy: Option<&str>) -> AgentConfig {
+        AgentConfig {
+            budget: Some(BudgetYamlConfig {
+                max_cost_per_session: None,
+                max_cost_per_day: None,
+                cloud_policy: policy.map(str::to_string),
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn parses_explicit_policy() {
+        assert_eq!(
+            cloud_policy_from_config(&config_with_policy(Some("local_only"))),
+            CloudPolicy::LocalOnly
+        );
+        assert_eq!(
+            cloud_policy_from_config(&config_with_policy(Some("cloud_within_cap"))),
+            CloudPolicy::CloudWithinCap
+        );
+    }
+
+    #[test]
+    fn defaults_when_absent_or_unparseable() {
+        assert_eq!(
+            cloud_policy_from_config(&config_with_policy(None)),
+            CloudPolicy::AskBeforeCloud
+        );
+        assert_eq!(
+            cloud_policy_from_config(&config_with_policy(Some("nonsense"))),
+            CloudPolicy::AskBeforeCloud
+        );
+        assert_eq!(
+            cloud_policy_from_config(&AgentConfig::default()),
+            CloudPolicy::AskBeforeCloud
+        );
+    }
+}

--- a/docs/three-plane-router.md
+++ b/docs/three-plane-router.md
@@ -96,6 +96,25 @@ user outcomes.
 The key distinction: a collapse can trigger an upgrade *offer*; it does not
 trigger automatic spend by default.
 
+## Enforcement in the routing loop
+
+`Router::route_with_tools` (in `quality_gate.rs`) consumes the planes directly:
+
+- **Availability failure → stays local.** A provider error (timeout / OOM /
+  crash) is a feasibility failure, so the re-route runs through
+  `Router::reroute_exclusions`, which calls `augment_exclusions_for_policy`.
+  Unless the cloud policy permits silent spend (`CloudWithinCap`), every cloud
+  arm is excluded and re-selection stays local. A slow laptop never escalates to
+  a paid model on its own.
+- **Quality collapse → offer, gated by the spend plane.** On a final-answer
+  turn the loop runs `detect_collapse`. An empty or repetition-loop collapse
+  asks `upgrade_offer` whether to offer cloud; cloud only becomes a retry
+  candidate when `CloudPolicy::permits_silent_cloud` is true. Otherwise the
+  router retries locally and emits a `RouterEvent::CloudEscalationBlocked` so the
+  quality→spend boundary is observable.
+
+`Router::with_cloud_policy` sets the posture; it defaults to `AskBeforeCloud`.
+
 ## The premise to measure
 
 The cost-vs-time premise is an explicit measurement, not an assumption.

--- a/docs/three-plane-router.md
+++ b/docs/three-plane-router.md
@@ -1,0 +1,115 @@
+# Three-Plane Router
+
+llama.cpp statistics measure feasibility and cost. They do **not** measure
+answer quality. Therefore they must never silently authorize cloud spend.
+
+The router separates three concerns that were previously conflated. Each plane
+answers a different question, and the planes may not borrow each other's
+authority.
+
+```text
+Availability changes what is possible.   -> feasibility plane
+Quality changes what is advisable.        -> collapse / adequacy plane
+Budget policy changes what is allowed.    -> spend plane
+```
+
+## Feasibility plane
+
+`arkavo_router::planes::feasibility`
+
+Consumes llama.cpp / runtime statistics only: `prompt_tokens` vs `n_ctx`,
+KV-cache availability, queue depth, tokens/sec, thermal/load state, whether a
+local model is loaded, and OOM / context overflow.
+
+Allowed conclusions (`FeasibilityVerdict`):
+
+- local can run now
+- local can run slowly
+- local cannot run
+- local needs chunking
+- local needs a smaller context
+
+There is deliberately **no** "local answer is wrong, therefore spend cloud
+dollars" conclusion. A slow laptop is not a budget-authorization event. A
+feasibility failure may make the router tell the user it is busy, continue
+locally, queue, retry locally, or return a partial answer — never silent spend.
+
+Corrected escalation behavior:
+
+- local is slow → tell the user local is busy / continue locally / ask before
+  cloud (not: escalate to cloud)
+- tokens/sec dropped → feasibility degraded, not quality degraded
+- timeout → local unavailable; ask before spending, queue, retry locally, or
+  return partial (not: cloud fallback)
+
+## Quality / adequacy plane
+
+`arkavo_router::planes::collapse`
+
+This is the hard, unsolved product problem. v1 cannot judge whether an answer is
+*good*; it can only catch visible **collapse**, so it is named a collapse
+detector, not a quality gate. A clean verdict means "did not visibly fall
+apart", not "this answer is adequate".
+
+Visible collapse signals (`CollapseSignal`): empty output, truncated output,
+repetition loop, format failure, tool-call schema failure, refusal on an allowed
+task, obvious instruction noncompliance.
+
+The honest v1 policy is: *local answer completed; cloud upgrade available; ask
+the user before spending* — never *local answer seems bad, auto-spend cloud
+budget*.
+
+A detected collapse may **request** a cloud upgrade offer. It may not authorize
+spend.
+
+## Spend plane
+
+`arkavo_budget::cloud_policy`
+
+This plane alone decides whether cloud spend is allowed. Inputs: user policy,
+remaining cap, per-request max, agent-loop budget, background-task budget, and
+user confirmation state. It must not accept hardware/load signals as spend
+justification — they are not parameters of `authorize_cloud_spend`.
+
+```rust
+enum CloudPolicy {
+    LocalOnly,
+    AskBeforeCloud,   // safe v1 default
+    CloudWithinCap,
+}
+```
+
+`CloudWithinCap` comes later, after the adequacy gate is validated against real
+user outcomes.
+
+## Router logic
+
+1. Check local feasibility.
+2. If local can run, run local.
+3. If local visibly collapses, mark it as collapse.
+4. If local completes, show the answer.
+5. Offer a cloud upgrade when: the user asks, a collapse occurred, the task
+   class is high-risk, and user policy allows asking.
+6. Before any cloud call, check budget.
+7. If budget is exhausted, stay local.
+
+The key distinction: a collapse can trigger an upgrade *offer*; it does not
+trigger automatic spend by default.
+
+## The premise to measure
+
+The cost-vs-time premise is an explicit measurement, not an assumption.
+Instrument: local wait time, user abandonment, "upgrade to cloud" clicks, cloud
+disabled, budget raised, budget lowered, retries after a slow local answer, task
+category, and hardware class. The product question — at what latency do
+cost-conscious, local-owning users prefer paid cloud — stays open until the data
+answers it.
+
+Until then the safe router posture is: bias local, do not auto-spend, make the
+cloud upgrade explicit, and measure behavior.
+
+## Final principle
+
+> Availability changes what is possible.
+> Quality changes what is advisable.
+> Budget policy changes what is allowed.

--- a/docs/three-plane-router.md
+++ b/docs/three-plane-router.md
@@ -18,8 +18,11 @@ Budget policy changes what is allowed.    -> spend plane
 `arkavo_router::planes::feasibility`
 
 Consumes llama.cpp / runtime statistics only: `prompt_tokens` vs `n_ctx`,
-KV-cache availability, queue depth, tokens/sec, thermal/load state, whether a
-local model is loaded, and OOM / context overflow.
+KV-cache availability, tokens/sec, whether a local model is loaded, and OOM /
+context overflow. `RuntimeStats` carries only fields with an honest local
+source — thermal/SMC temperature and OS queue depth have none, so "local busy"
+is represented by KV-cache saturation and degraded throughput rather than a
+stubbed field.
 
 Allowed conclusions (`FeasibilityVerdict`):
 
@@ -112,6 +115,15 @@ trigger automatic spend by default.
   candidate when `CloudPolicy::permits_silent_cloud` is true. Otherwise the
   router retries locally and emits a `RouterEvent::CloudEscalationBlocked` so the
   quality→spend boundary is observable.
+- **Feasibility is fed from real llama.cpp stats.** Before dispatch,
+  `Router::check_local_feasibility` assembles `RuntimeStats` (prompt estimate,
+  model context window, KV-cache slots) and classifies — emitting a
+  `RouterEvent::LocalFeasibility` when the prompt needs reshaping or local can't
+  run, before an inference is wasted. After dispatch, `record_local_throughput`
+  folds the call's real `InferenceTiming` decode rate into a per-config
+  `FeasibilityBaseline` (rolling median/MAD), so "slow" is judged relative to
+  each `model@context`'s own history rather than an absolute threshold — and
+  never authorizes cloud spend.
 
 `Router::with_cloud_policy` sets the posture; it defaults to `AskBeforeCloud`.
 


### PR DESCRIPTION
## Why

llama.cpp statistics measure **feasibility and cost** — how expensive a query was for a given model, quantization, context, cache state, and hardware. They do **not** measure answer **quality**. So they must never silently authorize cloud spend. Previously the router conflated these: a provider timeout/OOM could re-route to a paid cloud model with no budget gate, and the v1 "quality gate" was named as if it judged answer quality when it only catches visible collapse.

This PR splits routing into three strictly-bounded planes and makes all three load-bearing in the routing loop.

```
Availability changes what is possible.   -> feasibility plane
Quality changes what is advisable.        -> collapse / adequacy plane
Budget policy changes what is allowed.    -> spend plane
```

## The three planes

**Feasibility — `arkavo_router::planes::feasibility` (+ `feasibility_baseline`)**
Consumes runtime stats only and emits only feasibility verdicts: *run now / run slowly / needs chunking / needs smaller context / cannot run*. No verdict names the cloud — a slow laptop is not a spend event. It is now **fed from real telemetry**:
- `Router::check_local_feasibility` (pre-dispatch) assembles `RuntimeStats` from the prompt-token estimate, `model_context_size`, and live `PoolStats` KV-cache slots, and emits `RouterEvent::LocalFeasibility` when the prompt needs reshaping or local can't run — before an inference is wasted.
- `Router::record_local_throughput` (post-dispatch) folds the call's real `InferenceTiming` decode rate into a per-`(model@context)` `FeasibilityBaseline` (rolling window, robust z-score via median/MAD — not mean/stddev, since LLM latency is heavy-tailed). "Slow" is judged relative to each configuration's own history, so a Pi-5's normal 5 tok/s isn't flagged and an M3's 30 tok/s (vs its 80 median) is.

**Quality — `arkavo_router::planes::collapse`**
A v1 **collapse detector**, honestly named — it catches visible breakdown (empty / truncated / repetition-loop / format-failure / tool-schema-failure / refusal-on-allowed-task / instruction-noncompliance), **not** answer adequacy. A clean verdict means "did not visibly fall apart", not "this answer is good". A collapse may *request* a cloud upgrade offer but cannot authorize spend.

**Spend — `arkavo_budget::cloud_policy`**
The sole spend authority. Adds `CloudPolicy { LocalOnly, AskBeforeCloud, CloudWithinCap }` (default `AskBeforeCloud`, wired into `BudgetConfig` via serde default) and `authorize_cloud_spend()`, a pure function of policy, request, and budget caps. Hardware/feasibility signals are deliberately **not** inputs, so they structurally cannot authorize spend.

## What the routing loop now enforces (`quality_gate.rs`)

- **Availability failure stays local.** A provider error (timeout/OOM) re-routes through `Router::reroute_exclusions` → `augment_exclusions_for_policy`, which drops every cloud arm unless `CloudPolicy::permits_silent_cloud` (only `CloudWithinCap`). Under the default posture a failed local model retries locally — it never silently escalates to a paid model.
- **Quality collapse → offer, gated by the spend plane.** On a final-answer turn the loop runs `detect_collapse`; an empty/repetition collapse asks `upgrade_offer` whether to offer cloud, and cloud only becomes a retry candidate when the policy permits silent spend. Otherwise it retries locally and emits `RouterEvent::CloudEscalationBlocked`, making the quality→spend boundary observable.
- **Feasibility is sampled every local call** (pre-dispatch reshape/unavailable signal + post-dispatch per-config throughput learning), surfaced as `RouterEvent::LocalFeasibility` telemetry.

The corrected escalation behavior: *local is slow → continue locally / surface "busy"* (not escalate); *timeout → local unavailable, retry locally / ask before spending* (not cloud fallback); *collapse → offer an upgrade* (not auto-spend).

## Design decisions / honesty notes

- **No `arkavo-llm` change needed** — `complete_with_tools` already returns populated `InferenceTiming` on the response.
- **`RuntimeStats` carries only fields with an honest local source.** `thermal_throttling` and `queue_depth` were dropped: SMC temperature is macOS-private and OS queue depth isn't exposed. Per the no-placeholder rule, "local busy" is represented by KV-cache saturation + degraded throughput rather than stubbed fields.
- Feasibility never authorizes spend, and the absolute tokens/sec floor is only a cold-start fallback — the per-config baseline supersedes it once it has samples.

## Public API added

`CloudPolicy`, `CloudSpendRequest`, `CloudSpendDecision`, `SpendCaps`, `DenyReason`, `authorize_cloud_spend` (arkavo-budget); `RuntimeStats`, `FeasibilityVerdict`, `FeasibilityBaseline`, `CollapseSignal`, `CollapseVerdict`, `AnswerObservation`, `UpgradeOffer`/`UpgradeContext`, `assess_feasibility`/`plan_local`/`detect_collapse`/`upgrade_offer`/`authorize_upgrade`/`augment_exclusions_for_policy`, `Router::with_cloud_policy`, and the `RouterEvent::{CloudEscalationBlocked, LocalFeasibility}` telemetry events.

## Testing

- New unit tests across all three planes (spend authorization matrix, collapse detection, feasibility verdicts, the robust-z baseline incl. cold-start/upgrade/downgrade cases, and the cloud-exclusion logic). `cargo clippy --lib -D warnings` and `cargo fmt --check` clean on both crates.
- The `arkavo-llm`-dependent integration is exercised through the pure, fully-tested helpers (`augment_exclusions_for_policy`, `FeasibilityBaseline`); the end-to-end path needs local models, which model-gated tests skip in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update: all three planes fully wired (follow-on commits)

The planes are now load-bearing end to end, not just defined:

- **CloudPolicy from config → Router.** New `cloud_policy` in the AGENTS.md budget block (`CloudPolicy::parse`), wired with a shared live `BudgetTracker` into the Router at the server/CLI/AG-UI construction sites. The policy knob is no longer always-default.
- **Live budget cap in the loop.** The collapse-escalation path now authorizes via `authorize_cloud_spend` with `SpendCaps` from the live tracker (policy AND remaining cap), via `Router::with_budget_tracker`.
- **Ask-before-cloud flow.** The spend decision resolves fully: `Authorized` → escalate; `NeedsUserConfirmation` → emit `RouterEvent::CloudUpgradeOffered` and stay local; `Denied` → `CloudEscalationBlocked`. `Router::confirm_next_cloud_upgrade()` is the one-shot confirmation a frontend sets after the user approves, then re-dispatches.
- **Orchestrator reconciled.** `CostOrchestrator` cloud routing now clears `authorize_cloud_spend` (one authority) before the `try_spend` reservation, instead of a parallel budget-usage heuristic.
- **RouterEvent consumer.** A global `EventCounters` sink in `arkavo-observability`, incremented by kind at emit time (backend telemetry without a poller), plus a new `AgUiEvent::RouterTelemetry` the gateway broadcasts from the counter snapshot for the UI.
- **Uncertainty signal.** The llama.cpp decode loop reports `InferenceTiming.avg_logprob` (mean sampled-token log-probability via `LlamaModel::n_vocab` + a stable log-softmax); the collapse detector gains `CollapseSignal::LowConfidence` (weakest signal, never masks a structural collapse) and the loop feeds it through.
- **FeasibilityBaseline persisted.** Serde snapshot + autosave to `<cache>/arkavo/feasibility_baseline.json`, loaded at Router construction, so per-config throughput learning survives restarts.

All compile across the workspace (debug); unit tests added for the spend matrix, collapse signals (incl. low-confidence), the robust-z baseline + persistence, the log-softmax math, event counters, and policy parsing. The frontend last-mile (a CLI/UI prompt that calls `confirm_next_cloud_upgrade`) and model-backed validation of the live logprob values are the remaining runtime-only steps.
