### PR TITLE
Grok 4.6 xhigh support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -207,7 +207,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -339,6 +339,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +380,16 @@ name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -407,6 +434,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +480,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint",
+ "serde_with",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +528,16 @@ name = "ark-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -630,7 +704,7 @@ dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
  "chrono",
- "lru 0.16.4",
+ "lru",
  "prost",
  "reqwest 0.12.28",
  "serde",
@@ -1598,7 +1672,7 @@ dependencies = [
  "ipnet",
  "jsonrpsee",
  "jsonwebtoken",
- "lru 0.16.4",
+ "lru",
  "metrics",
  "metrics-exporter-prometheus",
  "notify",
@@ -1663,7 +1737,7 @@ dependencies = [
  "chrono",
  "ignore",
  "indicatif",
- "lru 0.16.4",
+ "lru",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -1720,7 +1794,7 @@ dependencies = [
 name = "arkavo-sat"
 version = "0.89.0"
 dependencies = [
- "lru 0.16.4",
+ "lru",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1760,7 +1834,7 @@ dependencies = [
  "dashmap",
  "governor",
  "jsonwebtoken",
- "lru 0.16.4",
+ "lru",
  "rand 0.8.6",
  "regex",
  "reqwest 0.12.28",
@@ -1827,7 +1901,7 @@ dependencies = [
  "if-addrs",
  "jsonrpsee",
  "jsonwebtoken",
- "lru 0.16.4",
+ "lru",
  "metrics",
  "metrics-exporter-prometheus",
  "notify",
@@ -3654,7 +3728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3708,6 +3782,9 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "derivative"
@@ -3862,7 +3939,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4169,7 +4246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5592,6 +5669,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -5602,6 +5680,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5908,7 +5988,7 @@ dependencies = [
  "iroh-base",
  "iroh-dns",
  "iroh-metrics",
- "lru 0.18.0",
+ "lru",
  "n0-error",
  "n0-future",
  "noq",
@@ -5999,7 +6079,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6063,10 +6143,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "windows-link",
 ]
 
 [[package]]
@@ -6078,6 +6160,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -6677,18 +6774,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
-dependencies = [
- "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "lru"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -7367,7 +7455,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8849,7 +8937,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.18.0",
+ "lru",
  "palette",
  "serde",
  "strum",
@@ -9340,14 +9428,15 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
@@ -9431,7 +9520,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9511,7 +9600,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.8",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9599,6 +9688,18 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -9715,7 +9816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9861,6 +9962,26 @@ dependencies = [
  "itoa 1.0.18",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "jiff",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "time",
 ]
 
 [[package]]
@@ -10170,7 +10291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10672,7 +10793,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10694,7 +10815,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12274,7 +12395,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui-protocol"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-test-macros",
  "serde",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-device-identity",
  "arkavo-test-macros",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "chrono",
  "serde",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-test-macros",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "git2",
  "tempfile",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1149,11 +1149,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-lesson-synthesis"
-version = "0.88.0"
+version = "0.89.0"
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1278,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1347,7 +1347,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1480,7 +1480,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1674,7 +1674,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "lru 0.16.4",
  "serde",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1749,7 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-shadow-consolidation"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-lesson-synthesis",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-test-macros",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2093,7 +2093,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.88.0"
+version = "0.89.0"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ keyring = "3.6"
 # Common utilities
 url = "2.5"
 http = "1.1"
-lru = "0.16"
+lru = "0.18"
 anthropic-agent-sdk = { path = "crates/anthropic-agent-sdk" }
 async-stream = "0.3"
 tower = "0.5"

--- a/crates/arkavo-budget/src/provider_costs.rs
+++ b/crates/arkavo-budget/src/provider_costs.rs
@@ -355,12 +355,12 @@ mod tests {
     }
 
     #[test]
-    fn test_grok45_priced_at_published_list_rates() {
-        // Grok 4.5: $2.00/$6.00 per MTok (+ $0.50 cached input).
+    fn test_grok46_priced_at_published_list_rates() {
+        // Grok 4.6: $2.00/$6.00 per MTok (+ $0.50 cached input) below 200k.
         // cents/MTok: 200 input, 600 output, 50 cached.
         let mut pricing = ProviderPricing::new();
         pricing.register(&PricingEntry {
-            model_id: "grok-4.5".into(),
+            model_id: "grok-4.6".into(),
             provider: "xai".into(),
             input_cents_per_mtok: 200,
             output_cents_per_mtok: 600,
@@ -371,7 +371,7 @@ mod tests {
         });
         // 200K in + 100K out = 200_000*200/1e6 + 100_000*600/1e6 = 40 + 60 = 100c.
         let cost = pricing
-            .estimate_cost("xai", "grok-4.5", 200_000, 100_000)
+            .estimate_cost("xai", "grok-4.6", 200_000, 100_000)
             .unwrap();
         assert_eq!(cost.as_cents(), 100);
     }

--- a/crates/arkavo-cli/src/commands/ui.rs
+++ b/crates/arkavo-cli/src/commands/ui.rs
@@ -1088,18 +1088,24 @@ async fn create_client_from_routing(
                 Err("GLM support requires glm feature".into())
             }
         }
-        ModelChoice::Grok45 => {
+        ModelChoice::Grok46 | ModelChoice::Grok46Xhigh => {
             #[cfg(feature = "xai")]
             {
-                use arkavo_llm::providers::xai_responses::{ResponsesConfig, ResponsesProvider};
+                use arkavo_llm::providers::xai_responses::{
+                    ReasoningEffort, ResponsesConfig, ResponsesProvider,
+                };
                 let api_key = std::env::var("XAI_API_KEY")?;
                 let base_url = std::env::var("XAI_BASE_URL")
                     .unwrap_or_else(|_| "https://api.x.ai/v1".to_string());
-                let config = ResponsesConfig::for_agent(
-                    api_key,
-                    base_url,
-                    decision.recommended_model.name().to_string(),
-                );
+                let api_model = decision
+                    .recommended_model
+                    .grok_api_model()
+                    .unwrap_or("grok-4.6")
+                    .to_string();
+                let mut config = ResponsesConfig::for_agent(api_key, base_url, api_model);
+                if matches!(decision.recommended_model, ModelChoice::Grok46Xhigh) {
+                    config = config.with_reasoning_effort(ReasoningEffort::Xhigh);
+                }
                 let provider = Box::new(ResponsesProvider::new(config)?);
                 Ok(LlmClient::new(provider))
             }

--- a/crates/arkavo-cli/src/commands/ui.rs
+++ b/crates/arkavo-cli/src/commands/ui.rs
@@ -1102,10 +1102,12 @@ async fn create_client_from_routing(
                     .grok_api_model()
                     .unwrap_or("grok-4.6")
                     .to_string();
-                let mut config = ResponsesConfig::for_agent(api_key, base_url, api_model);
-                if matches!(decision.recommended_model, ModelChoice::Grok46Xhigh) {
-                    config = config.with_reasoning_effort(ReasoningEffort::Xhigh);
-                }
+                let effort = if matches!(decision.recommended_model, ModelChoice::Grok46Xhigh) {
+                    ReasoningEffort::Xhigh
+                } else {
+                    ReasoningEffort::Low
+                };
+                let config = ResponsesConfig::for_routed_arm(api_key, base_url, api_model, effort);
                 let provider = Box::new(ResponsesProvider::new(config)?);
                 Ok(LlmClient::new(provider))
             }

--- a/crates/arkavo-llm/src/providers/xai_responses/config.rs
+++ b/crates/arkavo-llm/src/providers/xai_responses/config.rs
@@ -50,6 +50,15 @@ impl ReasoningEffort {
             Self::Xhigh => 3600,
         }
     }
+
+    /// Retry budget for this effort. `xhigh` already waits up to an hour;
+    /// retrying timeouts would triple wall-clock and token spend.
+    pub fn max_retries(self) -> u32 {
+        match self {
+            Self::Xhigh => 1,
+            _ => 3,
+        }
+    }
 }
 
 /// Configuration for the xAI Responses API.
@@ -131,11 +140,21 @@ impl ResponsesConfig {
     }
 
     /// Override reasoning effort after [`Self::for_agent`] / [`Self::from_env`].
-    /// Used by the `Grok46Xhigh` routing arm so the env default cannot
-    /// silently downgrade a max-effort selection.
     pub fn with_reasoning_effort(mut self, effort: ReasoningEffort) -> Self {
         self.reasoning_effort = effort;
         self
+    }
+
+    /// Routed Grok arm: same agent defaults as [`Self::for_agent`], but
+    /// `effort` is pinned so `XAI_REASONING_EFFORT` cannot collapse distinct
+    /// Thompson Sampling arms into one behavior.
+    pub fn for_routed_arm(
+        api_key: String,
+        base_url: String,
+        model: String,
+        effort: ReasoningEffort,
+    ) -> Self {
+        Self::for_agent(api_key, base_url, model).with_reasoning_effort(effort)
     }
 }
 
@@ -147,7 +166,10 @@ fn env_truthy(name: &str) -> bool {
 }
 
 fn env_reasoning_effort() -> ReasoningEffort {
-    ReasoningEffort::from_name(&std::env::var("XAI_REASONING_EFFORT").unwrap_or_default())
+    match std::env::var("XAI_REASONING_EFFORT") {
+        Ok(name) => ReasoningEffort::from_name(&name),
+        Err(_) => ReasoningEffort::Low,
+    }
 }
 
 #[cfg(test)]
@@ -202,5 +224,31 @@ mod tests {
         let cfg = ResponsesConfig::default().with_reasoning_effort(ReasoningEffort::Xhigh);
         assert_eq!(cfg.reasoning_effort, ReasoningEffort::Xhigh);
         assert_eq!(cfg.model, "grok-4.6");
+    }
+
+    #[test]
+    fn for_routed_arm_pins_effort_over_for_agent_default() {
+        let low = ResponsesConfig::for_routed_arm(
+            "k".into(),
+            "https://api.x.ai/v1".into(),
+            "grok-4.6".into(),
+            ReasoningEffort::Low,
+        );
+        let xhigh = ResponsesConfig::for_routed_arm(
+            "k".into(),
+            "https://api.x.ai/v1".into(),
+            "grok-4.6".into(),
+            ReasoningEffort::Xhigh,
+        );
+        assert_eq!(low.reasoning_effort, ReasoningEffort::Low);
+        assert_eq!(xhigh.reasoning_effort, ReasoningEffort::Xhigh);
+        assert_eq!(low.model, "grok-4.6");
+    }
+
+    #[test]
+    fn xhigh_retries_once() {
+        assert_eq!(ReasoningEffort::Xhigh.max_retries(), 1);
+        assert_eq!(ReasoningEffort::Low.max_retries(), 3);
+        assert_eq!(ReasoningEffort::High.max_retries(), 3);
     }
 }

--- a/crates/arkavo-llm/src/providers/xai_responses/config.rs
+++ b/crates/arkavo-llm/src/providers/xai_responses/config.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 /// Reasoning effort for Grok models.
 ///
 /// xAI's API default is `high`. Arkavo defaults to [`ReasoningEffort::Low`] for
-/// agent latency; set medium/high when the task needs deeper chain-of-thought.
+/// agent latency; set medium/high/`xhigh` when the task needs deeper
+/// chain-of-thought. `"xhigh"` is supported on `grok-4.6` and later; older
+/// models treat it as `"high"`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum ReasoningEffort {
@@ -11,6 +13,8 @@ pub enum ReasoningEffort {
     Low,
     Medium,
     High,
+    /// Maximum reasoning depth on Grok 4.6+. Correspondingly higher latency.
+    Xhigh,
 }
 
 impl ReasoningEffort {
@@ -19,6 +23,31 @@ impl ReasoningEffort {
             Self::Low => "low",
             Self::Medium => "medium",
             Self::High => "high",
+            Self::Xhigh => "xhigh",
+        }
+    }
+
+    /// Parse an effort name. Unknown values fall back to [`Self::Low`].
+    pub fn from_name(name: &str) -> Self {
+        match name.to_ascii_lowercase().as_str() {
+            "medium" => Self::Medium,
+            "high" => Self::High,
+            "xhigh" | "x-high" | "extra-high" => Self::Xhigh,
+            _ => Self::Low,
+        }
+    }
+
+    /// HTTP timeout for a Responses call at this effort.
+    ///
+    /// xAI's own examples use a 3600s ceiling for reasoning models; `xhigh`
+    /// is the only tier that needs the full hour. Lower tiers stay tighter
+    /// so a stuck agent loop fails faster.
+    pub fn request_timeout_secs(self) -> u64 {
+        match self {
+            Self::Low => 300,
+            Self::Medium => 600,
+            Self::High => 1800,
+            Self::Xhigh => 3600,
         }
     }
 }
@@ -56,7 +85,7 @@ impl Default for ResponsesConfig {
         Self {
             api_key: String::new(),
             base_url: "https://api.x.ai/v1".to_string(),
-            model: "grok-4.5".to_string(),
+            model: "grok-4.6".to_string(),
             reasoning_effort: ReasoningEffort::Low,
             store: false,
             service_tier: None,
@@ -100,6 +129,14 @@ impl ResponsesConfig {
             ..Default::default()
         }
     }
+
+    /// Override reasoning effort after [`Self::for_agent`] / [`Self::from_env`].
+    /// Used by the `Grok46Xhigh` routing arm so the env default cannot
+    /// silently downgrade a max-effort selection.
+    pub fn with_reasoning_effort(mut self, effort: ReasoningEffort) -> Self {
+        self.reasoning_effort = effort;
+        self
+    }
 }
 
 fn env_truthy(name: &str) -> bool {
@@ -110,15 +147,7 @@ fn env_truthy(name: &str) -> bool {
 }
 
 fn env_reasoning_effort() -> ReasoningEffort {
-    match std::env::var("XAI_REASONING_EFFORT")
-        .unwrap_or_default()
-        .to_ascii_lowercase()
-        .as_str()
-    {
-        "medium" => ReasoningEffort::Medium,
-        "high" => ReasoningEffort::High,
-        _ => ReasoningEffort::Low,
-    }
+    ReasoningEffort::from_name(&std::env::var("XAI_REASONING_EFFORT").unwrap_or_default())
 }
 
 #[cfg(test)]
@@ -129,6 +158,34 @@ mod tests {
     fn reasoning_effort_serializes_lowercase() {
         assert_eq!(ReasoningEffort::Low.as_str(), "low");
         assert_eq!(ReasoningEffort::High.as_str(), "high");
+        assert_eq!(ReasoningEffort::Xhigh.as_str(), "xhigh");
+    }
+
+    #[test]
+    fn reasoning_effort_from_name_recognizes_xhigh_aliases() {
+        assert_eq!(ReasoningEffort::from_name("xhigh"), ReasoningEffort::Xhigh);
+        assert_eq!(ReasoningEffort::from_name("XHIGH"), ReasoningEffort::Xhigh);
+        assert_eq!(ReasoningEffort::from_name("x-high"), ReasoningEffort::Xhigh);
+        assert_eq!(
+            ReasoningEffort::from_name("extra-high"),
+            ReasoningEffort::Xhigh
+        );
+        assert_eq!(
+            ReasoningEffort::from_name("medium"),
+            ReasoningEffort::Medium
+        );
+        assert_eq!(ReasoningEffort::from_name("high"), ReasoningEffort::High);
+        assert_eq!(ReasoningEffort::from_name(""), ReasoningEffort::Low);
+        assert_eq!(ReasoningEffort::from_name("nope"), ReasoningEffort::Low);
+    }
+
+    #[test]
+    fn xhigh_uses_hour_timeout() {
+        assert_eq!(ReasoningEffort::Xhigh.request_timeout_secs(), 3600);
+        assert!(
+            ReasoningEffort::Xhigh.request_timeout_secs()
+                > ReasoningEffort::High.request_timeout_secs()
+        );
     }
 
     #[test]
@@ -136,7 +193,14 @@ mod tests {
         let cfg = ResponsesConfig::default();
         assert!(!cfg.store);
         assert_eq!(cfg.reasoning_effort, ReasoningEffort::Low);
-        assert_eq!(cfg.model, "grok-4.5");
+        assert_eq!(cfg.model, "grok-4.6");
         assert!(cfg.prompt_cache_key.is_none());
+    }
+
+    #[test]
+    fn with_reasoning_effort_overrides_default() {
+        let cfg = ResponsesConfig::default().with_reasoning_effort(ReasoningEffort::Xhigh);
+        assert_eq!(cfg.reasoning_effort, ReasoningEffort::Xhigh);
+        assert_eq!(cfg.model, "grok-4.6");
     }
 }

--- a/crates/arkavo-llm/src/providers/xai_responses/mod.rs
+++ b/crates/arkavo-llm/src/providers/xai_responses/mod.rs
@@ -1,6 +1,6 @@
 //! xAI Responses API client (`POST /v1/responses`).
 //!
-//! Preferred path for Grok 4.5 agentic work. Uses the Responses surface (not
+//! Preferred path for Grok 4.6 agentic work. Uses the Responses surface (not
 //! Chat Completions) for configurable reasoning effort, function-call items,
 //! and optional SSE streaming.
 //!

--- a/crates/arkavo-llm/src/providers/xai_responses/provider.rs
+++ b/crates/arkavo-llm/src/providers/xai_responses/provider.rs
@@ -38,7 +38,7 @@ impl ResponsesProvider {
             base_url: config.base_url.clone(),
             auth_token: Some(config.api_key.clone()),
             timeout_secs: config.reasoning_effort.request_timeout_secs(),
-            max_retries: 3,
+            max_retries: config.reasoning_effort.max_retries(),
             initial_retry_delay_ms: 1000,
             backoff_factor: 2.0,
             max_retry_delay_ms: 30000,

--- a/crates/arkavo-llm/src/providers/xai_responses/provider.rs
+++ b/crates/arkavo-llm/src/providers/xai_responses/provider.rs
@@ -37,8 +37,7 @@ impl ResponsesProvider {
         let http_config = HttpClientConfig {
             base_url: config.base_url.clone(),
             auth_token: Some(config.api_key.clone()),
-            // Reasoning models can run long; keep a generous ceiling.
-            timeout_secs: 300,
+            timeout_secs: config.reasoning_effort.request_timeout_secs(),
             max_retries: 3,
             initial_retry_delay_ms: 1000,
             backoff_factor: 2.0,
@@ -388,5 +387,19 @@ mod tests {
         assert_eq!(req.store, Some(true));
         assert_eq!(req.prompt_cache_key.as_deref(), Some("session-abc"));
         assert_eq!(req.max_output_tokens, Some(64));
+    }
+
+    #[test]
+    fn build_request_serializes_xhigh_effort() {
+        let provider = ResponsesProvider::new(ResponsesConfig {
+            api_key: "test".to_string(),
+            model: "grok-4.6".to_string(),
+            reasoning_effort: ReasoningEffort::Xhigh,
+            ..Default::default()
+        })
+        .unwrap();
+        let req = provider.build_request(json!([]), None, None, false, None);
+        assert_eq!(req.model, "grok-4.6");
+        assert_eq!(req.reasoning.unwrap()["effort"], "xhigh");
     }
 }

--- a/crates/arkavo-llm/tests/e2e_grok.rs
+++ b/crates/arkavo-llm/tests/e2e_grok.rs
@@ -1,6 +1,6 @@
-//! End-to-end test against the **live Grok 4.5** xAI Responses API.
+//! End-to-end test against the **live Grok 4.6** xAI Responses API.
 //!
-//! Exercises the **router path** for `ModelChoice::Grok45`:
+//! Exercises the **router path** for `ModelChoice::Grok46`:
 //! [`ResponsesProvider`] behind [`LlmClient`] with agent defaults
 //! (`reasoning_effort: low`, `store: false` unless `XAI_STORE` is set).
 //!
@@ -27,7 +27,7 @@ fn grok_provider() -> Option<ResponsesProvider> {
         ResponsesProvider::new(ResponsesConfig::for_agent(
             api_key,
             base_url,
-            "grok-4.5".to_string(),
+            "grok-4.6".to_string(),
         ))
         .expect("ResponsesProvider construction should not fail with a valid config"),
     )
@@ -50,10 +50,10 @@ fn is_transient_provider_error(err: &impl std::fmt::Display) -> bool {
 }
 
 #[tokio::test]
-#[ignore = "Requires XAI_API_KEY — makes a live Grok 4.5 Responses call"]
-async fn grok45_round_trips_a_prompt() {
+#[ignore = "Requires XAI_API_KEY — makes a live Grok 4.6 Responses call"]
+async fn grok46_round_trips_a_prompt() {
     let Some(client) = grok_client() else {
-        eprintln!("XAI_API_KEY not set — skipping live Grok 4.5 e2e");
+        eprintln!("XAI_API_KEY not set — skipping live Grok 4.6 e2e");
         return;
     };
 
@@ -73,13 +73,13 @@ async fn grok45_round_trips_a_prompt() {
         Err(err) if is_transient_provider_error(&err) => {
             eprintln!("Skipping live Grok e2e on transient provider error: {err}");
         }
-        Err(err) => panic!("Grok 4.5 round-trip failed: {err}"),
+        Err(err) => panic!("Grok 4.6 round-trip failed: {err}"),
     }
 }
 
 #[tokio::test]
 #[ignore = "Requires XAI_API_KEY — live Grok provider construction check"]
-async fn grok45_provider_advertises_tools() {
+async fn grok46_provider_advertises_tools() {
     let Some(provider) = grok_provider() else {
         eprintln!("XAI_API_KEY not set — skipping Grok provider check");
         return;

--- a/crates/arkavo-llm/tests/e2e_xai_responses.rs
+++ b/crates/arkavo-llm/tests/e2e_xai_responses.rs
@@ -21,7 +21,7 @@ fn provider() -> Option<ResponsesProvider> {
         ResponsesProvider::new(ResponsesConfig::for_agent(
             api_key,
             base_url,
-            "grok-4.5".to_string(),
+            "grok-4.6".to_string(),
         ))
         .expect("ResponsesProvider construction"),
     )
@@ -130,6 +130,6 @@ fn provider_defaults_to_low_effort_and_ephemeral_store() {
         cfg.reasoning_effort,
         arkavo_llm::providers::xai_responses::ReasoningEffort::Low
     );
-    assert_eq!(cfg.model, "grok-4.5");
+    assert_eq!(cfg.model, "grok-4.6");
     assert!(!cfg.store, "default store is false for agent privacy");
 }

--- a/crates/arkavo-router/Cargo.toml
+++ b/crates/arkavo-router/Cargo.toml
@@ -57,7 +57,7 @@ kimi = ["arkavo-llm/kimi"]
 # GLM-5.2 routes through the generic OpenAI-compatible provider, which lives
 # behind arkavo-llm's `llm-remote` feature.
 glm = ["arkavo-llm/llm-remote"]
-# Grok 4.5 (xAI) uses the Responses API client in arkavo-llm (llm-remote).
+# Grok 4.6 (xAI) uses the Responses API client in arkavo-llm (llm-remote).
 xai = ["arkavo-llm/llm-remote"]
 llm-remote = ["arkavo-llm/llm-remote", "arkavo-context/llm-remote"]
 tdf-encrypt = ["dep:arkavo-tdf", "dep:arkavo-memory"]

--- a/crates/arkavo-router/src/architect/executor.rs
+++ b/crates/arkavo-router/src/architect/executor.rs
@@ -315,8 +315,9 @@ impl ArchitectExecutor {
             // GLM-5.2 is a low-cost cloud arm; escalate to a stronger tier
             // when it underperforms on a task.
             ModelChoice::Glm52 => ModelChoice::ClaudeSonnet,
-            // Grok 4.5 escalates toward Claude for hard failures.
-            ModelChoice::Grok45 => ModelChoice::ClaudeSonnet,
+            // Grok 4.6 climbs the effort ladder before leaving the family.
+            ModelChoice::Grok46 => ModelChoice::Grok46Xhigh,
+            ModelChoice::Grok46Xhigh => ModelChoice::ClaudeSonnet,
         }
     }
 
@@ -354,8 +355,8 @@ impl ArchitectExecutor {
             ModelChoice::ClaudeFable5 => {
                 (input_tokens / 1_000_000.0).mul_add(10.00, (output_tokens / 1_000_000.0) * 50.00)
             }
-            ModelChoice::Grok45 => {
-                // Grok 4.5 list rates: $2.00/1M input, $6.00/1M output
+            ModelChoice::Grok46 | ModelChoice::Grok46Xhigh => {
+                // Grok 4.6 list rates: $2.00/1M input, $6.00/1M output
                 (input_tokens / 1_000_000.0).mul_add(2.00, (output_tokens / 1_000_000.0) * 6.00)
             }
             ModelChoice::Glm52 => {
@@ -452,7 +453,11 @@ mod tests {
                 ModelChoice::ClaudeFable5
             );
             assert_eq!(
-                executor.escalate_model(&ModelChoice::Grok45),
+                executor.escalate_model(&ModelChoice::Grok46),
+                ModelChoice::Grok46Xhigh
+            );
+            assert_eq!(
+                executor.escalate_model(&ModelChoice::Grok46Xhigh),
                 ModelChoice::ClaudeSonnet
             );
         }
@@ -476,7 +481,7 @@ mod tests {
             ..Default::default()
         };
         // $2/M in + $6/M out → 2 + 3 = $5.00
-        let cost = executor.estimate_actual_cost(&ModelChoice::Grok45, &resp);
+        let cost = executor.estimate_actual_cost(&ModelChoice::Grok46, &resp);
         assert!(
             (cost - 5.0).abs() < 1e-9,
             "Grok actual cost should be $5.00 for 1M/0.5M tokens, got {cost}"
@@ -498,7 +503,7 @@ mod tests {
             ..Default::default()
         };
         // 500k output tokens at $6/M → $3.00 (not $3.00 + $1.80 double-count)
-        let thinking_cost = executor.estimate_actual_cost(&ModelChoice::Grok45, &with_thinking);
+        let thinking_cost = executor.estimate_actual_cost(&ModelChoice::Grok46, &with_thinking);
         assert!(
             (thinking_cost - 3.0).abs() < 1e-9,
             "thinking tokens must not double-count; got {thinking_cost}"

--- a/crates/arkavo-router/src/decision.rs
+++ b/crates/arkavo-router/src/decision.rs
@@ -84,12 +84,18 @@ pub enum ModelChoice {
     /// Sampling arm to respect the cold-start exploration cap; a thinking-tier
     /// (High/Max) split can follow once this base arm graduates probation.
     Glm52,
-    /// Grok 4.5 (xAI) - flagship cloud model via the xAI Responses API.
+    /// Grok 4.6 (xAI) — flagship cloud model via the xAI Responses API.
     /// Routed through `ResponsesProvider` (`XAI_API_KEY`, base
     /// `https://api.x.ai/v1`, `POST /v1/responses`) with low reasoning effort
-    /// by default for agent latency. Single Thompson Sampling arm for cold-start;
-    /// reasoning-tier splits can follow once this base arm graduates probation.
-    Grok45,
+    /// by default for agent latency. `Grok46Xhigh` is the max-effort companion.
+    /// `Grok45` remains a serde alias so persisted traces keep loading.
+    #[serde(alias = "Grok45")]
+    Grok46,
+    /// Grok 4.6 with `xhigh` reasoning effort — maximum depth for the hardest
+    /// problems. Distinct Thompson arm so cost and latency are visible to
+    /// routing. The API model id is still `grok-4.6`; effort is sent as
+    /// `reasoning.effort = "xhigh"`.
+    Grok46Xhigh,
 }
 
 impl ModelChoice {
@@ -131,7 +137,11 @@ impl ModelChoice {
             Self::DeepSeekV32 | Self::DeepSeekV32Speciale => "deepseek-chat",
             Self::KimiK2 => "kimi-k2.5",
             Self::Glm52 => "glm-5.2",
-            Self::Grok45 => "grok-4.5",
+            Self::Grok46 => "grok-4.6",
+            // Thompson Sampling sees each effort tier as a distinct arm, so
+            // the canonical name carries the suffix. `grok_api_model()`
+            // strips it back to the API model id for REST calls.
+            Self::Grok46Xhigh => "grok-4.6-xhigh",
         }
     }
 
@@ -161,7 +171,7 @@ impl ModelChoice {
             | Self::GeminiPro => "google",
             Self::ClaudeSonnet | Self::ClaudeOpus | Self::ClaudeFable5 => "anthropic",
             Self::KimiK2 => "kimi",
-            Self::Grok45 => "grok",
+            Self::Grok46 | Self::Grok46Xhigh => "grok",
         }
     }
 
@@ -189,9 +199,17 @@ impl ModelChoice {
             "deepseek-coder-v2-lite-instruct" => Some(Self::LocalDeepSeekCoder),
             "deepseek-chat" => Some(Self::DeepSeekV32),
             "kimi-k2.5" => Some(Self::KimiK2),
-            "grok-4.5" | "grok-4.5-latest" | "grok-build-latest" | "grok45" | "grok" => {
-                Some(Self::Grok45)
+            "grok-4.6-xhigh" | "grok-4.6-x-high" | "grok46-xhigh" | "grok-xhigh" => {
+                Some(Self::Grok46Xhigh)
             }
+            "grok-4.6"
+            | "grok-4.6-latest"
+            | "grok-build-latest"
+            | "grok46"
+            | "grok"
+            | "grok-4.5"
+            | "grok-4.5-latest"
+            | "grok45" => Some(Self::Grok46),
             "gemini-flash-latest" => Some(Self::GeminiFlash),
             "gemini-3.5-flash"
             | "gemini-3.5-flash-latest"
@@ -280,7 +298,8 @@ impl ModelChoice {
         Self::DeepSeekV32Speciale,
         Self::KimiK2,
         Self::Glm52,
-        Self::Grok45,
+        Self::Grok46,
+        Self::Grok46Xhigh,
     ];
 
     pub fn is_anthropic(&self) -> bool {
@@ -351,7 +370,16 @@ impl ModelChoice {
 
     /// Cloud Grok (xAI) arm, reached via the xAI Responses API client.
     pub fn is_grok(&self) -> bool {
-        matches!(self, Self::Grok45)
+        matches!(self, Self::Grok46 | Self::Grok46Xhigh)
+    }
+
+    /// Underlying xAI API model id (strips the per-arm effort suffix).
+    /// Returns `None` for non-Grok variants.
+    pub fn grok_api_model(&self) -> Option<&'static str> {
+        match self {
+            Self::Grok46 | Self::Grok46Xhigh => Some("grok-4.6"),
+            _ => None,
+        }
     }
 
     pub fn provider(&self) -> &str {
@@ -381,7 +409,7 @@ impl ModelChoice {
             Self::DeepSeekV32 | Self::DeepSeekV32Speciale => "deepseek",
             Self::KimiK2 => "kimi",
             Self::Glm52 => "zhipu",
-            Self::Grok45 => "xai",
+            Self::Grok46 | Self::Grok46Xhigh => "xai",
         }
     }
 
@@ -419,7 +447,8 @@ impl ModelChoice {
             | Self::DeepSeekV32Speciale
             | Self::KimiK2
             | Self::Glm52
-            | Self::Grok45 => PlannerTier::Large,
+            | Self::Grok46
+            | Self::Grok46Xhigh => PlannerTier::Large,
         }
     }
 
@@ -620,7 +649,8 @@ impl ModelChoice {
             Self::DeepSeekV32Speciale => "DeepSeek V3.2 Speciale",
             Self::KimiK2 => "Kimi K2.5",
             Self::Glm52 => "GLM-5.2",
-            Self::Grok45 => "Grok 4.5",
+            Self::Grok46 => "Grok 4.6",
+            Self::Grok46Xhigh => "Grok 4.6 (xhigh)",
         }
     }
 }
@@ -792,11 +822,18 @@ impl RoutingDecision {
                     ModelChoice::LocalMinistral8B,
                 ]
             }
-            // Grok 4.5 steps to mid-tier cloud then a local safety net.
-            (ModelChoice::Grok45, _) => {
+            // Grok 4.6 steps to mid-tier cloud then a local safety net.
+            (ModelChoice::Grok46, _) => {
                 vec![
                     ModelChoice::ClaudeSonnet,
                     ModelChoice::GeminiFlash,
+                    ModelChoice::LocalMinistral8B,
+                ]
+            }
+            (ModelChoice::Grok46Xhigh, _) => {
+                vec![
+                    ModelChoice::Grok46,
+                    ModelChoice::ClaudeSonnet,
                     ModelChoice::LocalMinistral8B,
                 ]
             }
@@ -896,13 +933,21 @@ impl RoutingDecision {
                 let output_cost = (token_estimate.output as f64 / 1_000_000.0) * 4.40;
                 input_cost + output_cost
             }
-            ModelChoice::Grok45 => {
-                // Grok 4.5 (xAI) list rates: $2.00/1M input, $6.00/1M output
-                // (docs.x.ai). Cached input is $0.50/1M when the API reports it;
-                // static estimates use the full input rate. Real spend should
-                // come from the response `usage` block once surfaced.
+            ModelChoice::Grok46 | ModelChoice::Grok46Xhigh => {
+                // Grok 4.6 (xAI) list rates: $2.00/1M input, $6.00/1M output
+                // below 200k prompt tokens (docs.x.ai). Cached input is $0.50/1M
+                // when the API reports it; static estimates use the full input
+                // rate. `xhigh` burns extra reasoning tokens billed as output,
+                // so that arm gets a thinking-multiplier prior — Thompson
+                // Sampling can see the cost difference. Real spend should come
+                // from the response `usage` block once surfaced.
+                let thinking_multiplier = match model {
+                    ModelChoice::Grok46Xhigh => 6.0,
+                    _ => 0.0,
+                };
+                let effective_output = (token_estimate.output as f64) * (1.0 + thinking_multiplier);
                 let input_cost = (token_estimate.input as f64 / 1_000_000.0) * 2.00;
-                let output_cost = (token_estimate.output as f64 / 1_000_000.0) * 6.00;
+                let output_cost = (effective_output / 1_000_000.0) * 6.00;
                 input_cost + output_cost
             }
             // All local models are free
@@ -962,8 +1007,10 @@ impl RoutingDecision {
             // GLM-5.2 reasons before answering; budget extra wall-clock on
             // hard tasks, in line with the other thinking cloud arms.
             ModelChoice::Glm52 => Duration::from_secs(8),
-            // Grok 4.5 is reasoning-capable; budget similar wall-clock.
-            ModelChoice::Grok45 => Duration::from_secs(7),
+            // Grok 4.6 is reasoning-capable; low-effort budget similar wall-clock.
+            ModelChoice::Grok46 => Duration::from_secs(7),
+            // xhigh is "maximum reasoning depth, correspondingly higher latency".
+            ModelChoice::Grok46Xhigh => Duration::from_secs(25),
         }
     }
 }
@@ -1191,75 +1238,145 @@ mod tests {
     }
 
     #[test]
-    fn test_grok45_properties() {
-        let model = ModelChoice::Grok45;
-        assert_eq!(model.name(), "grok-4.5");
+    fn test_grok46_properties() {
+        let model = ModelChoice::Grok46;
+        assert_eq!(model.name(), "grok-4.6");
+        assert_eq!(model.grok_api_model(), Some("grok-4.6"));
         assert_eq!(model.provider(), "xai");
         assert_eq!(model.family(), "grok");
-        assert_eq!(model.display_name(), "Grok 4.5");
+        assert_eq!(model.display_name(), "Grok 4.6");
         assert!(model.is_grok());
         assert!(model.is_cloud());
         assert!(!model.is_local());
         assert!(!model.is_glm());
         assert_eq!(model.capability(), PlannerTier::Large);
-        assert!(ModelChoice::ALL_CLOUD.contains(&ModelChoice::Grok45));
+        assert!(ModelChoice::ALL_CLOUD.contains(&ModelChoice::Grok46));
+        assert!(ModelChoice::ALL_CLOUD.contains(&ModelChoice::Grok46Xhigh));
     }
 
     #[test]
-    fn test_grok45_name_resolution() {
+    fn test_grok46_xhigh_properties() {
+        let model = ModelChoice::Grok46Xhigh;
+        assert_eq!(model.name(), "grok-4.6-xhigh");
+        assert_eq!(model.grok_api_model(), Some("grok-4.6"));
+        assert_eq!(model.display_name(), "Grok 4.6 (xhigh)");
+        assert!(model.is_grok());
+        assert_eq!(model.provider(), "xai");
+        assert_eq!(model.capability(), PlannerTier::Large);
+    }
+
+    #[test]
+    fn test_grok46_name_resolution() {
         for alias in [
+            "grok-4.6",
+            "grok-4.6-latest",
+            "grok-build-latest",
+            "grok46",
+            "grok",
+            "GROK-4.6",
+            // 4.5 aliases migrate to the 4.6 arm
             "grok-4.5",
             "grok-4.5-latest",
-            "grok-build-latest",
             "grok45",
-            "grok",
-            "GROK-4.5",
         ] {
             assert_eq!(
                 ModelChoice::from_name(alias),
-                Some(ModelChoice::Grok45),
-                "alias {alias} should resolve to Grok45"
+                Some(ModelChoice::Grok46),
+                "alias {alias} should resolve to Grok46"
             );
         }
         assert_eq!(
-            ModelChoice::from_name(ModelChoice::Grok45.name()),
-            Some(ModelChoice::Grok45),
+            ModelChoice::from_name(ModelChoice::Grok46.name()),
+            Some(ModelChoice::Grok46),
             "round-trip via primary name"
+        );
+        for alias in [
+            "grok-4.6-xhigh",
+            "grok-4.6-x-high",
+            "grok46-xhigh",
+            "grok-xhigh",
+        ] {
+            assert_eq!(
+                ModelChoice::from_name(alias),
+                Some(ModelChoice::Grok46Xhigh),
+                "alias {alias} should resolve to Grok46Xhigh"
+            );
+        }
+        assert_eq!(
+            ModelChoice::from_name(ModelChoice::Grok46Xhigh.name()),
+            Some(ModelChoice::Grok46Xhigh),
+            "round-trip via xhigh name"
         );
     }
 
     #[test]
-    fn test_grok45_cost_math_matches_published_rate() {
+    fn test_grok45_serde_alias_reads_as_grok46() {
+        let model: ModelChoice = serde_json::from_str("\"Grok45\"").expect("Grok45 alias");
+        assert_eq!(model, ModelChoice::Grok46);
+    }
+
+    #[test]
+    fn test_grok46_cost_math_matches_published_rate() {
         let cost =
-            RoutingDecision::estimate_cost(&ModelChoice::Grok45, TaskCategory::CodeGeneration);
+            RoutingDecision::estimate_cost(&ModelChoice::Grok46, TaskCategory::CodeGeneration);
         let input_cost = 800.0 / 1_000_000.0 * 2.00;
         let output_cost = 3000.0 / 1_000_000.0 * 6.00;
         let expected = input_cost + output_cost;
         assert!(
             (cost - expected).abs() < 1e-9,
-            "Grok 4.5 cost {cost} must equal {expected} at the published $2.00/$6.00 rate"
+            "Grok 4.6 cost {cost} must equal {expected} at the published $2.00/$6.00 rate"
         );
     }
 
     #[test]
-    fn test_grok45_fallback_chain_has_local_safety_net() {
+    fn test_grok46_xhigh_cost_includes_thinking_multiplier() {
+        let base =
+            RoutingDecision::estimate_cost(&ModelChoice::Grok46, TaskCategory::CodeGeneration);
+        let xhigh =
+            RoutingDecision::estimate_cost(&ModelChoice::Grok46Xhigh, TaskCategory::CodeGeneration);
+        assert!(
+            xhigh > base,
+            "xhigh prior must exceed the low-effort arm ({xhigh} vs {base})"
+        );
+    }
+
+    #[test]
+    fn test_grok46_fallback_chain_has_local_safety_net() {
         let decision = RoutingDecision::new(
-            ModelChoice::Grok45,
+            ModelChoice::Grok46,
             TaskCategory::CodeGeneration,
             0.9,
             "Test".to_string(),
         );
         let chain = &decision.fallback_chain;
-        assert!(!chain.is_empty(), "Grok 4.5 must have a fallback chain");
+        assert!(!chain.is_empty(), "Grok 4.6 must have a fallback chain");
         assert!(
             chain.last().is_some_and(ModelChoice::is_local),
-            "Grok 4.5 fallback chain must end on a local model: {chain:?}"
+            "Grok 4.6 fallback chain must end on a local model: {chain:?}"
         );
         assert_eq!(
             chain,
             &vec![
                 ModelChoice::ClaudeSonnet,
                 ModelChoice::GeminiFlash,
+                ModelChoice::LocalMinistral8B,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_grok46_xhigh_fallback_steps_down_to_base_arm() {
+        let decision = RoutingDecision::new(
+            ModelChoice::Grok46Xhigh,
+            TaskCategory::CodeGeneration,
+            0.9,
+            "Test".to_string(),
+        );
+        assert_eq!(
+            decision.fallback_chain,
+            vec![
+                ModelChoice::Grok46,
+                ModelChoice::ClaudeSonnet,
                 ModelChoice::LocalMinistral8B,
             ]
         );

--- a/crates/arkavo-router/src/provider.rs
+++ b/crates/arkavo-router/src/provider.rs
@@ -439,10 +439,12 @@ impl super::Router {
                     .unwrap_or_else(|_| "https://api.x.ai/v1".to_string());
                 let api_model = model.grok_api_model().unwrap_or("grok-4.6").to_string();
 
-                let mut config = ResponsesConfig::for_agent(api_key, base_url, api_model);
-                if matches!(model, ModelChoice::Grok46Xhigh) {
-                    config = config.with_reasoning_effort(ReasoningEffort::Xhigh);
-                }
+                let effort = if matches!(model, ModelChoice::Grok46Xhigh) {
+                    ReasoningEffort::Xhigh
+                } else {
+                    ReasoningEffort::Low
+                };
+                let config = ResponsesConfig::for_routed_arm(api_key, base_url, api_model, effort);
 
                 let provider = ResponsesProvider::new(config).map_err(|e| {
                     Error::ModelExecution(format!("Failed to create xAI Responses provider: {e}"))

--- a/crates/arkavo-router/src/provider.rs
+++ b/crates/arkavo-router/src/provider.rs
@@ -115,7 +115,9 @@ impl super::Router {
             }
             ModelChoice::KimiK2 => std::env::var("MOONSHOT_API_KEY").is_ok(),
             ModelChoice::Glm52 => cfg!(feature = "glm") && std::env::var("GLM_API_KEY").is_ok(),
-            ModelChoice::Grok45 => cfg!(feature = "xai") && std::env::var("XAI_API_KEY").is_ok(),
+            ModelChoice::Grok46 | ModelChoice::Grok46Xhigh => {
+                cfg!(feature = "xai") && std::env::var("XAI_API_KEY").is_ok()
+            }
             m if m.is_local() => match (m.repo_id(), m.gguf_filename()) {
                 (Some(repo), Some(file)) => model_discovery::is_model_cached(repo, file),
                 _ => false,
@@ -423,19 +425,24 @@ impl super::Router {
                 Ok(Box::new(provider))
             }
             #[cfg(feature = "xai")]
-            ModelChoice::Grok45 => {
-                // Grok 4.5 uses the xAI Responses API (not Chat Completions)
-                // for reasoning_effort control. v1 multi-turn is full-transcript;
-                // store stays off unless XAI_STORE opts in.
-                use arkavo_llm::providers::xai_responses::{ResponsesConfig, ResponsesProvider};
+            ModelChoice::Grok46 | ModelChoice::Grok46Xhigh => {
+                // Grok 4.6 uses the xAI Responses API (not Chat Completions)
+                // for reasoning_effort control. The API model is always
+                // `grok-4.6`; `Grok46Xhigh` forces `reasoning.effort = xhigh`.
+                use arkavo_llm::providers::xai_responses::{
+                    ReasoningEffort, ResponsesConfig, ResponsesProvider,
+                };
 
                 let api_key = std::env::var("XAI_API_KEY")
                     .map_err(|_| Error::ModelExecution("XAI_API_KEY not set".to_string()))?;
                 let base_url = std::env::var("XAI_BASE_URL")
                     .unwrap_or_else(|_| "https://api.x.ai/v1".to_string());
+                let api_model = model.grok_api_model().unwrap_or("grok-4.6").to_string();
 
-                let config =
-                    ResponsesConfig::for_agent(api_key, base_url, model.name().to_string());
+                let mut config = ResponsesConfig::for_agent(api_key, base_url, api_model);
+                if matches!(model, ModelChoice::Grok46Xhigh) {
+                    config = config.with_reasoning_effort(ReasoningEffort::Xhigh);
+                }
 
                 let provider = ResponsesProvider::new(config).map_err(|e| {
                     Error::ModelExecution(format!("Failed to create xAI Responses provider: {e}"))

--- a/crates/arkavo-router/src/selector.rs
+++ b/crates/arkavo-router/src/selector.rs
@@ -398,8 +398,10 @@ impl ModelSelector {
             models.push(ModelChoice::Glm52);
         }
         if self.availability.xai {
-            // Grok 4.5 enters as a single Thompson Sampling arm (cold-start).
-            models.push(ModelChoice::Grok45);
+            // Grok 4.6 base arm (low effort) plus the xhigh companion so
+            // Thompson Sampling can learn when max-depth reasoning pays off.
+            models.push(ModelChoice::Grok46);
+            models.push(ModelChoice::Grok46Xhigh);
         }
 
         // Fallback: always include Qwen3 as baseline
@@ -587,7 +589,8 @@ mod tests {
     fn test_feasible_models_xai_only() {
         let selector = ModelSelector::with_availability(xai_only());
         let feasible = selector.feasible_models();
-        assert!(feasible.contains(&ModelChoice::Grok45));
+        assert!(feasible.contains(&ModelChoice::Grok46));
+        assert!(feasible.contains(&ModelChoice::Grok46Xhigh));
         assert!(!feasible.contains(&ModelChoice::Glm52));
         assert!(!feasible.contains(&ModelChoice::ClaudeSonnet));
     }

--- a/crates/arkavo-router/src/selector_quality.rs
+++ b/crates/arkavo-router/src/selector_quality.rs
@@ -106,7 +106,8 @@ impl ModelSelector {
             ModelChoice::DeepSeekV32Speciale => "Planning-optimized (5s), reasoning-only, no tools",
             ModelChoice::KimiK2 => "Fast (5s), 256K context, thinking mode support",
             ModelChoice::Glm52 => "GLM-5.2 (8s), low-cost cloud reasoning, OpenAI-compatible",
-            ModelChoice::Grok45 => "Grok 4.5 (7s), xAI Responses API, tools + low-effort reasoning",
+            ModelChoice::Grok46 => "Grok 4.6 (7s), xAI Responses API, tools + low-effort reasoning",
+            ModelChoice::Grok46Xhigh => "Grok 4.6 xhigh (25s), maximum reasoning depth, tools",
         };
 
         format!(

--- a/crates/arkavo-router/src/tool_extraction.rs
+++ b/crates/arkavo-router/src/tool_extraction.rs
@@ -56,7 +56,8 @@ pub(crate) fn detail_level_for_model(
         | ModelChoice::DeepSeekV32Speciale
         | ModelChoice::KimiK2
         | ModelChoice::Glm52
-        | ModelChoice::Grok45 => arkavo_mcp_tools::DetailLevel::FullSchema,
+        | ModelChoice::Grok46
+        | ModelChoice::Grok46Xhigh => arkavo_mcp_tools::DetailLevel::FullSchema,
     }
 }
 

--- a/crates/arkavo-ui-core/src/llm_integration.rs
+++ b/crates/arkavo-ui-core/src/llm_integration.rs
@@ -119,22 +119,26 @@ impl LlmIntegration {
                     anyhow::bail!("GLM feature not enabled")
                 }
             }
-            ModelChoice::Grok45 => {
+            ModelChoice::Grok46 | ModelChoice::Grok46Xhigh => {
                 #[cfg(feature = "xai")]
                 {
                     use arkavo_llm::providers::xai_responses::{
-                        ResponsesConfig, ResponsesProvider,
+                        ReasoningEffort, ResponsesConfig, ResponsesProvider,
                     };
                     let Ok(api_key) = std::env::var("XAI_API_KEY") else {
                         anyhow::bail!("XAI_API_KEY not set")
                     };
                     let base_url = std::env::var("XAI_BASE_URL")
                         .unwrap_or_else(|_| "https://api.x.ai/v1".to_string());
-                    let config = ResponsesConfig::for_agent(
-                        api_key,
-                        base_url,
-                        decision.recommended_model.name().to_string(),
-                    );
+                    let api_model = decision
+                        .recommended_model
+                        .grok_api_model()
+                        .unwrap_or("grok-4.6")
+                        .to_string();
+                    let mut config = ResponsesConfig::for_agent(api_key, base_url, api_model);
+                    if matches!(decision.recommended_model, ModelChoice::Grok46Xhigh) {
+                        config = config.with_reasoning_effort(ReasoningEffort::Xhigh);
+                    }
                     let provider = ResponsesProvider::new(config)?;
                     Ok(LlmClient::new(Box::new(provider)))
                 }

--- a/crates/arkavo-ui-core/src/llm_integration.rs
+++ b/crates/arkavo-ui-core/src/llm_integration.rs
@@ -135,10 +135,13 @@ impl LlmIntegration {
                         .grok_api_model()
                         .unwrap_or("grok-4.6")
                         .to_string();
-                    let mut config = ResponsesConfig::for_agent(api_key, base_url, api_model);
-                    if matches!(decision.recommended_model, ModelChoice::Grok46Xhigh) {
-                        config = config.with_reasoning_effort(ReasoningEffort::Xhigh);
-                    }
+                    let effort = if matches!(decision.recommended_model, ModelChoice::Grok46Xhigh) {
+                        ReasoningEffort::Xhigh
+                    } else {
+                        ReasoningEffort::Low
+                    };
+                    let config =
+                        ResponsesConfig::for_routed_arm(api_key, base_url, api_model, effort);
                     let provider = ResponsesProvider::new(config)?;
                     Ok(LlmClient::new(Box::new(provider)))
                 }

--- a/docs/grok-4.5-support-plan.md
+++ b/docs/grok-4.5-support-plan.md
@@ -1,8 +1,26 @@
-# Grok 4.5 Support Plan
+# Grok 4.5 / 4.6 Support Plan
+
+## Grok 4.6 update (2026-08-13)
+
+The flagship xAI arm is now **Grok 4.6**. `ModelChoice::Grok46` is the
+low-effort Thompson arm (same role as the former `Grok45`).
+`ModelChoice::Grok46Xhigh` is a companion arm that forces
+`reasoning.effort = "xhigh"` (Grok 4.6+ only; 4.5 treated `xhigh` as `high`).
+Persisted `"Grok45"` traces deserialize as `Grok46`. Name aliases `grok-4.5`,
+`grok-4.5-latest`, and `grok45` resolve to `Grok46`. `XAI_REASONING_EFFORT`
+accepts `low` / `medium` / `high` / `xhigh`.
+
+| Item | Value |
+|------|--------|
+| Model ID | `grok-4.6` (aliases: `grok-4.6-latest`, `grok-build-latest`, `grok`) |
+| xhigh arm | `grok-4.6-xhigh` (API model still `grok-4.6`) |
+| Pricing | **$2.00 / $0.50 cached / $6.00** per 1M tokens below 200k prompt tokens |
+| Context | 500k tokens |
+| Arkavo reasoning default | `low` on `Grok46`; `xhigh` on `Grok46Xhigh` |
 
 ## Goal
 
-Add **xAI Grok 4.5** as a routable cloud model arm via the **xAI Responses API**
+Add **xAI Grok 4.5** (now superseded by 4.6) as a routable cloud model arm via the **xAI Responses API**
 (`POST /v1/responses`) using `ResponsesProvider` in `arkavo-llm`. Chat Completions
 remains available through `OpenAIProvider` for generic OpenAI-compatible hosts,
 but Grok routing intentionally uses Responses for reasoning effort, function-call
@@ -27,7 +45,7 @@ Env vars:
 - `XAI_BASE_URL` (optional, default `https://api.x.ai/v1`)
 - `XAI_STORE` (optional; `1`/`true` enables server-side store for response-id chaining)
 - `XAI_PROMPT_CACHE_KEY` (optional; stable key for multi-turn cache hits)
-- `XAI_REASONING_EFFORT` (optional; `low` / `medium` / `high`, default `low`)
+- `XAI_REASONING_EFFORT` (optional; `low` / `medium` / `high` / `xhigh`, default `low`)
 
 ## Approach
 


### PR DESCRIPTION
Update the xAI Grok arm from 4.5 to 4.6 and add the `xhigh` reasoning effort.

- `ModelChoice::Grok46` is the default low-effort arm (`grok-4.6`)
- `ModelChoice::Grok46Xhigh` sends `reasoning.effort = "xhigh"` (API model stays `grok-4.6`)
- `XAI_REASONING_EFFORT` accepts `low` / `medium` / `high` / `xhigh`
- `grok-4.5` aliases and persisted `Grok45` traces resolve to Grok 4.6
- xhigh requests use a 3600s timeout

Tested: `cargo build`, clippy `-D warnings` on touched crates, 35 Grok/xAI unit tests.
