### PR TITLE
Verify delegation JWTs and wire KAS trusted roots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,4 +131,6 @@ ARKAVO_DEBUG=1 ARKAVO_DEBUG_CHAT=1 cargo run -p arkavo -- chat --prompt "What ti
 ## 7. Environment Variables
 - `ARKAVO_DEBUG=1`: General debug logging.
 - `ARKAVO_DEBUG_CHAT=1`: Chat/Template/Token debug.
+- `ARKAVO_DELEGATION_PUBLIC_KEY_PEM`: Trusted authnz-rs ES256 public key (inline PEM or path to PEM file) used to verify delegation JWTs at registration. Unset → delegation entitlements are never granted (fail-closed).
+- `ARKAVO_ALLOW_UNVERIFIED_DELEGATION=1`: INSECURE dev/test escape hatch — accepts delegation JWTs without signature verification. Never set in production.
 - ccache must be installed for development builds

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui-protocol"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "serde",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-device-identity",
  "arkavo-test-macros",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "chrono",
  "serde",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-test-macros",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "git2",
  "tempfile",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1223,11 +1223,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-lesson-synthesis"
-version = "0.89.4"
+version = "0.89.5"
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "bindgen",
  "cc",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1676,6 +1676,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "notify",
+ "p256",
  "rand 0.8.6",
  "reqwest 0.12.28",
  "rustls",
@@ -1697,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1715,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1729,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1748,7 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1792,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "lru",
  "serde",
@@ -1805,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1823,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1852,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1931,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1966,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-shadow-consolidation"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-lesson-synthesis",
@@ -1984,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "libc",
@@ -1997,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-budget",
  "arkavo-test-macros",
@@ -2013,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -2039,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -2058,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -2081,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -2098,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -2122,7 +2123,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2133,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2146,7 +2147,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2158,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2167,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2181,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2200,7 +2201,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2215,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2240,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2250,7 +2251,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.89.4"
+version = "0.89.5"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-cli/src/commands/agent.rs
+++ b/crates/arkavo-cli/src/commands/agent.rs
@@ -2278,6 +2278,27 @@ This agent serves as Arkavo's side of the A2A protocol bridge.
         assert_eq!(agents[0].model, "ministral-3b");
         assert!(agents[0].a2a_enabled);
         assert!(agents[0].purpose.contains("A2A protocol bridge"));
+
+        // The runtime loads KAS config from AGENTS.md via arkavo-router, not
+        // through the CLI AgentConfig above. Verify the trusted_roots block in
+        // this fixture is no longer parsed-then-discarded on that path.
+        let mut file = tempfile::NamedTempFile::with_suffix(".md").unwrap();
+        use std::io::Write as _;
+        write!(file, "{content}").unwrap();
+        let runtime_config =
+            arkavo_router::preflight::load_agent_config_from_agents_md(file.path()).unwrap();
+        let kas = runtime_config.kas.expect("kas config should parse");
+        assert!(kas.enabled);
+        assert_eq!(kas.key_id.as_deref(), Some("bridge-demo-key-1"));
+        assert_eq!(kas.trusted_roots.len(), 1);
+        assert_eq!(
+            kas.trusted_roots[0].did,
+            "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+        );
+        assert_eq!(
+            kas.trusted_roots[0].name.as_deref(),
+            Some("Demo Root Authority")
+        );
     }
 
     #[test]

--- a/crates/arkavo-protocol/Cargo.toml
+++ b/crates/arkavo-protocol/Cargo.toml
@@ -131,6 +131,9 @@ jsonrpsee = { workspace = true, features = ["server", "macros"] }
 tracing-subscriber = { workspace = true }
 # For tests
 tempfile = { workspace = true }
+# Runtime ES256 key generation for delegation-JWT tests — test key material
+# must not be committed to the repo.
+p256 = { version = "0.13", features = ["pem"] }
 arkavo-crypto = { path = "../arkavo-crypto" }
 arkavo-server = { path = "../arkavo-server" }
 arkavo-test-macros = { path = "../arkavo-test-macros" }

--- a/crates/arkavo-protocol/src/a2a.rs
+++ b/crates/arkavo-protocol/src/a2a.rs
@@ -143,11 +143,6 @@ impl A2aClient {
         self.session_id.is_some()
     }
 
-    // Existing methods unchanged
-    pub fn send(&self, _message: &str) -> Result<String, Box<dyn std::error::Error>> {
-        Ok("A2A response".to_string())
-    }
-
     pub async fn call_mcp_tool(
         &self,
         tool_name: &str,

--- a/crates/arkavo-protocol/src/chat_session.rs
+++ b/crates/arkavo-protocol/src/chat_session.rs
@@ -437,7 +437,48 @@ impl ChatSessionManager {
 
             self.task_tracker
                 .spawn_named("delta-forwarder", async move {
-                    while let Ok(delta) = broadcast_rx.recv().await {
+                    loop {
+                        let delta = match broadcast_rx.recv().await {
+                            Ok(delta) => delta,
+                            Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                                // Dropped deltas corrupt the reassembled message, so a
+                                // lagging subscriber must see an explicit stream error
+                                // rather than a truncated stream that looks complete.
+                                warn!(
+                                    session.id = %session_id_clone,
+                                    skipped,
+                                    "Delta subscriber lagged; terminating stream with error"
+                                );
+                                let error_delta = MessageDelta {
+                                    session_id: session_id_clone.clone(),
+                                    message_id: uuid::Uuid::new_v4().to_string(),
+                                    sequence: 0,
+                                    delta: MessageDeltaContent::Error {
+                                        code: "STREAM_LAGGED".to_string(),
+                                        message: format!(
+                                            "Stream truncated: subscriber lagged, {skipped} deltas dropped"
+                                        ),
+                                    },
+                                    timestamp: chrono::Utc::now(),
+                                };
+                                if delta_tx.send(error_delta).await.is_err() {
+                                    break; // Receiver dropped
+                                }
+                                let end_delta = MessageDelta {
+                                    session_id: session_id_clone.clone(),
+                                    message_id: uuid::Uuid::new_v4().to_string(),
+                                    sequence: 1,
+                                    delta: MessageDeltaContent::StreamEnd {
+                                        reason: StreamEndReason::Error,
+                                    },
+                                    timestamp: chrono::Utc::now(),
+                                };
+                                let _ = delta_tx.send(end_delta).await;
+                                break;
+                            }
+                            Err(broadcast::error::RecvError::Closed) => break,
+                        };
+
                         // Record delta metrics
                         let delta_type = match &delta.delta {
                             MessageDeltaContent::Text { .. } => "text",
@@ -493,6 +534,24 @@ impl ChatSessionManager {
         // Update metrics state
         if let Some(metrics) = self.session_metrics.write().await.get_mut(session_id) {
             metrics.set_state(SessionState::Closing);
+        }
+
+        // Notify stream subscribers with a terminal StreamEnd before teardown,
+        // so the delta channel does not close silently — the streaming handler
+        // reports a channel close without StreamEnd as an abnormal termination.
+        {
+            let sessions = self.sessions.read().await;
+            if let Some(state) = sessions.get(session_id) {
+                let _ = state.delta_tx.send(MessageDelta {
+                    session_id: session_id.to_string(),
+                    message_id: uuid::Uuid::new_v4().to_string(),
+                    sequence: 0,
+                    delta: MessageDeltaContent::StreamEnd {
+                        reason: StreamEndReason::SessionClosed,
+                    },
+                    timestamp: chrono::Utc::now(),
+                });
+            }
         }
 
         // Gracefully shutdown session task manager
@@ -2072,6 +2131,76 @@ mod tests {
 
     #[tokio::test]
     #[spec("CHAT-008")]
+    async fn test_lagging_delta_stream_ends_with_error_not_silent_truncation() {
+        let manager = ChatSessionManager::new(None);
+        let session = manager.create_session(None).await;
+        let session_id = session.session_id.clone();
+
+        let mut delta_rx = manager
+            .get_delta_stream(&session_id)
+            .await
+            .expect("delta stream available");
+
+        // Flood the broadcast channel without consuming from the mpsc receiver,
+        // so the forwarder lags behind and deltas are dropped.
+        let broadcast_tx = {
+            let sessions = manager.sessions.read().await;
+            sessions
+                .get(&session_id)
+                .expect("session exists")
+                .delta_tx
+                .clone()
+        };
+        // Broadcast capacity is 256 and the mpsc buffer is 32; 512 guarantees lag.
+        const FLOOD: usize = 512;
+        for i in 0..FLOOD {
+            let _ = broadcast_tx.send(MessageDelta {
+                session_id: session_id.clone(),
+                message_id: "flood".to_string(),
+                sequence: i as u64,
+                delta: MessageDeltaContent::Text {
+                    text: "x".to_string(),
+                },
+                timestamp: chrono::Utc::now(),
+            });
+        }
+
+        // Drain until the stream closes; truncation must be surfaced as an
+        // explicit error followed by StreamEnd(Error), not silent completion.
+        let mut saw_lag_error = false;
+        let mut saw_error_end = false;
+        while let Ok(Some(delta)) =
+            tokio::time::timeout(std::time::Duration::from_secs(5), delta_rx.recv()).await
+        {
+            match &delta.delta {
+                MessageDeltaContent::Error { code, .. } if code == "STREAM_LAGGED" => {
+                    saw_lag_error = true;
+                }
+                MessageDeltaContent::StreamEnd { reason } => {
+                    assert!(
+                        matches!(reason, StreamEndReason::Error),
+                        "Truncated stream must end with StreamEndReason::Error"
+                    );
+                    saw_error_end = true;
+                }
+                _ => {}
+            }
+        }
+
+        assert!(
+            saw_lag_error,
+            "Lagged subscriber must receive an explicit STREAM_LAGGED error delta"
+        );
+        assert!(
+            saw_error_end,
+            "Lagged subscriber must receive StreamEnd with Error reason"
+        );
+
+        manager.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[spec("CHAT-008")]
     async fn test_get_delta_stream_closed_session_returns_none() {
         let adapter = create_mock_adapter(0);
         let manager = ChatSessionManager::new(Some(adapter));
@@ -2086,6 +2215,40 @@ mod tests {
         assert!(
             manager.get_delta_stream(&session_id).await.is_none(),
             "Closed session must not expose a delta stream"
+        );
+
+        manager.shutdown().await;
+    }
+
+    /// Regression: closing a session must deliver a terminal StreamEnd to
+    /// existing subscribers so the streaming handler does not report a
+    /// normal close as an abnormal STREAM_TERMINATED error.
+    #[tokio::test]
+    #[spec("CHAT-008")]
+    async fn test_close_session_delivers_stream_end_to_subscribers() {
+        let adapter = create_mock_adapter(0);
+        let manager = ChatSessionManager::new(Some(adapter));
+        let session = manager.create_session(None).await;
+        let session_id = session.session_id.clone();
+
+        let mut delta_rx = manager
+            .get_delta_stream(&session_id)
+            .await
+            .expect("active session must expose a delta stream");
+        manager.close_session(&session_id).await.unwrap();
+
+        let delta = tokio::time::timeout(std::time::Duration::from_secs(5), delta_rx.recv())
+            .await
+            .expect("subscriber must receive a terminal delta promptly")
+            .expect("stream must not close without a delta");
+        assert!(
+            matches!(
+                delta.delta,
+                MessageDeltaContent::StreamEnd {
+                    reason: StreamEndReason::SessionClosed
+                }
+            ),
+            "normal close must end the stream with StreamEndReason::SessionClosed"
         );
 
         manager.shutdown().await;

--- a/crates/arkavo-protocol/src/lib.rs
+++ b/crates/arkavo-protocol/src/lib.rs
@@ -90,8 +90,8 @@ pub use openrpc::{generate_openrpc_schema, openrpc_to_json};
 pub use rate_limit::{IpRateLimiter, RateLimitConfig, RateLimiter, spawn_cleanup_task};
 pub use rate_limit_middleware::{extract_client_ip, ip_rate_limit_middleware};
 pub use registration::{
-    ChallengeRequest, ChallengeResponse, RegistrationService, RegistrationStatus, VerifyRequest,
-    VerifyResponse,
+    ChallengeRequest, ChallengeResponse, DelegationConfig, RegistrationService, RegistrationStatus,
+    VerifyRequest, VerifyResponse,
 };
 pub use security::{AuthMethod, SecurityConfig, TlsSettings, TlsVersion};
 pub use session_persistence::SqliteSessionPersistence;

--- a/crates/arkavo-protocol/src/registration/mod.rs
+++ b/crates/arkavo-protocol/src/registration/mod.rs
@@ -6,12 +6,14 @@ pub use types::{
 
 use crate::error::{A2aError, Result};
 use base64::{Engine as _, engine::general_purpose};
+use jsonwebtoken::{Algorithm, DecodingKey, Validation};
 use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
+use tracing::warn;
 
 const CHALLENGE_TTL_SECONDS: u64 = 300;
 
@@ -32,9 +34,31 @@ pub struct Registration {
     pub delegated_entitlements: Vec<String>,
 }
 
+/// Verification policy for authnz-rs delegation JWTs (ES256).
+///
+/// Delegation entitlements are granted from a JWT issued by authnz-rs.
+/// Without a trusted public key the token cannot be authenticated, so the
+/// registration service fails closed and grants no delegated entitlements.
+#[derive(Clone, Default)]
+pub struct DelegationConfig {
+    /// Trusted authnz-rs ES256 public keys (PEM-encoded, SubjectPublicKeyInfo).
+    pub trusted_public_keys_pem: Vec<String>,
+    /// INSECURE escape hatch: accept delegation JWT claims without signature
+    /// verification. Development/testing only — any forged token can grant
+    /// entitlements when this is enabled. Never enable in production.
+    pub allow_unverified: bool,
+}
+
+#[derive(Clone, Default)]
+struct DelegationState {
+    decoding_keys: Arc<Vec<DecodingKey>>,
+    allow_unverified: bool,
+}
+
 pub struct RegistrationService {
     challenges: Arc<RwLock<HashMap<String, Challenge>>>,
     registrations: Arc<RwLock<HashMap<String, Registration>>>,
+    delegation: DelegationState,
 }
 
 impl Clone for RegistrationService {
@@ -42,16 +66,38 @@ impl Clone for RegistrationService {
         Self {
             challenges: Arc::clone(&self.challenges),
             registrations: Arc::clone(&self.registrations),
+            delegation: self.delegation.clone(),
         }
     }
 }
 
 impl RegistrationService {
+    /// Create a service with no trusted delegation keys (fail-closed).
     pub fn new() -> Self {
         Self {
             challenges: Arc::new(RwLock::new(HashMap::new())),
             registrations: Arc::new(RwLock::new(HashMap::new())),
+            delegation: DelegationState::default(),
         }
+    }
+
+    /// Configure how delegation JWTs are verified.
+    ///
+    /// Returns an error if any configured public key PEM is not a valid
+    /// ES256 (P-256) public key, so a misconfigured deployment fails at
+    /// startup instead of silently running without delegation trust.
+    pub fn with_delegation_config(mut self, config: &DelegationConfig) -> Result<Self> {
+        let mut decoding_keys = Vec::with_capacity(config.trusted_public_keys_pem.len());
+        for pem in &config.trusted_public_keys_pem {
+            decoding_keys.push(DecodingKey::from_ec_pem(pem.as_bytes()).map_err(|e| {
+                A2aError::Configuration(format!("Invalid authnz-rs ES256 public key PEM: {e}"))
+            })?);
+        }
+        self.delegation = DelegationState {
+            decoding_keys: Arc::new(decoding_keys),
+            allow_unverified: config.allow_unverified,
+        };
+        Ok(self)
     }
 
     /// # Panics
@@ -171,7 +217,7 @@ impl RegistrationService {
 
         // Extract delegated entitlements from delegation JWT (if present)
         let delegated_entitlements = if let Some(ref jwt) = request.delegation_jwt {
-            extract_delegation_entitlements(jwt, &public_key_bytes)?
+            self.extract_delegation_entitlements(jwt, &public_key_bytes)?
         } else {
             vec![]
         };
@@ -211,6 +257,112 @@ impl RegistrationService {
         }
     }
 
+    /// Extract delegated entitlements from a delegation JWT.
+    ///
+    /// The ES256 signature is verified against the trusted authnz-rs public
+    /// keys before any claim is trusted. With no trusted key configured the
+    /// service fails closed: no entitlements are granted (unless the insecure
+    /// `allow_unverified` escape hatch is explicitly enabled).
+    fn extract_delegation_entitlements(
+        &self,
+        jwt: &str,
+        agent_public_key: &[u8],
+    ) -> Result<Vec<String>> {
+        let claims: serde_json::Value = if !self.delegation.decoding_keys.is_empty() {
+            let mut validation = Validation::new(Algorithm::ES256);
+            validation.validate_exp = true;
+            // authnz-rs delegation JWTs carry no aud; subject binding to the
+            // agent's did:key is enforced below instead.
+            validation.validate_aud = false;
+            validation.required_spec_claims.clear();
+            validation.required_spec_claims.insert("exp".to_string());
+            let mut last_error_kind = None;
+            self.delegation
+                .decoding_keys
+                .iter()
+                .find_map(|key| {
+                    match jsonwebtoken::decode::<serde_json::Value>(jwt, key, &validation) {
+                        Ok(token_data) => Some(token_data.claims),
+                        Err(e) => {
+                            last_error_kind = Some(e.into_kind());
+                            None
+                        }
+                    }
+                })
+                .ok_or_else(|| {
+                    let detail = last_error_kind
+                        .map(|kind| format!("{kind:?}"))
+                        .unwrap_or_else(|| "unknown".to_string());
+                    A2aError::AuthenticationFailed(format!(
+                        "Delegation JWT signature verification failed: {detail}"
+                    ))
+                })?
+        } else if self.delegation.allow_unverified {
+            warn!(
+                "INSECURE: accepting delegation JWT without signature verification \
+                 (allow_unverified enabled); never enable in production"
+            );
+            decode_jwt_claims_unverified(jwt)?
+        } else {
+            warn!(
+                "No trusted authnz-rs public key configured; ignoring delegation JWT \
+                 (fail-closed, no entitlements granted). Configure \
+                 DelegationConfig::trusted_public_keys_pem to enable delegation."
+            );
+            return Ok(vec![]);
+        };
+
+        // Validate sub matches agent's did:key
+        if let Some(sub) = claims.get("sub").and_then(|v| v.as_str()) {
+            // Delegation JWTs use Ed25519 did:key identifiers
+            if agent_public_key.len() != 32 {
+                return Err(A2aError::InvalidRequest(
+                    "Delegation JWT only supported for Ed25519 keys".to_string(),
+                ));
+            }
+            let agent_pubkey = arkavo_crypto::AgentPublicKey::from_bytes(agent_public_key)
+                .map_err(|e| A2aError::InvalidRequest(format!("Invalid agent key: {e}")))?;
+            let agent_did = agent_pubkey.to_did_key();
+            if sub != agent_did {
+                return Err(A2aError::AuthenticationFailed(format!(
+                    "JWT sub '{sub}' does not match agent DID '{agent_did}'"
+                )));
+            }
+        } else {
+            return Err(A2aError::InvalidRequest(
+                "JWT missing 'sub' claim".to_string(),
+            ));
+        }
+
+        // Validate expiration (backstop for the unverified path; the verified
+        // path enforces exp via jsonwebtoken Validation)
+        if let Some(exp) = claims.get("exp").and_then(|v| v.as_i64()) {
+            #[allow(clippy::cast_possible_wrap)]
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64;
+            if now > exp {
+                return Err(A2aError::AuthenticationFailed(
+                    "Delegation JWT expired".to_string(),
+                ));
+            }
+        }
+
+        // Extract scope as entitlements
+        let entitlements = claims
+            .get("scope")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(entitlements)
+    }
+
     fn cleanup_expired_challenges(
         &self,
         challenges: &mut HashMap<String, Challenge>,
@@ -227,73 +379,21 @@ impl Default for RegistrationService {
     }
 }
 
-/// Extract delegated entitlements from a delegation JWT.
+/// Decode JWT claims without verifying the signature (structure only).
 ///
-/// Validates structural claims (sub matches agent DID, not expired) without
-/// full signature verification. Signature verification requires the authnz-rs
-/// public key, which is deferred until orchestrator key distribution is implemented.
-fn extract_delegation_entitlements(jwt: &str, agent_public_key: &[u8]) -> Result<Vec<String>> {
+/// Only used on the explicit insecure `allow_unverified` escape-hatch path.
+fn decode_jwt_claims_unverified(jwt: &str) -> Result<serde_json::Value> {
     // JWT format: header.payload.signature (base64url-encoded parts)
     let parts: Vec<&str> = jwt.split('.').collect();
     if parts.len() != 3 {
         return Err(A2aError::InvalidRequest("Invalid JWT format".to_string()));
     }
 
-    // Decode payload (second part)
     let payload_bytes = base64_url_decode(parts[1])
         .map_err(|e| A2aError::InvalidRequest(format!("Invalid JWT payload: {e}")))?;
 
-    let claims: serde_json::Value = serde_json::from_slice(&payload_bytes)
-        .map_err(|e| A2aError::InvalidRequest(format!("Invalid JWT claims: {e}")))?;
-
-    // Validate sub matches agent's did:key
-    if let Some(sub) = claims.get("sub").and_then(|v| v.as_str()) {
-        // Delegation JWTs use Ed25519 did:key identifiers
-        if agent_public_key.len() != 32 {
-            return Err(A2aError::InvalidRequest(
-                "Delegation JWT only supported for Ed25519 keys".to_string(),
-            ));
-        }
-        let agent_pubkey = arkavo_crypto::AgentPublicKey::from_bytes(agent_public_key)
-            .map_err(|e| A2aError::InvalidRequest(format!("Invalid agent key: {e}")))?;
-        let agent_did = agent_pubkey.to_did_key();
-        if sub != agent_did {
-            return Err(A2aError::AuthenticationFailed(format!(
-                "JWT sub '{sub}' does not match agent DID '{agent_did}'"
-            )));
-        }
-    } else {
-        return Err(A2aError::InvalidRequest(
-            "JWT missing 'sub' claim".to_string(),
-        ));
-    }
-
-    // Validate expiration
-    if let Some(exp) = claims.get("exp").and_then(|v| v.as_i64()) {
-        #[allow(clippy::cast_possible_wrap)]
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as i64;
-        if now > exp {
-            return Err(A2aError::AuthenticationFailed(
-                "Delegation JWT expired".to_string(),
-            ));
-        }
-    }
-
-    // Extract scope as entitlements
-    let entitlements = claims
-        .get("scope")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    Ok(entitlements)
+    serde_json::from_slice(&payload_bytes)
+        .map_err(|e| A2aError::InvalidRequest(format!("Invalid JWT claims: {e}")))
 }
 
 /// Decode base64url without padding (RFC 7515)
@@ -1943,6 +2043,54 @@ mod tests {
         format!("{header}.{payload}.{fake_sig}")
     }
 
+    /// Service with the insecure escape hatch enabled — used to exercise
+    /// structural claim validation independently of signature verification.
+    fn unverified_delegation_service() -> RegistrationService {
+        RegistrationService::new()
+            .with_delegation_config(&DelegationConfig {
+                trusted_public_keys_pem: vec![],
+                allow_unverified: true,
+            })
+            .unwrap()
+    }
+
+    /// Throwaway ES256 keypair standing in for authnz-rs, generated fresh at
+    /// runtime. Private key material is never committed to the repo — each
+    /// test run produces new keys. Returns (private_pem, public_pem).
+    fn test_es256_keypair() -> (String, String) {
+        use p256::pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
+        let secret = p256::SecretKey::random(&mut p256::elliptic_curve::rand_core::OsRng);
+        let private_pem = secret.to_pkcs8_pem(LineEnding::LF).unwrap().to_string();
+        let public_pem = secret
+            .public_key()
+            .to_public_key_pem(LineEnding::LF)
+            .unwrap();
+        (private_pem, public_pem)
+    }
+
+    fn trusted_delegation_service(public_key_pem: &str) -> RegistrationService {
+        RegistrationService::new()
+            .with_delegation_config(&DelegationConfig {
+                trusted_public_keys_pem: vec![public_key_pem.to_string()],
+                allow_unverified: false,
+            })
+            .unwrap()
+    }
+
+    fn sign_delegation_jwt(claims: &serde_json::Value, private_key_pem: &str) -> String {
+        let key = jsonwebtoken::EncodingKey::from_ec_pem(private_key_pem.as_bytes()).unwrap();
+        jsonwebtoken::encode(&jsonwebtoken::Header::new(Algorithm::ES256), claims, &key).unwrap()
+    }
+
+    fn delegation_claims(agent_did: &str) -> serde_json::Value {
+        serde_json::json!({
+            "iss": "did:key:z6MkHuman",
+            "sub": agent_did,
+            "scope": ["action/read", "action/execute"],
+            "exp": chrono::Utc::now().timestamp() + 3600,
+        })
+    }
+
     #[test]
     fn test_delegation_jwt_valid_entitlements() {
         let keypair = arkavo_crypto::AgentKeypair::generate();
@@ -1954,7 +2102,9 @@ mod tests {
             "exp": chrono::Utc::now().timestamp() + 3600,
         });
         let jwt = make_test_jwt(&claims);
-        let result = extract_delegation_entitlements(&jwt, &keypair.public_key().to_bytes());
+        let service = unverified_delegation_service();
+        let result =
+            service.extract_delegation_entitlements(&jwt, &keypair.public_key().to_bytes());
         assert_eq!(result.unwrap(), vec!["action/read", "action/execute"]);
     }
 
@@ -1968,7 +2118,9 @@ mod tests {
             "exp": chrono::Utc::now().timestamp() + 3600,
         });
         let jwt = make_test_jwt(&claims);
-        let result = extract_delegation_entitlements(&jwt, &keypair.public_key().to_bytes());
+        let service = unverified_delegation_service();
+        let result =
+            service.extract_delegation_entitlements(&jwt, &keypair.public_key().to_bytes());
         assert!(result.is_err());
         assert!(format!("{}", result.unwrap_err()).contains("does not match"));
     }
@@ -1984,7 +2136,9 @@ mod tests {
             "exp": chrono::Utc::now().timestamp() - 3600,
         });
         let jwt = make_test_jwt(&claims);
-        let result = extract_delegation_entitlements(&jwt, &keypair.public_key().to_bytes());
+        let service = unverified_delegation_service();
+        let result =
+            service.extract_delegation_entitlements(&jwt, &keypair.public_key().to_bytes());
         assert!(result.is_err());
         assert!(format!("{}", result.unwrap_err()).contains("expired"));
     }
@@ -1992,8 +2146,9 @@ mod tests {
     #[test]
     fn test_delegation_jwt_invalid_format() {
         let keypair = arkavo_crypto::AgentKeypair::generate();
-        let result =
-            extract_delegation_entitlements("not.a.valid.jwt", &keypair.public_key().to_bytes());
+        let service = unverified_delegation_service();
+        let result = service
+            .extract_delegation_entitlements("not.a.valid.jwt", &keypair.public_key().to_bytes());
         assert!(result.is_err());
     }
 
@@ -2008,8 +2163,245 @@ mod tests {
         let jwt = make_test_jwt(&claims);
         // P-256 uncompressed key is 65 bytes
         let fake_p256_key = vec![0u8; 65];
-        let result = extract_delegation_entitlements(&jwt, &fake_p256_key);
+        let service = unverified_delegation_service();
+        let result = service.extract_delegation_entitlements(&jwt, &fake_p256_key);
         assert!(result.is_err());
         assert!(format!("{}", result.unwrap_err()).contains("Ed25519"));
+    }
+
+    // ============================================================================
+    // SECURITY REGRESSION TESTS: delegation JWT signature verification
+    // ============================================================================
+
+    /// Regression test: valid authnz-rs-signed delegation JWT is accepted
+    ///
+    /// SECURITY FIX: Delegation entitlements were previously granted from
+    /// JWT claims without any signature verification, so any caller could
+    /// forge entitlements. Now the ES256 signature must verify against a
+    /// configured trusted authnz-rs public key.
+    #[test]
+    fn test_delegation_jwt_valid_signature_accepted() {
+        let keypair = arkavo_crypto::AgentKeypair::generate();
+        let agent_did = keypair.public_key().to_did_key();
+        let (authnz_private_pem, authnz_public_pem) = test_es256_keypair();
+        let jwt = sign_delegation_jwt(&delegation_claims(&agent_did), &authnz_private_pem);
+
+        let service = trusted_delegation_service(&authnz_public_pem);
+        let result =
+            service.extract_delegation_entitlements(&jwt, &keypair.public_key().to_bytes());
+        assert_eq!(result.unwrap(), vec!["action/read", "action/execute"]);
+    }
+
+    /// Regression test: forged delegation JWT (wrong signing key) is rejected
+    #[test]
+    fn test_delegation_jwt_forged_signature_rejected() {
+        let keypair = arkavo_crypto::AgentKeypair::generate();
+        let agent_did = keypair.public_key().to_did_key();
+        // Signed by an attacker-controlled key, not authnz-rs
+        let (_, authnz_public_pem) = test_es256_keypair();
+        let (forger_private_pem, _) = test_es256_keypair();
+        let jwt = sign_delegation_jwt(&delegation_claims(&agent_did), &forger_private_pem);
+
+        let service = trusted_delegation_service(&authnz_public_pem);
+        let result =
+            service.extract_delegation_entitlements(&jwt, &keypair.public_key().to_bytes());
+        assert!(result.is_err());
+        assert!(format!("{}", result.unwrap_err()).contains("signature"));
+    }
+
+    /// Regression test: unsigned (fake-signature) JWT is rejected when a
+    /// trusted key is configured
+    #[test]
+    fn test_delegation_jwt_fake_signature_rejected() {
+        let keypair = arkavo_crypto::AgentKeypair::generate();
+        let agent_did = keypair.public_key().to_did_key();
+        let jwt = make_test_jwt(&delegation_claims(&agent_did));
+
+        let (_, authnz_public_pem) = test_es256_keypair();
+        let service = trusted_delegation_service(&authnz_public_pem);
+        let result =
+            service.extract_delegation_entitlements(&jwt, &keypair.public_key().to_bytes());
+        assert!(result.is_err());
+        assert!(format!("{}", result.unwrap_err()).contains("signature"));
+    }
+
+    /// Regression test: no trusted key configured fails closed
+    ///
+    /// Even a correctly-signed delegation JWT grants no entitlements when no
+    /// authnz-rs public key is configured.
+    #[test]
+    fn test_delegation_jwt_no_key_fails_closed() {
+        let keypair = arkavo_crypto::AgentKeypair::generate();
+        let agent_did = keypair.public_key().to_did_key();
+        let (authnz_private_pem, _) = test_es256_keypair();
+        let jwt = sign_delegation_jwt(&delegation_claims(&agent_did), &authnz_private_pem);
+
+        let service = RegistrationService::new();
+        let result =
+            service.extract_delegation_entitlements(&jwt, &keypair.public_key().to_bytes());
+        assert_eq!(
+            result.unwrap(),
+            Vec::<String>::new(),
+            "no trusted key configured must grant no entitlements"
+        );
+    }
+
+    /// Regression test: expired but correctly-signed JWT is rejected
+    #[test]
+    fn test_delegation_jwt_expired_signature_rejected() {
+        let keypair = arkavo_crypto::AgentKeypair::generate();
+        let agent_did = keypair.public_key().to_did_key();
+        let mut claims = delegation_claims(&agent_did);
+        claims["exp"] = serde_json::json!(chrono::Utc::now().timestamp() - 3600);
+        let (authnz_private_pem, authnz_public_pem) = test_es256_keypair();
+        let jwt = sign_delegation_jwt(&claims, &authnz_private_pem);
+
+        let service = trusted_delegation_service(&authnz_public_pem);
+        let result =
+            service.extract_delegation_entitlements(&jwt, &keypair.public_key().to_bytes());
+        assert!(result.is_err());
+    }
+
+    /// Regression test: full registration path stores verified entitlements
+    #[spec("REG-002")]
+    #[tokio::test]
+    async fn test_verify_challenge_with_signed_delegation_jwt() {
+        let (authnz_private_pem, authnz_public_pem) = test_es256_keypair();
+        let service = trusted_delegation_service(&authnz_public_pem);
+        let device_id = "delegated-device".to_string();
+
+        let challenge_response = service
+            .create_challenge(ChallengeRequest {
+                device_id: device_id.clone(),
+            })
+            .await
+            .unwrap();
+
+        let keypair = arkavo_crypto::AgentKeypair::generate();
+        let challenge_bytes = general_purpose::STANDARD
+            .decode(&challenge_response.challenge)
+            .unwrap();
+        let signature = keypair.sign(&challenge_bytes);
+
+        let jwt = sign_delegation_jwt(
+            &delegation_claims(&keypair.public_key().to_did_key()),
+            &authnz_private_pem,
+        );
+
+        let verify_request = VerifyRequest {
+            challenge_id: challenge_response.challenge_id,
+            device_id: device_id.clone(),
+            public_key: keypair.public_key().to_base64(),
+            signature: general_purpose::STANDARD.encode(&signature),
+            delegation_jwt: Some(jwt),
+        };
+
+        service.verify_challenge(verify_request).await.unwrap();
+
+        let registrations = service.registrations.read().await;
+        let registration = registrations.get(&device_id).unwrap();
+        assert_eq!(
+            registration.delegated_entitlements,
+            vec!["action/read", "action/execute"]
+        );
+    }
+
+    /// Regression test: forged delegation JWT aborts registration
+    #[spec("REG-002")]
+    #[tokio::test]
+    async fn test_verify_challenge_forged_delegation_jwt_rejected() {
+        let (_, authnz_public_pem) = test_es256_keypair();
+        let (forger_private_pem, _) = test_es256_keypair();
+        let service = trusted_delegation_service(&authnz_public_pem);
+        let device_id = "forged-delegated-device".to_string();
+
+        let challenge_response = service
+            .create_challenge(ChallengeRequest {
+                device_id: device_id.clone(),
+            })
+            .await
+            .unwrap();
+
+        let keypair = arkavo_crypto::AgentKeypair::generate();
+        let challenge_bytes = general_purpose::STANDARD
+            .decode(&challenge_response.challenge)
+            .unwrap();
+        let signature = keypair.sign(&challenge_bytes);
+
+        let forged_jwt = sign_delegation_jwt(
+            &delegation_claims(&keypair.public_key().to_did_key()),
+            &forger_private_pem,
+        );
+
+        let verify_request = VerifyRequest {
+            challenge_id: challenge_response.challenge_id,
+            device_id: device_id.clone(),
+            public_key: keypair.public_key().to_base64(),
+            signature: general_purpose::STANDARD.encode(&signature),
+            delegation_jwt: Some(forged_jwt),
+        };
+
+        let result = service.verify_challenge(verify_request).await;
+        assert!(result.is_err(), "forged delegation JWT must be rejected");
+
+        let registrations = service.registrations.read().await;
+        assert!(
+            !registrations.contains_key(&device_id),
+            "registration must not be created from a forged token"
+        );
+    }
+
+    /// Regression test: fail-closed applies through the full registration path
+    #[spec("REG-002")]
+    #[tokio::test]
+    async fn test_verify_challenge_delegation_jwt_no_key_fails_closed() {
+        let service = RegistrationService::new();
+        let device_id = "no-key-delegated-device".to_string();
+
+        let challenge_response = service
+            .create_challenge(ChallengeRequest {
+                device_id: device_id.clone(),
+            })
+            .await
+            .unwrap();
+
+        let keypair = arkavo_crypto::AgentKeypair::generate();
+        let challenge_bytes = general_purpose::STANDARD
+            .decode(&challenge_response.challenge)
+            .unwrap();
+        let signature = keypair.sign(&challenge_bytes);
+
+        let (authnz_private_pem, _) = test_es256_keypair();
+        let jwt = sign_delegation_jwt(
+            &delegation_claims(&keypair.public_key().to_did_key()),
+            &authnz_private_pem,
+        );
+
+        let verify_request = VerifyRequest {
+            challenge_id: challenge_response.challenge_id,
+            device_id: device_id.clone(),
+            public_key: keypair.public_key().to_base64(),
+            signature: general_purpose::STANDARD.encode(&signature),
+            delegation_jwt: Some(jwt),
+        };
+
+        service.verify_challenge(verify_request).await.unwrap();
+
+        let registrations = service.registrations.read().await;
+        let registration = registrations.get(&device_id).unwrap();
+        assert!(
+            registration.delegated_entitlements.is_empty(),
+            "no trusted key configured must grant no entitlements"
+        );
+    }
+
+    /// Regression test: invalid trusted key PEM fails at configuration time
+    #[test]
+    fn test_delegation_config_rejects_invalid_pem() {
+        let result = RegistrationService::new().with_delegation_config(&DelegationConfig {
+            trusted_public_keys_pem: vec!["not a pem".to_string()],
+            allow_unverified: false,
+        });
+        assert!(result.is_err());
     }
 }

--- a/crates/arkavo-router/src/lib.rs
+++ b/crates/arkavo-router/src/lib.rs
@@ -58,8 +58,8 @@ pub use planes::{
 };
 pub use prediction::{BudgetRunway, WorkflowCostPrediction, WorkflowCostPredictor};
 pub use preflight::{
-    AgentConfig, BudgetYamlConfig, KasYamlConfig, ModerationResult, PolicyId, PreflightFeature,
-    PreflightModerator, build_moderator_from_config, load_agent_config,
+    AgentConfig, BudgetYamlConfig, KasTrustedRootYaml, KasYamlConfig, ModerationResult, PolicyId,
+    PreflightFeature, PreflightModerator, build_moderator_from_config, load_agent_config,
 };
 pub use prompt_advisor::{AdvisorIssue, DynamicSnapshot, PromptAdvice, PromptAdvisor};
 pub use provider_info::LlmInfo;

--- a/crates/arkavo-router/src/preflight/config.rs
+++ b/crates/arkavo-router/src/preflight/config.rs
@@ -191,6 +191,24 @@ pub struct KasYamlConfig {
     pub key_id: Option<String>,
     /// Cryptographic algorithm (e.g., "ec:secp256r1")
     pub algorithm: Option<String>,
+    /// Trusted root authorities for delegation chain verification.
+    /// A `kas.rewrap` delegation chain must terminate at one of these DIDs.
+    #[serde(default)]
+    pub trusted_roots: Vec<KasTrustedRootYaml>,
+}
+
+/// A trusted root authority entry in the KAS YAML config
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KasTrustedRootYaml {
+    /// DID:key identifier of the root authority
+    pub did: String,
+    /// Optional human-readable label
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Optional Ed25519 public key (base64). The verifying key is also
+    /// recoverable from the DID:key itself; this field documents intent.
+    #[serde(default)]
+    pub public_key: Option<String>,
 }
 
 /// Preflight section in AGENTS.md
@@ -562,6 +580,47 @@ budget:
         let budget = config.budget.unwrap();
         assert!((budget.max_cost_per_session.unwrap() - 5.0).abs() < f64::EPSILON);
         assert!((budget.max_cost_per_day.unwrap() - 25.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_load_agents_md_with_kas_trusted_roots() {
+        let mut file = NamedTempFile::with_suffix(".md").unwrap();
+        writeln!(
+            file,
+            r#"---
+name: kas-root-agent
+kas:
+  enabled: true
+  key_id: my-key-42
+  algorithm: ec:secp256r1
+  trusted_roots:
+    - did: "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+      name: "Demo Root Authority"
+    - did: "did:key:z6MkSecondRoot"
+      public_key: "dGVzdC1wdWJsaWMta2V5"
+---
+"#
+        )
+        .unwrap();
+
+        let path = file.path().to_path_buf();
+        let config = load_agent_config_from_agents_md(&path).unwrap();
+        let kas = config.kas.unwrap();
+        assert_eq!(kas.trusted_roots.len(), 2);
+        assert_eq!(
+            kas.trusted_roots[0].did,
+            "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+        );
+        assert_eq!(
+            kas.trusted_roots[0].name.as_deref(),
+            Some("Demo Root Authority")
+        );
+        assert!(kas.trusted_roots[0].public_key.is_none());
+        assert_eq!(kas.trusted_roots[1].did, "did:key:z6MkSecondRoot");
+        assert_eq!(
+            kas.trusted_roots[1].public_key.as_deref(),
+            Some("dGVzdC1wdWJsaWMta2V5")
+        );
     }
 
     #[test]

--- a/crates/arkavo-router/src/preflight/mod.rs
+++ b/crates/arkavo-router/src/preflight/mod.rs
@@ -48,8 +48,8 @@ pub mod normalize;
 mod result;
 
 pub use config::{
-    AgentConfig, BudgetYamlConfig, KasYamlConfig, PolicyAction, PolicyConfig, PolicyFileConfig,
-    PreflightConfig, build_moderator_from_config, load_agent_config,
+    AgentConfig, BudgetYamlConfig, KasTrustedRootYaml, KasYamlConfig, PolicyAction, PolicyConfig,
+    PolicyFileConfig, PreflightConfig, build_moderator_from_config, load_agent_config,
     load_agent_config_from_agents_md, load_policies_from_agents_md, load_policies_from_config,
 };
 pub use features::PreflightFeature;

--- a/crates/arkavo-server/src/server/a2a_server.rs
+++ b/crates/arkavo-server/src/server/a2a_server.rs
@@ -1293,7 +1293,10 @@ impl A2aServer {
             auth_backend: Arc::new(arkavo_protocol::auth::JwtAuthBackend::new(
                 "change-me-in-production",
             )),
-            registration_service: Arc::new(arkavo_agent::registration::RegistrationService::new()),
+            registration_service: Arc::new(
+                arkavo_agent::registration::RegistrationService::new()
+                    .with_delegation_config(&super::config_helpers::delegation_config_from_env()?)?,
+            ),
             conductor: self.conductor.read().await.clone(),
             router,
             learning_bus: learning_bus_for_rpc,
@@ -1308,11 +1311,20 @@ impl A2aServer {
             #[cfg(feature = "kas")]
             kas_handler: {
                 let agent_config = self.agent_config.read().await;
-                let kas_config = agent_config.kas.clone().map(|k| arkavo_tdf::KasA2aConfig {
-                    key_id: k.key_id.unwrap_or_else(|| "kas-key-1".to_string()),
-                    algorithm: k.algorithm.unwrap_or_else(|| "ec:secp256r1".to_string()),
-                });
-                let mut handler = KasA2aHandler::new(vec![], kas_config.unwrap_or_default());
+                let (kas_config, trusted_roots) = match agent_config.kas.as_ref() {
+                    Some(k) => (
+                        arkavo_tdf::KasA2aConfig {
+                            key_id: k.key_id.clone().unwrap_or_else(|| "kas-key-1".to_string()),
+                            algorithm: k
+                                .algorithm
+                                .clone()
+                                .unwrap_or_else(|| "ec:secp256r1".to_string()),
+                        },
+                        super::handlers::kas::trusted_roots_from_config(k),
+                    ),
+                    None => (arkavo_tdf::KasA2aConfig::default(), Vec::new()),
+                };
+                let mut handler = KasA2aHandler::new(trusted_roots, kas_config);
                 handler.set_keypair(arkavo_tdf::KasKeypair::generate());
                 Some(Arc::new(handler))
             },

--- a/crates/arkavo-server/src/server/config_helpers.rs
+++ b/crates/arkavo-server/src/server/config_helpers.rs
@@ -226,6 +226,52 @@ pub(super) async fn reload_configuration_for_watcher(
     Ok(())
 }
 
+/// Build delegation-JWT verification config from the environment.
+///
+/// - `ARKAVO_DELEGATION_PUBLIC_KEY_PEM`: trusted authnz-rs ES256 public key,
+///   either inline PEM (literal `\n` sequences are expanded) or a path to a
+///   PEM file.
+/// - `ARKAVO_ALLOW_UNVERIFIED_DELEGATION=1|true`: INSECURE escape hatch that
+///   accepts delegation JWT claims without signature verification. Dev/test
+///   only — any forged token can grant entitlements. Never set in production.
+///
+/// With neither set the registration service fails closed: delegation
+/// entitlements are never granted.
+///
+/// Returns an error when the env var names a key file that cannot be read —
+/// a configured-but-unreadable key must fail startup, not silently run with
+/// no trusted key (which hides the operator's misconfiguration).
+pub(super) fn delegation_config_from_env()
+-> arkavo_protocol::Result<arkavo_protocol::DelegationConfig> {
+    let mut config = arkavo_protocol::DelegationConfig::default();
+
+    if let Ok(raw) = std::env::var("ARKAVO_DELEGATION_PUBLIC_KEY_PEM") {
+        let pem = if raw.contains("-----BEGIN") {
+            raw.replace("\\n", "\n")
+        } else {
+            std::fs::read_to_string(&raw).map_err(|e| {
+                arkavo_protocol::A2aError::Configuration(format!(
+                    "Failed to read delegation public key from '{raw}': {e}"
+                ))
+            })?
+        };
+        config.trusted_public_keys_pem.push(pem);
+    }
+
+    let allow_unverified = std::env::var("ARKAVO_ALLOW_UNVERIFIED_DELEGATION")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    if allow_unverified {
+        warn!(
+            "INSECURE: ARKAVO_ALLOW_UNVERIFIED_DELEGATION is set; delegation JWTs are \
+             accepted without signature verification"
+        );
+        config.allow_unverified = true;
+    }
+
+    Ok(config)
+}
+
 /// Clean up old configuration backups
 pub(super) async fn cleanup_old_backups(backup_dir: &std::path::Path, keep_count: usize) {
     if let Ok(mut entries) = tokio::fs::read_dir(backup_dir).await {

--- a/crates/arkavo-server/src/server/handlers/kas.rs
+++ b/crates/arkavo-server/src/server/handlers/kas.rs
@@ -6,8 +6,57 @@ use arkavo_protocol::types::{
     KasPublicKeyRequest, KasPublicKeyResponse, KasRewrapRequest, KasRewrapResponse,
 };
 use arkavo_tdf::KasA2aHandler;
+use base64::{Engine as _, engine::general_purpose};
 use jsonrpsee::types::ErrorObjectOwned;
 use std::sync::Arc;
+
+/// Convert trusted roots from the AGENTS.md KAS YAML config into
+/// delegation verifier roots.
+///
+/// Roots with an undecodable `public_key` are still trusted by DID (the
+/// verifying key is recovered from the DID:key at verification time), but
+/// the decode failure is logged since it likely indicates a config mistake.
+/// A `public_key` that decodes but does not match the DID:key-embedded key
+/// would be silently ignored by the verifier, so the root is dropped as a
+/// config error instead of being trusted under false pretenses.
+pub fn trusted_roots_from_config(
+    config: &arkavo_router::KasYamlConfig,
+) -> Vec<arkavo_tdf::TrustedRoot> {
+    config
+        .trusted_roots
+        .iter()
+        .filter_map(|root| {
+            let public_key_bytes = match &root.public_key {
+                Some(encoded) => general_purpose::STANDARD
+                    .decode(encoded)
+                    .unwrap_or_else(|e| {
+                        tracing::warn!(
+                            did = %root.did,
+                            error = %e,
+                            "Invalid base64 public_key for KAS trusted root; trusting by DID only"
+                        );
+                        Vec::new()
+                    }),
+                None => Vec::new(),
+            };
+            if !public_key_bytes.is_empty()
+                && let Ok(did_key) = arkavo_crypto::AgentPublicKey::from_did_key(&root.did)
+                && did_key.to_bytes() != public_key_bytes
+            {
+                tracing::warn!(
+                    did = %root.did,
+                    "KAS trusted root public_key does not match the DID:key-embedded \
+                     key; dropping root (config error)"
+                );
+                return None;
+            }
+            Some(arkavo_tdf::TrustedRoot {
+                did: root.did.clone(),
+                public_key_bytes,
+            })
+        })
+        .collect()
+}
 
 /// Handle kas.rewrap RPC method.
 ///
@@ -143,6 +192,56 @@ mod tests {
 
     fn create_test_rate_limiter() -> RateLimiter {
         RateLimiter::new(RateLimitConfig::default())
+    }
+
+    fn kas_config_with_root(
+        did: String,
+        public_key: Option<String>,
+    ) -> arkavo_router::KasYamlConfig {
+        arkavo_router::KasYamlConfig {
+            enabled: true,
+            key_id: None,
+            algorithm: None,
+            trusted_roots: vec![arkavo_router::KasTrustedRootYaml {
+                did,
+                name: None,
+                public_key,
+            }],
+        }
+    }
+
+    #[test]
+    fn test_trusted_root_matching_public_key_kept() {
+        let keypair = arkavo_crypto::AgentKeypair::generate();
+        let did = keypair.public_key().to_did_key();
+        let encoded = general_purpose::STANDARD.encode(keypair.public_key().to_bytes());
+        let roots = trusted_roots_from_config(&kas_config_with_root(did, Some(encoded)));
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].public_key_bytes, keypair.public_key().to_bytes());
+    }
+
+    #[test]
+    fn test_trusted_root_mismatched_public_key_dropped() {
+        let keypair = arkavo_crypto::AgentKeypair::generate();
+        let other = arkavo_crypto::AgentKeypair::generate();
+        let did = keypair.public_key().to_did_key();
+        // public_key belongs to a different key than the DID:key embeds
+        let encoded = general_purpose::STANDARD.encode(other.public_key().to_bytes());
+        let roots = trusted_roots_from_config(&kas_config_with_root(did, Some(encoded)));
+        assert!(
+            roots.is_empty(),
+            "a public_key contradicting the DID:key must drop the root"
+        );
+    }
+
+    #[test]
+    fn test_trusted_root_invalid_base64_trusted_by_did_only() {
+        let keypair = arkavo_crypto::AgentKeypair::generate();
+        let did = keypair.public_key().to_did_key();
+        let roots =
+            trusted_roots_from_config(&kas_config_with_root(did, Some("!!not-base64!!".into())));
+        assert_eq!(roots.len(), 1);
+        assert!(roots[0].public_key_bytes.is_empty());
     }
 
     #[tokio::test]

--- a/crates/arkavo-server/src/server/handlers/mod.rs
+++ b/crates/arkavo-server/src/server/handlers/mod.rs
@@ -6,7 +6,7 @@ pub(super) mod chat;
 pub(super) mod config;
 pub(super) mod discovery;
 #[cfg(feature = "kas")]
-pub(super) mod kas;
+pub mod kas;
 pub(super) mod messaging;
 pub(super) mod registration;
 pub mod specialization;

--- a/crates/arkavo-server/src/server/handlers/streaming.rs
+++ b/crates/arkavo-server/src/server/handlers/streaming.rs
@@ -2,7 +2,7 @@ use arkavo_llm::{DeltaStream, DeltaType, LlmClientAdapter, StreamId, StreamLlmMo
 use arkavo_protocol::chat_session::ChatSessionManager;
 use arkavo_protocol::metrics::{MetricsCollector, RpcTimer};
 use arkavo_protocol::rate_limit::RateLimiter;
-use arkavo_protocol::types::{ChatRequest, MessageDelta, MessageDeltaContent};
+use arkavo_protocol::types::{ChatRequest, MessageDelta, MessageDeltaContent, StreamEndReason};
 use futures::StreamExt;
 use jsonrpsee::{PendingSubscriptionSink, core::SubscriptionResult};
 use std::sync::Arc;
@@ -108,14 +108,51 @@ pub async fn handle_chat_stream(
         tokio::spawn(async move {
             info!(session.id = %session_id, "Delta forwarder task started");
             let mut delta_count = 0;
+            let mut saw_stream_end = false;
             while let Some(delta) = delta_rx.recv().await {
                 delta_count += 1;
+                if matches!(delta.delta, MessageDeltaContent::StreamEnd { .. }) {
+                    saw_stream_end = true;
+                }
                 info!(session.id = %session_id, delta_count, "Forwarding delta to client");
                 if let Ok(msg) = serde_json::value::to_raw_value(&delta)
                     && sink.send(msg).await.is_err()
                 {
                     warn!(session.id = %session_id, "Client disconnected, stopping delta forwarding");
-                    break;
+                    return;
+                }
+            }
+            if !saw_stream_end {
+                // The delta channel closed without a StreamEnd (e.g. the upstream
+                // forwarder aborted). The client must not mistake the truncated
+                // stream for normal completion.
+                warn!(session.id = %session_id, total_deltas = delta_count, "Delta stream ended without StreamEnd; notifying client");
+                let error_delta = MessageDelta {
+                    session_id: session_id.clone(),
+                    message_id: uuid::Uuid::new_v4().to_string(),
+                    sequence: 0,
+                    delta: MessageDeltaContent::Error {
+                        code: "STREAM_TERMINATED".to_string(),
+                        message: "Stream ended abnormally without a terminal delta".to_string(),
+                    },
+                    timestamp: chrono::Utc::now(),
+                };
+                if let Ok(msg) = serde_json::value::to_raw_value(&error_delta)
+                    && sink.send(msg).await.is_err()
+                {
+                    return;
+                }
+                let end_delta = MessageDelta {
+                    session_id: session_id.clone(),
+                    message_id: uuid::Uuid::new_v4().to_string(),
+                    sequence: 1,
+                    delta: MessageDeltaContent::StreamEnd {
+                        reason: StreamEndReason::Error,
+                    },
+                    timestamp: chrono::Utc::now(),
+                };
+                if let Ok(msg) = serde_json::value::to_raw_value(&end_delta) {
+                    let _ = sink.send(msg).await;
                 }
             }
             info!(session.id = %session_id, total_deltas = delta_count, "Delta forwarder task ended");

--- a/crates/arkavo-server/src/server/well_known.rs
+++ b/crates/arkavo-server/src/server/well_known.rs
@@ -117,7 +117,9 @@ pub(super) async fn build_agent_card(state: &WellKnownState) -> AgentCard {
             url: Some("https://arkavo.com".to_string()),
         }),
         version: env!("CARGO_PKG_VERSION").to_string(),
-        protocol_versions: vec!["0.3".to_string(), "1.0".to_string()],
+        // The A2A method surface is v0.3-era only; do not advertise versions
+        // for which no conformant handler exists.
+        protocol_versions: vec!["0.3".to_string()],
         default_input_modes: vec!["text/plain".to_string(), "application/json".to_string()],
         default_output_modes: vec!["text/plain".to_string(), "application/json".to_string()],
         capabilities,
@@ -167,7 +169,7 @@ mod tests {
         );
         assert_eq!(card.url, "http://localhost:8080");
         assert!(card.capabilities.streaming);
-        assert!(card.protocol_versions.contains(&"0.3".to_string()));
+        assert_eq!(card.protocol_versions, vec!["0.3".to_string()]);
     }
 
     #[spec("SRV-002")]

--- a/crates/arkavo-server/tests/kas_delegation_test.rs
+++ b/crates/arkavo-server/tests/kas_delegation_test.rs
@@ -1,0 +1,172 @@
+//! Integration tests for KAS-gated delegation via AGENTS.md trusted roots
+//!
+//! Regression coverage for KAS trusted roots previously being dropped:
+//! the server used to build `KasA2aHandler::new(vec![], ...)`, so every
+//! `kas.rewrap` failed with `NoTrustedRoot`. These tests drive the full
+//! path: AGENTS.md YAML -> `KasYamlConfig.trusted_roots` ->
+//! `trusted_roots_from_config` -> `KasA2aHandler::handle_rewrap`.
+
+#![cfg(feature = "kas")]
+
+use arkavo_crypto::{AgentKeypair, KasEcKeypair};
+use arkavo_server::server::handlers::kas::trusted_roots_from_config;
+use arkavo_tdf::{
+    Attribute, DelegationError, DelegationToken, KasA2aConfig, KasA2aHandler, KasError, KasKeypair,
+    KasRewrapRequest, Policy, PolicyBinding,
+};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use chrono::{Duration, Utc};
+
+const ROLE_ADMIN_FQN: &str = "https://arkavo.net/attr/role/value/admin";
+
+struct ChainFixture {
+    root_did: String,
+    caller_did: String,
+    delegation_token: String,
+}
+
+/// Build a two-level delegation chain (root -> intermediate -> caller)
+/// signed with real Ed25519 keypairs.
+fn make_chain() -> ChainFixture {
+    let root_key = AgentKeypair::generate();
+    let root_did = root_key.public_key().to_did_key();
+    let intermediate_key = AgentKeypair::generate();
+    let intermediate_did = intermediate_key.public_key().to_did_key();
+    let caller_key = AgentKeypair::generate();
+    let caller_did = caller_key.public_key().to_did_key();
+
+    let mut parent = DelegationToken {
+        issuer_did: root_did.clone(),
+        subject_did: intermediate_did.clone(),
+        entitlements: vec![ROLE_ADMIN_FQN.to_string()],
+        expires_at: Utc::now() + Duration::hours(1),
+        signature: String::new(),
+        parent: None,
+    };
+    parent.signature = BASE64.encode(root_key.sign(&parent.payload_bytes().unwrap()));
+
+    let mut leaf = DelegationToken {
+        issuer_did: intermediate_did,
+        subject_did: caller_did.clone(),
+        entitlements: vec![ROLE_ADMIN_FQN.to_string()],
+        expires_at: Utc::now() + Duration::hours(1),
+        signature: String::new(),
+        parent: Some(Box::new(parent)),
+    };
+    leaf.signature = BASE64.encode(intermediate_key.sign(&leaf.payload_bytes().unwrap()));
+
+    ChainFixture {
+        root_did,
+        caller_did,
+        delegation_token: leaf.to_json().unwrap(),
+    }
+}
+
+/// Load an AGENTS.md containing a `kas:` block with the given trusted root
+/// DIDs and return the parsed KAS config.
+fn load_kas_config(trusted_root_dids: &[&str]) -> arkavo_router::KasYamlConfig {
+    let mut roots_yaml = String::new();
+    for did in trusted_root_dids {
+        roots_yaml.push_str(&format!(
+            "    - did: \"{did}\"\n      name: \"Test Root\"\n"
+        ));
+    }
+    let content = format!(
+        "---\nname: kas-agent\nkas:\n  enabled: true\n  key_id: test-key\n  algorithm: ec:secp256r1\n  trusted_roots:\n{roots_yaml}---\n"
+    );
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("AGENTS.md");
+    std::fs::write(&path, content).unwrap();
+
+    let agent_config = arkavo_router::preflight::load_agent_config_from_agents_md(&path).unwrap();
+    agent_config.kas.expect("kas config should parse")
+}
+
+fn make_rewrap_request(delegation_token: String) -> KasRewrapRequest {
+    // NanoTDF header stub: 3-byte magic + 33-byte compressed ephemeral key.
+    // The handler only needs a parseable ephemeral public key at offset 3.
+    let ephemeral = KasEcKeypair::generate();
+    let mut header = b"L1L".to_vec();
+    header.extend_from_slice(&ephemeral.public_key_sec1_compressed());
+
+    let policy = Policy {
+        id: Some("test-policy".to_string()),
+        attributes: vec![Attribute::new("https://arkavo.net/attr/role", &["admin"])],
+        dissemination: vec![],
+    };
+    let policy_json = serde_json::to_string(&policy).unwrap();
+
+    let client_key = KasEcKeypair::generate();
+
+    KasRewrapRequest {
+        wrapped_key: BASE64.encode(header),
+        policy_binding: PolicyBinding::new("test-binding-hash"),
+        policy: BASE64.encode(policy_json.as_bytes()),
+        delegation_token,
+        client_public_key: client_key.public_key_base64(),
+    }
+}
+
+#[tokio::test]
+async fn rewrap_succeeds_when_chain_terminates_at_configured_root() {
+    let chain = make_chain();
+    let kas_config = load_kas_config(&[&chain.root_did]);
+    let trusted_roots = trusted_roots_from_config(&kas_config);
+    assert_eq!(trusted_roots.len(), 1);
+    assert_eq!(trusted_roots[0].did, chain.root_did);
+
+    let mut handler = KasA2aHandler::new(trusted_roots, KasA2aConfig::default());
+    handler.set_keypair(KasKeypair::generate());
+
+    let request = make_rewrap_request(chain.delegation_token);
+    let response = handler.handle_rewrap(request, &chain.caller_did).await;
+
+    assert!(
+        response.is_ok(),
+        "rewrap should succeed: {:?}",
+        response.err()
+    );
+    assert!(!response.unwrap().entity_wrapped_key.is_empty());
+}
+
+#[tokio::test]
+async fn rewrap_denied_when_chain_terminates_at_unknown_root() {
+    let chain = make_chain();
+    // Configure a root that is not the chain's issuer.
+    let unknown_root = AgentKeypair::generate().public_key().to_did_key();
+    let kas_config = load_kas_config(&[&unknown_root]);
+    let trusted_roots = trusted_roots_from_config(&kas_config);
+
+    let mut handler = KasA2aHandler::new(trusted_roots, KasA2aConfig::default());
+    handler.set_keypair(KasKeypair::generate());
+
+    let request = make_rewrap_request(chain.delegation_token);
+    let result = handler.handle_rewrap(request, &chain.caller_did).await;
+
+    assert!(matches!(
+        result,
+        Err(KasError::Delegation(DelegationError::NoTrustedRoot))
+    ));
+}
+
+#[tokio::test]
+async fn rewrap_denied_when_no_roots_configured() {
+    // Regression guard for the original deny-all behavior: without
+    // trusted_roots in AGENTS.md the handler must keep denying.
+    let chain = make_chain();
+    let kas_config = load_kas_config(&[]);
+    let trusted_roots = trusted_roots_from_config(&kas_config);
+    assert!(trusted_roots.is_empty());
+
+    let mut handler = KasA2aHandler::new(trusted_roots, KasA2aConfig::default());
+    handler.set_keypair(KasKeypair::generate());
+
+    let request = make_rewrap_request(chain.delegation_token);
+    let result = handler.handle_rewrap(request, &chain.caller_did).await;
+
+    assert!(matches!(
+        result,
+        Err(KasError::Delegation(DelegationError::NoTrustedRoot))
+    ));
+}

--- a/crates/arkavo-tdf/src/delegation.rs
+++ b/crates/arkavo-tdf/src/delegation.rs
@@ -70,7 +70,10 @@ pub struct DelegationToken {
 
 impl DelegationToken {
     /// Compute the canonical payload bytes for signing.
-    fn payload_bytes(&self) -> Result<Vec<u8>, DelegationError> {
+    ///
+    /// Issuers sign these bytes; the verifier recomputes them when checking
+    /// the signature, so both sides must use this exact serialization.
+    pub fn payload_bytes(&self) -> Result<Vec<u8>, DelegationError> {
         let payload = serde_json::json!({
             "issuer_did": self.issuer_did,
             "subject_did": self.subject_did,


### PR DESCRIPTION
## Summary
Day-0 trust-layer security fixes identified during a codebase audit of the strategic plan.

- **Delegation JWT verification** (`arkavo-protocol`): `extract_delegation_entitlements` previously trusted JWT claims without signature verification, so entitlements were forgeable. Now verifies ES256 against `ARKAVO_DELEGATION_PUBLIC_KEY_PEM` (inline PEM or file path), fails closed when unconfigured, with a loudly-logged `ARKAVO_ALLOW_UNVERIFIED_DELEGATION` escape hatch for dev. Both env vars documented in AGENTS.md.
- **KAS trusted roots** (`arkavo-router`/`arkavo-server`): the server built `KasA2aHandler` with an empty trusted-root list, making every `kas.rewrap` fail `NoTrustedRoot` (deny-all). `kas.trusted_roots` in AGENTS.md frontmatter now parses (`KasYamlConfig`) and reaches the handler. New integration tests: valid chain rewraps, unknown root denied, empty config still denies.
- **Honest AgentCard**: removed `"1.0"` from `protocol_versions` — no v1.0-conformant handler exists.
- **Streaming truncation fix**: a lagging broadcast subscriber previously saw its stream end as normal completion; it now gets a `STREAM_LAGGED` error delta + `StreamEnd(Error)`. Regression test included.
- Removed the dead `A2aClient::send()` stub (zero callers; repo no-stub rule).

## Test plan
- `cargo test -p arkavo-protocol -p arkavo-server -p arkavo-router -p arkavo-tdf` — all green, incl. 9 new JWT regression tests and 3 new KAS integration tests
- `cargo clippy` on touched crates — no new warnings
- `cargo fmt --check` — clean

Note: version bump rides with the companion foundation PR to avoid a `Cargo.toml` conflict.