### PR TITLE
Default AG-UI gateway bind to loopback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui-protocol"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "serde",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-device-identity",
  "arkavo-test-macros",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "chrono",
  "serde",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-test-macros",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "git2",
  "tempfile",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1223,11 +1223,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-lesson-synthesis"
-version = "0.89.4"
+version = "0.89.6"
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "bindgen",
  "cc",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "lru",
  "serde",
@@ -1805,7 +1805,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-shadow-consolidation"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-lesson-synthesis",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "libc",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-budget",
  "arkavo-test-macros",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -2081,7 +2081,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.89.4"
+version = "0.89.6"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-agui/README.md
+++ b/crates/arkavo-agui/README.md
@@ -10,3 +10,7 @@ AG-UI (Agentic GUI) protocol implementation and web gateway for Arkavo Edge.
 - **Status Monitoring**: Integrated monitoring for system health, MCP tools, and LLM connections.
 - **AG-UI Protocol**: Full implementation of the Agentic GUI event protocol for agent-to-user interaction.
 - **MCP Tool Integration**: Designed to leverage MCP tools for data-driven UI generation and refinement.
+
+## Configuration
+
+- `ARKAVO_AGUI_BIND`: IP address the gateway listens on. Defaults to `127.0.0.1` (loopback only). The gateway has no authentication, so set this explicitly (e.g. `0.0.0.0`) only when you intentionally want remote browser access, such as developing from another machine. Invalid values fall back to loopback.

--- a/crates/arkavo-agui/src/gateway.rs
+++ b/crates/arkavo-agui/src/gateway.rs
@@ -486,9 +486,18 @@ impl AgUiGateway {
             .layer(crate::gateway_security::security_headers())
             .with_state(state);
 
-        let addr: SocketAddr = ([0, 0, 0, 0], self.port).into();
-        println!("Starting AG-UI Gateway on http://127.0.0.1:{}", self.port);
-        println!("Open http://127.0.0.1:{} in your web browser", self.port);
+        let addr = crate::gateway_bind::resolve_bind_addr(self.port);
+        if addr.ip().is_loopback() {
+            println!("Starting AG-UI Gateway on http://127.0.0.1:{}", self.port);
+            println!("Open http://127.0.0.1:{} in your web browser", self.port);
+        } else {
+            println!("Starting AG-UI Gateway on http://{addr}");
+            eprintln!(
+                "AG-UI: WARNING — gateway has no authentication and is reachable from the network ({}={})",
+                crate::gateway_bind::BIND_ENV_VAR,
+                addr.ip()
+            );
+        }
 
         let listener = tokio::net::TcpListener::bind(addr).await?;
         axum::serve(

--- a/crates/arkavo-agui/src/gateway_bind.rs
+++ b/crates/arkavo-agui/src/gateway_bind.rs
@@ -1,0 +1,86 @@
+//! Bind address resolution for the AG-UI gateway.
+//!
+//! The gateway serves an unauthenticated control surface (run agents, read
+//! config, stream telemetry), so it must not listen on a routable interface
+//! by default. The bind address defaults to loopback; set `ARKAVO_AGUI_BIND`
+//! to an IP (e.g. `0.0.0.0`) to explicitly expose it for remote browser
+//! access in development.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+pub const BIND_ENV_VAR: &str = "ARKAVO_AGUI_BIND";
+
+/// Resolve the gateway bind address for `port`, honoring `ARKAVO_AGUI_BIND`.
+pub fn resolve_bind_addr(port: u16) -> SocketAddr {
+    parse_bind_addr(std::env::var(BIND_ENV_VAR).ok().as_deref(), port)
+}
+
+/// Pure resolution logic, kept separate from env access for testability.
+fn parse_bind_addr(value: Option<&str>, port: u16) -> SocketAddr {
+    let Some(raw) = value else {
+        return loopback(port);
+    };
+    match raw.trim().parse::<IpAddr>() {
+        Ok(ip) => SocketAddr::new(ip, port),
+        Err(_) => {
+            // Fail closed: an invalid override must never widen the bind.
+            eprintln!("AG-UI: invalid {BIND_ENV_VAR} value '{raw}', falling back to 127.0.0.1");
+            loopback(port)
+        }
+    }
+}
+
+fn loopback(port: u16) -> SocketAddr {
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_bind_is_loopback() {
+        let addr = parse_bind_addr(None, 7700);
+        assert!(addr.ip().is_loopback());
+        assert_eq!(addr.port(), 7700);
+    }
+
+    #[test]
+    fn explicit_wildcard_bind_is_honored() {
+        let addr = parse_bind_addr(Some("0.0.0.0"), 7700);
+        assert_eq!(addr.ip(), IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+        assert_eq!(addr.port(), 7700);
+    }
+
+    #[test]
+    fn explicit_specific_bind_is_honored() {
+        let addr = parse_bind_addr(Some("192.168.1.10"), 8080);
+        assert_eq!(addr.ip(), IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)));
+        assert_eq!(addr.port(), 8080);
+    }
+
+    #[test]
+    fn invalid_bind_falls_back_to_loopback() {
+        let addr = parse_bind_addr(Some("not-an-ip"), 7700);
+        assert!(addr.ip().is_loopback());
+    }
+
+    #[test]
+    #[serial_test::serial(env_arkavo_agui_bind)]
+    fn env_override_resolution() {
+        let prev = std::env::var(BIND_ENV_VAR).ok();
+        // SAFETY: serial_test serializes any test in this binary that
+        // touches the same key, so set_var/remove_var calls do not race.
+        unsafe {
+            std::env::set_var(BIND_ENV_VAR, "0.0.0.0");
+        }
+        let addr = resolve_bind_addr(7700);
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(BIND_ENV_VAR, v),
+                None => std::env::remove_var(BIND_ENV_VAR),
+            }
+        }
+        assert_eq!(addr.ip(), IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+    }
+}

--- a/crates/arkavo-agui/src/lib.rs
+++ b/crates/arkavo-agui/src/lib.rs
@@ -10,6 +10,7 @@ pub mod dataflow_handler;
 pub mod debug_handler;
 pub mod gateway;
 pub mod gateway_agent;
+pub mod gateway_bind;
 pub mod gateway_config;
 pub mod gateway_context;
 pub mod gateway_events;


### PR DESCRIPTION
## What

The AG-UI gateway bound `0.0.0.0` with no authentication, exposing its full control surface (run agents, read/update config, telemetry, debug endpoints) to anything on the local network.

- Default bind is now `127.0.0.1` (loopback only).
- Opt into a wider bind explicitly via the `ARKAVO_AGUI_BIND` env var (e.g. `ARKAVO_AGUI_BIND=0.0.0.0 arkavo ui`), following the crate's existing `ARKAVO_*` env-var configuration pattern. Useful for remote browser access in development.
- Invalid `ARKAVO_AGUI_BIND` values fail closed to loopback, and a warning is printed whenever the gateway binds a non-loopback address.
- Documented in `crates/arkavo-agui/README.md`.

No new dependencies (tests use `serial_test`, already a dev-dependency). No auth layer added — deliberately out of scope for this PR.

## Test

New unit tests in `crates/arkavo-agui/src/gateway_bind.rs` assert the default bind is loopback, explicit wildcard/specific binds are honored, the env override works, and invalid values fall back to loopback. `cargo nextest run -p arkavo-agui`: 142 passed. Clippy clean on the CI-matching invocation (`--lib --bins --no-default-features --features mdns`).