### PR TITLE
feat(authorization): AuthZEN tools/call and tools/list PEP with CWT $token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -207,7 +207,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -645,7 +645,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tracing",
  "uuid",
@@ -704,14 +704,15 @@ dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
  "chrono",
+ "ciborium",
+ "coset",
  "lru",
- "prost",
+ "p256",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tonic",
  "tracing",
  "url",
  "wiremock",
@@ -1442,6 +1443,7 @@ name = "arkavo-mcp-runtime"
 version = "0.89.4"
 dependencies = [
  "anyhow",
+ "arkavo-authorization",
  "arkavo-llm",
  "arkavo-mcp",
  "arkavo-memory",
@@ -1688,7 +1690,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
- "tower 0.5.3",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -1921,7 +1923,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "torg-core",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -1957,7 +1959,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tracing",
  "uuid",
@@ -2515,7 +2517,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3327,6 +3329,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "coset"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8cc80f631f8307b887faca24dcc3abc427cd0367f6eb6188f6e8f5b7ad8fb"
+dependencies = [
+ "ciborium",
+ "ciborium-io",
+]
+
+[[package]]
 name = "cpu-time"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3930,7 +3942,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4237,7 +4249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5389,19 +5401,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5418,7 +5417,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5438,7 +5437,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5764,7 +5763,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.4",
+ "socket2",
  "widestring",
  "windows-registry",
  "windows-result 0.4.1",
@@ -6063,7 +6062,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6322,7 +6321,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tower 0.5.3",
+ "tower",
  "tracing",
  "wasm-bindgen-futures",
 ]
@@ -6346,7 +6345,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "url",
 ]
 
@@ -6386,7 +6385,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tracing",
 ]
 
@@ -6411,7 +6410,7 @@ dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "tower 0.5.3",
+ "tower",
 ]
 
 [[package]]
@@ -6424,7 +6423,7 @@ dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "tower 0.5.3",
+ "tower",
  "url",
 ]
 
@@ -6875,7 +6874,7 @@ dependencies = [
  "log",
  "mio",
  "socket-pktinfo",
- "socket2 0.6.4",
+ "socket2",
 ]
 
 [[package]]
@@ -7230,7 +7229,7 @@ dependencies = [
  "objc2-system-configuration",
  "pin-project-lite",
  "serde",
- "socket2 0.6.4",
+ "socket2",
  "time",
  "tokio",
  "tokio-util",
@@ -7338,7 +7337,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -7381,7 +7380,7 @@ checksum = "b56d621ed2c1773b5356ab39cc68c819f8d0103f7493d8661c4a5f5f8ea55f40"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -7428,7 +7427,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8555,29 +8554,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8641,7 +8617,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8679,7 +8655,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -9202,7 +9178,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -9244,7 +9220,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -9457,7 +9433,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9537,7 +9513,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.8",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9753,7 +9729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10210,18 +10186,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927136cc2ae6a1b0e66ac6b1210902b75c3f726db004a73bc18686dcd0dcd22f"
 dependencies = [
  "libc",
- "socket2 0.6.4",
+ "socket2",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10231,7 +10197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10733,7 +10699,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10755,7 +10721,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11023,7 +10989,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -11219,36 +11185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
-name = "tonic"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.22.1",
- "bytes",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost",
- "socket2 0.5.10",
- "tokio",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "torg-core"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11281,26 +11217,6 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.6",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -11327,7 +11243,7 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "url",
@@ -12298,7 +12214,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/arkavo-authorization/Cargo.toml
+++ b/crates/arkavo-authorization/Cargo.toml
@@ -4,36 +4,30 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-description = "OpenTDF Authorization v2 integration for Arkavo - Connect protocol client for entitlement-based access control"
+description = "AuthZEN PEP for Arkavo MCP tools/call and tools/list with CWT $token"
 repository.workspace = true
-keywords = ["authorization", "opentdf", "connect-rpc", "abac", "security"]
+keywords = ["authorization", "authzen", "cwt", "mcp", "security"]
 categories = ["authentication", "web-programming::http-client"]
 
 [dependencies]
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["rt", "macros", "time"] }
+tokio = { workspace = true, features = ["rt", "macros", "time", "sync"] }
 thiserror = { workspace = true }
 url = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }
 lru = { workspace = true }
 tracing = { workspace = true }
-
-# Optional gRPC support
-tonic = { workspace = true, optional = true }
-prost = { workspace = true, optional = true }
+coset = "0.3"
+ciborium = "0.2"
+p256 = { version = "0.13", features = ["ecdsa"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
 wiremock = "0.6"
 arkavo-test-macros = { path = "../arkavo-test-macros" }
-
-[features]
-default = ["connect"]
-connect = []
-grpc = ["tonic", "prost"]
 
 [lints]
 workspace = true

--- a/crates/arkavo-authorization/src/cache.rs
+++ b/crates/arkavo-authorization/src/cache.rs
@@ -1,15 +1,16 @@
-use crate::types::{Action, Decision, EntityIdentifier, Resource};
+use crate::types::Decision;
 use lru::LruCache;
-use std::collections::BTreeSet;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct CacheKey {
-    entity_id: String,
+    pdp_origin: String,
+    subject_id: String,
     action_name: String,
-    resource_fqns: BTreeSet<String>,
+    resource_type: String,
+    resource_id: String,
 }
 
 #[derive(Debug, Clone)]
@@ -28,8 +29,7 @@ impl DecisionCache {
     ///
     /// # Panics
     ///
-    /// This function will panic if unable to create a NonZeroUsize with value 1000,
-    /// which should never happen in practice.
+    /// Panics only if `NonZeroUsize::new(1000)` fails, which cannot happen.
     pub fn new(capacity: usize, default_ttl: Duration) -> Self {
         let capacity = NonZeroUsize::new(capacity).unwrap_or(NonZeroUsize::new(1000).unwrap());
         Self {
@@ -38,18 +38,24 @@ impl DecisionCache {
         }
     }
 
-    /// Gets a cached decision for the given entity, action, and resource.
-    ///
     /// # Panics
     ///
-    /// This function will panic if the cache mutex is poisoned.
+    /// Panics if the cache mutex is poisoned.
     pub fn get(
         &self,
-        entity: &EntityIdentifier,
-        action: &Action,
-        resource: &Resource,
+        pdp_origin: &str,
+        subject_id: &str,
+        action_name: &str,
+        resource_type: &str,
+        resource_id: &str,
     ) -> Option<Decision> {
-        let key = Self::make_key(entity, action, resource);
+        let key = Self::make_key(
+            pdp_origin,
+            subject_id,
+            action_name,
+            resource_type,
+            resource_id,
+        );
 
         let mut cache = self.cache.lock().unwrap();
         if let Some(entry) = cache.get(&key) {
@@ -61,20 +67,27 @@ impl DecisionCache {
         None
     }
 
-    /// Puts a decision into the cache for the given entity, action, and resource.
-    ///
     /// # Panics
     ///
-    /// This function will panic if the cache mutex is poisoned.
+    /// Panics if the cache mutex is poisoned.
+    #[allow(clippy::too_many_arguments)]
     pub fn put(
         &self,
-        entity: &EntityIdentifier,
-        action: &Action,
-        resource: &Resource,
+        pdp_origin: &str,
+        subject_id: &str,
+        action_name: &str,
+        resource_type: &str,
+        resource_id: &str,
         decision: Decision,
         ttl: Option<Duration>,
     ) {
-        let key = Self::make_key(entity, action, resource);
+        let key = Self::make_key(
+            pdp_origin,
+            subject_id,
+            action_name,
+            resource_type,
+            resource_id,
+        );
         let ttl = ttl.unwrap_or(self.default_ttl);
         let entry = CacheEntry {
             decision,
@@ -85,21 +98,17 @@ impl DecisionCache {
         cache.put(key, entry);
     }
 
-    /// Clears all entries from the cache.
-    ///
     /// # Panics
     ///
-    /// This function will panic if the cache mutex is poisoned.
+    /// Panics if the cache mutex is poisoned.
     pub fn clear(&self) {
         let mut cache = self.cache.lock().unwrap();
         cache.clear();
     }
 
-    /// Evicts expired entries from the cache.
-    ///
     /// # Panics
     ///
-    /// This function will panic if the cache mutex is poisoned.
+    /// Panics if the cache mutex is poisoned.
     pub fn evict_expired(&self) {
         let now = Instant::now();
         let mut cache = self.cache.lock().unwrap();
@@ -115,17 +124,19 @@ impl DecisionCache {
         }
     }
 
-    fn make_key(entity: &EntityIdentifier, action: &Action, resource: &Resource) -> CacheKey {
-        let resource_fqns = resource
-            .attribute_value_fqns
-            .iter()
-            .cloned()
-            .collect::<BTreeSet<_>>();
-
+    fn make_key(
+        pdp_origin: &str,
+        subject_id: &str,
+        action_name: &str,
+        resource_type: &str,
+        resource_id: &str,
+    ) -> CacheKey {
         CacheKey {
-            entity_id: entity.id.clone(),
-            action_name: action.name.clone(),
-            resource_fqns,
+            pdp_origin: pdp_origin.to_string(),
+            subject_id: subject_id.to_string(),
+            action_name: action_name.to_string(),
+            resource_type: resource_type.to_string(),
+            resource_id: resource_id.to_string(),
         }
     }
 
@@ -153,89 +164,99 @@ mod tests {
     #[test]
     fn test_cache_basic_operations() {
         let cache = DecisionCache::new(100, Duration::from_mins(1));
+        let pdp = "https://kas.arkavo.net";
 
-        let entity = EntityIdentifier {
-            id: "user123".to_string(),
-            entity_type: crate::types::EntityType::Subject,
-            attributes: None,
-        };
+        assert!(
+            cache
+                .get(pdp, "user123", "tools/call", "tool", "git_commit")
+                .is_none()
+        );
 
-        let action = Action::execute_tool();
-        let resource = Resource::mcp_tool("git.commit");
-
-        // Cache miss
-        assert!(cache.get(&entity, &action, &resource).is_none());
-
-        // Put and get
-        cache.put(&entity, &action, &resource, Decision::Permit, None);
+        cache.put(
+            pdp,
+            "user123",
+            "tools/call",
+            "tool",
+            "git_commit",
+            Decision::Permit,
+            None,
+        );
         assert_eq!(
-            cache.get(&entity, &action, &resource),
+            cache.get(pdp, "user123", "tools/call", "tool", "git_commit"),
             Some(Decision::Permit)
         );
 
-        // Clear
         cache.clear();
-        assert!(cache.get(&entity, &action, &resource).is_none());
+        assert!(
+            cache
+                .get(pdp, "user123", "tools/call", "tool", "git_commit")
+                .is_none()
+        );
     }
 
     #[test]
     fn test_cache_expiration() {
         let cache = DecisionCache::new(100, Duration::from_mins(1));
+        let pdp = "https://kas.arkavo.net";
 
-        let entity = EntityIdentifier {
-            id: "user123".to_string(),
-            entity_type: crate::types::EntityType::Subject,
-            attributes: None,
-        };
-
-        let action = Action::execute_tool();
-        let resource = Resource::mcp_tool("git.commit");
-
-        // Put with very short TTL
         cache.put(
-            &entity,
-            &action,
-            &resource,
+            pdp,
+            "user123",
+            "tools/call",
+            "tool",
+            "git_commit",
             Decision::Permit,
             Some(Duration::from_millis(1)),
         );
-
-        // Wait for expiration
         std::thread::sleep(Duration::from_millis(2));
-
-        // Should be expired
-        assert!(cache.get(&entity, &action, &resource).is_none());
+        assert!(
+            cache
+                .get(pdp, "user123", "tools/call", "tool", "git_commit")
+                .is_none()
+        );
     }
 
     #[test]
-    fn test_cache_key_uniqueness() {
+    fn test_cache_key_includes_pdp_origin() {
         let cache = DecisionCache::new(100, Duration::from_mins(1));
 
-        let entity1 = EntityIdentifier {
-            id: "user123".to_string(),
-            entity_type: crate::types::EntityType::Subject,
-            attributes: None,
-        };
-
-        let entity2 = EntityIdentifier {
-            id: "user456".to_string(),
-            entity_type: crate::types::EntityType::Subject,
-            attributes: None,
-        };
-
-        let action = Action::execute_tool();
-        let resource = Resource::mcp_tool("git.commit");
-
-        // Different entities should have different cache entries
-        cache.put(&entity1, &action, &resource, Decision::Permit, None);
-        cache.put(&entity2, &action, &resource, Decision::Deny, None);
+        cache.put(
+            "https://pdp-a",
+            "user123",
+            "tools/call",
+            "tool",
+            "git_commit",
+            Decision::Permit,
+            None,
+        );
+        cache.put(
+            "https://pdp-b",
+            "user123",
+            "tools/call",
+            "tool",
+            "git_commit",
+            Decision::Deny,
+            None,
+        );
 
         assert_eq!(
-            cache.get(&entity1, &action, &resource),
+            cache.get(
+                "https://pdp-a",
+                "user123",
+                "tools/call",
+                "tool",
+                "git_commit"
+            ),
             Some(Decision::Permit)
         );
         assert_eq!(
-            cache.get(&entity2, &action, &resource),
+            cache.get(
+                "https://pdp-b",
+                "user123",
+                "tools/call",
+                "tool",
+                "git_commit"
+            ),
             Some(Decision::Deny)
         );
     }

--- a/crates/arkavo-authorization/src/client.rs
+++ b/crates/arkavo-authorization/src/client.rs
@@ -1,74 +1,190 @@
 use crate::cache::DecisionCache;
 use crate::config::AuthorizationConfig;
+use crate::cwt_subject::{sarc_tools_call, sarc_tools_list, token_map, trust_anchor_ok};
+use crate::cwt_verify::CwtVerifier;
 use crate::error::{AuthorizationError, Result};
-use crate::types::{
-    Action, CreateEntityChainsFromTokensRequest, CreateEntityChainsFromTokensResponse, Decision,
-    DecisionRequest, EntityIdentifier, GetDecisionBulkRequest, GetDecisionBulkResponse,
-    GetDecisionRequest, GetDecisionResponse, McpToolMapping, Resource,
-};
-use base64::{Engine as _, engine::general_purpose};
+use crate::pep::{is_hardcoded_mapped, is_pass_through, subject_cwt_from, tool_name_from_params};
+use crate::types::{AuthzenEvaluationResponse, Decision, McpToolMapping};
 use reqwest::{Client, StatusCode};
+use serde_json::Value;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
 use tracing::{error, info, warn};
+use url::Url;
+
+const TOKEN_REFRESH_MARGIN: Duration = Duration::from_secs(60);
+
+struct CachedToken {
+    token: String,
+    expires_at: Instant,
+}
+
+#[derive(serde::Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    #[serde(default)]
+    expires_in: u64,
+}
+
+#[derive(serde::Deserialize)]
+struct AuthzenDiscovery {
+    policy_decision_point: Option<String>,
+    access_evaluation_endpoint: Option<String>,
+}
 
 pub struct AuthorizationClient {
     config: AuthorizationConfig,
     http_client: Client,
     cache: Arc<DecisionCache>,
+    verifier: CwtVerifier,
+    token_cache: Mutex<Option<CachedToken>>,
+    evaluation_url: Mutex<Option<Url>>,
 }
 
 impl AuthorizationClient {
     pub fn new(config: AuthorizationConfig) -> Result<Self> {
         let http_client = Client::builder()
             .timeout(config.timeout)
+            .redirect(reqwest::redirect::Policy::none())
             .danger_accept_invalid_certs(false)
             .build()
             .map_err(|e| AuthorizationError::ConfigError(e.to_string()))?;
 
-        let cache = Arc::new(DecisionCache::new(1000, config.cache_ttl));
+        let mut verifier = if let Some(url) = config.cose_keys_url() {
+            CwtVerifier::new(url, config.oidc_issuer.clone())
+        } else {
+            CwtVerifier::with_static_keys(vec![])
+        };
+        if let Some(iss) = &config.oidc_issuer {
+            verifier = verifier.with_expected_issuer(iss.clone());
+        }
+        verifier = verifier.with_audiences(config.expected_audiences());
 
         Ok(Self {
+            cache: Arc::new(DecisionCache::new(1000, config.cache_ttl)),
             config,
             http_client,
-            cache,
+            verifier,
+            token_cache: Mutex::new(None),
+            evaluation_url: Mutex::new(None),
         })
     }
 
+    #[must_use]
+    pub fn with_verifier(mut self, verifier: CwtVerifier) -> Self {
+        self.verifier = verifier;
+        self
+    }
+
     pub async fn authorize_mcp_tool(&self, token: &str, tool_name: &str) -> Result<Decision> {
-        // Check if it's a safe diagnostic tool
-        if McpToolMapping::is_safe_diagnostic(tool_name) {
-            info!(
-                event = "auth_decision",
-                action = "permit",
-                resource = tool_name,
-                "Safe diagnostic tool allowed"
-            );
+        match self
+            .authorize_mcp_method(
+                "tools/call",
+                Some(&serde_json::json!({ "name": tool_name })),
+                Some(token),
+            )
+            .await
+        {
+            Ok(d) => Ok(d),
+            Err(AuthorizationError::Denied) => Ok(Decision::Deny),
+            Err(e) => Err(e),
+        }
+    }
+
+    pub async fn authorize_mcp_method(
+        &self,
+        method: &str,
+        params: Option<&Value>,
+        subject_cwt: Option<&str>,
+    ) -> Result<Decision> {
+        if is_pass_through(method) {
             return Ok(Decision::Permit);
         }
-
-        // Get entity from token
-        let entity = self.resolve_entity_from_token(token).await?;
-
-        // Create resource for MCP tool
-        let resource = McpToolMapping::tool_to_resource(tool_name);
-        let action = Action::execute_tool();
-
-        // Check cache first
-        if let Some(cached) = self.cache.get(&entity, &action, &resource) {
-            info!(event = "auth_decision", action = ?cached, resource = tool_name, "Authorization cache hit");
-            return Ok(cached);
+        if !is_hardcoded_mapped(method) {
+            info!(
+                event = "auth_decision",
+                action = "deny",
+                method,
+                "Unknown MCP method denied"
+            );
+            return Err(AuthorizationError::Denied);
         }
 
-        // Make authorization request
-        let decision = self.get_decision(&entity, &action, &resource).await?;
+        let token = subject_cwt_from(subject_cwt).ok_or_else(|| {
+            AuthorizationError::Mapping(
+                "missing subject CWT (Authorization Bearer or CLAUDE_CODE_SESSION_ACCESS_TOKEN)"
+                    .into(),
+            )
+        })?;
 
-        // Cache the decision
-        let ttl = Self::extract_token_ttl(token);
-        self.cache
-            .put(&entity, &action, &resource, decision.clone(), Some(ttl));
+        if method == "tools/call" {
+            let tool_name = tool_name_from_params(params)?;
+            if McpToolMapping::is_safe_diagnostic(tool_name)
+                || self
+                    .config
+                    .safe_diagnostic_tools
+                    .iter()
+                    .any(|t| t == tool_name)
+            {
+                info!(
+                    event = "auth_decision",
+                    action = "permit",
+                    resource = tool_name,
+                    "Safe diagnostic tool allowed"
+                );
+                return Ok(Decision::Permit);
+            }
+        }
 
-        Ok(decision)
+        let claims = self.verifier.verify(&token).await?;
+        let token_json = token_map(&claims);
+        let platform = self.config.platform_audience.as_deref();
+        let (action_name, resource_type, resource_id, sarc) = if method == "tools/list" {
+            let slug = self.config.mcp_server_slug();
+            let sarc = sarc_tools_list(&claims, &self.config.mcp_resource_id, &slug, platform)?;
+            ("tools/list", "mcp_server", slug, sarc)
+        } else {
+            let tool_name = tool_name_from_params(params)?;
+            let slug = crate::cwt_subject::tool_value_slug(tool_name);
+            let sarc = sarc_tools_call(&claims, tool_name, platform);
+            ("tools/call", "tool", slug, sarc)
+        };
+
+        if !trust_anchor_ok(&sarc, &token_json) {
+            return Err(AuthorizationError::Mapping(
+                "subject.id does not equal $token.sub".into(),
+            ));
+        }
+
+        let pdp = self.config.pdp_origin();
+        if let Some(cached) =
+            self.cache
+                .get(&pdp, &claims.sub, action_name, resource_type, &resource_id)
+        {
+            info!(event = "auth_decision", action = ?cached, method, "Authorization cache hit");
+            return match cached {
+                Decision::Permit => Ok(Decision::Permit),
+                Decision::Deny => Err(AuthorizationError::Denied),
+            };
+        }
+
+        let decision = self.evaluate(&sarc).await?;
+        let ttl =
+            DecisionCache::calculate_ttl_from_token(Some(i64::try_from(claims.exp).unwrap_or(0)));
+        self.cache.put(
+            &pdp,
+            &claims.sub,
+            action_name,
+            resource_type,
+            &resource_id,
+            decision.clone(),
+            Some(ttl),
+        );
+        match decision {
+            Decision::Permit => Ok(Decision::Permit),
+            Decision::Deny => Err(AuthorizationError::Denied),
+        }
     }
 
     pub async fn authorize_mcp_tools_bulk(
@@ -76,183 +192,61 @@ impl AuthorizationClient {
         token: &str,
         tool_names: Vec<&str>,
     ) -> Result<Vec<(String, Decision)>> {
-        // Filter out safe diagnostic tools
         let mut results = Vec::new();
-        let mut tools_to_check = Vec::new();
-
-        for tool_name in &tool_names {
-            if McpToolMapping::is_safe_diagnostic(tool_name) {
-                results.push(((*tool_name).to_string(), Decision::Permit));
-            } else {
-                tools_to_check.push(*tool_name);
+        for tool_name in tool_names {
+            match self.authorize_mcp_tool(token, tool_name).await {
+                Ok(d) => results.push((tool_name.to_string(), d)),
+                Err(AuthorizationError::Denied) => {
+                    results.push((tool_name.to_string(), Decision::Deny));
+                }
+                Err(e) => return Err(e),
             }
         }
-
-        if tools_to_check.is_empty() {
-            return Ok(results);
-        }
-
-        // Get entity from token
-        let entity = self.resolve_entity_from_token(token).await?;
-
-        // Build bulk request
-        let decision_requests: Vec<DecisionRequest> = tools_to_check
-            .iter()
-            .map(|tool_name| DecisionRequest {
-                entity_identifier: entity.clone(),
-                action: Action::execute_tool(),
-                resource: McpToolMapping::tool_to_resource(tool_name),
-            })
-            .collect();
-
-        // Make bulk authorization request
-        let response = self.get_decision_bulk(decision_requests).await?;
-
-        // Process responses and cache
-        let ttl = Self::extract_token_ttl(token);
-        for (tool_name, decision_response) in tools_to_check.iter().zip(response.decision_responses)
-        {
-            let decision = decision_response.decision;
-
-            // Cache each decision
-            self.cache.put(
-                &entity,
-                &decision_response.action,
-                &decision_response.resource,
-                decision.clone(),
-                Some(ttl),
-            );
-
-            results.push(((*tool_name).to_string(), decision));
-        }
-
         Ok(results)
     }
 
-    async fn resolve_entity_from_token(&self, token: &str) -> Result<EntityIdentifier> {
-        let url = self
-            .config
-            .entity_resolution_v2_url("CreateEntityChainsFromTokens");
-
-        let request = CreateEntityChainsFromTokensRequest {
-            tokens: vec![token.to_string()],
-        };
-
-        let response = self
-            .http_client
-            .post(url)
-            .header("Content-Type", "application/json")
-            .header("Authorization", format!("Bearer {token}"))
-            .json(&request)
-            .send()
-            .await
-            .map_err(|e| {
-                error!("Entity resolution request failed: {}", e);
-                AuthorizationError::EntityResolutionError(e.to_string())
-            })?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            error!("Entity resolution failed with status {}: {}", status, body);
-            return Err(AuthorizationError::EntityResolutionError(format!(
-                "Status {status}: {body}"
-            )));
-        }
-
-        let ers_response: CreateEntityChainsFromTokensResponse = response.json().await?;
-
-        let entity_chain = ers_response
-            .entity_chains
-            .into_iter()
-            .next()
-            .ok_or_else(|| {
-                AuthorizationError::EntityResolutionError("No entity chains returned".to_string())
-            })?;
-
-        let entity = entity_chain.entities.into_iter().next().ok_or_else(|| {
-            AuthorizationError::EntityResolutionError("No entities in chain".to_string())
-        })?;
-
-        Ok(entity)
-    }
-
-    pub async fn get_decision(
-        &self,
-        entity: &EntityIdentifier,
-        action: &Action,
-        resource: &Resource,
-    ) -> Result<Decision> {
-        let url = self.config.authorization_v2_url("GetDecision");
-
-        let request = GetDecisionRequest {
-            entity_identifier: entity.clone(),
-            action: action.clone(),
-            resource: resource.clone(),
-        };
-
-        let response = self.make_connect_request(&url, &request).await?;
-
-        let decision_response: GetDecisionResponse = response.json().await?;
-        Ok(decision_response.decision)
-    }
-
-    async fn get_decision_bulk(
-        &self,
-        decision_requests: Vec<DecisionRequest>,
-    ) -> Result<GetDecisionBulkResponse> {
-        let url = self.config.authorization_v2_url("GetDecisionBulk");
-
-        let request = GetDecisionBulkRequest { decision_requests };
-
-        let response = self.make_connect_request(&url, &request).await?;
-
-        let bulk_response: GetDecisionBulkResponse = response.json().await?;
-        Ok(bulk_response)
-    }
-
-    async fn make_connect_request<T: serde::Serialize + Sync>(
-        &self,
-        url: &url::Url,
-        body: &T,
-    ) -> Result<reqwest::Response> {
+    async fn evaluate(&self, sarc: &Value) -> Result<Decision> {
+        let url = self.evaluation_endpoint().await?;
+        let service = self.service_bearer().await?;
         let mut retries = 0;
-
         loop {
             let response = self
                 .http_client
                 .post(url.clone())
                 .header("Content-Type", "application/json")
-                .header("Connect-Protocol-Version", "1")
-                .json(body)
+                .header("Authorization", format!("Bearer {service}"))
+                .json(sarc)
                 .send()
                 .await;
 
             match response {
-                Ok(resp) if resp.status().is_success() => return Ok(resp),
-                Ok(resp) if resp.status() == StatusCode::UNAUTHORIZED => {
-                    info!(
-                        event = "auth_decision",
-                        action = "deny",
-                        reason = "unauthorized",
-                        "Authorization denied: 401"
-                    );
-                    return Err(AuthorizationError::InvalidToken("Unauthorized".to_string()));
+                Ok(resp) if resp.status().is_success() => {
+                    let parsed: AuthzenEvaluationResponse = resp.json().await?;
+                    if required_obligations_nonempty(parsed.context.as_ref()) {
+                        info!(
+                            event = "auth_decision",
+                            action = "deny",
+                            reason = "obligations",
+                            "Fail closed on required obligations"
+                        );
+                        return Err(AuthorizationError::Denied);
+                    }
+                    return if parsed.decision {
+                        Ok(Decision::Permit)
+                    } else {
+                        Ok(Decision::Deny)
+                    };
                 }
-                Ok(resp) if resp.status() == StatusCode::FORBIDDEN => {
-                    info!(
-                        event = "auth_decision",
-                        action = "deny",
-                        reason = "forbidden",
-                        "Authorization denied: 403"
-                    );
-                    return Err(AuthorizationError::Denied);
+                Ok(resp) if resp.status() == StatusCode::UNAUTHORIZED => {
+                    return Err(AuthorizationError::PdpUnavailable(
+                        "PEP service CWT rejected by PDP (401)".into(),
+                    ));
                 }
                 Ok(resp)
                     if resp.status().is_server_error() && retries < self.config.max_retries =>
                 {
                     warn!(
-                        "Server error, retrying... (attempt {}/{})",
+                        "PDP server error, retrying... (attempt {}/{})",
                         retries + 1,
                         self.config.max_retries
                     );
@@ -262,41 +256,120 @@ impl AuthorizationClient {
                 Ok(resp) => {
                     let status = resp.status();
                     let body = resp.text().await.unwrap_or_default();
-                    error!("Request failed with status {}: {}", status, body);
-                    return Err(AuthorizationError::InvalidResponse(format!(
-                        "Status {status}: {body}"
+                    error!("AuthZEN evaluation failed: {status} {body}");
+                    return Err(AuthorizationError::PdpUnavailable(format!(
+                        "Status {status}"
                     )));
                 }
                 Err(e) if retries < self.config.max_retries => {
-                    warn!(
-                        "Request error, retrying... (attempt {}/{}): {}",
-                        retries + 1,
-                        self.config.max_retries,
-                        e
-                    );
+                    warn!("AuthZEN request error, retrying: {e}");
                     retries += 1;
                     tokio::time::sleep(Duration::from_millis(100 * (1 << retries))).await;
                 }
-                Err(e) => return Err(AuthorizationError::HttpError(e)),
+                Err(e) => return Err(AuthorizationError::PdpUnavailable(e.to_string())),
             }
         }
     }
 
-    fn extract_token_ttl(token: &str) -> Duration {
-        // Parse JWT to get expiration
-        let parts: Vec<&str> = token.split('.').collect();
-        if parts.len() != 3 {
-            return Duration::from_mins(1);
+    async fn evaluation_endpoint(&self) -> Result<Url> {
+        if let Some(u) = &self.config.evaluation_endpoint {
+            return Ok(u.clone());
         }
-
-        if let Ok(decoded) = general_purpose::URL_SAFE_NO_PAD.decode(parts[1])
-            && let Ok(claims) = serde_json::from_slice::<serde_json::Value>(&decoded)
-            && let Some(exp) = claims.get("exp").and_then(|v| v.as_i64())
         {
-            return DecisionCache::calculate_ttl_from_token(Some(exp));
+            let cached = self.evaluation_url.lock().await;
+            if let Some(u) = cached.as_ref() {
+                return Ok(u.clone());
+            }
         }
+        let well_known = format!(
+            "{}/.well-known/authzen-configuration",
+            self.config.pdp_origin()
+        );
+        let resp = self
+            .http_client
+            .get(&well_known)
+            .send()
+            .await
+            .map_err(|e| AuthorizationError::PdpUnavailable(e.to_string()))?;
+        if !resp.status().is_success() {
+            return Err(AuthorizationError::PdpUnavailable(format!(
+                "discovery HTTP {}",
+                resp.status()
+            )));
+        }
+        let disc: AuthzenDiscovery = resp
+            .json()
+            .await
+            .map_err(|e| AuthorizationError::PdpUnavailable(format!("discovery JSON: {e}")))?;
+        if let Some(pdp) = &disc.policy_decision_point {
+            let want = self.config.pdp_origin();
+            if pdp.trim_end_matches('/') != want {
+                return Err(AuthorizationError::PdpUnavailable(
+                    "policy_decision_point mismatch".into(),
+                ));
+            }
+        }
+        let endpoint = disc.access_evaluation_endpoint.ok_or_else(|| {
+            AuthorizationError::PdpUnavailable("missing access_evaluation_endpoint".into())
+        })?;
+        let url =
+            Url::parse(&endpoint).map_err(|e| AuthorizationError::PdpUnavailable(e.to_string()))?;
+        *self.evaluation_url.lock().await = Some(url.clone());
+        Ok(url)
+    }
 
-        Duration::from_mins(1)
+    async fn service_bearer(&self) -> Result<String> {
+        if let Some(t) = &self.config.service_token {
+            return Ok(t.clone());
+        }
+        let (token_url, client_id, client_secret) = match (
+            &self.config.token_url,
+            &self.config.client_id,
+            &self.config.client_secret,
+        ) {
+            (Some(u), Some(id), Some(sec)) => (u, id, sec),
+            _ => {
+                return Err(AuthorizationError::PdpUnavailable(
+                    "AUTHZEN_TOKEN_URL / AUTHZEN_CLIENT_ID / AUTHZEN_CLIENT_SECRET required".into(),
+                ));
+            }
+        };
+        let mut cache = self.token_cache.lock().await;
+        if let Some(cached) = cache.as_ref()
+            && Instant::now() < cached.expires_at
+        {
+            return Ok(cached.token.clone());
+        }
+        let resp = self
+            .http_client
+            .post(token_url)
+            .form(&[
+                ("grant_type", "client_credentials"),
+                ("client_id", client_id.as_str()),
+                ("client_secret", client_secret.as_str()),
+            ])
+            .send()
+            .await
+            .map_err(|e| AuthorizationError::PdpUnavailable(e.to_string()))?;
+        if !resp.status().is_success() {
+            return Err(AuthorizationError::PdpUnavailable(format!(
+                "token endpoint HTTP {}",
+                resp.status()
+            )));
+        }
+        let parsed: TokenResponse = resp
+            .json()
+            .await
+            .map_err(|e| AuthorizationError::PdpUnavailable(e.to_string()))?;
+        let ttl = Duration::from_secs(parsed.expires_in.max(120));
+        let expires_at = Instant::now() + ttl.saturating_sub(TOKEN_REFRESH_MARGIN);
+        let token = parsed.access_token.clone();
+        *cache = Some(CachedToken {
+            token: parsed.access_token,
+            expires_at,
+        });
+        drop(cache);
+        Ok(token)
     }
 
     pub fn clear_cache(&self) {
@@ -306,4 +379,12 @@ impl AuthorizationClient {
     pub fn evict_expired_cache(&self) {
         self.cache.evict_expired();
     }
+}
+
+fn required_obligations_nonempty(context: Option<&Value>) -> bool {
+    context
+        .and_then(|c| c.get("obligations"))
+        .and_then(|o| o.get("required"))
+        .and_then(Value::as_array)
+        .is_some_and(|a| !a.is_empty())
 }

--- a/crates/arkavo-authorization/src/config.rs
+++ b/crates/arkavo-authorization/src/config.rs
@@ -4,28 +4,47 @@ use url::Url;
 
 #[derive(Debug, Clone)]
 pub struct AuthorizationConfig {
-    pub base_url: Url,
+    pub pdp_url: Url,
+    pub token_url: Option<String>,
+    pub client_id: Option<String>,
+    pub client_secret: Option<String>,
+    pub mcp_resource_id: String,
+    pub mcp_server_slug: Option<String>,
     pub oidc_issuer: Option<String>,
     pub audience: Option<String>,
+    pub platform_audience: Option<String>,
+    pub cose_keys_url: Option<String>,
     pub timeout: Duration,
     pub max_retries: u32,
     pub cache_ttl: Duration,
     pub fail_closed: bool,
     pub safe_diagnostic_tools: Vec<String>,
+    /// Test/static override; skips well-known discovery when set.
+    pub evaluation_endpoint: Option<Url>,
+    /// Test/static service CWT; skips client_credentials when set.
+    pub service_token: Option<String>,
 }
 
 impl Default for AuthorizationConfig {
     fn default() -> Self {
-        let base_url = env::var("OPENTDF_BASE_URL")
-            .unwrap_or_else(|_| "https://platform.opentdf.io".to_string());
-
-        let base_url = Url::parse(&base_url)
-            .unwrap_or_else(|_| Url::parse("https://platform.opentdf.io").unwrap());
+        let pdp = env::var("AUTHZEN_PDP_URL")
+            .or_else(|_| env::var("OPENTDF_BASE_URL"))
+            .unwrap_or_else(|_| "https://kas.arkavo.net".to_string());
+        let pdp_url =
+            Url::parse(&pdp).unwrap_or_else(|_| Url::parse("https://kas.arkavo.net").unwrap());
 
         Self {
-            base_url,
+            pdp_url,
+            token_url: env::var("AUTHZEN_TOKEN_URL").ok(),
+            client_id: env::var("AUTHZEN_CLIENT_ID").ok(),
+            client_secret: env::var("AUTHZEN_CLIENT_SECRET").ok(),
+            mcp_resource_id: env::var("AUTHZEN_MCP_RESOURCE_ID")
+                .unwrap_or_else(|_| "https://mcp.arkavo.net".to_string()),
+            mcp_server_slug: env::var("AUTHZEN_MCP_SERVER_SLUG").ok(),
             oidc_issuer: env::var("OIDC_ISSUER").ok(),
             audience: env::var("AUD").ok(),
+            platform_audience: env::var("OIDC_PLATFORM_AUDIENCE").ok(),
+            cose_keys_url: env::var("AUTHZEN_COSE_KEYS_URL").ok(),
             timeout: Duration::from_secs(5),
             max_retries: 3,
             cache_ttl: Duration::from_mins(1),
@@ -35,6 +54,8 @@ impl Default for AuthorizationConfig {
                 "health".to_string(),
                 "version".to_string(),
             ],
+            evaluation_endpoint: None,
+            service_token: None,
         }
     }
 }
@@ -44,9 +65,13 @@ impl AuthorizationConfig {
         Self::default()
     }
 
-    pub fn with_base_url(mut self, url: &str) -> Result<Self, url::ParseError> {
-        self.base_url = Url::parse(url)?;
+    pub fn with_pdp_url(mut self, url: &str) -> Result<Self, url::ParseError> {
+        self.pdp_url = Url::parse(url)?;
         Ok(self)
+    }
+
+    pub fn with_base_url(self, url: &str) -> Result<Self, url::ParseError> {
+        self.with_pdp_url(url)
     }
 
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
@@ -59,8 +84,13 @@ impl AuthorizationConfig {
         self
     }
 
-    pub fn with_fail_open(mut self) -> Self {
-        self.fail_closed = false;
+    pub fn with_evaluation_endpoint(mut self, url: Url) -> Self {
+        self.evaluation_endpoint = Some(url);
+        self
+    }
+
+    pub fn with_service_token(mut self, token: impl Into<String>) -> Self {
+        self.service_token = Some(token.into());
         self
     }
 
@@ -69,17 +99,33 @@ impl AuthorizationConfig {
         self
     }
 
-    pub fn authorization_v2_url(&self, method: &str) -> Url {
-        self.base_url
-            .join(&format!("/authorization.v2.AuthorizationService/{method}"))
-            .unwrap_or_else(|_| self.base_url.clone())
+    pub fn mcp_server_slug(&self) -> String {
+        crate::cwt_subject::mcp_server_slug(&self.mcp_resource_id, self.mcp_server_slug.as_deref())
     }
 
-    pub fn entity_resolution_v2_url(&self, method: &str) -> Url {
-        self.base_url
-            .join(&format!(
-                "/entityresolution.v2.EntityResolutionService/{method}"
-            ))
-            .unwrap_or_else(|_| self.base_url.clone())
+    pub fn expected_audiences(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        if let Some(a) = &self.audience {
+            out.push(a.clone());
+        }
+        out.push(self.mcp_resource_id.clone());
+        out.push("arkavo".to_string());
+        if let Some(p) = &self.platform_audience {
+            out.push(p.clone());
+        }
+        out
+    }
+
+    pub fn cose_keys_url(&self) -> Option<String> {
+        if let Some(u) = &self.cose_keys_url {
+            return Some(u.clone());
+        }
+        self.oidc_issuer
+            .as_ref()
+            .map(|iss| format!("{}/.well-known/cose-keys", iss.trim_end_matches('/')))
+    }
+
+    pub fn pdp_origin(&self) -> String {
+        self.pdp_url.as_str().trim_end_matches('/').to_string()
     }
 }

--- a/crates/arkavo-authorization/src/cwt_decode.rs
+++ b/crates/arkavo-authorization/src/cwt_decode.rs
@@ -1,0 +1,171 @@
+//! CWT payload decoder: duplicate-key reject and minimum `$token` claims.
+#![allow(clippy::redundant_pub_crate)]
+
+use crate::cwt_subject::{Aud, DecodedClaims};
+use crate::cwt_verify::CwtError;
+use ciborium::value::Value;
+use tracing::warn;
+
+pub(crate) fn parse_claims(payload: &[u8]) -> Result<DecodedClaims, CwtError> {
+    let value: Value = ciborium::de::from_reader(payload).map_err(|_| CwtError::Malformed)?;
+    let Value::Map(entries) = value else {
+        return Err(CwtError::Malformed);
+    };
+    reject_duplicate_keys(&entries)?;
+
+    let mut iss = None;
+    let mut sub = None;
+    let mut aud = None;
+    let mut exp = None;
+    let mut iat = None;
+    let mut cti = None;
+    let mut email = None;
+    let mut email_verified = None;
+    let mut idp = None;
+    let mut arkavo_account_id = None;
+    let mut arkavo_roles = None;
+    let mut arkavo_entitlements = None;
+    let mut client_id = None;
+    let mut arkavo_patreon = None;
+
+    for (k, v) in entries {
+        match k {
+            Value::Integer(key) => match (i128::from(key), v) {
+                (1, Value::Text(s)) => iss = Some(s),
+                (2, Value::Text(s)) => sub = Some(s),
+                (3, Value::Text(s)) => aud = Some(Aud::One(s)),
+                (3, Value::Array(a)) => {
+                    let parts: Result<Vec<String>, _> = a
+                        .into_iter()
+                        .map(|x| match x {
+                            Value::Text(s) => Ok(s),
+                            _ => Err(CwtError::Malformed),
+                        })
+                        .collect();
+                    let parts = parts?;
+                    if parts.is_empty() {
+                        return Err(CwtError::Malformed);
+                    }
+                    aud = Some(Aud::Many(parts));
+                }
+                (4, Value::Integer(n)) => {
+                    exp = Some(u64::try_from(i128::from(n)).map_err(|_| CwtError::Malformed)?);
+                }
+                (6, Value::Integer(n)) => {
+                    iat = Some(u64::try_from(i128::from(n)).map_err(|_| CwtError::Malformed)?);
+                }
+                (7, Value::Bytes(b)) => {
+                    if b.len() != 16 {
+                        return Err(CwtError::Malformed);
+                    }
+                    cti = Some(b);
+                }
+                (8, _) => {}
+                _ => {}
+            },
+            Value::Text(key) => match (key.as_str(), v) {
+                ("email", Value::Text(s)) => email = Some(s),
+                ("email_verified", Value::Bool(b)) => email_verified = Some(b),
+                ("idp", Value::Text(s)) => idp = Some(s),
+                ("arkavo_account_id", Value::Text(s)) => arkavo_account_id = Some(s),
+                ("client_id", Value::Text(s)) => client_id = Some(s),
+                ("arkavo_roles", Value::Array(a)) => {
+                    arkavo_roles = Some(text_array(a)?);
+                }
+                ("arkavo_entitlements", Value::Array(a)) => {
+                    arkavo_entitlements = Some(text_array(a)?);
+                }
+                ("arkavo_patreon", patreon) => arkavo_patreon = Some(cbor_to_json(&patreon)),
+                _ => {}
+            },
+            _ => return Err(CwtError::Malformed),
+        }
+    }
+
+    Ok(DecodedClaims {
+        iss: iss.ok_or(CwtError::MissingClaim("iss"))?,
+        sub: sub.ok_or(CwtError::MissingClaim("sub"))?,
+        aud: aud.ok_or(CwtError::MissingClaim("aud"))?,
+        exp: exp.ok_or(CwtError::MissingClaim("exp"))?,
+        iat: iat.ok_or(CwtError::MissingClaim("iat"))?,
+        cti: cti.ok_or(CwtError::MissingClaim("cti"))?,
+        email,
+        email_verified,
+        idp,
+        arkavo_account_id,
+        arkavo_roles,
+        arkavo_entitlements,
+        client_id,
+        arkavo_patreon,
+    })
+}
+
+fn text_array(a: Vec<Value>) -> Result<Vec<String>, CwtError> {
+    a.into_iter()
+        .map(|x| match x {
+            Value::Text(s) => Ok(s),
+            _ => Err(CwtError::Malformed),
+        })
+        .collect()
+}
+
+fn reject_duplicate_keys(entries: &[(Value, Value)]) -> Result<(), CwtError> {
+    let mut seen_ints = Vec::new();
+    let mut seen_strs = Vec::new();
+    for (k, _) in entries {
+        match k {
+            Value::Integer(i) => {
+                let n: i128 = (*i).into();
+                if seen_ints.contains(&n) {
+                    return Err(CwtError::DuplicateKey);
+                }
+                seen_ints.push(n);
+            }
+            Value::Text(s) => {
+                if seen_strs.iter().any(|t: &String| t == s) {
+                    return Err(CwtError::DuplicateKey);
+                }
+                seen_strs.push(s.clone());
+            }
+            _ => return Err(CwtError::Malformed),
+        }
+    }
+    Ok(())
+}
+
+fn cbor_to_json(v: &Value) -> serde_json::Value {
+    use serde_json::Value as J;
+    match v {
+        Value::Text(s) => J::String(s.clone()),
+        Value::Integer(n) => {
+            let i: i128 = (*n).into();
+            i64::try_from(i)
+                .map(J::from)
+                .or_else(|_| u64::try_from(i).map(J::from))
+                .unwrap_or_else(|_| J::String(i.to_string()))
+        }
+        Value::Bool(b) => J::Bool(*b),
+        Value::Null => J::Null,
+        Value::Float(f) => serde_json::Number::from_f64(*f)
+            .map(J::Number)
+            .unwrap_or(J::Null),
+        Value::Bytes(b) => {
+            use base64::Engine;
+            J::String(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b))
+        }
+        Value::Array(a) => J::Array(a.iter().map(cbor_to_json).collect()),
+        Value::Map(m) => {
+            let mut obj = serde_json::Map::new();
+            for (k, val) in m {
+                if let Value::Text(key) = k {
+                    obj.insert(key.clone(), cbor_to_json(val));
+                }
+            }
+            J::Object(obj)
+        }
+        other => {
+            warn!("cbor_to_json: unexpected CBOR type: {other:?}");
+            J::String(format!("{other:?}"))
+        }
+    }
+}

--- a/crates/arkavo-authorization/src/cwt_subject.rs
+++ b/crates/arkavo-authorization/src/cwt_subject.rs
@@ -1,0 +1,459 @@
+//! Verification-agnostic CWT → `$token` / SARC projection (draft-arkavo-authzen-cwt-00).
+
+use crate::error::AuthorizationError;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde_json::{Map, Value, json};
+
+pub const DEVICECHECK_AUD: &str = "arkavo:devicecheck";
+
+/// Strip a single leading `arkavo:` prefix. Does not strip `apple:` or `client:`.
+pub fn subject_id_bind(s: &str) -> &str {
+    s.strip_prefix("arkavo:").unwrap_or(s)
+}
+
+#[derive(Debug, Clone)]
+pub enum Aud {
+    One(String),
+    Many(Vec<String>),
+}
+
+/// Already-verified CWT claims. Mapping only — no COSE verify here.
+#[derive(Debug, Clone)]
+pub struct DecodedClaims {
+    pub iss: String,
+    pub sub: String,
+    pub aud: Aud,
+    pub exp: u64,
+    pub iat: u64,
+    pub cti: Vec<u8>,
+    pub email: Option<String>,
+    pub email_verified: Option<bool>,
+    pub idp: Option<String>,
+    pub arkavo_account_id: Option<String>,
+    pub arkavo_roles: Option<Vec<String>>,
+    pub arkavo_entitlements: Option<Vec<String>>,
+    pub client_id: Option<String>,
+    pub arkavo_patreon: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeviceObject {
+    pub sub: String,
+    pub iss: String,
+    pub aud: String,
+    pub kid: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeviceError {
+    MissingField(&'static str),
+    BothDeviceAndDevices,
+    EmptyDevices,
+}
+
+/// `$token` map: text claim names, no integer keys, no `cnf`.
+pub fn token_map(claims: &DecodedClaims) -> Value {
+    let mut m = Map::new();
+    m.insert("iss".into(), json!(claims.iss));
+    m.insert("sub".into(), json!(claims.sub));
+    m.insert(
+        "aud".into(),
+        match &claims.aud {
+            Aud::One(s) => json!(s),
+            Aud::Many(v) => json!(v),
+        },
+    );
+    m.insert("exp".into(), json!(claims.exp));
+    m.insert("iat".into(), json!(claims.iat));
+    m.insert("cti".into(), json!(URL_SAFE_NO_PAD.encode(&claims.cti)));
+    insert_opt_str(&mut m, "email", claims.email.as_deref());
+    if let Some(v) = claims.email_verified {
+        m.insert("email_verified".into(), json!(v));
+    }
+    insert_opt_str(&mut m, "idp", claims.idp.as_deref());
+    insert_opt_str(
+        &mut m,
+        "arkavo_account_id",
+        claims.arkavo_account_id.as_deref(),
+    );
+    if let Some(roles) = &claims.arkavo_roles {
+        m.insert("arkavo_roles".into(), json!(roles));
+    }
+    if let Some(ents) = &claims.arkavo_entitlements {
+        m.insert("arkavo_entitlements".into(), json!(ents));
+    }
+    insert_opt_str(&mut m, "client_id", claims.client_id.as_deref());
+    if let Some(patreon) = &claims.arkavo_patreon {
+        m.insert("arkavo_patreon".into(), sanitize_patreon(patreon));
+    }
+    Value::Object(m)
+}
+
+fn insert_opt_str(m: &mut Map<String, Value>, k: &str, v: Option<&str>) {
+    if let Some(s) = v {
+        m.insert(k.into(), json!(s));
+    }
+}
+
+fn sanitize_patreon(p: &Value) -> Value {
+    let Some(obj) = p.as_object() else {
+        return p.clone();
+    };
+    let mut out = obj.clone();
+    if out.get("role").and_then(Value::as_str) == Some("consumer") {
+        out.remove("campaign_id");
+    }
+    Value::Object(out)
+}
+
+/// AuthZEN subject (`type=identity`, `id` as minted).
+pub fn subject(claims: &DecodedClaims) -> Value {
+    let mut properties = Map::new();
+    properties.insert("iss".into(), json!(claims.iss));
+    insert_opt_str(&mut properties, "email", claims.email.as_deref());
+    if let Some(v) = claims.email_verified {
+        properties.insert("email_verified".into(), json!(v));
+    }
+    insert_opt_str(&mut properties, "idp", claims.idp.as_deref());
+    insert_opt_str(
+        &mut properties,
+        "arkavo_account_id",
+        claims.arkavo_account_id.as_deref(),
+    );
+    if let Some(roles) = &claims.arkavo_roles {
+        properties.insert("arkavo_roles".into(), json!(roles));
+    }
+    if let Some(ents) = &claims.arkavo_entitlements {
+        properties.insert("arkavo_entitlements".into(), json!(ents));
+    }
+    if let Some(patreon) = &claims.arkavo_patreon {
+        properties.insert("arkavo_patreon".into(), sanitize_patreon(patreon));
+    }
+    json!({
+        "type": "identity",
+        "id": claims.sub,
+        "properties": properties,
+    })
+}
+
+pub fn devices_bind(pe_sub: &str, device_sub: &str) -> bool {
+    subject_id_bind(pe_sub) == subject_id_bind(device_sub)
+}
+
+pub fn allowlist_device(obj: &Value) -> Result<DeviceObject, DeviceError> {
+    let map = obj.as_object().ok_or(DeviceError::MissingField("sub"))?;
+    let req = |k: &'static str| -> Result<String, DeviceError> {
+        map.get(k)
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .ok_or(DeviceError::MissingField(k))
+    };
+    Ok(DeviceObject {
+        sub: req("sub")?,
+        iss: req("iss")?,
+        aud: req("aud")?,
+        kid: req("kid")?,
+    })
+}
+
+pub fn device_to_value(d: &DeviceObject) -> Value {
+    json!({
+        "sub": d.sub,
+        "iss": d.iss,
+        "aud": d.aud,
+        "kid": d.kid,
+    })
+}
+
+/// Environment allowlist: `{region}` plus optional `kind`. Other keys dropped.
+pub fn allowlist_environment(obj: &Value) -> Value {
+    let mut out = Map::new();
+    if let Some(map) = obj.as_object() {
+        if let Some(r) = map.get("region") {
+            out.insert("region".into(), r.clone());
+        }
+        if let Some(k) = map.get("kind") {
+            out.insert("kind".into(), k.clone());
+        }
+    }
+    Value::Object(out)
+}
+
+pub fn devices_from_context(context: &Value) -> Result<Vec<DeviceObject>, DeviceError> {
+    let Some(obj) = context.as_object() else {
+        return Ok(vec![]);
+    };
+    let has_device = obj.contains_key("device");
+    let has_devices = obj.contains_key("devices");
+    if has_device && has_devices {
+        return Err(DeviceError::BothDeviceAndDevices);
+    }
+    if has_device {
+        return Ok(vec![allowlist_device(&obj["device"])?]);
+    }
+    if has_devices {
+        let arr = obj["devices"].as_array().ok_or(DeviceError::EmptyDevices)?;
+        if arr.is_empty() {
+            return Err(DeviceError::EmptyDevices);
+        }
+        arr.iter().map(allowlist_device).collect()
+    } else {
+        Ok(vec![])
+    }
+}
+
+/// `context.agent` fallbacks (COAZ-MCP CWT profile override 3).
+pub fn context_agent(claims: &DecodedClaims, platform_audience: Option<&str>) -> Option<String> {
+    if let Some(id) = claims.client_id.as_deref().filter(|s| !s.is_empty()) {
+        return Some(id.to_string());
+    }
+    if let Some(rest) = claims.sub.strip_prefix("client:")
+        && !rest.is_empty()
+    {
+        return Some(rest.to_string());
+    }
+    let members: Vec<&str> = match &claims.aud {
+        Aud::One(s) => vec![s.as_str()],
+        Aud::Many(v) => v.iter().map(String::as_str).collect(),
+    };
+    let filtered: Vec<&str> = members
+        .into_iter()
+        .filter(|a| {
+            *a != "arkavo" && *a != DEVICECHECK_AUD && platform_audience.is_none_or(|p| *a != p)
+        })
+        .collect();
+    if filtered.len() == 1 {
+        Some(filtered[0].to_string())
+    } else {
+        None
+    }
+}
+
+/// Lowercase slug matching OpenTDF attribute-value charset.
+pub fn mcp_server_slug(resource_id: &str, override_slug: Option<&str>) -> String {
+    if let Some(s) = override_slug.filter(|s| !s.is_empty()) {
+        return s.to_ascii_lowercase();
+    }
+    let stripped = resource_id
+        .trim()
+        .trim_start_matches("https://")
+        .trim_start_matches("http://");
+    let mut out = String::new();
+    for c in stripped.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c.to_ascii_lowercase());
+        } else if (c == '-' || c == '_' || c == '.') && !out.ends_with('_') && !out.is_empty() {
+            out.push('_');
+        }
+    }
+    out.trim_matches('_').to_string()
+}
+
+pub fn tool_value_slug(tool_name: &str) -> String {
+    tool_name.replace('.', "_").to_ascii_lowercase()
+}
+
+pub fn aud_contains(aud: &Aud, member: &str) -> bool {
+    match aud {
+        Aud::One(s) => s == member,
+        Aud::Many(v) => v.iter().any(|s| s == member),
+    }
+}
+
+fn pep_context(claims: &DecodedClaims, platform_audience: Option<&str>) -> Map<String, Value> {
+    let mut context = Map::new();
+    if let Some(agent) = context_agent(claims, platform_audience) {
+        context.insert("agent".into(), json!(agent));
+    }
+    context.insert("pep".into(), json!({ "fulfillable_obligation_fqns": [] }));
+    context
+}
+
+/// Hardcoded COAZ-MCP `tools/call` SARC (no CEL).
+pub fn sarc_tools_call(
+    claims: &DecodedClaims,
+    tool_name: &str,
+    platform_audience: Option<&str>,
+) -> Value {
+    json!({
+        "subject": subject(claims),
+        "action": { "name": "tools/call" },
+        "resource": { "type": "tool", "id": tool_value_slug(tool_name) },
+        "context": pep_context(claims, platform_audience),
+    })
+}
+
+/// Hardcoded COAZ-MCP `tools/list` SARC (no CEL). `resource.id` is the slug.
+pub fn sarc_tools_list(
+    claims: &DecodedClaims,
+    resource_id: &str,
+    slug: &str,
+    platform_audience: Option<&str>,
+) -> Result<Value, AuthorizationError> {
+    if !aud_contains(&claims.aud, resource_id) {
+        return Err(AuthorizationError::Mapping(
+            "AUTHZEN_MCP_RESOURCE_ID is not a member of $token.aud".into(),
+        ));
+    }
+    Ok(json!({
+        "subject": subject(claims),
+        "action": { "name": "tools/list" },
+        "resource": { "type": "mcp_server", "id": slug },
+        "context": pep_context(claims, platform_audience),
+    }))
+}
+
+pub fn trust_anchor_ok(sarc: &Value, token: &Value) -> bool {
+    sarc.get("subject").and_then(|s| s.get("id")) == token.get("sub")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn oidc_pe() -> DecodedClaims {
+        DecodedClaims {
+            iss: "https://identity.arkavo.net".into(),
+            sub: "arkavo:550e8400-e29b-41d4-a716-446655440000".into(),
+            aud: Aud::Many(vec![
+                "https://mcp.arkavo.net".into(),
+                "https://platform.arkavo.net".into(),
+            ]),
+            exp: 1_780_000_000,
+            iat: 1_779_996_400,
+            cti: vec![0u8; 16],
+            email: Some("a@example.com".into()),
+            email_verified: Some(true),
+            idp: Some("arkavo".into()),
+            arkavo_account_id: Some("550e8400-e29b-41d4-a716-446655440000".into()),
+            arkavo_roles: Some(vec!["member".into()]),
+            arkavo_entitlements: None,
+            client_id: None,
+            arkavo_patreon: None,
+        }
+    }
+
+    #[test]
+    fn bind_strips_only_arkavo_prefix() {
+        assert_eq!(
+            subject_id_bind("arkavo:550e8400-e29b-41d4-a716-446655440000"),
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+        assert_eq!(
+            subject_id_bind("550e8400-e29b-41d4-a716-446655440000"),
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+        assert_eq!(subject_id_bind("apple:abc"), "apple:abc");
+        assert_eq!(
+            subject_id_bind("client:catalog-node"),
+            "client:catalog-node"
+        );
+        assert!(devices_bind(
+            "arkavo:550e8400-e29b-41d4-a716-446655440000",
+            "550e8400-e29b-41d4-a716-446655440000"
+        ));
+        assert!(!devices_bind("apple:abc", "abc"));
+        assert!(!devices_bind("client:x", "x"));
+    }
+
+    #[test]
+    fn token_map_text_names_omits_cnf() {
+        let v = token_map(&oidc_pe());
+        let obj = v.as_object().unwrap();
+        assert!(obj.contains_key("sub"));
+        assert_eq!(obj.get("cnf"), None);
+        assert!(!obj.keys().any(|k| k.chars().all(|c| c.is_ascii_digit())));
+        assert_eq!(
+            obj["sub"],
+            json!("arkavo:550e8400-e29b-41d4-a716-446655440000")
+        );
+    }
+
+    #[test]
+    fn consumer_patreon_omits_campaign_id() {
+        let mut c = oidc_pe();
+        c.arkavo_patreon = Some(json!({
+            "role": "consumer",
+            "patreon_user_id": "12345678",
+            "campaign_id": "87654321",
+            "memberships": []
+        }));
+        assert!(token_map(&c)["arkavo_patreon"].get("campaign_id").is_none());
+        let mut creator = oidc_pe();
+        creator.arkavo_patreon = Some(json!({
+            "role": "creator",
+            "patreon_user_id": "99990001",
+            "campaign_id": "87654321"
+        }));
+        assert_eq!(
+            token_map(&creator)["arkavo_patreon"]["campaign_id"],
+            json!("87654321")
+        );
+    }
+
+    #[test]
+    fn agent_fallbacks() {
+        let mut c = oidc_pe();
+        c.client_id = Some("agent-app".into());
+        assert_eq!(
+            context_agent(&c, Some("https://platform.arkavo.net")).as_deref(),
+            Some("agent-app")
+        );
+        c.client_id = None;
+        c.sub = "client:catalog-node".into();
+        assert_eq!(
+            context_agent(&c, Some("https://platform.arkavo.net")).as_deref(),
+            Some("catalog-node")
+        );
+        c.sub = "arkavo:550e8400-e29b-41d4-a716-446655440000".into();
+        assert_eq!(
+            context_agent(&c, Some("https://platform.arkavo.net")).as_deref(),
+            Some("https://mcp.arkavo.net")
+        );
+        c.aud = Aud::One("arkavo".into());
+        assert_eq!(context_agent(&c, Some("https://platform.arkavo.net")), None);
+    }
+
+    #[test]
+    fn slugs_and_tools_list_aud_check() {
+        assert_eq!(
+            mcp_server_slug("https://mcp.arkavo.net", None),
+            "mcp_arkavo_net"
+        );
+        assert_eq!(tool_value_slug("git.commit"), "git_commit");
+        let c = oidc_pe();
+        let sarc = sarc_tools_list(&c, "https://mcp.arkavo.net", "mcp_arkavo_net", None).unwrap();
+        assert_eq!(sarc["resource"]["id"], json!("mcp_arkavo_net"));
+        assert!(trust_anchor_ok(&sarc, &token_map(&c)));
+        assert!(sarc_tools_list(&c, "https://other.example", "x", None).is_err());
+        let call = sarc_tools_call(&c, "git.commit", Some("https://platform.arkavo.net"));
+        assert_eq!(call["resource"]["id"], json!("git_commit"));
+        assert_eq!(call["action"]["name"], json!("tools/call"));
+    }
+
+    #[test]
+    fn device_allowlist_and_environment() {
+        let raw = json!({
+            "sub": "550e8400-e29b-41d4-a716-446655440000",
+            "iss": "https://identity.arkavo.net",
+            "aud": "arkavo:devicecheck",
+            "kid": "YWxwaGEtZGV2aWNlLWtpZA",
+            "email": "nope@example.com"
+        });
+        let v = device_to_value(&allowlist_device(&raw).unwrap());
+        assert!(v.get("email").is_none());
+        let env = allowlist_environment(&json!({
+            "region": "us-east-1",
+            "kind": "environment",
+            "sub": "injected"
+        }));
+        assert_eq!(env.as_object().unwrap().len(), 2);
+        assert!(devices_from_context(&json!({})).unwrap().is_empty());
+        assert_eq!(
+            devices_from_context(&json!({"devices": []})),
+            Err(DeviceError::EmptyDevices)
+        );
+    }
+}

--- a/crates/arkavo-authorization/src/cwt_verify.rs
+++ b/crates/arkavo-authorization/src/cwt_verify.rs
@@ -1,0 +1,481 @@
+//! Union CWT verifier (draft-arkavo-authzen-cwt-00): stricter of authnz-rs and catalog.
+
+use crate::cwt_decode::parse_claims;
+use crate::cwt_subject::DecodedClaims;
+use crate::error::AuthorizationError;
+use ciborium::value::Value;
+use coset::{AsCborValue, CborSerializable};
+use p256::ecdsa::signature::Verifier;
+use p256::ecdsa::{Signature, VerifyingKey};
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+use tracing::info;
+
+const CWT_TAG_PREFIX: [u8; 2] = [0xD8, 0x3D];
+const SKEW_SECS: i64 = 60;
+const KEY_REFRESH_MIN_INTERVAL: Duration = Duration::from_secs(60);
+const KEY_FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, thiserror::Error)]
+pub enum CwtError {
+    #[error("malformed token")]
+    Malformed,
+    #[error("unsupported algorithm (ES256 required)")]
+    Algorithm,
+    #[error("unknown key id")]
+    UnknownKid,
+    #[error("signature verification failed")]
+    Signature,
+    #[error("token expired")]
+    Expired,
+    #[error("token not yet valid")]
+    NotYetValid,
+    #[error("required claim missing: {0}")]
+    MissingClaim(&'static str),
+    #[error("issuer mismatch")]
+    Issuer,
+    #[error("audience mismatch")]
+    Audience,
+    #[error("duplicate claim key")]
+    DuplicateKey,
+    #[error("key set unavailable: {0}")]
+    KeySet(String),
+}
+
+impl From<CwtError> for AuthorizationError {
+    fn from(e: CwtError) -> Self {
+        AuthorizationError::InvalidToken(e.to_string())
+    }
+}
+
+struct KeyCache {
+    keys: HashMap<Vec<u8>, VerifyingKey>,
+    last_fetch: Option<Instant>,
+}
+
+pub struct CwtVerifier {
+    cose_keys_url: Option<String>,
+    expected_iss: Option<String>,
+    expected_audiences: Vec<String>,
+    http: reqwest::Client,
+    cache: RwLock<KeyCache>,
+}
+
+fn bounded_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(KEY_FETCH_TIMEOUT)
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
+}
+
+impl CwtVerifier {
+    pub fn new(cose_keys_url: String, expected_iss: Option<String>) -> Self {
+        Self {
+            cose_keys_url: Some(cose_keys_url),
+            expected_iss,
+            expected_audiences: Vec::new(),
+            http: bounded_http_client(),
+            cache: RwLock::new(KeyCache {
+                keys: HashMap::new(),
+                last_fetch: None,
+            }),
+        }
+    }
+
+    pub fn with_static_keys(keys: Vec<(Vec<u8>, VerifyingKey)>) -> Self {
+        Self {
+            cose_keys_url: None,
+            expected_iss: None,
+            expected_audiences: Vec::new(),
+            http: bounded_http_client(),
+            cache: RwLock::new(KeyCache {
+                keys: keys.into_iter().collect(),
+                last_fetch: None,
+            }),
+        }
+    }
+
+    #[must_use]
+    pub fn with_expected_issuer(mut self, iss: String) -> Self {
+        self.expected_iss = Some(iss);
+        self
+    }
+
+    #[must_use]
+    pub fn with_audiences(mut self, audiences: Vec<String>) -> Self {
+        self.expected_audiences = audiences;
+        self
+    }
+
+    pub async fn verify(&self, token_b64: &str) -> Result<DecodedClaims, CwtError> {
+        self.verify_at(token_b64, chrono::Utc::now().timestamp())
+            .await
+    }
+
+    pub async fn verify_at(&self, token_b64: &str, now: i64) -> Result<DecodedClaims, CwtError> {
+        use base64::Engine;
+        let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(token_b64.trim())
+            .map_err(|_| CwtError::Malformed)?;
+        let inner = bytes
+            .strip_prefix(&CWT_TAG_PREFIX[..])
+            .ok_or(CwtError::Malformed)?;
+        let sign1 = coset::CoseSign1::from_slice(inner).map_err(|_| CwtError::Malformed)?;
+
+        match sign1.protected.header.alg {
+            Some(coset::Algorithm::Assigned(coset::iana::Algorithm::ES256)) => {}
+            _ => return Err(CwtError::Algorithm),
+        }
+        let kid = sign1.protected.header.key_id.clone();
+        if kid.is_empty() {
+            return Err(CwtError::UnknownKid);
+        }
+
+        let key = match self.lookup(&kid).await {
+            Some(k) => k,
+            None => {
+                self.refresh_keys().await?;
+                self.lookup(&kid).await.ok_or(CwtError::UnknownKid)?
+            }
+        };
+
+        sign1
+            .verify_signature(b"", |sig, data| {
+                let sig = Signature::from_slice(sig).map_err(|_| ())?;
+                key.verify(data, &sig).map_err(|_| ())
+            })
+            .map_err(|_| CwtError::Signature)?;
+
+        let payload = sign1.payload.as_deref().ok_or(CwtError::Malformed)?;
+        let claims = parse_claims(payload)?;
+
+        if claims.iat > claims.exp {
+            return Err(CwtError::Malformed);
+        }
+        let exp = i64::try_from(claims.exp).map_err(|_| CwtError::Malformed)?;
+        let iat = i64::try_from(claims.iat).map_err(|_| CwtError::Malformed)?;
+        if exp <= now - SKEW_SECS {
+            return Err(CwtError::Expired);
+        }
+        if iat > now + SKEW_SECS {
+            return Err(CwtError::NotYetValid);
+        }
+        if let Some(expected) = &self.expected_iss
+            && &claims.iss != expected
+        {
+            return Err(CwtError::Issuer);
+        }
+        if !self.expected_audiences.is_empty() {
+            let ok = self
+                .expected_audiences
+                .iter()
+                .any(|a| crate::cwt_subject::aud_contains(&claims.aud, a));
+            if !ok {
+                return Err(CwtError::Audience);
+            }
+        }
+        Ok(claims)
+    }
+
+    async fn lookup(&self, kid: &[u8]) -> Option<VerifyingKey> {
+        self.cache.read().await.keys.get(kid).copied()
+    }
+
+    async fn refresh_keys(&self) -> Result<(), CwtError> {
+        let Some(url) = &self.cose_keys_url else {
+            return Ok(());
+        };
+        {
+            let mut cache = self.cache.write().await;
+            if let Some(last) = cache.last_fetch
+                && last.elapsed() < KEY_REFRESH_MIN_INTERVAL
+            {
+                return Ok(());
+            }
+            cache.last_fetch = Some(Instant::now());
+        }
+        let resp = self
+            .http
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| CwtError::KeySet(format!("GET {url}: {e}")))?;
+        if !resp.status().is_success() {
+            return Err(CwtError::KeySet(format!(
+                "GET {url}: HTTP {}",
+                resp.status()
+            )));
+        }
+        let body = resp
+            .bytes()
+            .await
+            .map_err(|e| CwtError::KeySet(format!("read body: {e}")))?;
+        let keys = parse_cose_key_set(&body)?;
+        info!(count = keys.len(), "Refreshed COSE key set from IdP");
+        self.cache.write().await.keys = keys.into_iter().collect();
+        Ok(())
+    }
+}
+
+fn parse_cose_key_set(bytes: &[u8]) -> Result<Vec<(Vec<u8>, VerifyingKey)>, CwtError> {
+    let value: Value = ciborium::de::from_reader(bytes).map_err(|_| CwtError::Malformed)?;
+    let Value::Array(entries) = value else {
+        return Err(CwtError::KeySet("key set is not a CBOR array".into()));
+    };
+    let mut out = Vec::new();
+    for entry in entries {
+        let Ok(key) = coset::CoseKey::from_cbor_value(entry) else {
+            continue;
+        };
+        if key.key_id.is_empty() {
+            continue;
+        }
+        if let Ok(vk) = p256_from_cose_key(&key) {
+            out.push((key.key_id.clone(), vk));
+        }
+    }
+    if out.is_empty() {
+        return Err(CwtError::KeySet("no usable P-256 keys in key set".into()));
+    }
+    Ok(out)
+}
+
+fn p256_from_cose_key(key: &coset::CoseKey) -> Result<VerifyingKey, CwtError> {
+    use coset::iana::{Ec2KeyParameter, EnumI64};
+    if key.kty != coset::KeyType::Assigned(coset::iana::KeyType::EC2) {
+        return Err(CwtError::Malformed);
+    }
+    let mut x = None;
+    let mut y = None;
+    let mut crv_ok = false;
+    for (label, value) in &key.params {
+        match label {
+            coset::Label::Int(l) if *l == Ec2KeyParameter::Crv as i64 => {
+                crv_ok = matches!(
+                    value,
+                    Value::Integer(i)
+                        if i128::from(*i) == i128::from(coset::iana::EllipticCurve::P_256.to_i64())
+                );
+            }
+            coset::Label::Int(l) if *l == Ec2KeyParameter::X as i64 => {
+                if let Value::Bytes(b) = value {
+                    x = Some(b.as_slice());
+                }
+            }
+            coset::Label::Int(l) if *l == Ec2KeyParameter::Y as i64 => {
+                if let Value::Bytes(b) = value {
+                    y = Some(b.as_slice());
+                }
+            }
+            _ => {}
+        }
+    }
+    let (x, y) = (x.ok_or(CwtError::Malformed)?, y.ok_or(CwtError::Malformed)?);
+    if !crv_ok || x.len() != 32 || y.len() != 32 {
+        return Err(CwtError::Malformed);
+    }
+    let mut sec1 = Vec::with_capacity(65);
+    sec1.push(0x04);
+    sec1.extend_from_slice(x);
+    sec1.extend_from_slice(y);
+    VerifyingKey::from_sec1_bytes(&sec1).map_err(|_| CwtError::Malformed)
+}
+
+#[cfg(test)]
+#[allow(unreachable_pub)]
+pub(crate) mod test_support {
+    use super::*;
+    use crate::cwt_subject::Aud;
+    use coset::{CoseSign1Builder, HeaderBuilder, iana};
+    use p256::ecdsa::{SigningKey, signature::Signer};
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn mint(
+        key: &SigningKey,
+        kid: &[u8],
+        iss: &str,
+        sub: &str,
+        aud: Aud,
+        iat: i64,
+        exp: i64,
+        extras: &[(&str, Value)],
+        tagged: bool,
+        with_alg: bool,
+        with_kid: bool,
+    ) -> String {
+        use base64::Engine;
+        let mut entries: Vec<(Value, Value)> = vec![
+            (Value::Integer(1.into()), Value::Text(iss.into())),
+            (Value::Integer(2.into()), Value::Text(sub.into())),
+            (
+                Value::Integer(3.into()),
+                match &aud {
+                    Aud::One(s) => Value::Text(s.clone()),
+                    Aud::Many(v) => {
+                        Value::Array(v.iter().map(|s| Value::Text(s.clone())).collect())
+                    }
+                },
+            ),
+            (Value::Integer(4.into()), Value::Integer(exp.into())),
+            (Value::Integer(6.into()), Value::Integer(iat.into())),
+            (Value::Integer(7.into()), Value::Bytes(vec![0u8; 16])),
+        ];
+        for (k, v) in extras {
+            entries.push((Value::Text((*k).into()), v.clone()));
+        }
+        let mut payload = Vec::new();
+        ciborium::ser::into_writer(&Value::Map(entries), &mut payload).unwrap();
+
+        let mut hb = HeaderBuilder::new();
+        if with_alg {
+            hb = hb.algorithm(iana::Algorithm::ES256);
+        }
+        if with_kid {
+            hb = hb.key_id(kid.to_vec());
+        }
+        let sign1 = CoseSign1Builder::new()
+            .protected(hb.build())
+            .payload(payload)
+            .create_signature(b"", |to_sign| {
+                let sig: Signature = key.sign(to_sign);
+                sig.to_bytes().to_vec()
+            })
+            .build();
+        let inner = sign1.to_vec().unwrap();
+        let mut out = Vec::new();
+        if tagged {
+            out.extend_from_slice(&CWT_TAG_PREFIX);
+        }
+        out.extend_from_slice(&inner);
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(out)
+    }
+
+    pub fn keypair() -> (SigningKey, VerifyingKey) {
+        let sk = SigningKey::from_slice(&[0x17; 32]).expect("valid scalar");
+        let vk = *sk.verifying_key();
+        (sk, vk)
+    }
+
+    pub fn pe_token(sk: &SigningKey, kid: &[u8], now: i64) -> String {
+        mint(
+            sk,
+            kid,
+            "https://identity.arkavo.net",
+            "arkavo:550e8400-e29b-41d4-a716-446655440000",
+            Aud::One("https://mcp.arkavo.net".into()),
+            now,
+            now + 3600,
+            &[],
+            true,
+            true,
+            true,
+        )
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)]
+mod tests {
+    use super::test_support::{keypair, mint, pe_token};
+    use super::*;
+    use crate::cwt_subject::{Aud, token_map};
+
+    const NOW: i64 = 1_900_000_000;
+
+    fn verifier(kid: &[u8], vk: VerifyingKey) -> CwtVerifier {
+        CwtVerifier::with_static_keys(vec![(kid.to_vec(), vk)])
+            .with_expected_issuer("https://identity.arkavo.net".into())
+            .with_audiences(vec!["https://mcp.arkavo.net".into(), "arkavo".into()])
+    }
+
+    #[tokio::test]
+    async fn verify_roundtrip_omits_cnf() {
+        let (sk, vk) = keypair();
+        let token = pe_token(&sk, b"kid-1", NOW);
+        let claims = verifier(b"kid-1", vk).verify_at(&token, NOW).await.unwrap();
+        assert_eq!(claims.sub, "arkavo:550e8400-e29b-41d4-a716-446655440000");
+        assert_eq!(token_map(&claims).get("cnf"), None);
+    }
+
+    #[tokio::test]
+    async fn rejects_untagged_and_expired() {
+        let (sk, vk) = keypair();
+        let untagged = mint(
+            &sk,
+            b"kid-1",
+            "https://identity.arkavo.net",
+            "s",
+            Aud::One("https://mcp.arkavo.net".into()),
+            NOW,
+            NOW + 10,
+            &[],
+            false,
+            true,
+            true,
+        );
+        assert!(matches!(
+            verifier(b"kid-1", vk)
+                .verify_at(&untagged, NOW)
+                .await
+                .unwrap_err(),
+            CwtError::Malformed
+        ));
+        let expired = mint(
+            &sk,
+            b"kid-1",
+            "https://identity.arkavo.net",
+            "s",
+            Aud::One("https://mcp.arkavo.net".into()),
+            NOW - 120,
+            NOW - 60,
+            &[],
+            true,
+            true,
+            true,
+        );
+        assert!(matches!(
+            verifier(b"kid-1", vk)
+                .verify_at(&expired, NOW)
+                .await
+                .unwrap_err(),
+            CwtError::Expired
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_alg_and_duplicate_keys() {
+        let (sk, vk) = keypair();
+        let no_alg = mint(
+            &sk,
+            b"kid-1",
+            "https://identity.arkavo.net",
+            "s",
+            Aud::One("https://mcp.arkavo.net".into()),
+            NOW,
+            NOW + 10,
+            &[],
+            true,
+            false,
+            true,
+        );
+        assert!(matches!(
+            verifier(b"kid-1", vk)
+                .verify_at(&no_alg, NOW)
+                .await
+                .unwrap_err(),
+            CwtError::Algorithm
+        ));
+
+        let mut payload = Vec::new();
+        let entries = vec![
+            (Value::Integer(1.into()), Value::Text("iss".into())),
+            (Value::Integer(1.into()), Value::Text("iss2".into())),
+        ];
+        ciborium::ser::into_writer(&Value::Map(entries), &mut payload).unwrap();
+        assert!(matches!(
+            crate::cwt_decode::parse_claims(&payload),
+            Err(CwtError::DuplicateKey)
+        ));
+    }
+}

--- a/crates/arkavo-authorization/src/error.rs
+++ b/crates/arkavo-authorization/src/error.rs
@@ -1,5 +1,12 @@
 use thiserror::Error;
 
+/// JSON-RPC codes for the MCP PEP (draft-arkavo-authzen-cwt-00).
+pub mod jsonrpc_codes {
+    pub const DENIED: i32 = -32001;
+    pub const MAPPING: i32 = -32602;
+    pub const PDP: i32 = -32603;
+}
+
 #[derive(Error, Debug)]
 pub enum AuthorizationError {
     #[error("HTTP request failed: {0}")]
@@ -14,14 +21,14 @@ pub enum AuthorizationError {
     #[error("Authorization denied")]
     Denied,
 
-    #[error("Entity resolution failed: {0}")]
-    EntityResolutionError(String),
+    #[error("Mapping error: {0}")]
+    Mapping(String),
 
-    #[error("Invalid JWT token: {0}")]
+    #[error("PDP unavailable: {0}")]
+    PdpUnavailable(String),
+
+    #[error("Invalid CWT: {0}")]
     InvalidToken(String),
-
-    #[error("Cache error: {0}")]
-    CacheError(String),
 
     #[error("Timeout waiting for response")]
     Timeout,
@@ -31,6 +38,22 @@ pub enum AuthorizationError {
 
     #[error("Invalid response from server: {0}")]
     InvalidResponse(String),
+}
+
+impl AuthorizationError {
+    pub fn jsonrpc_code(&self) -> i32 {
+        match self {
+            Self::Denied => jsonrpc_codes::DENIED,
+            Self::Mapping(_) | Self::InvalidToken(_) => jsonrpc_codes::MAPPING,
+            Self::PdpUnavailable(_)
+            | Self::ServiceUnavailable
+            | Self::Timeout
+            | Self::HttpError(_)
+            | Self::InvalidResponse(_)
+            | Self::SerializationError(_)
+            | Self::ConfigError(_) => jsonrpc_codes::PDP,
+        }
+    }
 }
 
 pub type Result<T> = std::result::Result<T, AuthorizationError>;

--- a/crates/arkavo-authorization/src/lib.rs
+++ b/crates/arkavo-authorization/src/lib.rs
@@ -1,17 +1,18 @@
 pub mod cache;
 pub mod client;
 pub mod config;
+pub(crate) mod cwt_decode;
+pub mod cwt_subject;
+pub mod cwt_verify;
 pub mod error;
+pub mod pep;
 pub mod types;
 
 pub use client::AuthorizationClient;
 pub use config::AuthorizationConfig;
-pub use error::{AuthorizationError, Result};
-pub use types::{
-    Action, Decision, DecisionRequest, EntityIdentifier, GetDecisionBulkRequest,
-    GetDecisionBulkResponse, GetDecisionMultiResourceRequest, GetDecisionMultiResourceResponse,
-    GetDecisionRequest, GetDecisionResponse, Resource,
-};
+pub use error::{AuthorizationError, Result, jsonrpc_codes};
+pub use pep::{is_hardcoded_mapped, is_pass_through, subject_cwt_from};
+pub use types::{Action, Decision, McpToolMapping, Resource};
 
 #[cfg(test)]
 mod tests;

--- a/crates/arkavo-authorization/src/pep.rs
+++ b/crates/arkavo-authorization/src/pep.rs
@@ -1,0 +1,77 @@
+//! MCP JSON-RPC method classification for the COAZ-MCP CWT profile (PR 4, no CEL).
+
+use crate::error::{AuthorizationError, Result};
+use serde_json::Value;
+
+pub fn is_pass_through(method: &str) -> bool {
+    method == "ping" || method.starts_with("notifications/")
+}
+
+pub fn is_hardcoded_mapped(method: &str) -> bool {
+    method == "tools/call" || method == "tools/list"
+}
+
+pub fn tool_name_from_params(params: Option<&Value>) -> Result<&str> {
+    params
+        .and_then(|p| p.get("name").or_else(|| p.get("tool_name")))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| AuthorizationError::Mapping("tools/call requires params.name".into()))
+}
+
+/// Subject CWT from an explicit Bearer, else the CWT-only env var.
+/// `ANTHROPIC_API_KEY` is never accepted.
+pub fn subject_cwt_from(explicit: Option<&str>) -> Option<String> {
+    if let Some(t) = explicit.map(str::trim).filter(|s| !s.is_empty()) {
+        let t = t
+            .strip_prefix("Bearer ")
+            .or_else(|| t.strip_prefix("bearer "))
+            .unwrap_or(t);
+        if !t.is_empty() {
+            return Some(t.to_string());
+        }
+    }
+    std::env::var("CLAUDE_CODE_SESSION_ACCESS_TOKEN")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn pass_through_and_unknown() {
+        assert!(is_pass_through("ping"));
+        assert!(is_pass_through("notifications/initialized"));
+        assert!(!is_pass_through("initialize"));
+        assert!(!is_pass_through("resources/list"));
+        assert!(is_hardcoded_mapped("tools/call"));
+        assert!(is_hardcoded_mapped("tools/list"));
+        assert!(!is_hardcoded_mapped("prompts/list"));
+    }
+
+    #[test]
+    fn tools_call_name() {
+        assert_eq!(
+            tool_name_from_params(Some(&json!({"name": "git_commit"}))).unwrap(),
+            "git_commit"
+        );
+        assert!(tool_name_from_params(Some(&json!({}))).is_err());
+        assert_eq!(
+            tool_name_from_params(Some(&json!({"tool_name": "echo"}))).unwrap(),
+            "echo"
+        );
+    }
+
+    #[test]
+    fn subject_cwt_strips_bearer_and_ignores_empty() {
+        assert_eq!(
+            subject_cwt_from(Some("Bearer abc")),
+            Some("abc".to_string())
+        );
+        assert_eq!(subject_cwt_from(Some("   ")), None);
+    }
+}

--- a/crates/arkavo-authorization/src/tests.rs
+++ b/crates/arkavo-authorization/src/tests.rs
@@ -1,362 +1,388 @@
 #![allow(clippy::disallowed_methods)]
 
+use crate::cwt_subject::Aud;
+use crate::cwt_verify::test_support::{keypair, mint, pe_token};
+use crate::error::jsonrpc_codes;
 use crate::types::McpToolMapping;
 use crate::*;
 use arkavo_test_macros::spec;
-use wiremock::matchers::{header, method, path};
+use serde_json::json;
+use std::time::Duration;
+use wiremock::matchers::{body_string_contains, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const ISS: &str = "https://identity.arkavo.net";
+const KID: &[u8] = b"kid-1";
+const SVC: &str = "service-cwt";
+
+async fn mock_pdp_permit(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/access/v1/evaluation"))
+        .and(header("Authorization", format!("Bearer {SVC}")))
+        .and(header("Content-Type", "application/json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "decision": true,
+            "context": { "obligations": { "required": [] } }
+        })))
+        .mount(server)
+        .await;
+}
+
+fn test_client(server: &MockServer, vk: p256::ecdsa::VerifyingKey) -> AuthorizationClient {
+    let eval = url::Url::parse(&format!("{}/access/v1/evaluation", server.uri())).unwrap();
+    let config = AuthorizationConfig::default()
+        .with_pdp_url(&server.uri())
+        .unwrap()
+        .with_evaluation_endpoint(eval)
+        .with_service_token(SVC)
+        .with_timeout(Duration::from_secs(2));
+    let mut config = config;
+    config.oidc_issuer = Some(ISS.into());
+    config.mcp_resource_id = "https://mcp.arkavo.net".into();
+    config.max_retries = 1;
+    let verifier = crate::cwt_verify::CwtVerifier::with_static_keys(vec![(KID.to_vec(), vk)])
+        .with_expected_issuer(ISS.into())
+        .with_audiences(vec!["https://mcp.arkavo.net".into(), "arkavo".into()]);
+    AuthorizationClient::new(config)
+        .unwrap()
+        .with_verifier(verifier)
+}
+
+fn now() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+#[test]
+fn test_mcp_tool_mapping_underscores_not_dots() {
+    let resource = McpToolMapping::tool_to_resource("git_commit");
+    assert_eq!(
+        resource.attribute_value_fqns[0],
+        "https://arkavo.net/attr/mcp-tool/value/git_commit"
+    );
+    let resource = McpToolMapping::tool_to_resource("git.commit");
+    assert_eq!(
+        resource.attribute_value_fqns[0],
+        "https://arkavo.net/attr/mcp-tool/value/git_commit"
+    );
+    assert!(!resource.attribute_value_fqns[0].contains("git.commit"));
+}
+
+#[test]
+fn test_safe_diagnostic_excludes_list_tools() {
+    assert!(McpToolMapping::is_safe_diagnostic("status"));
+    assert!(McpToolMapping::is_safe_diagnostic("health"));
+    assert!(McpToolMapping::is_safe_diagnostic("version"));
+    assert!(!McpToolMapping::is_safe_diagnostic("list_tools"));
+    assert!(!McpToolMapping::is_safe_diagnostic("git_commit"));
+}
 
 #[tokio::test]
 async fn test_safe_diagnostic_tools() {
     let config = AuthorizationConfig::default();
     let client = AuthorizationClient::new(config).unwrap();
-
-    // Safe diagnostic tools should always be permitted
-    let decision = client
-        .authorize_mcp_tool("dummy_token", "status")
-        .await
-        .unwrap();
-    assert_eq!(decision, Decision::Permit);
-
-    let decision = client
-        .authorize_mcp_tool("dummy_token", "health")
-        .await
-        .unwrap();
-    assert_eq!(decision, Decision::Permit);
-
-    let decision = client
-        .authorize_mcp_tool("dummy_token", "version")
-        .await
-        .unwrap();
-    assert_eq!(decision, Decision::Permit);
+    assert_eq!(
+        client.authorize_mcp_tool("dummy", "status").await.unwrap(),
+        Decision::Permit
+    );
+    assert_eq!(
+        client.authorize_mcp_tool("dummy", "health").await.unwrap(),
+        Decision::Permit
+    );
 }
 
 #[tokio::test]
-async fn test_get_decision_permit() {
+async fn test_tools_call_permit_uses_service_bearer() {
     let mock_server = MockServer::start().await;
-
-    // Mock Entity Resolution Service
-    Mock::given(method("POST"))
-        .and(path(
-            "/entityresolution.v2.EntityResolutionService/CreateEntityChainsFromTokens",
-        ))
-        .and(header("Content-Type", "application/json"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "entity_chains": [{
-                "id": "chain1",
-                "entities": [{
-                    "id": "user123",
-                    "type": "subject"
-                }]
-            }]
-        })))
-        .mount(&mock_server)
-        .await;
-
-    // Mock Authorization Service - Permit
-    Mock::given(method("POST"))
-        .and(path("/authorization.v2.AuthorizationService/GetDecision"))
-        .and(header("Content-Type", "application/json"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "decision": "permit"
-        })))
-        .mount(&mock_server)
-        .await;
-
-    let config = AuthorizationConfig::default()
-        .with_base_url(&mock_server.uri())
-        .unwrap();
-    let client = AuthorizationClient::new(config).unwrap();
-
+    mock_pdp_permit(&mock_server).await;
+    let (sk, vk) = keypair();
+    let client = test_client(&mock_server, vk);
+    let token = pe_token(&sk, KID, now());
     let decision = client
-        .authorize_mcp_tool("test_token", "git.commit")
+        .authorize_mcp_tool(&token, "git.commit")
         .await
         .unwrap();
     assert_eq!(decision, Decision::Permit);
 }
 
 #[tokio::test]
-async fn test_get_decision_deny() {
+async fn test_tools_call_deny_and_jsonrpc_code() {
     let mock_server = MockServer::start().await;
-
-    // Mock Entity Resolution Service
     Mock::given(method("POST"))
-        .and(path(
-            "/entityresolution.v2.EntityResolutionService/CreateEntityChainsFromTokens",
-        ))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "entity_chains": [{
-                "id": "chain1",
-                "entities": [{
-                    "id": "user123",
-                    "type": "subject"
-                }]
-            }]
-        })))
+        .and(path("/access/v1/evaluation"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "decision": false })))
         .mount(&mock_server)
         .await;
+    let (sk, vk) = keypair();
+    let client = test_client(&mock_server, vk);
+    let token = pe_token(&sk, KID, now());
+    let err = client
+        .authorize_mcp_method(
+            "tools/call",
+            Some(&json!({"name": "filesystem_write"})),
+            Some(&token),
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, AuthorizationError::Denied));
+    assert_eq!(err.jsonrpc_code(), jsonrpc_codes::DENIED);
+}
 
-    // Mock Authorization Service - Deny
+#[tokio::test]
+async fn test_tools_list_requires_resource_id_in_aud() {
+    let mock_server = MockServer::start().await;
+    let (sk, vk) = keypair();
+    let client = test_client(&mock_server, vk);
+    let token = mint(
+        &sk,
+        KID,
+        ISS,
+        "arkavo:550e8400-e29b-41d4-a716-446655440000",
+        Aud::One("arkavo".into()),
+        now(),
+        now() + 3600,
+        &[],
+        true,
+        true,
+        true,
+    );
+    let err = client
+        .authorize_mcp_method("tools/list", Some(&json!({})), Some(&token))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, AuthorizationError::Mapping(_)));
+    assert_eq!(err.jsonrpc_code(), jsonrpc_codes::MAPPING);
+}
+
+#[tokio::test]
+async fn test_tools_list_permit() {
+    let mock_server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/authorization.v2.AuthorizationService/GetDecision"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "decision": "deny"
-        })))
+        .and(path("/access/v1/evaluation"))
+        .and(body_string_contains("mcp_server"))
+        .and(body_string_contains("mcp_arkavo_net"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "decision": true })))
         .mount(&mock_server)
         .await;
-
-    let config = AuthorizationConfig::default()
-        .with_base_url(&mock_server.uri())
-        .unwrap();
-    let client = AuthorizationClient::new(config).unwrap();
-
+    let (sk, vk) = keypair();
+    let client = test_client(&mock_server, vk);
+    let token = pe_token(&sk, KID, now());
     let decision = client
-        .authorize_mcp_tool("test_token", "filesystem.write")
+        .authorize_mcp_method("tools/list", Some(&json!({})), Some(&token))
         .await
         .unwrap();
-    assert_eq!(decision, Decision::Deny);
+    assert_eq!(decision, Decision::Permit);
 }
 
 #[tokio::test]
-async fn test_bulk_authorization() {
+async fn test_unknown_method_denied_ping_passthrough() {
     let mock_server = MockServer::start().await;
-
-    // Mock Entity Resolution Service
-    Mock::given(method("POST"))
-        .and(path(
-            "/entityresolution.v2.EntityResolutionService/CreateEntityChainsFromTokens",
-        ))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "entity_chains": [{
-                "id": "chain1",
-                "entities": [{
-                    "id": "user123",
-                    "type": "subject"
-                }]
-            }]
-        })))
-        .mount(&mock_server)
-        .await;
-
-    // Mock Bulk Authorization Service
-    Mock::given(method("POST"))
-        .and(path("/authorization.v2.AuthorizationService/GetDecisionBulk"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "decision_responses": [
-                {
-                    "entity_identifier": {"id": "user123", "type": "subject"},
-                    "action": {"name": "execute_tool"},
-                    "resource": {"attribute_value_fqns": ["https://arkavo.net/attr/mcp-tool/value/git.commit"]},
-                    "decision": "permit"
-                },
-                {
-                    "entity_identifier": {"id": "user123", "type": "subject"},
-                    "action": {"name": "execute_tool"},
-                    "resource": {"attribute_value_fqns": ["https://arkavo.net/attr/mcp-tool/value/filesystem.write"]},
-                    "decision": "deny"
-                }
-            ]
-        })))
-        .mount(&mock_server)
-        .await;
-
-    let config = AuthorizationConfig::default()
-        .with_base_url(&mock_server.uri())
-        .unwrap();
-    let client = AuthorizationClient::new(config).unwrap();
-
-    let tools = vec!["git.commit", "filesystem.write", "status"];
-    let results = client
-        .authorize_mcp_tools_bulk("test_token", tools)
+    let (_sk, vk) = keypair();
+    let client = test_client(&mock_server, vk);
+    assert_eq!(
+        client
+            .authorize_mcp_method("ping", None, None)
+            .await
+            .unwrap(),
+        Decision::Permit
+    );
+    assert_eq!(
+        client
+            .authorize_mcp_method("notifications/initialized", None, None)
+            .await
+            .unwrap(),
+        Decision::Permit
+    );
+    let err = client
+        .authorize_mcp_method("resources/list", None, Some("x"))
         .await
-        .unwrap();
-
-    assert_eq!(results.len(), 3);
-
-    // Check individual results
-    let status_result = results.iter().find(|(name, _)| name == "status").unwrap();
-    assert_eq!(status_result.1, Decision::Permit);
-
-    let git_result = results
-        .iter()
-        .find(|(name, _)| name == "git.commit")
-        .unwrap();
-    assert_eq!(git_result.1, Decision::Permit);
-
-    let fs_result = results
-        .iter()
-        .find(|(name, _)| name == "filesystem.write")
-        .unwrap();
-    assert_eq!(fs_result.1, Decision::Deny);
+        .unwrap_err();
+    assert_eq!(err.jsonrpc_code(), jsonrpc_codes::DENIED);
 }
 
 #[tokio::test]
-async fn test_cache_hit() {
+async fn test_pdp_unavailable_and_obligations_fail_closed() {
     let mock_server = MockServer::start().await;
-
-    // Mock Entity Resolution Service - called twice (once per authorize_mcp_tool call)
     Mock::given(method("POST"))
-        .and(path(
-            "/entityresolution.v2.EntityResolutionService/CreateEntityChainsFromTokens",
-        ))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "entity_chains": [{
-                "id": "chain1",
-                "entities": [{
-                    "id": "user123",
-                    "type": "subject"
-                }]
-            }]
-        })))
-        .expect(2)
+        .and(path("/access/v1/evaluation"))
+        .respond_with(ResponseTemplate::new(503))
         .mount(&mock_server)
         .await;
+    let (sk, vk) = keypair();
+    let mut client_cfg_unavailable = test_client(&mock_server, vk);
+    let token = pe_token(&sk, KID, now());
+    let err = client_cfg_unavailable
+        .authorize_mcp_method(
+            "tools/call",
+            Some(&json!({"name": "git_commit"})),
+            Some(&token),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.jsonrpc_code(), jsonrpc_codes::PDP);
 
-    // Mock Authorization Service - should only be called once
+    let mock_server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/authorization.v2.AuthorizationService/GetDecision"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "decision": "permit"
+        .and(path("/access/v1/evaluation"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "decision": true,
+            "context": { "obligations": { "required": ["https://example/obl"] } }
+        })))
+        .mount(&mock_server)
+        .await;
+    client_cfg_unavailable = test_client(&mock_server, vk);
+    let err = client_cfg_unavailable
+        .authorize_mcp_method(
+            "tools/call",
+            Some(&json!({"name": "git_commit"})),
+            Some(&token),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.jsonrpc_code(), jsonrpc_codes::DENIED);
+}
+
+#[tokio::test]
+async fn test_cache_hit_skips_second_pdp_call() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/access/v1/evaluation"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "decision": true })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+    let (sk, vk) = keypair();
+    let client = test_client(&mock_server, vk);
+    let token = pe_token(&sk, KID, now());
+    assert_eq!(
+        client
+            .authorize_mcp_tool(&token, "git_commit")
+            .await
+            .unwrap(),
+        Decision::Permit
+    );
+    assert_eq!(
+        client
+            .authorize_mcp_tool(&token, "git_commit")
+            .await
+            .unwrap(),
+        Decision::Permit
+    );
+}
+
+#[tokio::test]
+async fn test_ttl_from_token_exp_not_jwt_split() {
+    let ttl = crate::cache::DecisionCache::calculate_ttl_from_token(Some(now() + 30));
+    assert!(ttl <= Duration::from_secs(30));
+    let expired = crate::cache::DecisionCache::calculate_ttl_from_token(Some(now() - 10));
+    assert_eq!(expired, Duration::from_mins(1));
+}
+
+#[tokio::test]
+async fn test_missing_token_is_mapping_error() {
+    let mock_server = MockServer::start().await;
+    let (_sk, vk) = keypair();
+    let client = test_client(&mock_server, vk);
+    let err = client
+        .authorize_mcp_method("tools/call", Some(&json!({"name": "x"})), None)
+        .await
+        .unwrap_err();
+    assert_eq!(err.jsonrpc_code(), jsonrpc_codes::MAPPING);
+}
+
+#[tokio::test]
+async fn test_service_cwt_from_client_credentials() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "minted-service-cwt",
+            "expires_in": 3600
         })))
         .expect(1)
         .mount(&mock_server)
         .await;
+    Mock::given(method("POST"))
+        .and(path("/access/v1/evaluation"))
+        .and(header("Authorization", "Bearer minted-service-cwt"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "decision": true })))
+        .mount(&mock_server)
+        .await;
 
-    let config = AuthorizationConfig::default()
-        .with_base_url(&mock_server.uri())
-        .unwrap();
-    let client = AuthorizationClient::new(config).unwrap();
-
-    // First call - should hit the server
-    let decision1 = client
-        .authorize_mcp_tool("test_token", "git.commit")
-        .await
-        .unwrap();
-    assert_eq!(decision1, Decision::Permit);
-
-    // Second call - should hit the cache
-    let decision2 = client
-        .authorize_mcp_tool("test_token", "git.commit")
-        .await
-        .unwrap();
-    assert_eq!(decision2, Decision::Permit);
+    let (sk, vk) = keypair();
+    let eval = url::Url::parse(&format!("{}/access/v1/evaluation", mock_server.uri())).unwrap();
+    let mut config = AuthorizationConfig::default()
+        .with_pdp_url(&mock_server.uri())
+        .unwrap()
+        .with_evaluation_endpoint(eval);
+    config.token_url = Some(format!("{}/oauth/token", mock_server.uri()));
+    config.client_id = Some("mcp-edge".into());
+    config.client_secret = Some("secret".into());
+    config.oidc_issuer = Some(ISS.into());
+    config.mcp_resource_id = "https://mcp.arkavo.net".into();
+    config.service_token = None;
+    let verifier = crate::cwt_verify::CwtVerifier::with_static_keys(vec![(KID.to_vec(), vk)])
+        .with_expected_issuer(ISS.into())
+        .with_audiences(vec!["https://mcp.arkavo.net".into()]);
+    let client = AuthorizationClient::new(config)
+        .unwrap()
+        .with_verifier(verifier);
+    let token = pe_token(&sk, KID, now());
+    assert_eq!(
+        client
+            .authorize_mcp_tool(&token, "git_commit")
+            .await
+            .unwrap(),
+        Decision::Permit
+    );
 }
 
 #[tokio::test]
-async fn test_server_error_retry() {
+async fn test_discovery_then_evaluate() {
     let mock_server = MockServer::start().await;
-
-    // Mock Entity Resolution Service
-    Mock::given(method("POST"))
-        .and(path(
-            "/entityresolution.v2.EntityResolutionService/CreateEntityChainsFromTokens",
-        ))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "entity_chains": [{
-                "id": "chain1",
-                "entities": [{
-                    "id": "user123",
-                    "type": "subject"
-                }]
-            }]
+    Mock::given(method("GET"))
+        .and(path("/.well-known/authzen-configuration"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "policy_decision_point": mock_server.uri(),
+            "access_evaluation_endpoint": format!("{}/access/v1/evaluation", mock_server.uri())
         })))
         .mount(&mock_server)
         .await;
-
-    // Mock Authorization Service - use up_to(2) to handle both initial failure and retry
     Mock::given(method("POST"))
-        .and(path("/authorization.v2.AuthorizationService/GetDecision"))
-        .respond_with(ResponseTemplate::new(503).append_header("content-type", "application/json"))
-        .up_to_n_times(1) // First request fails
+        .and(path("/access/v1/evaluation"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "decision": true })))
         .mount(&mock_server)
         .await;
-
-    Mock::given(method("POST"))
-        .and(path("/authorization.v2.AuthorizationService/GetDecision"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "decision": "permit"
-        })))
-        .expect(1) // Second request succeeds
-        .mount(&mock_server)
-        .await;
-
-    let config = AuthorizationConfig::default()
-        .with_base_url(&mock_server.uri())
+    let (sk, vk) = keypair();
+    let mut config = AuthorizationConfig::default()
+        .with_pdp_url(&mock_server.uri())
         .unwrap()
-        .with_timeout(std::time::Duration::from_secs(1));
-    let client = AuthorizationClient::new(config).unwrap();
-
-    // Should retry and succeed
-    let decision = client
-        .authorize_mcp_tool("test_token", "git.commit")
-        .await
-        .unwrap();
-    assert_eq!(decision, Decision::Permit);
-}
-
-#[test]
-fn test_mcp_tool_mapping() {
-    let resource = McpToolMapping::tool_to_resource("git_commit");
+        .with_service_token(SVC);
+    config.evaluation_endpoint = None;
+    config.oidc_issuer = Some(ISS.into());
+    config.mcp_resource_id = "https://mcp.arkavo.net".into();
+    let verifier = crate::cwt_verify::CwtVerifier::with_static_keys(vec![(KID.to_vec(), vk)])
+        .with_expected_issuer(ISS.into())
+        .with_audiences(vec!["https://mcp.arkavo.net".into()]);
+    let client = AuthorizationClient::new(config)
+        .unwrap()
+        .with_verifier(verifier);
+    let token = pe_token(&sk, KID, now());
     assert_eq!(
-        resource.attribute_value_fqns[0],
-        "https://arkavo.net/attr/mcp-tool/value/git.commit"
+        client.authorize_mcp_tool(&token, "echo").await.unwrap(),
+        Decision::Permit
     );
-
-    let resource = McpToolMapping::tool_to_resource("filesystem_read");
-    assert_eq!(
-        resource.attribute_value_fqns[0],
-        "https://arkavo.net/attr/mcp-tool/value/filesystem.read"
-    );
-
-    let resource = McpToolMapping::tool_to_resource("custom_tool");
-    assert_eq!(
-        resource.attribute_value_fqns[0],
-        "https://arkavo.net/attr/mcp-tool/value/custom_tool"
-    );
-}
-
-#[test]
-fn test_safe_diagnostic_detection() {
-    assert!(McpToolMapping::is_safe_diagnostic("status"));
-    assert!(McpToolMapping::is_safe_diagnostic("health"));
-    assert!(McpToolMapping::is_safe_diagnostic("version"));
-    assert!(McpToolMapping::is_safe_diagnostic("list_tools"));
-
-    assert!(!McpToolMapping::is_safe_diagnostic("git_commit"));
-    assert!(!McpToolMapping::is_safe_diagnostic("filesystem_write"));
 }
 
 #[spec("AUTHZ-001")]
 #[tokio::test]
 async fn test_authz_001_get_decision_permit() {
     let mock_server = MockServer::start().await;
-
-    Mock::given(method("POST"))
-        .and(path("/authorization.v2.AuthorizationService/GetDecision"))
-        .and(header("Content-Type", "application/json"))
-        .and(header("Connect-Protocol-Version", "1"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "decision": "permit"
-        })))
-        .expect(1)
-        .mount(&mock_server)
-        .await;
-
-    let config = AuthorizationConfig::default()
-        .with_base_url(&mock_server.uri())
-        .unwrap();
-    let client = AuthorizationClient::new(config).unwrap();
-
-    let entity = EntityIdentifier {
-        id: "user123".to_string(),
-        entity_type: types::EntityType::Subject,
-        attributes: None,
-    };
-    let action = Action::execute_tool();
-    let resource = Resource::mcp_tool("git.commit");
-
+    mock_pdp_permit(&mock_server).await;
+    let (sk, vk) = keypair();
+    let client = test_client(&mock_server, vk);
+    let token = pe_token(&sk, KID, now());
     let decision = client
-        .get_decision(&entity, &action, &resource)
+        .authorize_mcp_tool(&token, "git_commit")
         .await
         .unwrap();
     assert_eq!(decision, Decision::Permit);
@@ -366,33 +392,16 @@ async fn test_authz_001_get_decision_permit() {
 #[tokio::test]
 async fn test_authz_001_get_decision_deny() {
     let mock_server = MockServer::start().await;
-
     Mock::given(method("POST"))
-        .and(path("/authorization.v2.AuthorizationService/GetDecision"))
-        .and(header("Content-Type", "application/json"))
-        .and(header("Connect-Protocol-Version", "1"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "decision": "deny"
-        })))
-        .expect(1)
+        .and(path("/access/v1/evaluation"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "decision": false })))
         .mount(&mock_server)
         .await;
-
-    let config = AuthorizationConfig::default()
-        .with_base_url(&mock_server.uri())
-        .unwrap();
-    let client = AuthorizationClient::new(config).unwrap();
-
-    let entity = EntityIdentifier {
-        id: "user123".to_string(),
-        entity_type: types::EntityType::Subject,
-        attributes: None,
-    };
-    let action = Action::execute_tool();
-    let resource = Resource::mcp_tool("filesystem.write");
-
+    let (sk, vk) = keypair();
+    let client = test_client(&mock_server, vk);
+    let token = pe_token(&sk, KID, now());
     let decision = client
-        .get_decision(&entity, &action, &resource)
+        .authorize_mcp_tool(&token, "filesystem.write")
         .await
         .unwrap();
     assert_eq!(decision, Decision::Deny);
@@ -402,81 +411,102 @@ async fn test_authz_001_get_decision_deny() {
 #[tokio::test]
 async fn test_authz_001_get_decision_service_unavailable() {
     let mock_server = MockServer::start().await;
-
     Mock::given(method("POST"))
-        .and(path("/authorization.v2.AuthorizationService/GetDecision"))
-        .respond_with(ResponseTemplate::new(503).append_header("content-type", "application/json"))
-        .expect(1)
+        .and(path("/access/v1/evaluation"))
+        .respond_with(ResponseTemplate::new(503))
         .mount(&mock_server)
         .await;
-
-    let config = AuthorizationConfig::default()
-        .with_base_url(&mock_server.uri())
-        .unwrap()
-        .with_timeout(std::time::Duration::from_millis(100));
-    let mut config = config;
-    config.max_retries = 0;
-    let client = AuthorizationClient::new(config).unwrap();
-
-    let entity = EntityIdentifier {
-        id: "user123".to_string(),
-        entity_type: types::EntityType::Subject,
-        attributes: None,
-    };
-    let action = Action::execute_tool();
-    let resource = Resource::mcp_tool("git.commit");
-
-    let result = client.get_decision(&entity, &action, &resource).await;
+    let (sk, vk) = keypair();
+    let client = test_client(&mock_server, vk);
+    let token = pe_token(&sk, KID, now());
+    let result = client.authorize_mcp_tool(&token, "git_commit").await;
     assert!(result.is_err());
+    assert_eq!(result.unwrap_err().jsonrpc_code(), jsonrpc_codes::PDP);
 }
 
 #[spec("AUTHZ-001")]
 #[tokio::test]
 async fn test_authz_001_get_decision_caches_with_ttl() {
     let mock_server = MockServer::start().await;
-
     Mock::given(method("POST"))
-        .and(path(
-            "/entityresolution.v2.EntityResolutionService/CreateEntityChainsFromTokens",
-        ))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "entity_chains": [{
-                "id": "chain1",
-                "entities": [{
-                    "id": "user123",
-                    "type": "subject"
-                }]
-            }]
-        })))
-        .expect(2)
-        .mount(&mock_server)
-        .await;
-
-    Mock::given(method("POST"))
-        .and(path("/authorization.v2.AuthorizationService/GetDecision"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "decision": "permit"
-        })))
+        .and(path("/access/v1/evaluation"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "decision": true })))
         .expect(1)
         .mount(&mock_server)
         .await;
+    let (sk, vk) = keypair();
+    let client = test_client(&mock_server, vk);
+    let token = pe_token(&sk, KID, now());
+    assert_eq!(
+        client
+            .authorize_mcp_tool(&token, "git_commit")
+            .await
+            .unwrap(),
+        Decision::Permit
+    );
+    assert_eq!(
+        client
+            .authorize_mcp_tool(&token, "git_commit")
+            .await
+            .unwrap(),
+        Decision::Permit
+    );
+}
 
-    let config = AuthorizationConfig::default()
-        .with_base_url(&mock_server.uri())
-        .unwrap();
-    let client = AuthorizationClient::new(config).unwrap();
-
-    // First call fetches and caches the decision.
-    let decision1 = client
-        .authorize_mcp_tool("test_token", "git.commit")
+#[tokio::test]
+async fn test_bulk_authorization() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/access/v1/evaluation"))
+        .and(body_string_contains("git_commit"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "decision": true })))
+        .mount(&mock_server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/access/v1/evaluation"))
+        .and(body_string_contains("filesystem_write"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "decision": false })))
+        .mount(&mock_server)
+        .await;
+    let (sk, vk) = keypair();
+    let client = test_client(&mock_server, vk);
+    let token = pe_token(&sk, KID, now());
+    let results = client
+        .authorize_mcp_tools_bulk(&token, vec!["git.commit", "filesystem.write", "status"])
         .await
         .unwrap();
-    assert_eq!(decision1, Decision::Permit);
+    assert_eq!(results.len(), 3);
+    assert_eq!(
+        results.iter().find(|(n, _)| n == "status").unwrap().1,
+        Decision::Permit
+    );
+    assert_eq!(
+        results.iter().find(|(n, _)| n == "git.commit").unwrap().1,
+        Decision::Permit
+    );
+    assert_eq!(
+        results
+            .iter()
+            .find(|(n, _)| n == "filesystem.write")
+            .unwrap()
+            .1,
+        Decision::Deny
+    );
+}
 
-    // Second call hits the cache; no new authorization request is made.
-    let decision2 = client
-        .authorize_mcp_tool("test_token", "git.commit")
-        .await
-        .unwrap();
-    assert_eq!(decision2, Decision::Permit);
+#[tokio::test]
+async fn test_user_cwt_not_sent_as_authzen_bearer() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/access/v1/evaluation"))
+        .and(header("Authorization", format!("Bearer {SVC}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "decision": true })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+    let (sk, vk) = keypair();
+    let client = test_client(&mock_server, vk);
+    let token = pe_token(&sk, KID, now());
+    assert_ne!(token, SVC);
+    client.authorize_mcp_tool(&token, "echo").await.unwrap();
 }

--- a/crates/arkavo-authorization/src/types.rs
+++ b/crates/arkavo-authorization/src/types.rs
@@ -1,30 +1,10 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum Decision {
     Permit,
     Deny,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EntityIdentifier {
-    pub id: String,
-    #[serde(rename = "type")]
-    pub entity_type: EntityType,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub attributes: Option<HashMap<String, String>>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum EntityType {
-    ClientId,
-    Email,
-    Username,
-    Subject,
-    Custom(String),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -40,11 +20,9 @@ impl Resource {
     }
 
     pub fn mcp_tool(tool_name: &str) -> Self {
+        let slug = crate::cwt_subject::tool_value_slug(tool_name);
         Self {
-            attribute_value_fqns: vec![format!(
-                "https://arkavo.net/attr/mcp-tool/value/{}",
-                tool_name
-            )],
+            attribute_value_fqns: vec![format!("https://arkavo.net/attr/mcp-tool/value/{slug}")],
         }
     }
 }
@@ -55,9 +33,15 @@ pub struct Action {
 }
 
 impl Action {
-    pub fn execute_tool() -> Self {
+    pub fn tools_call() -> Self {
         Self {
-            name: "execute_tool".to_string(),
+            name: "tools/call".to_string(),
+        }
+    }
+
+    pub fn tools_list() -> Self {
+        Self {
+            name: "tools/list".to_string(),
         }
     }
 
@@ -68,105 +52,24 @@ impl Action {
     }
 }
 
-// Entity Resolution v2 types
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CreateEntityChainsFromTokensRequest {
-    pub tokens: Vec<String>,
+#[derive(Debug, Clone, Deserialize)]
+pub struct AuthzenEvaluationResponse {
+    pub decision: bool,
+    #[serde(default)]
+    pub context: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CreateEntityChainsFromTokensResponse {
-    pub entity_chains: Vec<EntityChain>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EntityChain {
-    pub id: String,
-    pub entities: Vec<EntityIdentifier>,
-}
-
-// Authorization v2 - GetDecision
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GetDecisionRequest {
-    pub entity_identifier: EntityIdentifier,
-    pub action: Action,
-    pub resource: Resource,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GetDecisionResponse {
-    pub decision: Decision,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub obligations: Option<Vec<String>>,
-}
-
-// Authorization v2 - GetDecisionMultiResource
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GetDecisionMultiResourceRequest {
-    pub entity_identifier: EntityIdentifier,
-    pub action: Action,
-    pub resources: Vec<Resource>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GetDecisionMultiResourceResponse {
-    pub decisions: Vec<ResourceDecision>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ResourceDecision {
-    pub resource: Resource,
-    pub decision: Decision,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub obligations: Option<Vec<String>>,
-}
-
-// Authorization v2 - GetDecisionBulk
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GetDecisionBulkRequest {
-    pub decision_requests: Vec<DecisionRequest>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DecisionRequest {
-    pub entity_identifier: EntityIdentifier,
-    pub action: Action,
-    pub resource: Resource,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GetDecisionBulkResponse {
-    pub decision_responses: Vec<DecisionResponse>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DecisionResponse {
-    pub entity_identifier: EntityIdentifier,
-    pub action: Action,
-    pub resource: Resource,
-    pub decision: Decision,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub obligations: Option<Vec<String>>,
-}
-
-// MCP Tool mapping helpers
 pub struct McpToolMapping;
 
 impl McpToolMapping {
+    /// OpenTDF attribute values cannot contain `.`; dots become underscores.
     pub fn tool_to_resource(tool_name: &str) -> Resource {
-        let fqn = match tool_name {
-            "filesystem_read" => "https://arkavo.net/attr/mcp-tool/value/filesystem.read",
-            "filesystem_write" => "https://arkavo.net/attr/mcp-tool/value/filesystem.write",
-            "git_commit" => "https://arkavo.net/attr/mcp-tool/value/git.commit",
-            "git_push" => "https://arkavo.net/attr/mcp-tool/value/git.push",
-            "device_tap" => "https://arkavo.net/attr/mcp-tool/value/device_management.tap",
-            "device_swipe" => "https://arkavo.net/attr/mcp-tool/value/device_management.swipe",
-            _ => &format!("https://arkavo.net/attr/mcp-tool/value/{tool_name}"),
-        };
-        Resource::new(vec![fqn.to_string()])
+        Resource::mcp_tool(tool_name)
     }
 
+    /// `list_tools` is a normal `tools/call` tool, not a diagnostic bypass.
+    /// `status` / `health` / `version` remain a documented 90-day exception.
     pub fn is_safe_diagnostic(tool_name: &str) -> bool {
-        matches!(tool_name, "status" | "health" | "version" | "list_tools")
+        matches!(tool_name, "status" | "health" | "version")
     }
 }

--- a/crates/arkavo-mcp-claude/src/policy_bridge.rs
+++ b/crates/arkavo-mcp-claude/src/policy_bridge.rs
@@ -176,9 +176,8 @@ impl PolicyBridge {
         auth_client: &AuthorizationClient,
         tool_name: &str,
     ) -> Result<Decision> {
-        let token = std::env::var("CLAUDE_CODE_SESSION_ACCESS_TOKEN")
-            .or_else(|_| std::env::var("ANTHROPIC_API_KEY"))
-            .unwrap_or_default();
+        // Subject credential MUST be an Arkavo CWT. ANTHROPIC_API_KEY is not a CWT.
+        let token = std::env::var("CLAUDE_CODE_SESSION_ACCESS_TOKEN").unwrap_or_default();
 
         if token.is_empty() {
             warn!("No auth token available for authorization check, denying tool: {tool_name}");

--- a/crates/arkavo-mcp-runtime/Cargo.toml
+++ b/crates/arkavo-mcp-runtime/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 arkavo-mcp = { path = "../arkavo-mcp" }
+arkavo-authorization = { path = "../arkavo-authorization" }
 arkavo-llm = { path = "../arkavo-llm", default-features = false, features = ["llm-remote"] }
 arkavo-memory = { path = "../arkavo-memory" }
 arkavo-validation = { path = "../arkavo-validation" }

--- a/crates/arkavo-mcp-runtime/src/server.rs
+++ b/crates/arkavo-mcp-runtime/src/server.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use arkavo_authorization::{AuthorizationClient, AuthorizationError};
 use arkavo_mcp::{RpcError, RpcRequest, RpcResponse, Tool, ToolRequest, ToolResponse, error_codes};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -9,6 +10,7 @@ use tracing::{debug, info};
 /// MCP server that manages tools and handles requests
 pub struct McpServer {
     tools: Arc<RwLock<HashMap<String, Arc<dyn Tool>>>>,
+    pep: Option<Arc<AuthorizationClient>>,
 }
 
 impl McpServer {
@@ -16,7 +18,14 @@ impl McpServer {
     pub fn new() -> Self {
         Self {
             tools: Arc::new(RwLock::new(HashMap::new())),
+            pep: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_pep(mut self, pep: Arc<AuthorizationClient>) -> Self {
+        self.pep = Some(pep);
+        self
     }
 
     /// Register a tool with the server
@@ -95,52 +104,118 @@ impl McpServer {
         })
     }
 
-    /// Handle a JSON-RPC request
+    async fn list_mcp_tools(&self) -> Value {
+        let tools = self.tools.read().await;
+        let listed: Vec<Value> = tools
+            .values()
+            .map(|tool| {
+                let schema = tool.schema();
+                serde_json::json!({
+                    "name": schema.name,
+                    "description": schema.description,
+                    "inputSchema": schema.parameters
+                })
+            })
+            .collect();
+        serde_json::json!({ "tools": listed })
+    }
+
+    async fn pep_gate(
+        &self,
+        method: &str,
+        params: Option<&Value>,
+        subject_cwt: Option<&str>,
+    ) -> Option<RpcError> {
+        let Some(pep) = &self.pep else {
+            return None;
+        };
+        match pep.authorize_mcp_method(method, params, subject_cwt).await {
+            Ok(_) => None,
+            Err(e) => Some(pep_rpc_error(&e)),
+        }
+    }
+
+    /// Handle a JSON-RPC request. `subject_cwt` is the inbound Bearer or CWT-only env.
     pub async fn handle_rpc_request(&self, request: RpcRequest) -> RpcResponse {
+        self.handle_rpc_request_with_subject(request, None).await
+    }
+
+    pub async fn handle_rpc_request_with_subject(
+        &self,
+        request: RpcRequest,
+        subject_cwt: Option<&str>,
+    ) -> RpcResponse {
         debug!("Handling RPC request: method={}", request.method);
 
+        if request.method == "ping" || request.method.starts_with("notifications/") {
+            return rpc_ok(request.id, serde_json::json!({}));
+        }
+
         match request.method.as_str() {
+            "tools/call" => {
+                if let Some(err) = self
+                    .pep_gate("tools/call", request.params.as_ref(), subject_cwt)
+                    .await
+                {
+                    return rpc_err(request.id, err);
+                }
+                self.handle_tools_call(request).await
+            }
+            "tools/list" => {
+                if let Some(err) = self
+                    .pep_gate("tools/list", request.params.as_ref(), subject_cwt)
+                    .await
+                {
+                    return rpc_err(request.id, err);
+                }
+                rpc_ok(request.id, self.list_mcp_tools().await)
+            }
             "execute_tool" => match request.params {
-                Some(params) => match serde_json::from_value::<ToolRequest>(params) {
+                Some(params) => match serde_json::from_value::<ToolRequest>(params.clone()) {
                     Ok(tool_request) => {
-                        let response = self.execute_tool(tool_request).await;
-                        RpcResponse {
-                            jsonrpc: "2.0".to_string(),
-                            id: request.id,
-                            result: Some(serde_json::to_value(response).unwrap_or(Value::Null)),
-                            error: None,
+                        let mapped = serde_json::json!({ "name": tool_request.tool_name });
+                        if let Some(err) = self
+                            .pep_gate("tools/call", Some(&mapped), subject_cwt)
+                            .await
+                        {
+                            return rpc_err(request.id, err);
                         }
+                        let response = self.execute_tool(tool_request).await;
+                        rpc_ok(
+                            request.id,
+                            serde_json::to_value(response).unwrap_or(Value::Null),
+                        )
                     }
-                    Err(e) => RpcResponse {
-                        jsonrpc: "2.0".to_string(),
-                        id: request.id,
-                        result: None,
-                        error: Some(RpcError {
+                    Err(e) => rpc_err(
+                        request.id,
+                        RpcError {
                             code: error_codes::INVALID_PARAMS,
                             message: format!("Invalid tool request: {e}"),
                             data: None,
-                        }),
-                    },
+                        },
+                    ),
                 },
-                None => RpcResponse {
-                    jsonrpc: "2.0".to_string(),
-                    id: request.id,
-                    result: None,
-                    error: Some(RpcError {
+                None => rpc_err(
+                    request.id,
+                    RpcError {
                         code: error_codes::INVALID_PARAMS,
                         message: "Missing parameters".to_string(),
                         data: None,
-                    }),
-                },
+                    },
+                ),
             },
             "list_tools" => {
-                let tools = self.list_tools().await;
-                RpcResponse {
-                    jsonrpc: "2.0".to_string(),
-                    id: request.id,
-                    result: Some(serde_json::to_value(tools).unwrap_or(Value::Null)),
-                    error: None,
+                if let Some(err) = self
+                    .pep_gate("tools/list", request.params.as_ref(), subject_cwt)
+                    .await
+                {
+                    return rpc_err(request.id, err);
                 }
+                let tools = self.list_tools().await;
+                rpc_ok(
+                    request.id,
+                    serde_json::to_value(tools).unwrap_or(Value::Null),
+                )
             }
             "get_tool_schema" => {
                 let tool_name = request
@@ -151,46 +226,127 @@ impl McpServer {
 
                 match tool_name {
                     Some(tool_name) => match self.get_tool_schema(tool_name).await {
-                        Some(schema) => RpcResponse {
-                            jsonrpc: "2.0".to_string(),
-                            id: request.id,
-                            result: Some(schema),
-                            error: None,
-                        },
-                        None => RpcResponse {
-                            jsonrpc: "2.0".to_string(),
-                            id: request.id,
-                            result: None,
-                            error: Some(RpcError {
+                        Some(schema) => rpc_ok(request.id, schema),
+                        None => rpc_err(
+                            request.id,
+                            RpcError {
                                 code: error_codes::INVALID_PARAMS,
                                 message: format!("Tool '{tool_name}' not found"),
                                 data: None,
-                            }),
-                        },
+                            },
+                        ),
                     },
-                    None => RpcResponse {
-                        jsonrpc: "2.0".to_string(),
-                        id: request.id,
-                        result: None,
-                        error: Some(RpcError {
+                    None => rpc_err(
+                        request.id,
+                        RpcError {
                             code: error_codes::INVALID_PARAMS,
                             message: "Missing 'tool_name' parameter".to_string(),
                             data: None,
-                        }),
-                    },
+                        },
+                    ),
                 }
             }
-            _ => RpcResponse {
-                jsonrpc: "2.0".to_string(),
-                id: request.id,
-                result: None,
-                error: Some(RpcError {
+            _ if self.pep.is_some() => rpc_err(
+                request.id,
+                RpcError {
+                    code: error_codes::AUTHORIZATION_DENIED,
+                    message: format!("Unknown method denied: {}", request.method),
+                    data: None,
+                },
+            ),
+            _ => rpc_err(
+                request.id,
+                RpcError {
                     code: error_codes::METHOD_NOT_FOUND,
                     message: format!("Unknown method: {}", request.method),
                     data: None,
-                }),
-            },
+                },
+            ),
         }
+    }
+
+    async fn handle_tools_call(&self, request: RpcRequest) -> RpcResponse {
+        let Some(params) = request.params else {
+            return rpc_err(
+                request.id,
+                RpcError {
+                    code: error_codes::INVALID_PARAMS,
+                    message: "Missing parameters".to_string(),
+                    data: None,
+                },
+            );
+        };
+        let Some(tool_name) = params
+            .get("name")
+            .or_else(|| params.get("tool_name"))
+            .and_then(|v| v.as_str())
+        else {
+            return rpc_err(
+                request.id,
+                RpcError {
+                    code: error_codes::INVALID_PARAMS,
+                    message: "tools/call requires params.name".to_string(),
+                    data: None,
+                },
+            );
+        };
+        let args = params
+            .get("arguments")
+            .cloned()
+            .or_else(|| params.get("params").cloned())
+            .unwrap_or(Value::Null);
+        let response = self
+            .execute_tool(ToolRequest {
+                tool_name: tool_name.to_string(),
+                params: args,
+            })
+            .await;
+        if response.success {
+            rpc_ok(
+                request.id,
+                serde_json::json!({
+                    "content": [{
+                        "type": "text",
+                        "text": response.result.to_string()
+                    }]
+                }),
+            )
+        } else {
+            rpc_err(
+                request.id,
+                RpcError {
+                    code: error_codes::INTERNAL_ERROR,
+                    message: response.result.to_string(),
+                    data: None,
+                },
+            )
+        }
+    }
+}
+
+fn pep_rpc_error(err: &AuthorizationError) -> RpcError {
+    RpcError {
+        code: err.jsonrpc_code(),
+        message: err.to_string(),
+        data: None,
+    }
+}
+
+fn rpc_ok(id: Option<Value>, result: Value) -> RpcResponse {
+    RpcResponse {
+        jsonrpc: "2.0".to_string(),
+        id,
+        result: Some(result),
+        error: None,
+    }
+}
+
+fn rpc_err(id: Option<Value>, error: RpcError) -> RpcResponse {
+    RpcResponse {
+        jsonrpc: "2.0".to_string(),
+        id,
+        result: None,
+        error: Some(error),
     }
 }
 

--- a/crates/arkavo-mcp-runtime/tests/mcp_runtime_critical_spec_tests.rs
+++ b/crates/arkavo-mcp-runtime/tests/mcp_runtime_critical_spec_tests.rs
@@ -57,6 +57,54 @@ async fn mcp_server_creation_initializes_state_and_serves_requests() {
         .expect("list_tools result should be an array")
         .clone();
     assert!(result_tools.iter().any(|v| v.as_str() == Some("echo")));
+
+    let ping = server
+        .handle_rpc_request(RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(2)),
+            method: "ping".to_string(),
+            params: None,
+        })
+        .await;
+    assert!(ping.error.is_none());
+
+    let call = server
+        .handle_rpc_request(RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(3)),
+            method: "tools/call".to_string(),
+            params: Some(serde_json::json!({"name": "echo", "arguments": {"msg": "hi"}})),
+        })
+        .await;
+    assert!(call.error.is_none());
+
+    let listed = server
+        .handle_rpc_request(RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(4)),
+            method: "tools/list".to_string(),
+            params: Some(serde_json::json!({})),
+        })
+        .await;
+    assert!(listed.error.is_none());
+    assert!(
+        listed
+            .result
+            .as_ref()
+            .and_then(|v| v.get("tools"))
+            .and_then(|v| v.as_array())
+            .is_some()
+    );
+
+    let note = server
+        .handle_rpc_request(RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            method: "notifications/initialized".to_string(),
+            params: None,
+        })
+        .await;
+    assert!(note.error.is_none());
 }
 
 #[cfg(unix)]

--- a/crates/arkavo-mcp/src/lib.rs
+++ b/crates/arkavo-mcp/src/lib.rs
@@ -149,4 +149,6 @@ pub mod error_codes {
     pub const METHOD_NOT_FOUND: i32 = -32601;
     pub const INVALID_PARAMS: i32 = -32602;
     pub const INTERNAL_ERROR: i32 = -32603;
+    /// AuthZEN deny (draft-arkavo-authzen-cwt-00).
+    pub const AUTHORIZATION_DENIED: i32 = -32001;
 }


### PR DESCRIPTION
## Summary

Implements spec **PR 4** from [draft-arkavo-authzen-cwt-00](https://github.com/arkavo-org/specifications/blob/main/authzen-cwt/draft-arkavo-authzen-cwt-00.md).

- Hardcoded AuthZEN SARC for MCP `tools/call` and `tools/list` (no CEL)
- Union CWT verify + `$token` mapper (copy, no shared crate)
- Service CWT authenticates the PEP; user CWT is never the AuthZEN Bearer
- Dispatcher: `crates/arkavo-mcp-runtime/src/server.rs` (there is no `arkavo-mcp-proxy`)
- Dropped `ANTHROPIC_API_KEY` as a subject credential
- `git.commit` FQNs become `git_commit`; `list_tools` is no longer a diagnostic bypass
- Fail-closed: JSON-RPC `-32001` / `-32602` / `-32603`

PEP attaches only when AuthZEN is configured so existing local MCP tests still run.

## Test plan

- [x] `cargo test -p arkavo-authorization` — 35 passed (mock AuthZEN / wiremock)
- [ ] `cargo clippy -p arkavo-authorization -- -D warnings`
- [ ] Manual: with `AUTHZEN_PDP_URL` set, `tools/list` requires `AUTHZEN_MCP_RESOURCE_ID` in `$token.aud`