### PR TITLE
Amend token-binding spec from DPoP/JWT to CWT/COSE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui-protocol"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "serde",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-device-identity",
  "arkavo-test-macros",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "chrono",
  "serde",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-test-macros",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "git2",
  "tempfile",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1223,11 +1223,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-lesson-synthesis"
-version = "0.89.4"
+version = "0.89.5"
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "bindgen",
  "cc",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "lru",
  "serde",
@@ -1805,7 +1805,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-shadow-consolidation"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-lesson-synthesis",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "libc",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-budget",
  "arkavo-test-macros",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -2081,7 +2081,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.89.4"
+version = "0.89.5"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/specs/arkavo-edge/hardware-attestation.spec.yaml
+++ b/specs/arkavo-edge/hardware-attestation.spec.yaml
@@ -30,7 +30,7 @@ keypair_architecture:
   attestation_key:
     algorithm: P-256 / ES256 (ECDSA P-256 with SHA-256)
     residency: Secure Enclave (macOS) / TPM 2.0 (Linux, Windows), non-extractable
-    usage: signing only — attestation quotes, DPoP proof-of-possession (token-binding.spec.yaml), orchestrator registration signing
+    usage: signing only — attestation quotes, CWT/COSE cnf proof-of-possession (token-binding.spec.yaml), orchestrator registration signing
     did: did:key with P-256 multicodec 0x1200 (varint 0x80 0x24, prefix zDn)
     crate: arkavo-attestation (keygen + quote), arkavo-crypto (P256SigningKeypair operations)
     note: distinct from the TDF KAS-wrap key — sign vs key-agreement usages differ and Secure Enclave / TPM key-usage flags must not be conflated
@@ -354,7 +354,7 @@ security:
 
 # Composed and cross-referenced specs
 composed_specs:
-  - { spec: token-binding.spec.yaml, relation: the attested key is the DPoP/mTLS proof-of-possession key }
+  - { spec: token-binding.spec.yaml, relation: the attested key is the CWT cnf / mTLS proof-of-possession key }
   - { spec: agent-credentials.spec.yaml, relation: attestation expressed as a credential; key rotation drives revocation }
   - { spec: trusted-agent.spec.yaml, phases: [1, 2], relation: additive P-256 key in Phase 1; signed quote replaces metadata in Phase 2 }
   - { spec: attestation.spec.yaml, relation: this file is the hardware-bound successor; attestation.spec.yaml documents today's software-fingerprint behavior }

--- a/specs/arkavo-edge/index.yaml
+++ b/specs/arkavo-edge/index.yaml
@@ -1,7 +1,7 @@
 # Arkavo Edge Behavior Specification Index
 
 version: 0.87.0
-last_updated: 2026-06-28
+last_updated: 2026-08-26
 
 components:
   - name: trusted-agent
@@ -31,7 +31,7 @@ components:
   - name: token-binding
     file: token-binding.spec.yaml
     module: arkavo_agent_auth
-    description: Sender-constrained agent tokens (DPoP/mTLS) and attestation-based OAuth Token Exchange
+    description: Sender-constrained agent tokens (CWT/COSE cnf, mTLS) and attestation-based OAuth Token Exchange
     criticality: critical
     scenario_count: 10
     invariants:

--- a/specs/arkavo-edge/token-binding.spec.yaml
+++ b/specs/arkavo-edge/token-binding.spec.yaml
@@ -2,13 +2,13 @@
 
 feature: Sender-Constrained Agent Tokens and Attestation-Based Issuance
 module: arkavo-agent-auth, arkavo-protocol
-version: 0.81.0
+version: 0.81.1
 
 invariants:
   - "Proof-of-possession: a stolen bearer token is unusable without proof-of-possession of the agent's hardware key"
   - "PoP key is the attested key: the proof-of-possession key MUST equal the attestation key from hardware-attestation.spec.yaml (HATT). Binding to any other key silently loses the hardware root"
   - "IdP-agnostic by construction: token issuance is delegable to any external IdP via RFC 8693 over OIDC discovery, with no IdP-specific logic in core — only at an adapter boundary"
-  - "No silent downgrade: stripping DPoP or falling back to an unbound bearer token where binding is required fails closed"
+  - "No silent downgrade: stripping the cnf proof-of-possession binding or falling back to an unbound bearer token where binding is required fails closed"
   - "Human accountability: where an agent acts for a human, the issued token carries the human principal (RFC 8693 act / may_act) so governance attributes agent actions to the human"
 
 # Adapter boundary (structured data)
@@ -18,9 +18,17 @@ adapter_boundary:
 
 # Conformance targets (verified against live spec text on 2026-06-15 unless noted)
 conformance_targets:
-  - id: RFC9449
-    name: "OAuth 2.0 Demonstrating Proof of Possession (DPoP)"
-    url: https://www.rfc-editor.org/rfc/rfc9449
+  - id: RFC8392
+    name: "CBOR Web Token (CWT)"
+    url: https://www.rfc-editor.org/rfc/rfc8392
+    status: verified
+  - id: RFC8152
+    name: "CBOR Object Signing and Encryption (COSE)"
+    url: https://www.rfc-editor.org/rfc/rfc8152
+    status: verified
+  - id: RFC8747
+    name: "Proof-of-Possession Key Semantics for CBOR Web Tokens (CWTs)"
+    url: https://www.rfc-editor.org/rfc/rfc8747
     status: verified
   - id: RFC8693
     name: "OAuth 2.0 Token Exchange"
@@ -49,56 +57,56 @@ conformance_targets:
 
 scenarios:
   - id: TOK-001
-    name: DPoP proof-of-possession on the token request
+    name: CWT proof-of-possession on the token request
     criticality: critical
     wip: true
     issue: https://github.com/arkavo-org/arkavo-edge/issues/629
-    conformance: [RFC9449]
+    conformance: [RFC8392, RFC8152, RFC8747]
     conformance_status: verified
     given:
       - The hardware attestation key (HATT-001 / HATT-002)
     when: Agent requests an access token
     then:
-      - Agent sends a DPoP proof JWT (JOSE header typ = dpop+jwt) signed by the hardware key
-      - The issued access token carries cnf.jkt = base64url SHA-256 JWK thumbprint of the key (RFC 9449 sec 6.1)
+      - Agent sends a COSE_Sign1 proof (RFC 8152) over the token request, signed by the hardware key
+      - The issued token is a CWT (RFC 8392) carrying the cnf confirmation claim with the COSE_Key of the hardware key (RFC 8747)
     refs:
       - crates/arkavo-agent-auth/src/types.rs:1-70
-    changed: "2026-06-15"
+    changed: "2026-08-26"
 
   - id: TOK-002
-    name: DPoP-bound token rejected without a matching proof
+    name: cnf-bound CWT rejected without a matching proof
     criticality: critical
     wip: true
     issue: https://github.com/arkavo-org/arkavo-edge/issues/629
-    conformance: [RFC9449]
+    conformance: [RFC8392, RFC8747]
     conformance_status: verified
     given:
-      - An access token carrying cnf.jkt
+      - An access token carrying a cnf confirmation claim
     when: The token is presented to a resource server
     then:
-      - A request without a valid DPoP proof is rejected
+      - A request without a valid COSE proof of the cnf key is rejected
       - A proof signed by a different key is rejected
     edge_cases:
-      - condition: Replayed proof (same jti)
+      - condition: Replayed proof (same cti)
         expected: Rejected
-      - condition: htm or htu mismatch with the actual request
+      - condition: Request target (uri/method) mismatch with the values bound in the signed proof payload
         expected: Rejected
       - condition: iat outside the acceptance window
         expected: Rejected
-    changed: "2026-06-15"
+    changed: "2026-08-26"
 
   - id: TOK-003
     name: mTLS certificate-bound token, extending existing mTLS
     criticality: high
     wip: true
     issue: https://github.com/arkavo-org/arkavo-edge/issues/629
-    conformance: [RFC8705]
+    conformance: [RFC8705, RFC8747]
     conformance_status: verified
     given:
       - An agent client certificate whose private key is the hardware attestation key
     when: Agent requests a token over a mutually-authenticated TLS connection
     then:
-      - The token carries cnf.x5t#S256 = base64url SHA-256 of the DER client certificate
+      - The issued token is a CWT carrying the cnf confirmation claim with the COSE_Key of the client certificate's public key (RFC 8747); the RFC 8705 transport binding semantics apply
       - The token presented over a different TLS connection is rejected
     refs:
       - crates/arkavo-protocol/src/websocket.rs:101
@@ -106,23 +114,23 @@ scenarios:
     edge_cases:
       - condition: mTLS transport exists, but cert key is not yet hardware-resident
         expected: Hardware-resident cert key is the wip delta; mTLS plumbing is reused, not rebuilt
-    changed: "2026-06-15"
+    changed: "2026-08-26"
 
   - id: TOK-004
     name: Token Exchange — attestation for a scoped sender-constrained token
     criticality: critical
     wip: true
     issue: https://github.com/arkavo-org/arkavo-edge/issues/629
-    conformance: [RFC8693, RFC9449, OIDC-DISCOVERY]
+    conformance: [RFC8693, RFC8392, RFC8747, OIDC-DISCOVERY]
     conformance_status: verified
     given:
       - A verified attestation quote (HATT-007)
       - An external IdP that supports RFC 8693
     when: Agent calls the IdP token endpoint with grant_type urn:ietf:params:oauth:grant-type:token-exchange and subject_token set to the attestation/agent assertion
     then:
-      - The IdP returns a scoped access token bound to the agent key (cnf.jkt)
+      - The IdP returns a scoped access token bound to the agent key (CWT cnf confirmation claim, RFC 8747)
       - This is the integration seam — the IdP owns issuance and governance; Arkavo owns the hardware-rooted agent
-    changed: "2026-06-15"
+    changed: "2026-08-26"
 
   - id: TOK-005
     name: Human-to-agent accountability via the actor claim
@@ -204,18 +212,18 @@ scenarios:
     criticality: high
     wip: true
     issue: https://github.com/arkavo-org/arkavo-edge/issues/629
-    conformance: [RFC9449, RFC8693]
+    conformance: [RFC8392, RFC8693]
     conformance_status: verified
     given:
       - A disconnected or air-gapped environment with no reachable external IdP
     when: The agent needs a token
     then:
-      - A local in-environment token issuer issues sender-constrained tokens (the token-layer parallel of a self-hosted KAS)
+      - A local in-environment token issuer issues sender-constrained CWTs (the token-layer parallel of a self-hosted KAS)
       - Proof-of-possession and attestation gating continue to function offline
     edge_cases:
       - condition: RFC 8693 assumes a reachable IdP
         expected: Closed by the local issuer; mirrors the self-hosted-KAS air-gap story in SECURITY.md
-    changed: "2026-06-15"
+    changed: "2026-08-26"
 
   - id: TOK-010
     name: TDF/KAS rewrap is bound to the attested DID
@@ -243,10 +251,10 @@ security:
     description: The cnf key MUST be the HATT hardware attestation key. Binding a token to a software key, or to any key other than the attested one, is rejected. This is the critical seam between token-binding and hardware-attestation.
   - id: SEC-TB-002
     name: No bearer downgrade
-    description: Removing the DPoP proof, or presenting an unbound token where binding is required, fails closed.
+    description: Removing the COSE proof or cnf binding, or presenting an unbound token where binding is required, fails closed.
   - id: SEC-TB-003
     name: Replay resistance
-    description: DPoP jti/htm/htu/iat are enforced; mTLS connection identity is enforced for certificate-bound tokens.
+    description: COSE proof cti/iat and request-target binding are enforced; mTLS connection identity is enforced for certificate-bound tokens.
   - id: SEC-TB-004
     name: No ambient IdP trust
     description: Issuance is gated on a verified attestation (HATT) and a current, non-Suspended agent state.

--- a/specs/arkavo-edge/trusted-agent.spec.yaml
+++ b/specs/arkavo-edge/trusted-agent.spec.yaml
@@ -49,7 +49,7 @@ trust_chain:
       inputs: [device_public_key, registration_record]
       outputs: [auth_token]
       gate: auth_token is valid and initially carries only config-fetch capability
-      v2_upgrade: auth_token is sender-constrained to the attested key (DPoP cnf.jkt / mTLS) and obtainable via OAuth Token Exchange from an external IdP (token-binding.spec.yaml TOK-001/004)
+      v2_upgrade: auth_token is a sender-constrained CWT bound to the attested key (cnf COSE_Key per RFC 8747 / mTLS) and obtainable via OAuth Token Exchange from an external IdP (token-binding.spec.yaml TOK-001/004)
 
     - phase: 5
       name: Config encryption


### PR DESCRIPTION
## Summary
Implements the locked credential-format decision (tracked in #655): the agent permit/credential format is **CWT (RFC 8392) signed with COSE (RFC 8152)** with an **RFC 8747 `cnf` confirmation claim**, superseding the DPoP/JWT (RFC 9449) direction. Aligns `token-binding.spec.yaml` with the already-locked DEC in `docs/a2a/realignment-scope.md` (CWT/DID-only auth).

- `conformance_targets`: RFC9449 → RFC8392 + RFC8152 + RFC8747. RFC 8693 token exchange, OIDC-discovery adapter boundary (TOK-004/TOK-007), RFC 8705, RFC 7662 unchanged.
- TOK-001/002/003/009, invariant 4, SEC-TB-002/003 re-expressed in cnf/COSE terms (replayed `cti`, request-target binding inside the signed payload). TOK-003 deliberately does not claim an x5t CWT confirmation method (RFC 9360 registers x5t only as COSE header params).
- All 10 scenario IDs, `wip: true` flags, #629 refs, criticalities unchanged — this unblocks implementation without re-scoping.
- Cross-spec DPoP references in `hardware-attestation.spec.yaml` and `trusted-agent.spec.yaml` amended.

## Test plan
- Replicated the CI `validate-specs` job locally: schema validation (ajv, all 80 files) ✅, required fields (751 scenarios) ✅, index sync (80 components) ✅
- `xtask spec-test validate-refs --skip-wip --fail` ✅