### PR TITLE
Bump llama.cpp to b10615

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -191,7 +191,7 @@ jobs:
           cd vendor/llama.cpp
           git init
           git remote add origin https://github.com/ggerganov/llama.cpp
-          git fetch --depth 1 origin ef570f63087b6a5a2930210a13f87990e8113927
+          git fetch --depth 1 origin f280b26983ad0fdb705a0d9ebf0503e76f2899b0
           git checkout FETCH_HEAD
           echo "llama.cpp checked out at commit $(git rev-parse --short HEAD)"
 
@@ -325,7 +325,7 @@ jobs:
           cd vendor/llama.cpp
           git init
           git remote add origin https://github.com/ggerganov/llama.cpp
-          git fetch --depth 1 origin ef570f63087b6a5a2930210a13f87990e8113927
+          git fetch --depth 1 origin f280b26983ad0fdb705a0d9ebf0503e76f2899b0
           git checkout FETCH_HEAD
           echo "llama.cpp checked out at commit $(git rev-parse --short HEAD)"
 
@@ -524,7 +524,7 @@ jobs:
           git init
           git remote add origin https://github.com/ggerganov/llama.cpp
           # GDN fused ops, Metal/Vulkan kernels, Qwen3.5 NVFP4 support
-          git fetch --depth 1 origin ef570f63087b6a5a2930210a13f87990e8113927
+          git fetch --depth 1 origin f280b26983ad0fdb705a0d9ebf0503e76f2899b0
           git checkout FETCH_HEAD
           echo "llama.cpp checked out at commit $(git rev-parse --short HEAD)"
       - name: Install CMake and build dependencies
@@ -661,7 +661,7 @@ jobs:
           git init
           git remote add origin https://github.com/ggerganov/llama.cpp
           # GDN fused ops, Metal/Vulkan kernels, Qwen3.5 NVFP4 support
-          git fetch --depth 1 origin ef570f63087b6a5a2930210a13f87990e8113927
+          git fetch --depth 1 origin f280b26983ad0fdb705a0d9ebf0503e76f2899b0
           git checkout FETCH_HEAD
           echo "llama.cpp checked out at commit $(git rev-parse --short HEAD)"
       - uses: dtolnay/rust-toolchain@stable
@@ -680,7 +680,7 @@ jobs:
           path: |
             vendor/llama.cpp/build
             target/aarch64-apple-darwin/release/build/arkavo-llama-cpp-sys-*/out
-          key: llama-cpp-${{ runner.os }}-${{ hashFiles('crates/arkavo-llama-cpp-sys/build.rs') }}-ef570f63087b6a5a2930210a13f87990e8113927
+          key: llama-cpp-${{ runner.os }}-${{ hashFiles('crates/arkavo-llama-cpp-sys/build.rs') }}-f280b26983ad0fdb705a0d9ebf0503e76f2899b0
           restore-keys: |
             llama-cpp-${{ runner.os }}-
 
@@ -779,7 +779,7 @@ jobs:
           git init
           git remote add origin https://github.com/ggerganov/llama.cpp
           # GDN fused ops, Metal/Vulkan kernels, Qwen3.5 NVFP4 support
-          git fetch --depth 1 origin ef570f63087b6a5a2930210a13f87990e8113927
+          git fetch --depth 1 origin f280b26983ad0fdb705a0d9ebf0503e76f2899b0
           git checkout FETCH_HEAD
           echo "llama.cpp checked out at commit $(git rev-parse --short HEAD)"
 
@@ -814,7 +814,7 @@ jobs:
           path: |
             vendor/llama.cpp/build
             target/x86_64-pc-windows-msvc/release/build/arkavo-llama-cpp-sys-*/out
-          key: llama-cpp-${{ runner.os }}-${{ hashFiles('crates/arkavo-llama-cpp-sys/build.rs') }}-ef570f63087b6a5a2930210a13f87990e8113927
+          key: llama-cpp-${{ runner.os }}-${{ hashFiles('crates/arkavo-llama-cpp-sys/build.rs') }}-f280b26983ad0fdb705a0d9ebf0503e76f2899b0
           restore-keys: |
             llama-cpp-${{ runner.os }}-
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           git clone https://github.com/ggerganov/llama.cpp vendor/llama.cpp
           cd vendor/llama.cpp
-          git checkout ef570f63087b6a5a2930210a13f87990e8113927
+          git checkout f280b26983ad0fdb705a0d9ebf0503e76f2899b0
 
       - name: Install build dependencies
         run: |
@@ -83,7 +83,7 @@ jobs:
         run: |
           git clone https://github.com/ggerganov/llama.cpp vendor/llama.cpp
           cd vendor/llama.cpp
-          git checkout ef570f63087b6a5a2930210a13f87990e8113927
+          git checkout f280b26983ad0fdb705a0d9ebf0503e76f2899b0
 
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
@@ -132,7 +132,7 @@ jobs:
           cd vendor/llama.cpp
           git init
           git remote add origin https://github.com/ggerganov/llama.cpp
-          git fetch --depth 1 origin ef570f63087b6a5a2930210a13f87990e8113927
+          git fetch --depth 1 origin f280b26983ad0fdb705a0d9ebf0503e76f2899b0
           git checkout FETCH_HEAD
           echo "llama.cpp checked out at commit $(git rev-parse --short HEAD)"
 

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup vendor/llama.cpp
         run: |
           git clone https://github.com/ggerganov/llama.cpp vendor/llama.cpp
-          cd vendor/llama.cpp && git checkout ef570f63087b6a5a2930210a13f87990e8113927
+          cd vendor/llama.cpp && git checkout f280b26983ad0fdb705a0d9ebf0503e76f2899b0
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,7 +113,7 @@ jobs:
           git clone https://github.com/ggerganov/llama.cpp vendor/llama.cpp
           cd vendor/llama.cpp
           # GDN fused ops, Metal/Vulkan kernels, Qwen3.5 NVFP4 support
-          git checkout ef570f63087b6a5a2930210a13f87990e8113927
+          git checkout f280b26983ad0fdb705a0d9ebf0503e76f2899b0
           echo "llama.cpp cloned at commit $(git rev-parse --short HEAD)"
 
       - name: Set up Rust
@@ -224,7 +224,7 @@ jobs:
           git clone https://github.com/ggerganov/llama.cpp vendor/llama.cpp
           cd vendor/llama.cpp
           # GDN fused ops, Metal/Vulkan kernels, Qwen3.5 NVFP4 support
-          git checkout ef570f63087b6a5a2930210a13f87990e8113927
+          git checkout f280b26983ad0fdb705a0d9ebf0503e76f2899b0
           echo "llama.cpp cloned at commit $(git rev-parse --short HEAD)"
 
       - name: Set up Rust
@@ -289,7 +289,7 @@ jobs:
           git clone https://github.com/ggerganov/llama.cpp vendor/llama.cpp
           cd vendor/llama.cpp
           # GDN fused ops, Metal/Vulkan kernels, Qwen3.5 NVFP4 support
-          git checkout ef570f63087b6a5a2930210a13f87990e8113927
+          git checkout f280b26983ad0fdb705a0d9ebf0503e76f2899b0
           echo "llama.cpp cloned at commit $(git rev-parse --short HEAD)"
 
       - name: Install CMake
@@ -403,7 +403,7 @@ jobs:
           git clone https://github.com/ggerganov/llama.cpp vendor/llama.cpp
           cd vendor/llama.cpp
           # GDN fused ops, Metal/Vulkan kernels, Qwen3.5 NVFP4 support
-          git checkout ef570f63087b6a5a2930210a13f87990e8113927
+          git checkout f280b26983ad0fdb705a0d9ebf0503e76f2899b0
           echo "llama.cpp cloned at commit $(git rev-parse --short HEAD)"
 
       - uses: dtolnay/rust-toolchain@stable
@@ -757,7 +757,7 @@ jobs:
           git clone https://github.com/ggerganov/llama.cpp vendor/llama.cpp
           cd vendor/llama.cpp
           # GDN fused ops, Metal/Vulkan kernels, Qwen3.5 NVFP4 support
-          git checkout ef570f63087b6a5a2930210a13f87990e8113927
+          git checkout f280b26983ad0fdb705a0d9ebf0503e76f2899b0
           echo "llama.cpp cloned at commit $(git rev-parse --short HEAD)"
 
       - name: Setup Rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui-protocol"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-test-macros",
  "serde",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-device-identity",
  "arkavo-test-macros",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "chrono",
  "serde",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-test-macros",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "git2",
  "tempfile",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1223,11 +1223,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-lesson-synthesis"
-version = "0.89.3"
+version = "0.89.4"
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "bindgen",
  "cc",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "lru",
  "serde",
@@ -1805,7 +1805,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-shadow-consolidation"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-lesson-synthesis",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "libc",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-budget",
  "arkavo-test-macros",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -2081,7 +2081,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.89.3"
+version = "0.89.4"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Clone the llama.cpp dependency (not tracked in git):
 ```bash
 git clone https://github.com/ggerganov/llama.cpp vendor/llama.cpp
 cd vendor/llama.cpp
-git checkout ef570f63087b6a5a2930210a13f87990e8113927
+git checkout f280b26983ad0fdb705a0d9ebf0503e76f2899b0  # b10615
 cd ../..
 ```
 

--- a/crates/arkavo-llama-cpp-sys/patches/001-gemma4-constrained-tool-grammar.patch
+++ b/crates/arkavo-llama-cpp-sys/patches/001-gemma4-constrained-tool-grammar.patch
@@ -1,7 +1,7 @@
-# BASE_COMMIT: ef570f630
+# BASE_COMMIT: f280b2698
 # VERIFY_ABSENT: TODO @aldehir : need to extend json-schema-to-grammar
 # VERIFY_PRESENT: gemma4-dict-nonempty
-# Reapplied for b9292 — upstream still uses gemma4-dict (allows {}) for all
+# Reapplied for b10615 — upstream still uses gemma4-dict (allows {}) for all
 # tool args, and gemma4_to_json() returns "" for unknown composite rules. Both
 # combine to let Gemma 4 emit tool calls like `step({})` that satisfy the
 # grammar but lack required schema fields, which downstream MCP rejects.

--- a/crates/arkavo-llama-cpp/src/lib.rs
+++ b/crates/arkavo-llama-cpp/src/lib.rs
@@ -236,6 +236,16 @@ impl LlamaModel {
         Self::from_file_with_options(path, true, false)
     }
 
+    fn load_mode_from_flags(use_mmap: bool, use_direct_io: bool) -> ffi::llama_load_mode {
+        if use_direct_io {
+            ffi::llama_load_mode_LLAMA_LOAD_MODE_DIRECT_IO
+        } else if use_mmap {
+            ffi::llama_load_mode_LLAMA_LOAD_MODE_MMAP
+        } else {
+            ffi::llama_load_mode_LLAMA_LOAD_MODE_NONE
+        }
+    }
+
     /// Load model with explicit options
     /// - `use_direct_io`: Use direct I/O for faster loading (bypasses OS cache)
     /// - `use_mmap`: Use memory-mapped I/O (default: true, ignored if use_direct_io is true)
@@ -261,7 +271,7 @@ impl LlamaModel {
             let mut params = unsafe { ffi::llama_model_default_params() };
             params.n_gpu_layers = -1; // Offload all layers (negative = all in llama.cpp b7785+)
             params.main_gpu = 0; // Use GPU 0 (primary GPU)
-            params.use_mmap = use_mmap;
+            params.load_mode = Self::load_mode_from_flags(use_mmap, use_direct_io);
 
             if LLAMA_LOGGING_ENABLED.load(Ordering::Relaxed) {
                 eprintln!(
@@ -295,7 +305,7 @@ impl LlamaModel {
         // SAFETY: Null return is checked immediately after this call
         let mut cpu_params = unsafe { ffi::llama_model_default_params() };
         cpu_params.n_gpu_layers = 0; // CPU only
-        cpu_params.use_mmap = use_mmap;
+        cpu_params.load_mode = Self::load_mode_from_flags(use_mmap, use_direct_io);
 
         // SAFETY: CString is valid null-terminated UTF-8; pointer is valid for the duration of the call
         let cpu_model = unsafe { ffi::llama_load_model_from_file(c_path.as_ptr(), cpu_params) };
@@ -1721,7 +1731,7 @@ impl LlamaSampler {
     /// CRITICAL for GLM-4.7-Flash: Without dry_multiplier ~1.1, the model loops.
     ///
     /// - `vocab`: Model vocabulary for sequence detection
-    /// - `n_ctx_train`: Training context size
+    /// - `n_ctx_train`: Unused since llama.cpp b10615; kept for caller compatibility
     /// - `dry_multiplier`: Penalty multiplier (1.1 recommended for GLM-4.7)
     /// - `dry_base`: Base for exponential penalty growth (default 1.75)
     /// - `dry_allowed_length`: Min length before penalty applies (default 2)
@@ -1732,7 +1742,7 @@ impl LlamaSampler {
     pub unsafe fn add_dry(
         &self,
         vocab: *const ffi::llama_vocab,
-        n_ctx_train: i32,
+        _n_ctx_train: i32,
         dry_multiplier: f32,
         dry_base: f32,
         dry_allowed_length: i32,
@@ -1743,10 +1753,11 @@ impl LlamaSampler {
             [c"\n".as_ptr(), c":".as_ptr(), c"\"".as_ptr(), c"*".as_ptr()];
 
         // SAFETY: Batch/sampler pointers originate from llama.cpp allocation and remain valid for the struct's lifetime
+        // b10615 dropped n_ctx_train from llama_sampler_init_dry; keep the
+        // wrapper argument so existing callers compile.
         let dry_sampler = unsafe {
             ffi::llama_sampler_init_dry(
                 vocab,
-                n_ctx_train,
                 dry_multiplier,
                 dry_base,
                 dry_allowed_length,
@@ -2136,8 +2147,7 @@ pub fn test_minimal_init() -> Result<(), String> {
     // SAFETY: Null return is checked immediately after this call
     let mut _model_params = unsafe { ffi::llama_model_default_params() };
     _model_params.vocab_only = true; // only read vocab & metadata
-    _model_params.use_mmap = false; // avoid vm tricks until stable
-    _model_params.use_mlock = false; // avoid locking (needs perms)
+    _model_params.load_mode = ffi::llama_load_mode_LLAMA_LOAD_MODE_NONE;
 
     // Only show debug output if debug logging is enabled
     if LLAMA_LOGGING_ENABLED.load(Ordering::Relaxed) {

--- a/crates/arkavo-llama-cpp/src/multimodal.rs
+++ b/crates/arkavo-llama-cpp/src/multimodal.rs
@@ -205,6 +205,7 @@ pub fn tokenize_with_images(
 
     let text_input = ffi::mtmd_input_text {
         text: text_cstring.as_ptr(),
+        text_len: text_cstring.as_bytes().len(),
         add_special: true,
         parse_special: true,
     };

--- a/crates/arkavo-protocol/fuzz/Cargo.lock
+++ b/crates/arkavo-protocol/fuzz/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "async-trait",
  "serde",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "base64",
  "bs58",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "chrono",
  "serde",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-crypto",
  "chrono",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "bytes",
  "dashmap",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "git2",
  "tempfile",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-crypto",
  "chrono",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-budget",
  "arkavo-events",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-deepseek",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-mcp",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.89.3"
+version = "0.89.4"
 dependencies = [
  "arkavo-arp",
  "ipnet",

--- a/docs/vendor-setup.md
+++ b/docs/vendor-setup.md
@@ -14,26 +14,19 @@ Clone the llama.cpp repository:
 # Clone llama.cpp to the vendor directory
 git clone https://github.com/ggerganov/llama.cpp vendor/llama.cpp
 
-# Checkout the required version (includes Ministral 3 support)
+# Checkout the required version
 cd vendor/llama.cpp
-git checkout d23355afc  # GDN regression fix, Vulkan GDN, Qwen3.5 NVFP4
+git checkout f280b26983ad0fdb705a0d9ebf0503e76f2899b0  # b10615
 ```
 
 ### Required Version
 
-**Recommended commit:** `d23355afc` (model: wire up Qwen3.5/Qwen3.5MoE tensors for NVFP4 support) - March 14, 2026
+**Recommended commit:** `f280b2698` (tag `b10615`, 2026-08-24)
 
-This commit includes:
-- Ministral 3 architecture support (3B/8B/14B)
-- Multimodal (mtmd) warmup field
-- `GGML_OP_GATED_DELTA_NET` fused recurrence op (CPU + Metal + CUDA + Vulkan)
-- Metal GPU kernel for DeltaNet-based models (Qwen3.5, etc.) on Apple Silicon
-- Chunked fused GDN path for efficient inference
-- GDN state transpose optimization (39% Metal perf regression fix)
-- Vulkan GATED_DELTA_NET op support
-- Qwen3.5/Qwen3.5MoE NVFP4 tensor support
-- Fix pooling assertion crash in chunked GDN detection path
-- OpenCL cumsum op support
+This pin includes:
+- llama.cpp `b9292` → `b10615` (Metal flash-attn vec per-device tuning, NVFP4, GDN, Ministral 3, Gemma 4)
+- Semantic versioning tags (`vX.Y.Z`) exist upstream; this repo stays on `b` tags to match CI's shallow fetch
+- The Gemma 4 constrained-tool-grammar patch still applies (`gemma4-dict-nonempty`)
 
 ### Updating llama.cpp
 


### PR DESCRIPTION
Stacked on #650.

Bumps the vendored llama.cpp pin from **b9292** (`ef570f630`) to **b10615** (`f280b26983ad0fdb705a0d9ebf0503e76f2899b0`), the current upstream `b` tag, and the workspace patch to **0.89.4**.

CI, README, and `docs/vendor-setup.md` all checkout the new rev. The Gemma 4 constrained-tool-grammar patch still applies on this commit.

llama.cpp API drift in this range:

- `llama_model_params.use_mmap` / `use_mlock` → `load_mode` (`NONE` / `MMAP` / `DIRECT_IO`)
- `mtmd_input_text` gained `text_len`
- `llama_sampler_init_dry` dropped `n_ctx_train`

`arkavo-llama-cpp` maps those through. `use_direct_io` now actually sets `LLAMA_LOAD_MODE_DIRECT_IO` instead of only logging it.

Verified locally:

- `cargo build -p arkavo-llama-cpp -p arkavo-llm --features llama-cpp`
- `cargo test -p arkavo-llama-cpp --lib` (27/27)
- `cargo clippy -p arkavo-llama-cpp --lib --bins -- -D warnings`