### PR TITLE
Fix stale model expectation in router fallback test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui-protocol"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "serde",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-device-identity",
  "arkavo-test-macros",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "chrono",
  "serde",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-test-macros",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "git2",
  "tempfile",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1223,11 +1223,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-lesson-synthesis"
-version = "0.89.4"
+version = "0.89.6"
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "bindgen",
  "cc",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "lru",
  "serde",
@@ -1805,7 +1805,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-shadow-consolidation"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-lesson-synthesis",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "libc",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-budget",
  "arkavo-test-macros",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -2081,7 +2081,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.89.4"
+version = "0.89.6"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-orchestrator/tests/gemini_3_orc_suite_c.rs
+++ b/crates/arkavo-orchestrator/tests/gemini_3_orc_suite_c.rs
@@ -1,7 +1,7 @@
 // Phase 2: Orchestrator E2E Tests - Suite C (Multi-Agent Handoffs)
 // Issue #358: Gemini 3 Pro Preview Multi-Environment E2E Test Plan
 
-use arkavo_router::{ModelChoice, Router};
+use arkavo_router::Router;
 
 fn should_skip_integration_tests() -> bool {
     std::env::var("GEMINI_API_KEY").is_err()
@@ -135,12 +135,12 @@ async fn test_orc_01c_router_fallback() {
 
     println!("Offline mode routed to: {:?}", decision.recommended_model);
 
-    // In offline mode, should always use a local model
+    // In offline mode, should always use a local model. Assert against the
+    // canonical registry predicate instead of a hardcoded variant list — the
+    // selector picks among all cached local models, so any `is_local()` arm
+    // is a valid fallback.
     assert!(
-        matches!(
-            decision.recommended_model,
-            ModelChoice::LocalGemma4B | ModelChoice::LocalQwen3
-        ),
+        decision.recommended_model.is_local(),
         "Offline mode should route to local model, got: {:?}",
         decision.recommended_model
     );


### PR DESCRIPTION
## What

`test_orc_01c_router_fallback` (crates/arkavo-orchestrator/tests/gemini_3_orc_suite_c.rs) asserted the offline-mode fallback must be exactly `LocalGemma4B | LocalQwen3`. The router's selector now picks among all cached local models via Thompson Sampling / availability (observed on this machine: `LocalGlm47Flash`, `LocalQwen35_27B`; `LocalGemma4_31B` is also reachable), so the hardcoded list went stale and the test failed on any machine with newer local models cached.

## Fix

The router behavior is correct — every model it returns is a valid local arm in the canonical `ModelChoice` registry (crates/arkavo-router/src/decision.rs). The test is what was stale. It now asserts `decision.recommended_model.is_local()`, the registry's own predicate, which matches the test's documented intent ("in offline mode, should always use a local model") without enumerating variants that drift as the registry grows. No other test logic changed; no router code changed.

## Version

Bumps workspace version to 0.89.6 (Verify Version Increment gate) and commits the regenerated `Cargo.lock`.

## Dependencies

No new dependencies.

## Verification

- `cargo nextest run -p arkavo-orchestrator`: 173 passed, 0 failed, 3 skipped (includes the previously failing `test_orc_01c_router_fallback`, now passing in 92s)
- `cargo fmt` applied; `git diff --check` clean
- Clippy note: CI lints only `--lib --bins` and does not include arkavo-orchestrator; `--all-targets` on this crate has pre-existing pedantic warnings and 3 `disallowed_methods` hits on the pre-existing `eprintln!` calls in this test file (unchanged by this PR)