### PR TITLE
Feature-gate llama-cpp to unblock slim Linux builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui-protocol"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "serde",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-device-identity",
  "arkavo-test-macros",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "chrono",
  "serde",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-test-macros",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "git2",
  "tempfile",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1223,11 +1223,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-lesson-synthesis"
-version = "0.89.4"
+version = "0.89.5"
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "bindgen",
  "cc",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "lru",
  "serde",
@@ -1805,7 +1805,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-shadow-consolidation"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-lesson-synthesis",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "libc",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-budget",
  "arkavo-test-macros",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -2081,7 +2081,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.89.4"
+version = "0.89.5"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.89.4"
+version = "0.89.5"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-agui/Cargo.toml
+++ b/crates/arkavo-agui/Cargo.toml
@@ -12,7 +12,7 @@ default = ["mdns", "llama-cpp", "web-ui"]
 web-ui = []  # Current warp-based web UI (default)
 cef-ui = ["dep:arkavo-cef"]  # CEF-based native UI (macOS .pkg only)
 mdns = ["dep:mdns-sd"]
-llama-cpp = ["arkavo-router/llama-cpp"]
+llama-cpp = ["arkavo-router/llama-cpp", "arkavo-ui-generator/llama-cpp"]
 # Windows compatible features (no C++ dependencies)
 windows = ["mdns", "arkavo-router/windows"]
 # Auto-launch can decrypt .swarmkit.tdf files at gateway boot via opentdf-rs.
@@ -44,7 +44,7 @@ arkavo-router = { path = "../arkavo-router", default-features = false }
 arkavo-events = { path = "../arkavo-events" }
 arkavo-memory = { path = "../arkavo-memory" }
 arkavo-debugger = { path = "../arkavo-debugger" }
-arkavo-ui-generator = { path = "../arkavo-ui-generator" }
+arkavo-ui-generator = { path = "../arkavo-ui-generator", default-features = false }
 arkavo-mcp-tools = { path = "../arkavo-mcp-tools" }
 arkavo-llm = { path = "../arkavo-llm", default-features = false }
 arkavo-validation = { path = "../arkavo-validation" }

--- a/crates/arkavo-cli/Cargo.toml
+++ b/crates/arkavo-cli/Cargo.toml
@@ -28,12 +28,12 @@ memory = []
 embeddings = ["memory", "arkavo-memory/embeddings"]
 mdns = ["mdns-sd", "arkavo-agui/mdns", "arkavo-protocol/mdns", "arkavo-orchestrator/mdns"]
 llm-remote = ["arkavo-llm/llm-remote", "arkavo-dataflow/llm-remote", "arkavo-terminal/llm-remote", "arkavo-router/llm-remote"]
-kimi = ["arkavo-llm/kimi"]
-deepseek = ["arkavo-llm/deepseek"]
-glm = ["arkavo-llm/llm-remote", "arkavo-router/glm", "arkavo-ui-core/glm"]
-xai = ["arkavo-llm/llm-remote", "arkavo-router/xai", "arkavo-ui-core/xai"]
+kimi = ["arkavo-llm/kimi", "arkavo-orchestrator/kimi"]
+deepseek = ["arkavo-llm/deepseek", "arkavo-orchestrator/deepseek"]
+glm = ["arkavo-llm/llm-remote", "arkavo-router/glm", "arkavo-ui-core/glm", "arkavo-orchestrator/glm"]
+xai = ["arkavo-llm/llm-remote", "arkavo-router/xai", "arkavo-ui-core/xai", "arkavo-orchestrator/xai"]
 gemini = ["arkavo-llm/gemini", "arkavo-router/gemini"]
-llama-cpp = ["arkavo-llm/llama-cpp", "arkavo-agui/llama-cpp", "arkavo-ui-core/llama-cpp", "arkavo-router/llama-cpp", "arkavo-context/llama-cpp", "arkavo-server/llama-cpp"]
+llama-cpp = ["arkavo-llm/llama-cpp", "arkavo-agui/llama-cpp", "arkavo-ui-core/llama-cpp", "arkavo-router/llama-cpp", "arkavo-context/llama-cpp", "arkavo-server/llama-cpp", "arkavo-orchestrator/llama-cpp"]
 snpe = ["arkavo-llm/snpe"]
 cef-ui = ["dep:arkavo-cef", "arkavo-agui/cef-ui", "arkavo-ui-core/cef-ui"]
 web-ui = ["arkavo-agui/web-ui", "arkavo-ui-core/web-ui"]
@@ -58,7 +58,7 @@ arkavo-critic = { path = "../arkavo-critic" }
 arkavo-agui = { path = "../arkavo-agui", default-features = false, features = ["mdns"] }
 arkavo-ui-core = { path = "../arkavo-ui-core", default-features = false }
 arkavo-observability = { path = "../arkavo-observability" }
-arkavo-orchestrator = { path = "../arkavo-orchestrator" }
+arkavo-orchestrator = { path = "../arkavo-orchestrator", default-features = false }
 arkavo-budget = { path = "../arkavo-budget" }
 arkavo-events = { path = "../arkavo-events" }
 arkavo-hrm = { path = "../arkavo-hrm" }

--- a/crates/arkavo-orchestrator/Cargo.toml
+++ b/crates/arkavo-orchestrator/Cargo.toml
@@ -30,7 +30,7 @@ arkavo-budget = { path = "../arkavo-budget" }
 arkavo-arp = { path = "../arkavo-arp" }
 arkavo-memory = { path = "../arkavo-memory" }
 arkavo-github = { path = "../arkavo-github" }
-arkavo-router = { path = "../arkavo-router", features = ["llama-cpp", "gemini"] }
+arkavo-router = { path = "../arkavo-router", default-features = false, features = ["gemini"] }
 arkavo-llm = { path = "../arkavo-llm" }
 arkavo-mcp-tools = { path = "../arkavo-mcp-tools" }
 arkavo-context = { path = "../arkavo-context" }
@@ -53,8 +53,16 @@ tempfile = { workspace = true }
 arkavo-test-macros = { path = "../arkavo-test-macros" }
 
 [features]
-default = []
+default = ["llama-cpp", "deepseek", "kimi", "glm", "xai"]
 mdns = ["mdns-sd"]
+# Router model providers previously enabled unconditionally via arkavo-router's
+# default features. Default-ON here so standalone builds are unchanged; the
+# CLI turns them off for slim builds with default-features = false.
+llama-cpp = ["arkavo-router/llama-cpp"]
+deepseek = ["arkavo-router/deepseek"]
+kimi = ["arkavo-router/kimi"]
+glm = ["arkavo-router/glm"]
+xai = ["arkavo-router/xai"]
 # Real TDF bundle encryption via OpenTdfService. Pulls arkavo-tdf (opentdf)
 # and arkavo-protocol's KAS-side wrap_bundle. Off by default so non-KAS
 # builds stay light; the CLI's kas feature turns it on.

--- a/crates/arkavo-server/Cargo.toml
+++ b/crates/arkavo-server/Cargo.toml
@@ -89,7 +89,7 @@ arkavo-llm = { path = "../arkavo-llm", default-features = false, features = ["ki
 # Direct llama.cpp handle for LlamaTokenEstimator (real tokenizer); only under llama-cpp.
 arkavo-llama-cpp = { path = "../arkavo-llama-cpp", optional = true }
 arkavo-budget = { path = "../arkavo-budget" }
-arkavo-router = { path = "../arkavo-router", features = ["advisor-persistence", "persistence"] }
+arkavo-router = { path = "../arkavo-router", default-features = false, features = ["advisor-persistence", "persistence"] }
 arkavo-observability = { path = "../arkavo-observability" }
 arkavo-events = { path = "../arkavo-events" }
 arkavo-crypto = { path = "../arkavo-crypto" }

--- a/crates/arkavo-ui-generator/Cargo.toml
+++ b/crates/arkavo-ui-generator/Cargo.toml
@@ -7,6 +7,10 @@ license.workspace = true
 repository.workspace = true
 description = "AI-driven UI code generation for Arkavo Edge"
 
+[features]
+default = ["llama-cpp"]
+llama-cpp = ["arkavo-llm/llama-cpp"]
+
 [dependencies]
 # Core dependencies
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "fs", "sync", "time", "io-util"] }
@@ -16,7 +20,7 @@ anyhow = { workspace = true }
 
 # Arkavo dependencies
 arkavo-router = { path = "../arkavo-router", default-features = false, features = ["gemini", "llm-remote"] }
-arkavo-llm = { path = "../arkavo-llm", default-features = false, features = ["llama-cpp"] }
+arkavo-llm = { path = "../arkavo-llm", default-features = false }
 arkavo-gemini = { path = "../arkavo-gemini" }
 arkavo-observability = { path = "../arkavo-observability" }
 base64 = { workspace = true }
@@ -36,3 +40,7 @@ tempfile = { workspace = true }
 arkavo-browser = { path = "../arkavo-browser" }
 chromiumoxide = { version = "0.7", default-features = false, features = ["tokio-runtime"] }
 futures = { workspace = true }
+
+[[example]]
+name = "vision_test"
+required-features = ["llama-cpp"]


### PR DESCRIPTION
## Summary
Epic 1.1 unblocker (tracked in #655). The slim no-inference build (`--no-default-features --features memory,mdns,mcp-tools,llm-remote,web-ui`) previously still compiled `arkavo-llama-cpp-sys` (cmake + vendored llama.cpp) through three unconditional dependency paths. This makes the `Dockerfile` from #654 buildable without a C++ toolchain or vendor checkout.

- `arkavo-ui-generator`: `llama-cpp` is now an optional feature (default-ON) forwarding to `arkavo-llm/llama-cpp`; `vision_test` example gated via `required-features`. No source changes needed — the crate only uses feature-independent `arkavo_llm` APIs.
- `arkavo-agui`: forwards its `llama-cpp` feature to ui-generator; dep is now `default-features = false`.
- `arkavo-orchestrator` / `arkavo-server`: removed their own unconditional router `llama-cpp` pulls (default-ON passthrough features preserve standalone behavior exactly).
- `arkavo-cli`: threads the matching features through orchestrator.

Follow-up once this lands: simplify the `Dockerfile` builder stage in #654 (drop cmake/vendor workaround) — noted in `docs/deploy/container.md`.

## Test plan
- `cargo tree --no-default-features --features memory,mdns,mcp-tools,llm-remote,web-ui -p arkavo -e normal` → zero `arkavo-llama-cpp-sys` (was 1)
- `cargo check` with the slim feature set → passes; `cargo check -p arkavo` (default) → passes, default tree still contains llama-cpp
- `cargo nextest run -p arkavo-ui-generator -p arkavo-agui -p arkavo-orchestrator -p arkavo-server` → all pass except one **pre-existing** failure (`test_orc_01c_router_fallback` expects outdated `LocalGemma4B | LocalQwen3`; router now returns `LocalGemma4_31B` — unrelated, needs a separate fix)
- `cargo nextest run -p arkavo-ui-generator --no-default-features` → 33 passed
- clippy + fmt clean on all touched crates