### PR TITLE
Manifest pricing into live cost gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui-protocol"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-test-macros",
  "serde",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-device-identity",
  "serde",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "chrono",
  "serde",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-test-macros",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "git2",
  "tempfile",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1144,11 +1144,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-lesson-synthesis"
-version = "0.86.0"
+version = "0.87.0"
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1383,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1553,10 +1553,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
+ "arkavo-budget",
  "arkavo-crypto",
  "arkavo-events",
  "arkavo-gossip",
@@ -1614,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1632,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1646,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1665,7 +1666,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1709,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "lru 0.16.4",
  "serde",
@@ -1722,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1740,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1769,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1848,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1883,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-shadow-consolidation"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-lesson-synthesis",
@@ -1901,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1914,8 +1915,9 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
+ "arkavo-budget",
  "arkavo-test-macros",
  "base64 0.22.1",
  "blake3",
@@ -1929,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -1955,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1974,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1997,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -2014,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -2038,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2049,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2062,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2074,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2083,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2097,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2116,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2131,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2156,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2166,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.86.0"
+version = "0.87.0"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.86.0"
+version = "0.87.0"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-orchestrator/src/swarmkit_apply.rs
+++ b/crates/arkavo-orchestrator/src/swarmkit_apply.rs
@@ -544,6 +544,11 @@ async fn build_bundle(
         persona,
         api_tokens,
         arp_overlay,
+        manifest_pricing: manifest
+            .pricing
+            .iter()
+            .map(arkavo_budget::provider_costs::PricingEntry::from)
+            .collect(),
         role_context,
     }
 }

--- a/crates/arkavo-orchestrator/src/swarmkit_encrypt.rs
+++ b/crates/arkavo-orchestrator/src/swarmkit_encrypt.rs
@@ -114,6 +114,7 @@ mod tests {
             },
             api_tokens: Default::default(),
             arp_overlay,
+            manifest_pricing: Vec::new(),
             role_context: RoleContext {
                 kit_id: "kit:demo:0.1.0".into(),
                 flight_id: "44444444-4444-4444-4444-444444444444".into(),

--- a/crates/arkavo-protocol/Cargo.toml
+++ b/crates/arkavo-protocol/Cargo.toml
@@ -29,6 +29,7 @@ webpki-roots = { workspace = true }
 # Server dependencies
 governor = { workspace = true, features = ["std", "jitter"] }
 arkavo-arp = { path = "../arkavo-arp" }
+arkavo-budget = { path = "../arkavo-budget" }
 dashmap = { workspace = true }
 crossbeam-queue = { workspace = true }
 

--- a/crates/arkavo-protocol/src/agent_specialization.rs
+++ b/crates/arkavo-protocol/src/agent_specialization.rs
@@ -59,6 +59,14 @@ pub struct AgentSpecializationBundle {
     /// ARP document used to spin up a per-agent runtime for this role.
     /// Carries budget, network, tool_use, isolation, etc.
     pub arp_overlay: ArpDocument,
+    /// Authored per-MTok model pricing for this flight. When non-empty, the
+    /// receiving agent loads these rates as authoritative for its live cost
+    /// gate, overriding the built-in static estimate. Travels inside the
+    /// TDF-encrypted, DID-bound bundle — same trust envelope as `arp_overlay`.
+    /// Flight-global (every role gets the same rates); per-role spend ceilings
+    /// live in `arp_overlay`. Default empty for backward compatibility.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub manifest_pricing: Vec<arkavo_budget::provider_costs::PricingEntry>,
     /// Flight provenance the agent uses to tag tool outcomes back to the
     /// right per-role `DecisionTrace` on the orchestrator's flight.
     pub role_context: RoleContext,
@@ -428,6 +436,7 @@ mod tests {
             },
             api_tokens: tokens,
             arp_overlay: sample_arp(),
+            manifest_pricing: Vec::new(),
             role_context: RoleContext {
                 kit_id: "kit:campaign-kit:0.1.0".to_string(),
                 flight_id: "11111111-1111-1111-1111-111111111111".to_string(),
@@ -456,6 +465,27 @@ mod tests {
         assert_eq!(original.persona, recovered.persona);
         assert_eq!(original.api_tokens, recovered.api_tokens);
         assert_eq!(original.role_context, recovered.role_context);
+    }
+
+    #[test]
+    fn bundle_without_manifest_pricing_deserializes_as_empty() {
+        // #635 backward compat: a bundle serialized before manifest_pricing
+        // existed (or with an empty table) must deserialize cleanly, defaulting
+        // the field to an empty vec. Build a real bundle, serialize it, then
+        // assert deserialization works whether or not pricing is present.
+        let bundle = sample_bundle(); // empty manifest_pricing
+        let json = serde_json::to_string(&bundle).expect("serialize");
+        // skip_serializing_if = "Vec::is_empty" → field absent from JSON.
+        assert!(
+            !json.contains("manifest_pricing"),
+            "empty pricing must be skipped on serialize (preserves kit.id)"
+        );
+        let recovered: AgentSpecializationBundle =
+            serde_json::from_str(&json).expect("deserialize without manifest_pricing");
+        assert!(
+            recovered.manifest_pricing.is_empty(),
+            "absent manifest_pricing must default to empty"
+        );
     }
 
     #[test]

--- a/crates/arkavo-protocol/tests/swarmkit_bundle_round_trip.rs
+++ b/crates/arkavo-protocol/tests/swarmkit_bundle_round_trip.rs
@@ -78,6 +78,7 @@ fn build_bundle(role: &str, agent_did: &str) -> AgentSpecializationBundle {
         },
         api_tokens: tokens,
         arp_overlay: arp_doc(),
+        manifest_pricing: Vec::new(),
         role_context: RoleContext {
             kit_id: "kit:demo:0.1.0".into(),
             flight_id: "44444444-4444-4444-4444-444444444444".into(),
@@ -150,6 +151,7 @@ async fn bundle_round_trips_orchestrator_to_agent() {
         &decryptor,
         &no_event_tx(),
         None,
+        None,
         AgentSpecializeRequest {
             requester_id: "did:web:orchestrator.arkavo.net".into(),
             encrypted_bundle: encoded,
@@ -213,6 +215,7 @@ async fn bundle_for_other_agent_is_rejected_at_unwrap() {
         &role_store,
         &decryptor,
         &no_event_tx(),
+        None,
         None,
         AgentSpecializeRequest {
             requester_id: "did:web:orchestrator.arkavo.net".into(),

--- a/crates/arkavo-router/src/lib.rs
+++ b/crates/arkavo-router/src/lib.rs
@@ -248,6 +248,17 @@ pub struct Router {
     /// cloud-escalation decision consults the real remaining cap via
     /// `authorize_cloud_spend`; when absent there is no cap to enforce.
     budget_tracker: Option<Arc<arkavo_budget::BudgetTracker>>,
+    /// Authored per-MTok pricing registry (spend plane). When non-empty,
+    /// `projected_cloud_cost` prices a cloud arm from these authored rates
+    /// (the manifest is the pricing home); when empty it falls back to the
+    /// built-in static per-model estimate. Behind an `Arc<RwLock>` so a
+    /// specialization bundle can replace it live without rebuilding the
+    /// Router (which is shared across handlers via `Arc`). Populated from a
+    /// specialization bundle's `manifest_pricing` via [`Router::with_pricing`]
+    /// (builder) or [`Router::apply_manifest_pricing`] (live update). Uses a
+    /// std `RwLock` (not tokio) so `projected_cloud_cost` can read it without
+    /// `.await` on the (rare) collapse-driven upgrade path.
+    pricing: Arc<std::sync::RwLock<arkavo_budget::provider_costs::ProviderPricing>>,
     /// One-shot user confirmation for the next cloud upgrade under
     /// `AskBeforeCloud`. The caller sets it via `confirm_next_cloud_upgrade()`
     /// after the user approves a `CloudUpgradeOffered`; the loop consumes it
@@ -304,6 +315,9 @@ impl Router {
                     .unwrap_or_default(),
             ),
             budget_tracker: None,
+            pricing: Arc::new(std::sync::RwLock::new(
+                arkavo_budget::provider_costs::ProviderPricing::new(),
+            )),
             cloud_confirmation: std::sync::atomic::AtomicBool::new(false),
         })
     }
@@ -356,6 +370,9 @@ impl Router {
                     .unwrap_or_default(),
             ),
             budget_tracker: None,
+            pricing: Arc::new(std::sync::RwLock::new(
+                arkavo_budget::provider_costs::ProviderPricing::new(),
+            )),
             cloud_confirmation: std::sync::atomic::AtomicBool::new(false),
         })
     }
@@ -412,6 +429,28 @@ impl Router {
         self
     }
 
+    /// Install authored per-MTok pricing as the cost source for the spend
+    /// plane's projected-cost gate. When a cloud arm is present in the
+    /// registry, its authored rate is authoritative; otherwise the built-in
+    /// static estimate is used. Typically populated from a specialization
+    /// bundle's `manifest_pricing` so distributed agents share one trusted
+    /// cost model sourced from the signed manifest.
+    pub fn with_pricing(mut self, pricing: arkavo_budget::provider_costs::ProviderPricing) -> Self {
+        self.pricing = Arc::new(std::sync::RwLock::new(pricing));
+        self
+    }
+
+    /// Replace the live cost gate's pricing registry in place. Used when a
+    /// specialization bundle arrives after the Router is already running: the
+    /// bundle's `manifest_pricing` (trusted, TDF-delivered config) becomes the
+    /// authoritative source for `projected_cloud_cost`. Safe to call from a
+    /// shared `&Arc<Router>` because pricing is behind an `RwLock`.
+    pub fn apply_manifest_pricing(&self, pricing: arkavo_budget::provider_costs::ProviderPricing) {
+        if let Ok(mut guard) = self.pricing.write() {
+            *guard = pricing;
+        }
+    }
+
     /// Spend caps for a cloud-escalation decision, read from the live budget
     /// tracker. Without a tracker (or a session limit) there is no cap to
     /// enforce, so the remaining cap is reported as effectively unbounded — the
@@ -442,6 +481,11 @@ impl Router {
     /// plane's cap check. Estimates against the first cloud arm in the decision's
     /// fallback chain (or a cheap default), since the concrete arm is only
     /// chosen after the spend gate passes.
+    ///
+    /// Pricing source: authored registry first (`with_pricing`), falling back to
+    /// the built-in static per-model estimate when the arm is absent from the
+    /// registry. This makes authored manifest rates authoritative for the live
+    /// gate (#635) while keeping a safe static fallback for unknown models.
     fn projected_cloud_cost(&self, decision: &RoutingDecision) -> arkavo_budget::TokenCost {
         let arm = decision
             .fallback_chain
@@ -449,10 +493,18 @@ impl Router {
             .find(|m| m.is_cloud())
             .cloned()
             .unwrap_or(ModelChoice::GeminiFlash);
-        arkavo_budget::TokenCost::from_dollars(RoutingDecision::estimate_cost(
-            &arm,
-            decision.task_category,
-        ))
+        let est = decision.task_category.estimated_tokens();
+        let authored = self
+            .pricing
+            .read()
+            .ok()
+            .and_then(|p| p.estimate_cost(arm.provider(), arm.name(), est.input, est.output));
+        authored.unwrap_or_else(|| {
+            arkavo_budget::TokenCost::from_dollars(RoutingDecision::estimate_cost(
+                &arm,
+                decision.task_category,
+            ))
+        })
     }
 
     /// Exclusion set for a feasibility/quality-driven re-route.
@@ -1359,6 +1411,7 @@ impl Router {
             cloud_policy: self.cloud_policy,
             feasibility_baseline: self.feasibility_baseline.clone(),
             budget_tracker: self.budget_tracker.clone(),
+            pricing: Arc::clone(&self.pricing),
             cloud_confirmation: std::sync::atomic::AtomicBool::new(false),
         })
     }
@@ -1396,5 +1449,147 @@ mod tests {
         };
         let size = router.min_feasible_context_size();
         assert_eq!(size, 4096);
+    }
+
+    /// #635 acceptance test: the live spend-plane gate (`projected_cloud_cost`)
+    /// prices a cloud arm from authored manifest rates when present, and falls
+    /// back to the static per-model estimate when the arm is absent. Proves
+    /// "editing a model rate in the authored config changes the cost the live
+    /// budget gate uses."
+    #[tokio::test]
+    async fn projected_cloud_cost_uses_authored_pricing_over_static() {
+        use arkavo_budget::provider_costs::{PricingEntry, ProviderPricing};
+
+        // A decision whose first cloud fallback arm is GeminiFlash.
+        let decision = RoutingDecision {
+            recommended_model: ModelChoice::GeminiFlash,
+            fallback_chain: vec![ModelChoice::GeminiFlash],
+            confidence: 0.9,
+            reasoning: String::new(),
+            estimated_cost_usd: 0.0,
+            estimated_time: std::time::Duration::ZERO,
+            task_category: TaskCategory::FrontendUI,
+            should_compress: false,
+            compression_target: None,
+            use_spec_decoding: false,
+            trace: arkavo_router_learning_default_trace(),
+        };
+
+        // Baseline: empty pricing → static estimate.
+        let router = match Router::new_offline().await {
+            Ok(r) => r,
+            Err(_) => {
+                eprintln!("Skipping: Router::new_offline requires llama-cpp");
+                return;
+            }
+        };
+        let static_cost = router.projected_cloud_cost(&decision);
+
+        // Authored: a deliberately distinct rate for gemini-flash-latest.
+        // FrontendUI = 500 input / 2000 output. TokenCost is integer cents, so
+        // use rates that clear 1 cent: $100/MTok in (10000 cents) + $50/MTok
+        // out (5000 cents) → (500/1M)*10000 + (2000/1M)*5000 = 5 + 10 = 15 cents.
+        // The static table for GeminiFlash gives a sub-cent result (0 cents),
+        // so authored (15) is cleanly distinguishable from static (0).
+        let mut pricing = ProviderPricing::new();
+        pricing.register(&PricingEntry {
+            model_id: "gemini-flash-latest".to_string(),
+            provider: "google".to_string(),
+            input_cents_per_mtok: 10000,
+            output_cents_per_mtok: 5000,
+            cached_input_cents_per_mtok: None,
+            cache_write_cents_per_mtok: None,
+            context_window: None,
+            max_output_tokens: None,
+        });
+        let router = router.with_pricing(pricing);
+        let authored_cost = router.projected_cloud_cost(&decision);
+
+        assert_ne!(
+            static_cost.as_cents(),
+            authored_cost.as_cents(),
+            "authored pricing must change the projected cost vs the static estimate"
+        );
+        assert_eq!(
+            authored_cost.as_cents(),
+            15,
+            "authored cost should match the 15-cent rate we set (5 in + 10 out)"
+        );
+        assert_eq!(
+            static_cost.as_cents(),
+            0,
+            "static estimate for GeminiFlash/FrontendUI is sub-cent → 0 cents; \
+             the authored rate is what makes the gate see real cost"
+        );
+    }
+
+    /// #635: `apply_manifest_pricing` updates the live gate in place on a
+    /// shared `&Arc<Router>` (the path the specialization handler uses).
+    #[tokio::test]
+    async fn apply_manifest_pricing_updates_live_gate() {
+        use arkavo_budget::provider_costs::{PricingEntry, ProviderPricing};
+
+        let router = Arc::new(match Router::new_offline().await {
+            Ok(r) => r,
+            Err(_) => {
+                eprintln!("Skipping: Router::new_offline requires llama-cpp");
+                return;
+            }
+        });
+        let decision = RoutingDecision {
+            recommended_model: ModelChoice::GeminiFlash,
+            fallback_chain: vec![ModelChoice::GeminiFlash],
+            confidence: 0.9,
+            reasoning: String::new(),
+            estimated_cost_usd: 0.0,
+            estimated_time: std::time::Duration::ZERO,
+            task_category: TaskCategory::FrontendUI,
+            should_compress: false,
+            compression_target: None,
+            use_spec_decoding: false,
+            trace: arkavo_router_learning_default_trace(),
+        };
+
+        let before = router.projected_cloud_cost(&decision);
+
+        // Apply authored pricing through the live setter (shared-reference path).
+        let mut pricing = ProviderPricing::new();
+        pricing.register(&PricingEntry {
+            model_id: "gemini-flash-latest".to_string(),
+            provider: "google".to_string(),
+            input_cents_per_mtok: 10000,
+            output_cents_per_mtok: 5000,
+            cached_input_cents_per_mtok: None,
+            cache_write_cents_per_mtok: None,
+            context_window: None,
+            max_output_tokens: None,
+        });
+        router.apply_manifest_pricing(pricing);
+
+        let after = router.projected_cloud_cost(&decision);
+        assert_ne!(
+            before.as_cents(),
+            after.as_cents(),
+            "live pricing update must change the gate's projected cost"
+        );
+        assert_eq!(
+            after.as_cents(),
+            15,
+            "after live apply the gate must use the authored 15-cent rate"
+        );
+    }
+
+    /// Helper: a minimal `DecisionTrace` for constructing test decisions.
+    fn arkavo_router_learning_default_trace() -> crate::learning::DecisionTrace {
+        crate::learning::DecisionTrace::thompson(
+            TaskCategory::FrontendUI,
+            0.0,
+            vec![],
+            vec![],
+            "",
+            0,
+            0.0,
+            vec![],
+        )
     }
 }

--- a/crates/arkavo-router/src/lib.rs
+++ b/crates/arkavo-router/src/lib.rs
@@ -446,9 +446,15 @@ impl Router {
     /// authoritative source for `projected_cloud_cost`. Safe to call from a
     /// shared `&Arc<Router>` because pricing is behind an `RwLock`.
     pub fn apply_manifest_pricing(&self, pricing: arkavo_budget::provider_costs::ProviderPricing) {
-        if let Ok(mut guard) = self.pricing.write() {
-            *guard = pricing;
-        }
+        // Recover the guard on poison: the inner data is still valid after a
+        // panic elsewhere, and a pricing assignment can never itself panic, so
+        // we always want the update to land rather than silently leaving the
+        // gate on the stale/static table.
+        let mut guard = match self.pricing.write() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        *guard = pricing;
     }
 
     /// Spend caps for a cloud-escalation decision, read from the live budget
@@ -486,6 +492,12 @@ impl Router {
     /// the built-in static per-model estimate when the arm is absent from the
     /// registry. This makes authored manifest rates authoritative for the live
     /// gate (#635) while keeping a safe static fallback for unknown models.
+    ///
+    /// Naming contract: the manifest's `provider`/`model_id` must match the
+    /// router's `ModelChoice::provider()`/`name()` strings exactly (e.g.
+    /// `google` / `gemini-flash-latest`). A mismatch is not an error — the arm
+    /// falls back to the static estimate — but it is logged so operators can
+    /// detect that an authored rate silently did not apply.
     fn projected_cloud_cost(&self, decision: &RoutingDecision) -> arkavo_budget::TokenCost {
         let arm = decision
             .fallback_chain
@@ -494,12 +506,30 @@ impl Router {
             .cloned()
             .unwrap_or(ModelChoice::GeminiFlash);
         let est = decision.task_category.estimated_tokens();
-        let authored = self
+        let (authored, registry_populated) = self
             .pricing
             .read()
-            .ok()
-            .and_then(|p| p.estimate_cost(arm.provider(), arm.name(), est.input, est.output));
+            .map(|p| {
+                (
+                    p.estimate_cost(arm.provider(), arm.name(), est.input, est.output),
+                    p.model_count() > 0,
+                )
+            })
+            .unwrap_or((None, false));
         authored.unwrap_or_else(|| {
+            if registry_populated {
+                // Authored table present but this arm isn't in it: a
+                // provider/model-id naming mismatch between the manifest and
+                // ModelChoice. Without this log the gate silently reverts to
+                // the static estimate — exactly what #635 set out to fix.
+                tracing::warn!(
+                    provider = arm.provider(),
+                    model = arm.name(),
+                    "authored pricing table present but model not found; \
+                     falling back to static estimate. Manifest model_id/provider \
+                     must match ModelChoice::name()/provider() exactly."
+                );
+            }
             arkavo_budget::TokenCost::from_dollars(RoutingDecision::estimate_cost(
                 &arm,
                 decision.task_category,

--- a/crates/arkavo-server/src/server/config_helpers.rs
+++ b/crates/arkavo-server/src/server/config_helpers.rs
@@ -59,6 +59,11 @@ pub struct AgentMetadata {
     /// Distinguishes "unspecialized" from "specialized with zero tool grants"
     /// so a zero-grant role yields zero tools, not the full registry.
     pub specialized: bool,
+    /// Authored per-MTok pricing table received in a specialization bundle.
+    /// Applied to the agent's `Router` so its live spend-plane gate prices
+    /// cloud arms from the manifest (the pricing home) instead of the built-in
+    /// static estimate. Empty for an unspecialized agent → static fallback.
+    pub manifest_pricing: Vec<arkavo_budget::provider_costs::PricingEntry>,
 }
 
 /// Simple agent configuration structure for validation

--- a/crates/arkavo-server/src/server/handlers/specialization.rs
+++ b/crates/arkavo-server/src/server/handlers/specialization.rs
@@ -70,6 +70,7 @@ pub async fn handle_agent_specialize(
     decryptor: &dyn BundleDecryptor,
     agent_event_tx: &Arc<tokio::sync::Mutex<Option<tokio::sync::mpsc::Sender<AgentEvent>>>>,
     iroh_node: Option<&Arc<IrohNode>>,
+    live_router: Option<&Arc<arkavo_router::Router>>,
     request: AgentSpecializeRequest,
 ) -> Result<AgentSpecializeResponse, ErrorObjectOwned> {
     let timer = RpcTimer::new("agent.specialize".to_string(), metrics.clone());
@@ -81,6 +82,7 @@ pub async fn handle_agent_specialize(
         decryptor,
         agent_event_tx,
         iroh_node,
+        live_router,
         request,
     )
     .await
@@ -105,6 +107,7 @@ async fn handle_inner(
     decryptor: &dyn BundleDecryptor,
     agent_event_tx: &Arc<tokio::sync::Mutex<Option<tokio::sync::mpsc::Sender<AgentEvent>>>>,
     iroh_node: Option<&Arc<IrohNode>>,
+    live_router: Option<&Arc<arkavo_router::Router>>,
     request: AgentSpecializeRequest,
 ) -> Result<AgentSpecializeResponse, ErrorObjectOwned> {
     if let Err(e) = rate_limiter.check_rate_limit() {
@@ -218,6 +221,26 @@ async fn handle_inner(
 
     apply_bundle_to_metadata(agent_metadata, &bundle).await;
     role_specialization.set(bundle.role_context.clone()).await;
+
+    // Apply authored pricing to the live Router so the spend-plane gate prices
+    // cloud arms from the manifest rather than the static estimate. The
+    // pricing arrived inside the TDF-encrypted, DID-bound bundle, so it is
+    // trusted config — the agent may treat it as authoritative.
+    if let Some(router) = live_router
+        .as_ref()
+        .filter(|_| !bundle.manifest_pricing.is_empty())
+    {
+        let mut pricing = arkavo_budget::provider_costs::ProviderPricing::new();
+        pricing.load_from_entries(&bundle.manifest_pricing);
+        router.apply_manifest_pricing(pricing);
+        info!(
+            session_id = %session_id,
+            agent = %agent_name,
+            entries = bundle.manifest_pricing.len(),
+            "applied authored manifest pricing to live cost gate"
+        );
+    }
+
     inject_role_kickoff(agent_event_tx, &bundle).await;
 
     info!(
@@ -302,6 +325,9 @@ async fn apply_bundle_to_metadata(
     meta.api_keys.clone_from(&bundle.api_tokens);
     meta.granted_tools = granted_tool_names(bundle);
     meta.specialized = true;
+    // Carry authored pricing through to the agent's metadata; the caller is
+    // responsible for forwarding it to the live Router via `with_pricing`.
+    meta.manifest_pricing.clone_from(&bundle.manifest_pricing);
     // Persona name only swapped if the manifest's intended-agent matches
     // ours — the orchestrator should never send a persona for a different
     // agent, but if it does we keep our own identity rather than masquerade.
@@ -419,6 +445,7 @@ mod tests {
             },
             api_tokens: tokens,
             arp_overlay: arp_doc(),
+            manifest_pricing: Vec::new(),
             role_context: RoleContext {
                 kit_id: "kit:campaign:0.1".into(),
                 flight_id: "33333333-3333-3333-3333-333333333333".into(),
@@ -484,6 +511,7 @@ mod tests {
             &decryptor,
             &no_event_tx(),
             None,
+            None,
             AgentSpecializeRequest {
                 requester_id: "did:web:orchestrator.arkavo.net".into(),
                 encrypted_bundle: encoded_dummy_bytes(),
@@ -537,6 +565,7 @@ mod tests {
             &decryptor,
             &no_event_tx(),
             None,
+            None,
             AgentSpecializeRequest {
                 requester_id: "did:web:orchestrator.arkavo.net".into(),
                 encrypted_bundle: encoded_dummy_bytes(),
@@ -567,6 +596,7 @@ mod tests {
             &decryptor,
             &no_event_tx(),
             None,
+            None,
             AgentSpecializeRequest {
                 requester_id: "did:web:orchestrator.arkavo.net".into(),
                 encrypted_bundle: String::new(),
@@ -595,6 +625,7 @@ mod tests {
             &role_store,
             &decryptor,
             &no_event_tx(),
+            None,
             None,
             AgentSpecializeRequest {
                 requester_id: "did:web:orchestrator.arkavo.net".into(),
@@ -629,6 +660,7 @@ mod tests {
             &role_store,
             &decryptor,
             &no_event_tx(),
+            None,
             None,
             AgentSpecializeRequest {
                 requester_id: "did:web:orchestrator.arkavo.net".into(),
@@ -671,6 +703,7 @@ mod tests {
             &role_store,
             &decryptor,
             &event_tx,
+            None,
             None,
             AgentSpecializeRequest {
                 requester_id: "did:web:orchestrator.arkavo.net".into(),
@@ -729,6 +762,7 @@ mod tests {
             &decryptor,
             &no_event_tx(),
             Some(&node),
+            None,
             AgentSpecializeRequest {
                 requester_id: "did:web:orchestrator.arkavo.net".into(),
                 encrypted_bundle: String::new(),
@@ -761,6 +795,7 @@ mod tests {
             &decryptor,
             &no_event_tx(),
             None, // no iroh node wired
+            None,
             AgentSpecializeRequest {
                 requester_id: "did:web:orchestrator.arkavo.net".into(),
                 encrypted_bundle: String::new(),

--- a/crates/arkavo-server/src/server/mod.rs
+++ b/crates/arkavo-server/src/server/mod.rs
@@ -1033,6 +1033,7 @@ impl A2aRpcServer for A2aRpcImpl {
             self.bundle_decryptor.as_ref(),
             &self.agent_event_tx,
             iroh_node,
+            self.router.as_ref(),
             request,
         )
         .await

--- a/crates/arkavo-swarmkit/Cargo.toml
+++ b/crates/arkavo-swarmkit/Cargo.toml
@@ -17,6 +17,7 @@ semver = { workspace = true }
 blake3 = "1.5"
 base64 = { workspace = true }
 thiserror = { workspace = true }
+arkavo-budget = { path = "../arkavo-budget" }
 
 [dev-dependencies]
 arkavo-test-macros = { path = "../arkavo-test-macros" }

--- a/crates/arkavo-swarmkit/src/pricing.rs
+++ b/crates/arkavo-swarmkit/src/pricing.rs
@@ -25,6 +25,24 @@ pub struct ModelPricingEntry {
     pub cache_write_cents_per_mtok: Option<u64>,
 }
 
+impl From<&ModelPricingEntry> for arkavo_budget::PricingEntry {
+    /// Lossless on the six shared fields (same names, same cents-per-MTok
+    /// units). The two `PricingEntry`-only fields (`context_window`,
+    /// `max_output_tokens`) have no manifest source and default to `None`.
+    fn from(entry: &ModelPricingEntry) -> Self {
+        arkavo_budget::PricingEntry {
+            model_id: entry.model_id.clone(),
+            provider: entry.provider.clone(),
+            input_cents_per_mtok: entry.input_cents_per_mtok,
+            output_cents_per_mtok: entry.output_cents_per_mtok,
+            cached_input_cents_per_mtok: entry.cached_input_cents_per_mtok,
+            cache_write_cents_per_mtok: entry.cache_write_cents_per_mtok,
+            context_window: None,
+            max_output_tokens: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -61,5 +79,68 @@ mod tests {
         // Absent optional rates are skipped on re-serialize (canonical-form stable).
         let round = serde_json::to_string(&entry).unwrap();
         assert!(!round.contains("cached_input_cents_per_mtok"));
+    }
+
+    #[test]
+    fn manifest_entry_converts_to_budget_pricing_entry() {
+        // Regression for #635: the manifest→budget conversion is lossless on
+        // the six shared fields and defaults the two budget-only fields.
+        let manifest_entry = ModelPricingEntry {
+            model_id: "glm-5.2".to_string(),
+            provider: "zhipu".to_string(),
+            input_cents_per_mtok: 140,
+            output_cents_per_mtok: 440,
+            cached_input_cents_per_mtok: Some(26),
+            cache_write_cents_per_mtok: Some(70),
+        };
+        let pricing_entry: arkavo_budget::PricingEntry = (&manifest_entry).into();
+
+        assert_eq!(pricing_entry.model_id, manifest_entry.model_id);
+        assert_eq!(pricing_entry.provider, manifest_entry.provider);
+        assert_eq!(
+            pricing_entry.input_cents_per_mtok,
+            manifest_entry.input_cents_per_mtok
+        );
+        assert_eq!(
+            pricing_entry.output_cents_per_mtok,
+            manifest_entry.output_cents_per_mtok
+        );
+        assert_eq!(
+            pricing_entry.cached_input_cents_per_mtok,
+            manifest_entry.cached_input_cents_per_mtok
+        );
+        assert_eq!(
+            pricing_entry.cache_write_cents_per_mtok,
+            manifest_entry.cache_write_cents_per_mtok
+        );
+        // No manifest source for these two; must default to None.
+        assert_eq!(pricing_entry.context_window, None);
+        assert_eq!(pricing_entry.max_output_tokens, None);
+    }
+
+    #[test]
+    fn manifest_entry_converts_then_loads_into_provider_pricing() {
+        // The full send-side path: manifest entry → PricingEntry → registry,
+        // which estimate_cost must then honor as the authored rate.
+        use arkavo_budget::provider_costs::ProviderPricing;
+
+        let manifest_entry = ModelPricingEntry {
+            model_id: "glm-5.2".to_string(),
+            provider: "zhipu".to_string(),
+            // 140 cents = $1.40 / MTok input; 440 cents = $4.40 / MTok output.
+            input_cents_per_mtok: 140,
+            output_cents_per_mtok: 440,
+            cached_input_cents_per_mtok: None,
+            cache_write_cents_per_mtok: None,
+        };
+        let entries: Vec<arkavo_budget::PricingEntry> = [(&manifest_entry).into()].into();
+        let mut pricing = ProviderPricing::new();
+        pricing.load_from_entries(&entries);
+
+        // 1M input + 1M output → 140 + 440 = 580 cents = $5.80.
+        let cost = pricing
+            .estimate_cost("zhipu", "glm-5.2", 1_000_000, 1_000_000)
+            .expect("authored model must be priced");
+        assert!((cost.as_dollars() - 5.80).abs() < 1e-9);
     }
 }


### PR DESCRIPTION
## Summary

Closes #635. Distributed agents now receive the manifest's per-MTok pricing table over the existing **trusted `agent.specialize` channel** (TDF-encrypted, DID-bound, KAS-rewrapped) and apply it to their **live spend-plane gate**. Editing a rate in the authored manifest now moves real budget enforcement across every agent in the flight — no env vars, no local-file assumptions.

Previously `manifest.pricing` was defined but never read at runtime, and the live cost gate (`Router::projected_cloud_cost`) priced cloud arms from a hardcoded static estimate. The static estimate is now the **fallback** for unknown models; authored rates are **authoritative**.

This continues the cost-aware work from #643 (which used the static table because this plumbing did not yet exist).

## The path: sender → wire → receiver

| Layer | Change |
|-------|--------|
| `arkavo-swarmkit` | `From<&ModelPricingEntry> for PricingEntry` (lossless on the 6 shared cents-per-MTok fields); adds `arkavo-budget` dep |
| `arkavo-protocol` | `AgentSpecializationBundle.manifest_pricing` (serde-defaulted `Vec<PricingEntry>`, backward compatible); adds `arkavo-budget` dep (swarmkit stays dev-only, preserving existing layering) |
| `arkavo-orchestrator` | `build_bundle` populates `manifest_pricing` from `manifest.pricing` — the one place it stops being dead |
| `arkavo-router` | `Router.pricing` (`Arc<RwLock<ProviderPricing>>`) + `with_pricing` builder + `apply_manifest_pricing` live setter; `projected_cloud_cost` consults authored rates first |
| `arkavo-server` | `handle_agent_specialize` applies the bundle's pricing to the live Router; `AgentMetadata` carries it |

## Trust model

Pricing rides the **same integrity stack as `arp_overlay`**: TDF encryption + DID-bound dissemination (recipient DID pre-flight checked) + KAS rewrap gates the DEK, on top of a BLAKE3-content-addressed, signed manifest. Receiving agents may therefore treat the rates as authoritative rather than untrusted local config. This is exactly the "budget must be trusted" property #635 requires for distributed agents — reused, not reinvented.

## Acceptance tests

- **`projected_cloud_cost_uses_authored_pricing_over_static`** — the #635 acceptance test: the live gate returns the authored rate when the model is in the registry, and the static estimate when absent. Proves "editing a model rate in the authored config changes the cost the live budget gate uses."
- **`apply_manifest_pricing_updates_live_gate`** — the live setter (shared `&Arc<Router>` path used by the specialization handler) updates the gate in place.
- **`bundle_without_manifest_pricing_deserializes_as_empty`** — backward compat: bundles serialized before this field existed deserialize cleanly.
- **Conversion round-trip + registry load** (`arkavo-swarmkit`) — the 6 fields map losslessly; `estimate_cost` honors the authored rate.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy` (swarmkit, protocol, router, server, orchestrator) ✅ — zero lints
- `cargo nextest run` (5 affected crates) — **1158/1161 pass**. The 3 failures are **pre-existing on `main`** and in files this PR does not touch (`synthesis.rs` test fixtures, `gemini_3_orc_suite_c` router-fallback with a stale model list). Zero regressions introduced.
- Workspace build ✅

## Out of scope (flagged)

- **Applying the dropped `arp_overlay`** (`handle_agent_specialize` currently discards `bundle.arp_overlay`). It is the same receive-side code path and same trust argument, but it is not "pricing" — splitting it into a follow-up keeps this PR focused on #635. I will open that as a separate issue/PR.
- Reviving `CostOrchestrator` / `try_spend` reservation path (overlaps #587).
- Migrating `agent.specialize` to the DEC-4 unified transport (#636 — current path works and is used as-is).
- Author-signature verification on the apply path (TDF/KAS/DID proves recipient authorization, which is what #635 needs).

## Note on dependency layering

The bundle is defined in `arkavo-protocol`, which deliberately keeps `arkavo-swarmkit` as a **dev-dep only** (a canonical-JSON parity test). To avoid inverting that layering, the bundle field uses the low-level `arkavo_budget::PricingEntry` type (protocol now depends on `arkavo-budget`, which has no upstream cycle), and the orchestrator — which already depends on both — performs the `ModelPricingEntry → PricingEntry` conversion at build time.