### PR TITLE
Add arkavo-permit crate with CWT permit schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -207,7 +207,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui-protocol"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "serde",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-device-identity",
  "arkavo-test-macros",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "chrono",
  "serde",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-test-macros",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "git2",
  "tempfile",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1223,11 +1223,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-lesson-synthesis"
-version = "0.89.4"
+version = "0.89.6"
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "bindgen",
  "cc",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1624,8 +1624,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "arkavo-permit"
+version = "0.89.6"
+dependencies = [
+ "arkavo-crypto",
+ "blake3",
+ "ciborium",
+ "coset",
+ "hex",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "arkavo-policy-cache"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1635,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1697,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1715,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1729,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1748,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1792,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "lru",
  "serde",
@@ -1805,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1823,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1852,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1931,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1966,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-shadow-consolidation"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-lesson-synthesis",
@@ -1984,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "libc",
@@ -1997,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-budget",
  "arkavo-test-macros",
@@ -2013,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -2039,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -2058,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -2081,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -2098,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -2122,7 +2136,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2133,7 +2147,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2146,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2158,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2167,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2181,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2200,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2215,7 +2229,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2240,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2250,7 +2264,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.89.4"
+version = "0.89.6"
 dependencies = [
  "alloy-primitives",
  "bip39",
@@ -3327,6 +3341,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "coset"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8cc80f631f8307b887faca24dcc3abc427cd0367f6eb6188f6e8f5b7ad8fb"
+dependencies = [
+ "ciborium",
+ "ciborium-io",
+]
+
+[[package]]
 name = "cpu-time"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3930,7 +3954,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4237,7 +4261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5418,7 +5442,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5438,7 +5462,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6063,7 +6087,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7338,7 +7362,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -7381,7 +7405,7 @@ checksum = "b56d621ed2c1773b5356ab39cc68c819f8d0103f7493d8661c4a5f5f8ea55f40"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -7428,7 +7452,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8641,7 +8665,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8679,7 +8703,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -9457,7 +9481,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9537,7 +9561,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.8",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9753,7 +9777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10231,7 +10255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10733,7 +10757,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10755,7 +10779,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12298,7 +12322,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ members = [
     "crates/arkavo-policy-cache",
     "crates/arkavo-adaptation",
     "crates/arkavo-arp-runtime",
+    "crates/arkavo-permit",
     "crates/arkavo-swarmkit",
     "crates/arkavo-swarmkit-runtime",
     "crates/arkavo-mcp-identity",
@@ -153,7 +154,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.89.4"
+version = "0.89.6"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-permit/Cargo.toml
+++ b/crates/arkavo-permit/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "arkavo-permit"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "CWT (RFC 8392) permits for permit-bound tool execution, signed as COSE_Sign1 (RFC 8152)"
+
+[dependencies]
+arkavo-crypto = { path = "../arkavo-crypto" }
+coset = "0.3"
+ciborium = "0.2"
+blake3 = "1.5"
+sha2 = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+hex = { workspace = true }

--- a/crates/arkavo-permit/examples/generate_vectors.rs
+++ b/crates/arkavo-permit/examples/generate_vectors.rs
@@ -1,0 +1,153 @@
+//! Regenerate the published test vectors in `tests/vectors/`.
+//!
+//! Run from the crate root: `cargo run -p arkavo-permit --example generate_vectors`
+//!
+//! The vectors are fully deterministic: fixed secret keys, fixed claims, and
+//! fixed timestamps, so re-running this example must produce byte-identical
+//! files. `tests/vectors_test.rs` verifies the committed files.
+
+use std::path::PathBuf;
+
+use arkavo_crypto::{AgentKeypair, P256SigningKeypair};
+use arkavo_permit::{Budget, HashAlgorithm, PermitClaims, PermitSigner, argument_hash, mint};
+use serde_json::{Value, json};
+
+const IAT: i64 = 1_700_000_000;
+const EXP: i64 = 1_700_000_300;
+
+fn base_claims(tool_name: &str, arguments: &Value, hash_algorithm: HashAlgorithm) -> PermitClaims {
+    PermitClaims {
+        issuer: "https://permit-issuer.arkavo.example".to_string(),
+        subject: "did:example:human-alice".to_string(),
+        agent_workload_id: "spiffe://arkavo-edge/ns/default/sa/edge-agent-001".to_string(),
+        policy_bundle_hash: hash_algorithm.digest(b"arkavo-policy-bundle-2026-08"),
+        tool_name: tool_name.to_string(),
+        argument_hash: argument_hash(arguments, hash_algorithm),
+        data_classifications: vec![
+            "tdf:classification:confidential".to_string(),
+            "tdf:region:us".to_string(),
+        ],
+        budget: Budget {
+            max_invocations: 5,
+            token_ceiling: Some(100_000),
+            cost_micro_usd: Some(250_000),
+        },
+        sequence_state_hash: hash_algorithm.digest(b"sequence-state-0"),
+        issued_at: IAT,
+        not_before: IAT,
+        expires_at: EXP,
+        parent_permit: None,
+    }
+}
+
+fn vector_json(
+    name: &str,
+    signer: &PermitSigner,
+    secret_key_hex: &str,
+    claims: &PermitClaims,
+    arguments: &Value,
+    hash_algorithm: HashAlgorithm,
+) -> Value {
+    let cwt = mint(claims, signer).expect("mint permit");
+    let algorithm = match signer {
+        PermitSigner::Ed25519(_) => "EdDSA",
+        PermitSigner::P256(_) => "ES256",
+    };
+    json!({
+        "name": name,
+        "description": "Signed CWT permit test vector for arkavo-permit; regenerate with `cargo run -p arkavo-permit --example generate_vectors`",
+        "algorithm": algorithm,
+        "hash_algorithm": hash_algorithm.name(),
+        "secret_key_hex": secret_key_hex,
+        "public_key_hex": hex::encode(signer.public_key().public_key_bytes()),
+        "now_for_verification": IAT + 60,
+        "cwt_hex": hex::encode(cwt),
+        "claims": {
+            "iss": claims.issuer,
+            "sub": claims.subject,
+            "agent_workload_id": claims.agent_workload_id,
+            "policy_bundle_hash_hex": hex::encode(&claims.policy_bundle_hash),
+            "tool_name": claims.tool_name,
+            "arguments": arguments,
+            "argument_hash_hex": hex::encode(&claims.argument_hash),
+            "data_classifications": claims.data_classifications,
+            "budget": {
+                "max_invocations": claims.budget.max_invocations,
+                "token_ceiling": claims.budget.token_ceiling,
+                "cost_micro_usd": claims.budget.cost_micro_usd,
+            },
+            "sequence_state_hash_hex": hex::encode(&claims.sequence_state_hash),
+            "iat": claims.issued_at,
+            "nbf": claims.not_before,
+            "exp": claims.expires_at,
+            "parent_permit_hex": claims.parent_permit.as_ref().map(hex::encode),
+        }
+    })
+}
+
+fn write_vector(dir: &std::path::Path, name: &str, vector: &Value) {
+    let path = dir.join(format!("{name}.json"));
+    let mut text = serde_json::to_string_pretty(vector).expect("serialize vector");
+    text.push('\n');
+    std::fs::write(&path, text).expect("write vector file");
+    println!("wrote {}", path.display());
+}
+
+fn main() {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/vectors");
+    std::fs::create_dir_all(&dir).expect("create vectors dir");
+
+    // Vector 1: Ed25519 (EdDSA) with SHA-256 hashes.
+    let ed_secret = [0x11u8; 32];
+    let ed_signer =
+        PermitSigner::Ed25519(AgentKeypair::from_bytes(&ed_secret).expect("valid ed25519 secret"));
+    let read_args = json!({"path": "/tmp/data.csv", "max_bytes": 4096});
+    let claims = base_claims("arkavo.fs.read_file", &read_args, HashAlgorithm::Sha256);
+    let vector = vector_json(
+        "ed25519-sha256",
+        &ed_signer,
+        &hex::encode(ed_secret),
+        &claims,
+        &read_args,
+        HashAlgorithm::Sha256,
+    );
+    let parent_cwt_hex = vector["cwt_hex"].as_str().expect("cwt hex").to_string();
+    write_vector(&dir, "ed25519-sha256", &vector);
+
+    // Vector 2: P-256 (ES256) with BLAKE3 hashes.
+    let p256_secret = [0x22u8; 32];
+    let p256_signer = PermitSigner::P256(
+        P256SigningKeypair::from_bytes(&p256_secret).expect("valid p256 secret"),
+    );
+    let exec_args = json!({"argv": ["ls", "-la"], "cwd": "/tmp", "timeout_ms": 5000});
+    let claims = base_claims("arkavo.shell.exec", &exec_args, HashAlgorithm::Blake3);
+    let vector = vector_json(
+        "es256-blake3",
+        &p256_signer,
+        &hex::encode(p256_secret),
+        &claims,
+        &exec_args,
+        HashAlgorithm::Blake3,
+    );
+    write_vector(&dir, "es256-blake3", &vector);
+
+    // Vector 3: Ed25519 child permit chained to vector 1 via parent_permit.
+    let child_secret = [0x33u8; 32];
+    let child_signer = PermitSigner::Ed25519(
+        AgentKeypair::from_bytes(&child_secret).expect("valid ed25519 secret"),
+    );
+    let delegate_args =
+        json!({"agent": "spiffe://arkavo-edge/ns/default/sa/edge-agent-002", "task": "summarize"});
+    let mut claims = base_claims("arkavo.a2a.delegate", &delegate_args, HashAlgorithm::Sha256);
+    claims.parent_permit =
+        Some(HashAlgorithm::Sha256.digest(&hex::decode(&parent_cwt_hex).expect("parent cwt hex")));
+    let vector = vector_json(
+        "ed25519-parent-chain",
+        &child_signer,
+        &hex::encode(child_secret),
+        &claims,
+        &delegate_args,
+        HashAlgorithm::Sha256,
+    );
+    write_vector(&dir, "ed25519-parent-chain", &vector);
+}

--- a/crates/arkavo-permit/src/canonical.rs
+++ b/crates/arkavo-permit/src/canonical.rs
@@ -1,0 +1,162 @@
+//! Canonical JSON encoding for tool-call argument hashing.
+//!
+//! Canonicalization rules (see `docs/permit-cwt-schema.md`):
+//! - UTF-8 output with no insignificant whitespace.
+//! - Object keys sorted by Unicode code point; no duplicate keys (the input
+//!   `serde_json::Value` cannot hold duplicates).
+//! - Strings escaped per RFC 8259 section 7 (short escapes where defined,
+//!   `\u00XX` for other control characters).
+//! - Numbers rendered with `serde_json::Number`'s shortest representation.
+
+use crate::error::PermitError;
+use crate::hash::HashAlgorithm;
+use serde_json::Value;
+
+/// Encode a JSON value in canonical form.
+pub fn canonical_json(value: &Value) -> Vec<u8> {
+    let mut out = Vec::new();
+    write_canonical(value, &mut out);
+    out
+}
+
+/// Hash canonicalized tool-call arguments with the selected algorithm.
+pub fn argument_hash(arguments: &Value, algorithm: HashAlgorithm) -> Vec<u8> {
+    algorithm.digest(&canonical_json(arguments))
+}
+
+fn write_canonical(value: &Value, out: &mut Vec<u8>) {
+    match value {
+        Value::Null => out.extend_from_slice(b"null"),
+        Value::Bool(b) => out.extend_from_slice(if *b { b"true" } else { b"false" }),
+        Value::Number(n) => out.extend_from_slice(n.to_string().as_bytes()),
+        Value::String(s) => write_json_string(s, out),
+        Value::Array(items) => {
+            out.push(b'[');
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(b',');
+                }
+                write_canonical(item, out);
+            }
+            out.push(b']');
+        }
+        Value::Object(map) => {
+            let mut entries: Vec<(&String, &Value)> = map.iter().collect();
+            entries.sort_by(|a, b| a.0.cmp(b.0));
+            out.push(b'{');
+            for (i, (key, val)) in entries.iter().enumerate() {
+                if i > 0 {
+                    out.push(b',');
+                }
+                write_json_string(key, out);
+                out.push(b':');
+                write_canonical(val, out);
+            }
+            out.push(b'}');
+        }
+    }
+}
+
+fn write_json_string(s: &str, out: &mut Vec<u8>) {
+    out.push(b'"');
+    for ch in s.chars() {
+        match ch {
+            '"' => out.extend_from_slice(b"\\\""),
+            '\\' => out.extend_from_slice(b"\\\\"),
+            '\u{08}' => out.extend_from_slice(b"\\b"),
+            '\u{0C}' => out.extend_from_slice(b"\\f"),
+            '\n' => out.extend_from_slice(b"\\n"),
+            '\r' => out.extend_from_slice(b"\\r"),
+            '\t' => out.extend_from_slice(b"\\t"),
+            c if (c as u32) < 0x20 => {
+                out.extend_from_slice(format!("\\u{:04x}", c as u32).as_bytes());
+            }
+            c => {
+                let mut buf = [0u8; 4];
+                out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+            }
+        }
+    }
+    out.push(b'"');
+}
+
+/// Parse raw JSON text and return its canonical encoding.
+///
+/// Used by integrators that receive arguments as a JSON string rather than a
+/// parsed value; fails closed on invalid JSON.
+pub fn canonicalize_json_text(text: &str) -> Result<Vec<u8>, PermitError> {
+    let value: Value = serde_json::from_str(text)
+        .map_err(|_| PermitError::MalformedClaim("arguments are not valid JSON"))?;
+    Ok(canonical_json(&value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn object_keys_are_sorted() {
+        let value = json!({"b": 2, "a": 1, "c": {"z": 1, "y": 2}});
+        assert_eq!(
+            canonical_json(&value),
+            br#"{"a":1,"b":2,"c":{"y":2,"z":1}}"#
+        );
+    }
+
+    #[test]
+    fn no_whitespace_anywhere() {
+        let value = json!({"a": [1, 2, {"b": "c"}], "d": true, "e": null});
+        let canonical = canonical_json(&value);
+        assert_eq!(canonical, br#"{"a":[1,2,{"b":"c"}],"d":true,"e":null}"#);
+    }
+
+    #[test]
+    fn strings_escaped_per_rfc8259() {
+        let value = json!("quote\" backslash\\ newline\n tab\t nul\u{0}");
+        assert_eq!(
+            canonical_json(&value),
+            br#""quote\" backslash\\ newline\n tab\t nul\u0000""#
+        );
+    }
+
+    #[test]
+    fn unicode_strings_stay_utf8() {
+        let value = json!({"k": "héllo wörld ✓"});
+        let canonical = canonical_json(&value);
+        assert_eq!(canonical, "{\"k\":\"héllo wörld ✓\"}".as_bytes());
+    }
+
+    #[test]
+    fn argument_hash_is_stable_across_key_order() {
+        let a = json!({"x": 1, "y": [true, null]});
+        let b = json!({"y": [true, null], "x": 1});
+        assert_eq!(
+            argument_hash(&a, HashAlgorithm::Sha256),
+            argument_hash(&b, HashAlgorithm::Sha256)
+        );
+        assert_eq!(
+            argument_hash(&a, HashAlgorithm::Blake3),
+            argument_hash(&b, HashAlgorithm::Blake3)
+        );
+    }
+
+    #[test]
+    fn different_arguments_hash_differently() {
+        let a = json!({"path": "/tmp/a"});
+        let b = json!({"path": "/tmp/b"});
+        assert_ne!(
+            argument_hash(&a, HashAlgorithm::Sha256),
+            argument_hash(&b, HashAlgorithm::Sha256)
+        );
+    }
+
+    #[test]
+    fn canonicalize_json_text_roundtrip_and_rejects_garbage() {
+        assert_eq!(
+            canonicalize_json_text("{ \"b\": 1, \"a\": 2 }").unwrap(),
+            br#"{"a":2,"b":1}"#
+        );
+        assert!(canonicalize_json_text("{not json").is_err());
+    }
+}

--- a/crates/arkavo-permit/src/claims.rs
+++ b/crates/arkavo-permit/src/claims.rs
@@ -1,0 +1,476 @@
+//! Permit claim set: standard CWT claims plus Arkavo private-use claims.
+//!
+//! Claim labels are defined in `docs/permit-cwt-schema.md`. Private-use
+//! labels live below -65536 per RFC 8392 section 4.
+
+use crate::canonical::argument_hash;
+use crate::error::PermitError;
+use crate::hash::HashAlgorithm;
+use ciborium::value::{Integer, Value};
+use coset::{AsCborValue, CoseKey};
+
+// Standard CWT claims (RFC 8392) and confirmation (RFC 8747).
+pub const CLAIM_ISSUER: i64 = 1;
+pub const CLAIM_SUBJECT: i64 = 2;
+pub const CLAIM_EXPIRATION: i64 = 4;
+pub const CLAIM_NOT_BEFORE: i64 = 5;
+pub const CLAIM_ISSUED_AT: i64 = 6;
+pub const CLAIM_CONFIRMATION: i64 = 8;
+
+// Arkavo private-use claims.
+pub const CLAIM_AGENT_WORKLOAD_ID: i64 = -70001;
+pub const CLAIM_POLICY_BUNDLE_HASH: i64 = -70002;
+pub const CLAIM_TOOL_NAME: i64 = -70003;
+pub const CLAIM_ARGUMENT_HASH: i64 = -70004;
+pub const CLAIM_DATA_CLASSIFICATIONS: i64 = -70005;
+pub const CLAIM_BUDGET: i64 = -70006;
+pub const CLAIM_SEQUENCE_STATE_HASH: i64 = -70007;
+pub const CLAIM_PARENT_PERMIT: i64 = -70008;
+
+// Keys inside the budget map (claim -70006).
+pub const BUDGET_MAX_INVOCATIONS: i64 = 1;
+pub const BUDGET_TOKEN_CEILING: i64 = 2;
+pub const BUDGET_COST_MICRO_USD: i64 = 3;
+
+// Key inside the cnf map (claim 8) per RFC 8747: 1 = COSE_Key.
+pub const CNF_COSE_KEY: i64 = 1;
+
+/// Execution budget bound into the permit.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Budget {
+    /// Maximum number of tool invocations this permit authorizes.
+    pub max_invocations: u64,
+    /// Optional ceiling on total tokens consumed across invocations.
+    pub token_ceiling: Option<u64>,
+    /// Optional cost ceiling in micro-USD (10^-6 USD).
+    pub cost_micro_usd: Option<u64>,
+}
+
+impl Budget {
+    fn validate(&self) -> Result<(), PermitError> {
+        if self.max_invocations == 0 {
+            return Err(PermitError::MalformedClaim(
+                "budget.max_invocations is zero",
+            ));
+        }
+        Ok(())
+    }
+
+    fn to_value(&self) -> Value {
+        let mut entries = vec![int_pair(BUDGET_MAX_INVOCATIONS, self.max_invocations)];
+        if let Some(tokens) = self.token_ceiling {
+            entries.push(int_pair(BUDGET_TOKEN_CEILING, tokens));
+        }
+        if let Some(cost) = self.cost_micro_usd {
+            entries.push(int_pair(BUDGET_COST_MICRO_USD, cost));
+        }
+        Value::Map(entries)
+    }
+
+    fn from_value(value: &Value) -> Result<Self, PermitError> {
+        let map = as_map(value, "budget")?;
+        let raw = take_int(map, BUDGET_MAX_INVOCATIONS, "budget.max_invocations")?;
+        let max_invocations = u64::try_from(raw)
+            .map_err(|_| PermitError::MalformedClaim("budget.max_invocations is negative"))?;
+        let budget = Self {
+            max_invocations,
+            token_ceiling: get_u64(map, BUDGET_TOKEN_CEILING, "budget.token_ceiling")?,
+            cost_micro_usd: get_u64(map, BUDGET_COST_MICRO_USD, "budget.cost_micro_usd")?,
+        };
+        budget.validate()?;
+        Ok(budget)
+    }
+}
+
+/// Claims carried by a permit CWT. All fields except `parent_permit` are
+/// required; the `cnf` confirmation claim is handled separately because it is
+/// derived from the signing key at mint time.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PermitClaims {
+    /// iss: permit issuer identity (URI or DID).
+    pub issuer: String,
+    /// sub: delegator / human identity on whose behalf the agent acts.
+    pub subject: String,
+    /// Agent workload identity (SPIFFE-style workload ID).
+    pub agent_workload_id: String,
+    /// Hash of the policy bundle authorizing this permit.
+    pub policy_bundle_hash: Vec<u8>,
+    /// Fully-qualified tool name this permit authorizes.
+    pub tool_name: String,
+    /// Hash of the canonicalized tool arguments (see `canonical_json`).
+    pub argument_hash: Vec<u8>,
+    /// TDF data-classification attributes the tool may touch.
+    pub data_classifications: Vec<String>,
+    /// Execution budget bound into the permit.
+    pub budget: Budget,
+    /// Hash of the sequence state (replay/ordering anchor).
+    pub sequence_state_hash: Vec<u8>,
+    /// iat: seconds since UNIX epoch.
+    pub issued_at: i64,
+    /// nbf: seconds since UNIX epoch.
+    pub not_before: i64,
+    /// exp: seconds since UNIX epoch.
+    pub expires_at: i64,
+    /// Hash of the parent permit's CWT bytes, for A2A delegation chains.
+    pub parent_permit: Option<Vec<u8>>,
+}
+
+impl PermitClaims {
+    /// Structural validation, independent of signature and wall-clock time.
+    pub fn validate(&self) -> Result<(), PermitError> {
+        for (value, name) in [
+            (&self.issuer, "iss"),
+            (&self.subject, "sub"),
+            (&self.agent_workload_id, "agent_workload_id"),
+            (&self.tool_name, "tool_name"),
+        ] {
+            if value.is_empty() {
+                return Err(PermitError::MalformedClaim(name));
+            }
+        }
+        for (value, name) in [
+            (&self.policy_bundle_hash, "policy_bundle_hash"),
+            (&self.argument_hash, "argument_hash"),
+            (&self.sequence_state_hash, "sequence_state_hash"),
+        ] {
+            if value.is_empty() {
+                return Err(PermitError::MalformedClaim(name));
+            }
+        }
+        for classification in &self.data_classifications {
+            if classification.is_empty() {
+                return Err(PermitError::MalformedClaim("data_classifications"));
+            }
+        }
+        if let Some(parent) = &self.parent_permit
+            && parent.is_empty()
+        {
+            return Err(PermitError::MalformedClaim("parent_permit"));
+        }
+        self.budget.validate()?;
+        if self.not_before >= self.expires_at {
+            return Err(PermitError::MalformedClaim("nbf is not before exp"));
+        }
+        Ok(())
+    }
+
+    /// Check that a tool invocation matches this permit's binding.
+    pub fn verify_invocation(
+        &self,
+        tool_name: &str,
+        arguments: &serde_json::Value,
+        algorithm: HashAlgorithm,
+    ) -> Result<(), PermitError> {
+        if self.tool_name != tool_name {
+            return Err(PermitError::BindingMismatch(format!(
+                "tool name {} is not {}",
+                tool_name, self.tool_name
+            )));
+        }
+        let hash = argument_hash(arguments, algorithm);
+        if hash != self.argument_hash {
+            return Err(PermitError::BindingMismatch(
+                "canonical argument hash mismatch".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Encode the claims (plus the confirmation key) as a CBOR value.
+    pub fn to_cbor_value(&self, confirmation_key: &CoseKey) -> Result<Value, PermitError> {
+        let cnf_key_value = confirmation_key
+            .clone()
+            .to_cbor_value()
+            .map_err(|e| PermitError::CborSerialize(format!("cnf COSE_Key: {e}")))?;
+        let cnf = Value::Map(vec![(int_value(CNF_COSE_KEY), cnf_key_value)]);
+        let classifications = Value::Array(
+            self.data_classifications
+                .iter()
+                .map(|c| Value::Text(c.clone()))
+                .collect(),
+        );
+        let mut entries = vec![
+            (int_value(CLAIM_ISSUER), Value::Text(self.issuer.clone())),
+            (int_value(CLAIM_SUBJECT), Value::Text(self.subject.clone())),
+            int_pair(CLAIM_EXPIRATION, self.expires_at),
+            int_pair(CLAIM_NOT_BEFORE, self.not_before),
+            int_pair(CLAIM_ISSUED_AT, self.issued_at),
+            (int_value(CLAIM_CONFIRMATION), cnf),
+            (
+                int_value(CLAIM_AGENT_WORKLOAD_ID),
+                Value::Text(self.agent_workload_id.clone()),
+            ),
+            (
+                int_value(CLAIM_POLICY_BUNDLE_HASH),
+                Value::Bytes(self.policy_bundle_hash.clone()),
+            ),
+            (
+                int_value(CLAIM_TOOL_NAME),
+                Value::Text(self.tool_name.clone()),
+            ),
+            (
+                int_value(CLAIM_ARGUMENT_HASH),
+                Value::Bytes(self.argument_hash.clone()),
+            ),
+            (int_value(CLAIM_DATA_CLASSIFICATIONS), classifications),
+            (int_value(CLAIM_BUDGET), self.budget.to_value()),
+            (
+                int_value(CLAIM_SEQUENCE_STATE_HASH),
+                Value::Bytes(self.sequence_state_hash.clone()),
+            ),
+        ];
+        if let Some(parent) = &self.parent_permit {
+            entries.push((int_value(CLAIM_PARENT_PERMIT), Value::Bytes(parent.clone())));
+        }
+        Ok(Value::Map(entries))
+    }
+
+    /// Parse a claims-map CBOR value, returning the claims and the
+    /// confirmation key. Fails closed on any malformed required claim;
+    /// unknown claims are ignored for forward compatibility.
+    pub fn from_cbor_value(value: &Value) -> Result<(Self, CoseKey), PermitError> {
+        let map = as_map(value, "claims set")?;
+        let classifications = match take(map, CLAIM_DATA_CLASSIFICATIONS, "data_classifications")? {
+            Value::Array(items) => items
+                .iter()
+                .map(|item| {
+                    item.as_text()
+                        .map(str::to_string)
+                        .ok_or(PermitError::MalformedClaim("data_classifications entry"))
+                })
+                .collect::<Result<Vec<String>, PermitError>>()?,
+            _ => return Err(PermitError::MalformedClaim("data_classifications")),
+        };
+        let cnf_map = as_map(
+            take(map, CLAIM_CONFIRMATION, "cnf")?,
+            "cnf confirmation map",
+        )?;
+        let cnf_key_value = take(cnf_map, CNF_COSE_KEY, "cnf COSE_Key")?;
+        let confirmation_key = CoseKey::from_cbor_value(cnf_key_value.clone())
+            .map_err(|e| PermitError::InvalidConfirmationKey(format!("COSE_Key parse: {e}")))?;
+        let parent_permit = match get(map, CLAIM_PARENT_PERMIT) {
+            Some(Value::Bytes(bytes)) => Some(bytes.clone()),
+            Some(_) => return Err(PermitError::MalformedClaim("parent_permit")),
+            None => None,
+        };
+        let claims = Self {
+            issuer: take_text(map, CLAIM_ISSUER, "iss")?,
+            subject: take_text(map, CLAIM_SUBJECT, "sub")?,
+            agent_workload_id: take_text(map, CLAIM_AGENT_WORKLOAD_ID, "agent_workload_id")?,
+            policy_bundle_hash: take_bytes(map, CLAIM_POLICY_BUNDLE_HASH, "policy_bundle_hash")?,
+            tool_name: take_text(map, CLAIM_TOOL_NAME, "tool_name")?,
+            argument_hash: take_bytes(map, CLAIM_ARGUMENT_HASH, "argument_hash")?,
+            data_classifications: classifications,
+            budget: Budget::from_value(take(map, CLAIM_BUDGET, "budget")?)?,
+            sequence_state_hash: take_bytes(map, CLAIM_SEQUENCE_STATE_HASH, "sequence_state_hash")?,
+            issued_at: take_int(map, CLAIM_ISSUED_AT, "iat")?,
+            not_before: take_int(map, CLAIM_NOT_BEFORE, "nbf")?,
+            expires_at: take_int(map, CLAIM_EXPIRATION, "exp")?,
+            parent_permit,
+        };
+        claims.validate()?;
+        Ok((claims, confirmation_key))
+    }
+}
+
+fn int_value(key: i64) -> Value {
+    Value::Integer(Integer::from(key))
+}
+
+fn int_pair<V: Into<Integer>>(key: i64, value: V) -> (Value, Value) {
+    (int_value(key), Value::Integer(value.into()))
+}
+
+fn as_map<'a>(value: &'a Value, name: &'static str) -> Result<&'a [(Value, Value)], PermitError> {
+    match value {
+        Value::Map(entries) => Ok(entries),
+        _ => Err(PermitError::MalformedClaim(name)),
+    }
+}
+
+fn get(map: &[(Value, Value)], key: i64) -> Option<&Value> {
+    let key = Integer::from(key);
+    map.iter()
+        .find(|(k, _)| matches!(k, Value::Integer(i) if *i == key))
+        .map(|(_, v)| v)
+}
+
+fn take<'a>(
+    map: &'a [(Value, Value)],
+    key: i64,
+    name: &'static str,
+) -> Result<&'a Value, PermitError> {
+    get(map, key).ok_or(PermitError::MissingClaim(name))
+}
+
+fn take_text(map: &[(Value, Value)], key: i64, name: &'static str) -> Result<String, PermitError> {
+    match take(map, key, name)? {
+        Value::Text(text) => Ok(text.clone()),
+        _ => Err(PermitError::MalformedClaim(name)),
+    }
+}
+
+fn take_bytes(
+    map: &[(Value, Value)],
+    key: i64,
+    name: &'static str,
+) -> Result<Vec<u8>, PermitError> {
+    match take(map, key, name)? {
+        Value::Bytes(bytes) => Ok(bytes.clone()),
+        _ => Err(PermitError::MalformedClaim(name)),
+    }
+}
+
+fn take_int(map: &[(Value, Value)], key: i64, name: &'static str) -> Result<i64, PermitError> {
+    match take(map, key, name)? {
+        Value::Integer(i) => i64::try_from(*i).map_err(|_| PermitError::MalformedClaim(name)),
+        _ => Err(PermitError::MalformedClaim(name)),
+    }
+}
+
+fn get_u64(
+    map: &[(Value, Value)],
+    key: i64,
+    name: &'static str,
+) -> Result<Option<u64>, PermitError> {
+    match get(map, key) {
+        Some(Value::Integer(i)) => {
+            let raw = i128::from(*i);
+            u64::try_from(raw)
+                .map(Some)
+                .map_err(|_| PermitError::MalformedClaim(name))
+        }
+        Some(_) => Err(PermitError::MalformedClaim(name)),
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::keys::PermitSigner;
+    use arkavo_crypto::AgentKeypair;
+
+    fn sample_claims() -> PermitClaims {
+        PermitClaims {
+            issuer: "https://issuer.example".to_string(),
+            subject: "did:example:alice".to_string(),
+            agent_workload_id: "spiffe://edge/agent-1".to_string(),
+            policy_bundle_hash: vec![1; 32],
+            tool_name: "arkavo.fs.read".to_string(),
+            argument_hash: vec![2; 32],
+            data_classifications: vec!["tdf:confidential".to_string()],
+            budget: Budget {
+                max_invocations: 3,
+                token_ceiling: Some(10_000),
+                cost_micro_usd: None,
+            },
+            sequence_state_hash: vec![3; 32],
+            issued_at: 1_000,
+            not_before: 1_000,
+            expires_at: 1_300,
+            parent_permit: Some(vec![9; 32]),
+        }
+    }
+
+    fn sample_key() -> CoseKey {
+        PermitSigner::Ed25519(AgentKeypair::generate()).cose_key()
+    }
+
+    #[test]
+    fn claims_cbor_roundtrip() {
+        let claims = sample_claims();
+        let key = sample_key();
+        let value = claims.to_cbor_value(&key).unwrap();
+        let (decoded, decoded_key) = PermitClaims::from_cbor_value(&value).unwrap();
+        assert_eq!(claims, decoded);
+        assert_eq!(
+            key.to_cbor_value().unwrap(),
+            decoded_key.to_cbor_value().unwrap()
+        );
+    }
+
+    #[test]
+    fn missing_required_claim_fails_closed() {
+        let claims = sample_claims();
+        let key = sample_key();
+        let value = claims.to_cbor_value(&key).unwrap();
+        let Value::Map(entries) = value else { panic!() };
+        let stripped: Vec<(Value, Value)> = entries
+            .into_iter()
+            .filter(|(k, _)| k != &int_value(CLAIM_TOOL_NAME))
+            .collect();
+        let result = PermitClaims::from_cbor_value(&Value::Map(stripped));
+        assert!(matches!(
+            result,
+            Err(PermitError::MissingClaim("tool_name"))
+        ));
+    }
+
+    #[test]
+    fn wrong_claim_type_fails_closed() {
+        let claims = sample_claims();
+        let key = sample_key();
+        let value = claims.to_cbor_value(&key).unwrap();
+        let Value::Map(mut entries) = value else {
+            panic!()
+        };
+        for (k, v) in &mut entries {
+            if k == &int_value(CLAIM_ARGUMENT_HASH) {
+                *v = Value::Text("not bytes".to_string());
+            }
+        }
+        let result = PermitClaims::from_cbor_value(&Value::Map(entries));
+        assert!(matches!(
+            result,
+            Err(PermitError::MalformedClaim("argument_hash"))
+        ));
+    }
+
+    #[test]
+    fn invalid_temporal_order_rejected() {
+        let mut claims = sample_claims();
+        claims.not_before = claims.expires_at;
+        assert!(claims.validate().is_err());
+    }
+
+    #[test]
+    fn zero_invocation_budget_rejected() {
+        let mut claims = sample_claims();
+        claims.budget.max_invocations = 0;
+        assert!(claims.validate().is_err());
+    }
+
+    #[test]
+    fn empty_required_strings_rejected() {
+        let mut claims = sample_claims();
+        claims.tool_name = String::new();
+        assert!(claims.validate().is_err());
+    }
+
+    #[test]
+    fn verify_invocation_checks_tool_and_arguments() {
+        let arguments = serde_json::json!({"b": 1, "a": "x"});
+        let mut claims = sample_claims();
+        claims.tool_name = "arkavo.fs.read".to_string();
+        claims.argument_hash = argument_hash(&arguments, HashAlgorithm::Sha256);
+
+        // Same arguments in a different key order must match.
+        let reordered = serde_json::json!({"a": "x", "b": 1});
+        assert!(
+            claims
+                .verify_invocation("arkavo.fs.read", &reordered, HashAlgorithm::Sha256)
+                .is_ok()
+        );
+
+        assert!(matches!(
+            claims.verify_invocation("arkavo.fs.write", &arguments, HashAlgorithm::Sha256),
+            Err(PermitError::BindingMismatch(_))
+        ));
+        let different_args = serde_json::json!({"a": "x", "b": 2});
+        assert!(matches!(
+            claims.verify_invocation("arkavo.fs.read", &different_args, HashAlgorithm::Sha256),
+            Err(PermitError::BindingMismatch(_))
+        ));
+    }
+}

--- a/crates/arkavo-permit/src/claims.rs
+++ b/crates/arkavo-permit/src/claims.rs
@@ -128,12 +128,15 @@ impl PermitClaims {
                 return Err(PermitError::MalformedClaim(name));
             }
         }
+        // SHA-256 and BLAKE3 default outputs are 32 bytes. Reject any other
+        // length at validate time so a 1-byte hash cannot pass as well-formed.
+        const DIGEST_LEN: usize = 32;
         for (value, name) in [
             (&self.policy_bundle_hash, "policy_bundle_hash"),
             (&self.argument_hash, "argument_hash"),
             (&self.sequence_state_hash, "sequence_state_hash"),
         ] {
-            if value.is_empty() {
+            if value.len() != DIGEST_LEN {
                 return Err(PermitError::MalformedClaim(name));
             }
         }
@@ -143,7 +146,7 @@ impl PermitClaims {
             }
         }
         if let Some(parent) = &self.parent_permit
-            && parent.is_empty()
+            && parent.len() != DIGEST_LEN
         {
             return Err(PermitError::MalformedClaim("parent_permit"));
         }
@@ -446,6 +449,37 @@ mod tests {
         let mut claims = sample_claims();
         claims.tool_name = String::new();
         assert!(claims.validate().is_err());
+    }
+
+    #[test]
+    fn digest_claims_must_be_32_bytes() {
+        let mut claims = sample_claims();
+        claims.policy_bundle_hash = vec![1];
+        assert!(matches!(
+            claims.validate(),
+            Err(PermitError::MalformedClaim("policy_bundle_hash"))
+        ));
+
+        claims = sample_claims();
+        claims.argument_hash = vec![1; 31];
+        assert!(matches!(
+            claims.validate(),
+            Err(PermitError::MalformedClaim("argument_hash"))
+        ));
+
+        claims = sample_claims();
+        claims.sequence_state_hash = vec![1; 33];
+        assert!(matches!(
+            claims.validate(),
+            Err(PermitError::MalformedClaim("sequence_state_hash"))
+        ));
+
+        claims = sample_claims();
+        claims.parent_permit = Some(vec![1]);
+        assert!(matches!(
+            claims.validate(),
+            Err(PermitError::MalformedClaim("parent_permit"))
+        ));
     }
 
     #[test]

--- a/crates/arkavo-permit/src/error.rs
+++ b/crates/arkavo-permit/src/error.rs
@@ -1,0 +1,44 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum PermitError {
+    #[error("CBOR serialization failed: {0}")]
+    CborSerialize(String),
+    #[error("CBOR deserialization failed: {0}")]
+    CborDeserialize(String),
+    #[error("COSE processing failed: {0}")]
+    Cose(String),
+    #[error("missing required claim: {0}")]
+    MissingClaim(&'static str),
+    #[error("malformed claim: {0}")]
+    MalformedClaim(&'static str),
+    #[error("invalid confirmation key: {0}")]
+    InvalidConfirmationKey(String),
+    #[error("unsupported signing algorithm: {0}")]
+    UnsupportedAlgorithm(String),
+    #[error("confirmation key does not match the COSE header algorithm")]
+    KeyAlgorithmMismatch,
+    #[error("signature verification failed")]
+    InvalidSignature,
+    #[error("permit is not yet valid (nbf {nbf} > now {now})")]
+    NotYetValid { nbf: i64, now: i64 },
+    #[error("permit has expired (exp {exp} <= now {now})")]
+    Expired { exp: i64, now: i64 },
+    #[error("permit was issued in the future (iat {iat} > now {now})")]
+    IssuedInFuture { iat: i64, now: i64 },
+    #[error("invocation does not match the permit binding: {0}")]
+    BindingMismatch(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_display_is_descriptive() {
+        let e = PermitError::Expired { exp: 100, now: 200 };
+        assert!(e.to_string().contains("100"));
+        let e = PermitError::MissingClaim("iss");
+        assert!(e.to_string().contains("iss"));
+    }
+}

--- a/crates/arkavo-permit/src/hash.rs
+++ b/crates/arkavo-permit/src/hash.rs
@@ -1,0 +1,83 @@
+use sha2::Digest;
+
+/// Pluggable digest algorithm for permit-bound hashes (policy bundle,
+/// canonical arguments, sequence state). SHA-256 is the default.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum HashAlgorithm {
+    #[default]
+    Sha256,
+    Blake3,
+}
+
+impl HashAlgorithm {
+    pub fn digest(self, data: &[u8]) -> Vec<u8> {
+        match self {
+            Self::Sha256 => sha2::Sha256::digest(data).to_vec(),
+            Self::Blake3 => blake3::hash(data).as_bytes().to_vec(),
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Sha256 => "sha256",
+            Self::Blake3 => "blake3",
+        }
+    }
+
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "sha256" => Some(Self::Sha256),
+            "blake3" => Some(Self::Blake3),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_matches_known_vector() {
+        // SHA-256("abc") per FIPS 180-4.
+        let digest = HashAlgorithm::Sha256.digest(b"abc");
+        assert_eq!(
+            digest,
+            [
+                0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde, 0x5d, 0xae,
+                0x22, 0x23, 0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c, 0xb4, 0x10, 0xff, 0x61,
+                0xf2, 0x00, 0x15, 0xad
+            ]
+        );
+    }
+
+    #[test]
+    fn blake3_matches_known_vector() {
+        // BLAKE3("abc") from the official BLAKE3 test vectors.
+        let digest = HashAlgorithm::Blake3.digest(b"abc");
+        assert_eq!(
+            digest,
+            [
+                0x64, 0x37, 0xb3, 0xac, 0x38, 0x46, 0x51, 0x33, 0xff, 0xb6, 0x3b, 0x75, 0x27, 0x3a,
+                0x8d, 0xb5, 0x48, 0xc5, 0x58, 0x46, 0x5d, 0x79, 0xdb, 0x03, 0xfd, 0x35, 0x9c, 0x6c,
+                0xd5, 0xbd, 0x9d, 0x85
+            ]
+        );
+    }
+
+    #[test]
+    fn name_roundtrip() {
+        assert_eq!(
+            HashAlgorithm::from_name("sha256"),
+            Some(HashAlgorithm::Sha256)
+        );
+        assert_eq!(
+            HashAlgorithm::from_name("blake3"),
+            Some(HashAlgorithm::Blake3)
+        );
+        assert_eq!(HashAlgorithm::from_name("md5"), None);
+        for alg in [HashAlgorithm::Sha256, HashAlgorithm::Blake3] {
+            assert_eq!(HashAlgorithm::from_name(alg.name()), Some(alg));
+        }
+    }
+}

--- a/crates/arkavo-permit/src/keys.rs
+++ b/crates/arkavo-permit/src/keys.rs
@@ -1,0 +1,350 @@
+//! Signing and verification keys for permits, reusing `arkavo-crypto` key
+//! types (Ed25519 primary, P-256/ES256 supported) and encoding them as
+//! COSE_Key confirmation keys per RFC 8747.
+
+use crate::error::PermitError;
+use arkavo_crypto::{AgentKeypair, AgentPublicKey, P256SigningKeypair, P256VerifyingKey};
+use ciborium::value::{Integer, Value};
+use coset::iana::{Algorithm, Ec2KeyParameter, EllipticCurve, EnumI64, KeyType, OkpKeyParameter};
+use coset::{CoseKey, CoseKeyBuilder, Label, RegisteredLabel};
+
+/// A permit signing key. Determines the COSE algorithm in the protected
+/// header and the COSE_Key placed in the `cnf` claim.
+pub enum PermitSigner {
+    Ed25519(AgentKeypair),
+    P256(P256SigningKeypair),
+}
+
+impl PermitSigner {
+    pub fn algorithm(&self) -> Algorithm {
+        match self {
+            Self::Ed25519(_) => Algorithm::EdDSA,
+            Self::P256(_) => Algorithm::ES256,
+        }
+    }
+
+    pub fn public_key(&self) -> PermitVerifier {
+        match self {
+            Self::Ed25519(keypair) => PermitVerifier::Ed25519(keypair.public_key()),
+            Self::P256(keypair) => PermitVerifier::P256(keypair.public_key()),
+        }
+    }
+
+    /// COSE_Key for the public half, suitable for the `cnf` claim.
+    pub fn cose_key(&self) -> CoseKey {
+        self.public_key().to_cose_key()
+    }
+
+    /// Sign a COSE Sig_structure, producing the encoding required by RFC
+    /// 8152: raw Ed25519 signature bytes, or IEEE P1363 r||s for ES256.
+    pub fn sign(&self, data: &[u8]) -> Vec<u8> {
+        match self {
+            Self::Ed25519(keypair) => keypair.sign(data),
+            Self::P256(keypair) => {
+                let der = keypair.sign(data);
+                // Infallible for signatures produced by p256::ecdsa.
+                der_to_p1363(&der).unwrap_or(der)
+            }
+        }
+    }
+}
+
+/// A permit verification key, recovered from the `cnf` claim or supplied
+/// out of band.
+#[derive(Clone)]
+pub enum PermitVerifier {
+    Ed25519(AgentPublicKey),
+    P256(P256VerifyingKey),
+}
+
+impl PermitVerifier {
+    pub fn algorithm(&self) -> Algorithm {
+        match self {
+            Self::Ed25519(_) => Algorithm::EdDSA,
+            Self::P256(_) => Algorithm::ES256,
+        }
+    }
+
+    pub fn to_cose_key(&self) -> CoseKey {
+        match self {
+            Self::Ed25519(key) => CoseKeyBuilder::new_okp_key()
+                .algorithm(Algorithm::EdDSA)
+                .param(
+                    OkpKeyParameter::Crv.to_i64(),
+                    int_value(EllipticCurve::Ed25519.to_i64()),
+                )
+                .param(OkpKeyParameter::X.to_i64(), Value::Bytes(key.to_bytes()))
+                .build(),
+            Self::P256(key) => {
+                let sec1 = key.to_sec1_bytes();
+                CoseKeyBuilder::new_ec2_pub_key(
+                    EllipticCurve::P_256,
+                    sec1[1..33].to_vec(),
+                    sec1[33..65].to_vec(),
+                )
+                .algorithm(Algorithm::ES256)
+                .build()
+            }
+        }
+    }
+
+    /// Recover a verification key from a COSE_Key, failing closed on any
+    /// unexpected key type, curve, or parameter encoding.
+    pub fn from_cose_key(key: &CoseKey) -> Result<Self, PermitError> {
+        match key.kty {
+            RegisteredLabel::Assigned(KeyType::OKP) => Self::from_okp(key),
+            RegisteredLabel::Assigned(KeyType::EC2) => Self::from_ec2(key),
+            _ => Err(PermitError::InvalidConfirmationKey(
+                "kty must be OKP (Ed25519) or EC2 (P-256)".to_string(),
+            )),
+        }
+    }
+
+    fn from_okp(key: &CoseKey) -> Result<Self, PermitError> {
+        expect_curve(key, EllipticCurve::Ed25519)?;
+        let x = param_bytes(key, OkpKeyParameter::X.to_i64())?;
+        let public = AgentPublicKey::from_bytes(&x)
+            .map_err(|e| PermitError::InvalidConfirmationKey(e.to_string()))?;
+        Ok(Self::Ed25519(public))
+    }
+
+    fn from_ec2(key: &CoseKey) -> Result<Self, PermitError> {
+        expect_curve(key, EllipticCurve::P_256)?;
+        let x = param_bytes(key, Ec2KeyParameter::X.to_i64())?;
+        let y = param_bytes(key, Ec2KeyParameter::Y.to_i64())?;
+        if x.len() != 32 || y.len() != 32 {
+            return Err(PermitError::InvalidConfirmationKey(
+                "P-256 coordinates must be 32 bytes".to_string(),
+            ));
+        }
+        let mut sec1 = Vec::with_capacity(65);
+        sec1.push(0x04);
+        sec1.extend_from_slice(&x);
+        sec1.extend_from_slice(&y);
+        let public = P256VerifyingKey::from_sec1_bytes(&sec1)
+            .map_err(|e| PermitError::InvalidConfirmationKey(e.to_string()))?;
+        Ok(Self::P256(public))
+    }
+
+    /// Verify a COSE signature value against a Sig_structure.
+    pub fn verify(
+        &self,
+        algorithm: Algorithm,
+        data: &[u8],
+        signature: &[u8],
+    ) -> Result<(), PermitError> {
+        if algorithm != self.algorithm() {
+            return Err(PermitError::KeyAlgorithmMismatch);
+        }
+        match self {
+            Self::Ed25519(key) => key
+                .verify(data, signature)
+                .map_err(|_| PermitError::InvalidSignature),
+            Self::P256(key) => key
+                .verify(data, signature)
+                .map_err(|_| PermitError::InvalidSignature),
+        }
+    }
+
+    /// Raw public key bytes: 32 bytes for Ed25519, 65-byte SEC1 uncompressed
+    /// for P-256.
+    pub fn public_key_bytes(&self) -> Vec<u8> {
+        match self {
+            Self::Ed25519(key) => key.to_bytes(),
+            Self::P256(key) => key.to_sec1_bytes(),
+        }
+    }
+}
+
+fn int_value(value: i64) -> Value {
+    Value::Integer(Integer::from(value))
+}
+
+fn param_bytes(key: &CoseKey, label: i64) -> Result<Vec<u8>, PermitError> {
+    let wanted = Label::Int(label);
+    match key.params.iter().find(|(l, _)| *l == wanted) {
+        Some((_, Value::Bytes(bytes))) => Ok(bytes.clone()),
+        Some(_) => Err(PermitError::InvalidConfirmationKey(format!(
+            "parameter {label} is not a bstr"
+        ))),
+        None => Err(PermitError::InvalidConfirmationKey(format!(
+            "missing parameter {label}"
+        ))),
+    }
+}
+
+fn expect_curve(key: &CoseKey, curve: EllipticCurve) -> Result<(), PermitError> {
+    let wanted = Integer::from(curve.to_i64());
+    let found = key
+        .params
+        .iter()
+        .find_map(|(label, value)| match (label, value) {
+            (Label::Int(l), Value::Integer(v)) if *l == -1 => Some(*v),
+            _ => None,
+        });
+    match found {
+        Some(v) if v == wanted => Ok(()),
+        _ => Err(PermitError::InvalidConfirmationKey(format!(
+            "unexpected curve, want {:?}",
+            curve.to_i64()
+        ))),
+    }
+}
+
+/// Convert a DER-encoded ECDSA signature to the IEEE P1363 fixed-size
+/// r||s form required by COSE ES256 (RFC 8152 section 8.1).
+fn der_to_p1363(der: &[u8]) -> Result<Vec<u8>, PermitError> {
+    fn read_len(bytes: &[u8], pos: &mut usize) -> Result<usize, PermitError> {
+        let first = *bytes
+            .get(*pos)
+            .ok_or_else(|| PermitError::Cose("truncated DER signature".to_string()))?;
+        *pos += 1;
+        if first & 0x80 == 0 {
+            return Ok(first as usize);
+        }
+        let count = (first & 0x7f) as usize;
+        if count == 0 || count > 2 {
+            return Err(PermitError::Cose("invalid DER length".to_string()));
+        }
+        let mut len = 0usize;
+        for _ in 0..count {
+            let byte = *bytes
+                .get(*pos)
+                .ok_or_else(|| PermitError::Cose("truncated DER length".to_string()))?;
+            *pos += 1;
+            len = (len << 8) | byte as usize;
+        }
+        Ok(len)
+    }
+
+    let mut pos = 0usize;
+    let bad = || PermitError::Cose("malformed DER ECDSA signature".to_string());
+    if der.first() != Some(&0x30) {
+        return Err(bad());
+    }
+    pos += 1;
+    let seq_len = read_len(der, &mut pos)?;
+    if pos + seq_len != der.len() {
+        return Err(bad());
+    }
+    let mut out = Vec::with_capacity(64);
+    for _ in 0..2 {
+        if der.get(pos) != Some(&0x02) {
+            return Err(bad());
+        }
+        pos += 1;
+        let int_len = read_len(der, &mut pos)?;
+        let bytes = der.get(pos..pos + int_len).ok_or_else(bad)?;
+        pos += int_len;
+        // Strip the sign-padding zero, then left-pad to 32 bytes.
+        let significant = bytes
+            .iter()
+            .position(|b| *b != 0)
+            .map(|i| &bytes[i..])
+            .unwrap_or(&[][..]);
+        if significant.len() > 32 {
+            return Err(bad());
+        }
+        out.resize(out.len() + (32 - significant.len()), 0);
+        out.extend_from_slice(significant);
+    }
+    if pos != der.len() {
+        return Err(bad());
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ed25519_cose_key_roundtrip() {
+        let keypair = AgentKeypair::generate();
+        let signer = PermitSigner::Ed25519(keypair);
+        let cose_key = signer.cose_key();
+        assert_eq!(cose_key.kty, RegisteredLabel::Assigned(KeyType::OKP));
+        let verifier = PermitVerifier::from_cose_key(&cose_key).unwrap();
+        assert_eq!(
+            signer.public_key().public_key_bytes(),
+            verifier.public_key_bytes()
+        );
+    }
+
+    #[test]
+    fn p256_cose_key_roundtrip() {
+        let keypair = P256SigningKeypair::generate();
+        let signer = PermitSigner::P256(keypair);
+        let cose_key = signer.cose_key();
+        assert_eq!(cose_key.kty, RegisteredLabel::Assigned(KeyType::EC2));
+        let verifier = PermitVerifier::from_cose_key(&cose_key).unwrap();
+        assert_eq!(
+            signer.public_key().public_key_bytes(),
+            verifier.public_key_bytes()
+        );
+    }
+
+    #[test]
+    fn ed25519_sign_verify_via_signer() {
+        let signer = PermitSigner::Ed25519(AgentKeypair::generate());
+        let verifier = signer.public_key();
+        let data = b"sig structure bytes";
+        let signature = signer.sign(data);
+        assert_eq!(signature.len(), 64);
+        assert!(verifier.verify(Algorithm::EdDSA, data, &signature).is_ok());
+        assert!(
+            verifier
+                .verify(Algorithm::EdDSA, b"other", &signature)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn p256_sign_produces_p1363_and_verifies() {
+        let signer = PermitSigner::P256(P256SigningKeypair::generate());
+        let verifier = signer.public_key();
+        let data = b"sig structure bytes";
+        let signature = signer.sign(data);
+        assert_eq!(signature.len(), 64, "COSE ES256 requires raw r||s");
+        assert!(verifier.verify(Algorithm::ES256, data, &signature).is_ok());
+    }
+
+    #[test]
+    fn algorithm_mismatch_rejected() {
+        let signer = PermitSigner::Ed25519(AgentKeypair::generate());
+        let verifier = signer.public_key();
+        let signature = signer.sign(b"data");
+        assert!(matches!(
+            verifier.verify(Algorithm::ES256, b"data", &signature),
+            Err(PermitError::KeyAlgorithmMismatch)
+        ));
+    }
+
+    #[test]
+    fn wrong_curve_cose_key_rejected() {
+        // An EC2 key on P-384 must not be accepted as an ES256 permit key.
+        let key =
+            CoseKeyBuilder::new_ec2_pub_key(EllipticCurve::P_384, vec![1; 48], vec![2; 48]).build();
+        assert!(PermitVerifier::from_cose_key(&key).is_err());
+    }
+
+    #[test]
+    fn der_to_p1363_converts_and_rejects_garbage() {
+        let keypair = P256SigningKeypair::generate();
+        let der = keypair.sign(b"message");
+        assert_eq!(der[0], 0x30);
+        let raw = der_to_p1363(&der).unwrap();
+        assert_eq!(raw.len(), 64);
+        keypair
+            .public_key()
+            .verify(b"message", &raw)
+            .expect("raw signature must verify");
+
+        assert!(der_to_p1363(&[]).is_err());
+        assert!(der_to_p1363(&[0x30]).is_err());
+        assert!(der_to_p1363(&[0x31, 0x00]).is_err());
+        let mut truncated = der.clone();
+        truncated.truncate(der.len() - 1);
+        assert!(der_to_p1363(&truncated).is_err());
+    }
+}

--- a/crates/arkavo-permit/src/lib.rs
+++ b/crates/arkavo-permit/src/lib.rs
@@ -1,0 +1,29 @@
+//! CWT permits for permit-bound tool execution.
+//!
+//! A permit is a CBOR Web Token (RFC 8392) signed as COSE_Sign1 (RFC 8152).
+//! Every permit carries a `cnf` confirmation claim (RFC 8747) holding the
+//! COSE_Key proof-of-possession key; the signature is verified against that
+//! key, so a permit is bound to the key that minted it.
+//!
+//! See `docs/permit-cwt-schema.md` for the full claim schema and
+//! canonicalization rules.
+
+mod canonical;
+mod claims;
+mod error;
+mod hash;
+mod keys;
+mod permit;
+
+pub use canonical::{argument_hash, canonical_json, canonicalize_json_text};
+pub use claims::{
+    BUDGET_COST_MICRO_USD, BUDGET_MAX_INVOCATIONS, BUDGET_TOKEN_CEILING, Budget,
+    CLAIM_AGENT_WORKLOAD_ID, CLAIM_ARGUMENT_HASH, CLAIM_BUDGET, CLAIM_CONFIRMATION,
+    CLAIM_DATA_CLASSIFICATIONS, CLAIM_EXPIRATION, CLAIM_ISSUED_AT, CLAIM_ISSUER, CLAIM_NOT_BEFORE,
+    CLAIM_PARENT_PERMIT, CLAIM_POLICY_BUNDLE_HASH, CLAIM_SEQUENCE_STATE_HASH, CLAIM_SUBJECT,
+    CLAIM_TOOL_NAME, CNF_COSE_KEY, PermitClaims,
+};
+pub use error::PermitError;
+pub use hash::HashAlgorithm;
+pub use keys::{PermitSigner, PermitVerifier};
+pub use permit::{Permit, decode, mint, verify};

--- a/crates/arkavo-permit/src/lib.rs
+++ b/crates/arkavo-permit/src/lib.rs
@@ -26,4 +26,4 @@ pub use claims::{
 pub use error::PermitError;
 pub use hash::HashAlgorithm;
 pub use keys::{PermitSigner, PermitVerifier};
-pub use permit::{Permit, decode, mint, verify};
+pub use permit::{MAX_PERMIT_BYTES, Permit, decode, mint, verify};

--- a/crates/arkavo-permit/src/permit.rs
+++ b/crates/arkavo-permit/src/permit.rs
@@ -16,6 +16,10 @@ use coset::{
 /// CBOR tag 61 (CWT) prefix bytes: 0xd8 0x3d.
 const CWT_TAG_PREFIX: [u8; 2] = [0xd8, 0x3d];
 
+/// Permits are small CWTs. Untrusted `decode`/`verify` input larger than this
+/// is rejected before COSE/CBOR parse.
+pub const MAX_PERMIT_BYTES: usize = 16 * 1024;
+
 /// A decoded permit: the validated claims plus the confirmation key they
 /// were bound to. Instances returned by [`verify`] are additionally
 /// signature- and time-checked.
@@ -54,6 +58,8 @@ pub fn mint(claims: &PermitClaims, signer: &PermitSigner) -> Result<Vec<u8>, Per
 /// The claims are structurally validated (fail-closed on malformed input),
 /// but callers must not make authorization decisions from the result; use
 /// [`verify`] for that.
+///
+/// Input larger than [`MAX_PERMIT_BYTES`] is rejected before parse.
 pub fn decode(cwt: &[u8]) -> Result<Permit, PermitError> {
     let sign1 = parse_sign1(cwt)?;
     extract(&sign1)
@@ -62,6 +68,8 @@ pub fn decode(cwt: &[u8]) -> Result<Permit, PermitError> {
 /// Decode and fully verify a permit: structure, signature against the `cnf`
 /// key, algorithm/key agreement, and the nbf/exp/iat window at `now`
 /// (seconds since UNIX epoch).
+///
+/// Input larger than [`MAX_PERMIT_BYTES`] is rejected before parse.
 pub fn verify(cwt: &[u8], now: i64) -> Result<Permit, PermitError> {
     let sign1 = parse_sign1(cwt)?;
     let algorithm = header_algorithm(&sign1)?;
@@ -92,6 +100,9 @@ pub fn verify(cwt: &[u8], now: i64) -> Result<Permit, PermitError> {
 }
 
 fn parse_sign1(cwt: &[u8]) -> Result<CoseSign1, PermitError> {
+    if cwt.len() > MAX_PERMIT_BYTES {
+        return Err(PermitError::Cose("permit exceeds maximum size".to_string()));
+    }
     let tagged = cwt
         .strip_prefix(&CWT_TAG_PREFIX)
         .ok_or(PermitError::Cose("missing CBOR tag 61 (CWT)".to_string()))?;
@@ -363,6 +374,19 @@ mod tests {
             permit.claims.parent_permit.as_deref(),
             Some(HashAlgorithm::Sha256.digest(&parent).as_slice())
         );
+    }
+
+    #[test]
+    fn oversized_permit_rejected_before_parse() {
+        let oversized = vec![0u8; MAX_PERMIT_BYTES + 1];
+        assert!(matches!(
+            decode(&oversized),
+            Err(PermitError::Cose(msg)) if msg.contains("maximum size")
+        ));
+        assert!(matches!(
+            verify(&oversized, NOW),
+            Err(PermitError::Cose(msg)) if msg.contains("maximum size")
+        ));
     }
 
     #[test]

--- a/crates/arkavo-permit/src/permit.rs
+++ b/crates/arkavo-permit/src/permit.rs
@@ -1,0 +1,431 @@
+//! Minting, decoding, and verifying CWT permits.
+//!
+//! Wire format: CBOR tag 61 (CWT) wrapping a tagged COSE_Sign1 (tag 18)
+//! whose payload is the CBOR-encoded claims set. The protected header carries
+//! the signing algorithm and a content type of `application/cwt`.
+
+use crate::claims::PermitClaims;
+use crate::error::PermitError;
+use crate::keys::{PermitSigner, PermitVerifier};
+use ciborium::value::Value;
+use coset::iana::{Algorithm, CoapContentFormat};
+use coset::{
+    CoseSign1, CoseSign1Builder, HeaderBuilder, RegisteredLabelWithPrivate, TaggedCborSerializable,
+};
+
+/// CBOR tag 61 (CWT) prefix bytes: 0xd8 0x3d.
+const CWT_TAG_PREFIX: [u8; 2] = [0xd8, 0x3d];
+
+/// A decoded permit: the validated claims plus the confirmation key they
+/// were bound to. Instances returned by [`verify`] are additionally
+/// signature- and time-checked.
+pub struct Permit {
+    pub claims: PermitClaims,
+    pub confirmation_key: PermitVerifier,
+}
+
+/// Mint a signed permit CWT. The `cnf` claim is derived from the signer.
+pub fn mint(claims: &PermitClaims, signer: &PermitSigner) -> Result<Vec<u8>, PermitError> {
+    claims.validate()?;
+    let claims_value = claims.to_cbor_value(&signer.cose_key())?;
+    let mut payload = Vec::new();
+    ciborium::into_writer(&claims_value, &mut payload)
+        .map_err(|e| PermitError::CborSerialize(format!("claims set: {e}")))?;
+    let header = HeaderBuilder::new()
+        .algorithm(signer.algorithm())
+        .content_format(CoapContentFormat::Cwt)
+        .build();
+    let sign1 = CoseSign1Builder::new()
+        .protected(header)
+        .payload(payload)
+        .create_signature(&[], |data| signer.sign(data))
+        .build();
+    let sign1_bytes = sign1
+        .to_tagged_vec()
+        .map_err(|e| PermitError::Cose(format!("COSE_Sign1 encode: {e}")))?;
+    let mut out = Vec::with_capacity(CWT_TAG_PREFIX.len() + sign1_bytes.len());
+    out.extend_from_slice(&CWT_TAG_PREFIX);
+    out.extend_from_slice(&sign1_bytes);
+    Ok(out)
+}
+
+/// Decode a permit without verifying the signature or validity window.
+///
+/// The claims are structurally validated (fail-closed on malformed input),
+/// but callers must not make authorization decisions from the result; use
+/// [`verify`] for that.
+pub fn decode(cwt: &[u8]) -> Result<Permit, PermitError> {
+    let sign1 = parse_sign1(cwt)?;
+    extract(&sign1)
+}
+
+/// Decode and fully verify a permit: structure, signature against the `cnf`
+/// key, algorithm/key agreement, and the nbf/exp/iat window at `now`
+/// (seconds since UNIX epoch).
+pub fn verify(cwt: &[u8], now: i64) -> Result<Permit, PermitError> {
+    let sign1 = parse_sign1(cwt)?;
+    let algorithm = header_algorithm(&sign1)?;
+    let permit = extract(&sign1)?;
+    sign1.verify_signature(&[], |signature, data| {
+        permit.confirmation_key.verify(algorithm, data, signature)
+    })?;
+    let claims = &permit.claims;
+    if now < claims.not_before {
+        return Err(PermitError::NotYetValid {
+            nbf: claims.not_before,
+            now,
+        });
+    }
+    if now >= claims.expires_at {
+        return Err(PermitError::Expired {
+            exp: claims.expires_at,
+            now,
+        });
+    }
+    if claims.issued_at > now {
+        return Err(PermitError::IssuedInFuture {
+            iat: claims.issued_at,
+            now,
+        });
+    }
+    Ok(permit)
+}
+
+fn parse_sign1(cwt: &[u8]) -> Result<CoseSign1, PermitError> {
+    let tagged = cwt
+        .strip_prefix(&CWT_TAG_PREFIX)
+        .ok_or(PermitError::Cose("missing CBOR tag 61 (CWT)".to_string()))?;
+    CoseSign1::from_tagged_slice(tagged)
+        .map_err(|e| PermitError::Cose(format!("COSE_Sign1 decode: {e}")))
+}
+
+fn header_algorithm(sign1: &CoseSign1) -> Result<Algorithm, PermitError> {
+    match &sign1.protected.header.alg {
+        Some(RegisteredLabelWithPrivate::Assigned(alg @ (Algorithm::EdDSA | Algorithm::ES256))) => {
+            Ok(*alg)
+        }
+        Some(other) => Err(PermitError::UnsupportedAlgorithm(format!("{other:?}"))),
+        None => Err(PermitError::MalformedClaim("protected header alg")),
+    }
+}
+
+fn extract(sign1: &CoseSign1) -> Result<Permit, PermitError> {
+    let payload = sign1
+        .payload
+        .as_ref()
+        .ok_or(PermitError::MalformedClaim("detached payload"))?;
+    let value: Value = ciborium::from_reader(payload.as_slice())
+        .map_err(|e| PermitError::CborDeserialize(format!("claims set: {e}")))?;
+    let (claims, cose_key) = PermitClaims::from_cbor_value(&value)?;
+    let confirmation_key = PermitVerifier::from_cose_key(&cose_key)?;
+    Ok(Permit {
+        claims,
+        confirmation_key,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::claims::{BUDGET_MAX_INVOCATIONS, Budget, CLAIM_CONFIRMATION, CNF_COSE_KEY};
+    use crate::hash::HashAlgorithm;
+    use crate::{argument_hash, keys::PermitVerifier as Verifier};
+    use arkavo_crypto::{AgentKeypair, P256SigningKeypair};
+    use coset::{AsCborValue, CborSerializable};
+
+    const IAT: i64 = 1_700_000_000;
+    const NOW: i64 = 1_700_000_060;
+    const EXP: i64 = 1_700_000_300;
+
+    fn sample_claims() -> PermitClaims {
+        let arguments = serde_json::json!({"path": "/tmp/data.csv", "max_bytes": 4096});
+        PermitClaims {
+            issuer: "https://issuer.example".to_string(),
+            subject: "did:example:alice".to_string(),
+            agent_workload_id: "spiffe://edge/agent-1".to_string(),
+            policy_bundle_hash: HashAlgorithm::Sha256.digest(b"policy-bundle-v1"),
+            tool_name: "arkavo.fs.read".to_string(),
+            argument_hash: argument_hash(&arguments, HashAlgorithm::Sha256),
+            data_classifications: vec!["tdf:confidential".to_string()],
+            budget: Budget {
+                max_invocations: 5,
+                token_ceiling: Some(100_000),
+                cost_micro_usd: Some(250_000),
+            },
+            sequence_state_hash: HashAlgorithm::Sha256.digest(b"sequence-0"),
+            issued_at: IAT,
+            not_before: IAT,
+            expires_at: EXP,
+            parent_permit: None,
+        }
+    }
+
+    fn ed25519_signer() -> PermitSigner {
+        PermitSigner::Ed25519(AgentKeypair::generate())
+    }
+
+    #[test]
+    fn roundtrip_ed25519() {
+        let signer = ed25519_signer();
+        let claims = sample_claims();
+        let cwt = mint(&claims, &signer).unwrap();
+        let permit = verify(&cwt, NOW).unwrap();
+        assert_eq!(permit.claims, claims);
+        assert_eq!(
+            permit.confirmation_key.public_key_bytes(),
+            signer.public_key().public_key_bytes()
+        );
+    }
+
+    #[test]
+    fn roundtrip_es256() {
+        let signer = PermitSigner::P256(P256SigningKeypair::generate());
+        let claims = sample_claims();
+        let cwt = mint(&claims, &signer).unwrap();
+        let permit = verify(&cwt, NOW).unwrap();
+        assert_eq!(permit.claims, claims);
+    }
+
+    #[test]
+    fn wire_format_starts_with_cwt_tag() {
+        let cwt = mint(&sample_claims(), &ed25519_signer()).unwrap();
+        // Tag 61 (CWT) then tag 18 (COSE_Sign1), both in canonical CBOR.
+        assert_eq!(&cwt[..4], &[0xd8, 0x3d, 0xd2, 0x84], "tag 61 then tag 18");
+    }
+
+    #[test]
+    fn tampered_signature_rejected() {
+        let signer = ed25519_signer();
+        let cwt = mint(&sample_claims(), &signer).unwrap();
+        // Flip a bit in the final byte: Ed25519 signatures sit at the tail
+        // of the COSE_Sign1 array.
+        let mut tampered = cwt.clone();
+        let last = tampered.len() - 1;
+        tampered[last] ^= 0x01;
+        assert!(matches!(
+            verify(&tampered, NOW),
+            Err(PermitError::InvalidSignature) | Err(PermitError::Cose(_))
+        ));
+    }
+
+    #[test]
+    fn tampered_payload_rejected() {
+        let signer = ed25519_signer();
+        let claims = sample_claims();
+        let cwt = mint(&claims, &signer).unwrap();
+        // Corrupt a byte in the middle of the claims payload.
+        let mut tampered = cwt.clone();
+        let mid = tampered.len() / 2;
+        tampered[mid] ^= 0x40;
+        assert!(verify(&tampered, NOW).is_err());
+    }
+
+    #[test]
+    fn expired_permit_rejected() {
+        let signer = ed25519_signer();
+        let cwt = mint(&sample_claims(), &signer).unwrap();
+        assert!(matches!(
+            verify(&cwt, EXP),
+            Err(PermitError::Expired { .. })
+        ));
+        assert!(matches!(
+            verify(&cwt, EXP + 10_000),
+            Err(PermitError::Expired { .. })
+        ));
+    }
+
+    #[test]
+    fn not_yet_valid_permit_rejected() {
+        let signer = ed25519_signer();
+        let mut claims = sample_claims();
+        claims.not_before = NOW + 60;
+        claims.issued_at = IAT;
+        let cwt = mint(&claims, &signer).unwrap();
+        assert!(matches!(
+            verify(&cwt, NOW),
+            Err(PermitError::NotYetValid { .. })
+        ));
+    }
+
+    #[test]
+    fn future_iat_rejected() {
+        let signer = ed25519_signer();
+        let mut claims = sample_claims();
+        claims.issued_at = NOW + 60;
+        let cwt = mint(&claims, &signer).unwrap();
+        assert!(matches!(
+            verify(&cwt, NOW),
+            Err(PermitError::IssuedInFuture { .. })
+        ));
+    }
+
+    #[test]
+    fn wrong_cnf_key_rejected() {
+        // Sign with key A but place key B in the cnf claim: the signature
+        // cannot verify against the confirmation key.
+        let signer_a = ed25519_signer();
+        let signer_b = ed25519_signer();
+        let claims = sample_claims();
+        let mut value = claims.to_cbor_value(&signer_a.cose_key()).unwrap();
+        if let Value::Map(entries) = &mut value {
+            for (k, v) in entries.iter_mut() {
+                if matches!(k, Value::Integer(i) if i128::from(*i) == CLAIM_CONFIRMATION as i128) {
+                    let cnf_key = signer_b
+                        .cose_key()
+                        .to_cbor_value()
+                        .expect("cnf key encodes");
+                    *v = Value::Map(vec![(
+                        Value::Integer(ciborium::value::Integer::from(CNF_COSE_KEY)),
+                        cnf_key,
+                    )]);
+                }
+            }
+        }
+        let mut payload = Vec::new();
+        ciborium::into_writer(&value, &mut payload).unwrap();
+        let header = HeaderBuilder::new().algorithm(Algorithm::EdDSA).build();
+        let sign1 = CoseSign1Builder::new()
+            .protected(header)
+            .payload(payload)
+            .create_signature(&[], |data| signer_a.sign(data))
+            .build();
+        let sign1_bytes = sign1.to_tagged_vec().unwrap();
+        let mut cwt = CWT_TAG_PREFIX.to_vec();
+        cwt.extend_from_slice(&sign1_bytes);
+        assert!(matches!(
+            verify(&cwt, NOW),
+            Err(PermitError::InvalidSignature)
+        ));
+    }
+
+    #[test]
+    fn canonical_argument_hash_mismatch_rejected() {
+        let signer = ed25519_signer();
+        let claims = sample_claims();
+        let cwt = mint(&claims, &signer).unwrap();
+        let permit = verify(&cwt, NOW).unwrap();
+
+        let expected_args = serde_json::json!({"max_bytes": 4096, "path": "/tmp/data.csv"});
+        assert!(
+            permit
+                .claims
+                .verify_invocation("arkavo.fs.read", &expected_args, HashAlgorithm::Sha256)
+                .is_ok()
+        );
+
+        let wrong_args = serde_json::json!({"max_bytes": 8192, "path": "/tmp/data.csv"});
+        assert!(matches!(
+            permit
+                .claims
+                .verify_invocation("arkavo.fs.read", &wrong_args, HashAlgorithm::Sha256),
+            Err(PermitError::BindingMismatch(_))
+        ));
+    }
+
+    #[test]
+    fn unknown_claims_are_tolerated() {
+        let signer = ed25519_signer();
+        let claims = sample_claims();
+        let mut value = claims.to_cbor_value(&signer.cose_key()).unwrap();
+        if let Value::Map(entries) = &mut value {
+            entries.push((
+                Value::Integer(ciborium::value::Integer::from(-79999)),
+                Value::Text("future extension".to_string()),
+            ));
+        }
+        let mut payload = Vec::new();
+        ciborium::into_writer(&value, &mut payload).unwrap();
+        let sign1 = CoseSign1Builder::new()
+            .protected(HeaderBuilder::new().algorithm(Algorithm::EdDSA).build())
+            .payload(payload)
+            .create_signature(&[], |data| signer.sign(data))
+            .build();
+        let mut cwt = CWT_TAG_PREFIX.to_vec();
+        cwt.extend_from_slice(&sign1.to_tagged_vec().unwrap());
+        let permit = verify(&cwt, NOW).unwrap();
+        assert_eq!(permit.claims, claims);
+    }
+
+    #[test]
+    fn parent_permit_chain_roundtrip() {
+        let parent_signer = ed25519_signer();
+        let parent = mint(&sample_claims(), &parent_signer).unwrap();
+
+        let child_signer = ed25519_signer();
+        let mut child_claims = sample_claims();
+        child_claims.tool_name = "arkavo.a2a.delegate".to_string();
+        child_claims.parent_permit = Some(HashAlgorithm::Sha256.digest(&parent));
+        let child = mint(&child_claims, &child_signer).unwrap();
+
+        let permit = verify(&child, NOW).unwrap();
+        // The parent hash binds the child to the exact parent CWT bytes.
+        assert_eq!(
+            permit.claims.parent_permit.as_deref(),
+            Some(HashAlgorithm::Sha256.digest(&parent).as_slice())
+        );
+    }
+
+    #[test]
+    fn decode_does_not_verify_but_validates_structure() {
+        let signer = ed25519_signer();
+        let claims = sample_claims();
+        let cwt = mint(&claims, &signer).unwrap();
+        // Expired at this instant, but decode must still succeed.
+        let permit = decode(&cwt).unwrap();
+        assert_eq!(permit.claims, claims);
+        assert!(decode(&cwt[..10]).is_err());
+        assert!(decode(b"\xd8\x3dgarbage").is_err());
+    }
+
+    #[test]
+    fn missing_budget_field_rejected() {
+        let signer = ed25519_signer();
+        let claims = sample_claims();
+        let mut value = claims.to_cbor_value(&signer.cose_key()).unwrap();
+        if let Value::Map(entries) = &mut value {
+            for (k, v) in entries.iter_mut() {
+                let is_budget = matches!(k, Value::Integer(i) if i128::from(*i) == -70006);
+                if is_budget && let Value::Map(budget) = v {
+                    budget.retain(|(bk, _)| {
+                        !matches!(bk, Value::Integer(i) if i128::from(*i) == BUDGET_MAX_INVOCATIONS as i128)
+                    });
+                }
+            }
+        }
+        let mut payload = Vec::new();
+        ciborium::into_writer(&value, &mut payload).unwrap();
+        let sign1 = CoseSign1Builder::new()
+            .protected(HeaderBuilder::new().algorithm(Algorithm::EdDSA).build())
+            .payload(payload)
+            .create_signature(&[], |data| signer.sign(data))
+            .build();
+        let mut cwt = CWT_TAG_PREFIX.to_vec();
+        cwt.extend_from_slice(&sign1.to_tagged_vec().unwrap());
+        assert!(matches!(
+            verify(&cwt, NOW),
+            Err(PermitError::MissingClaim("budget.max_invocations"))
+        ));
+    }
+
+    #[test]
+    fn cnf_key_recovers_expected_verifier() {
+        let signer = ed25519_signer();
+        let cwt = mint(&sample_claims(), &signer).unwrap();
+        let permit = decode(&cwt).unwrap();
+        let _expected: Verifier = signer.public_key();
+        assert_eq!(
+            permit.confirmation_key.public_key_bytes(),
+            _expected.public_key_bytes()
+        );
+    }
+
+    #[test]
+    fn cbor_serializable_sign1_roundtrip_used_internally() {
+        let signer = ed25519_signer();
+        let cwt = mint(&sample_claims(), &signer).unwrap();
+        let sign1 = parse_sign1(&cwt).unwrap();
+        let bytes = sign1.clone().to_vec().unwrap();
+        let parsed = CoseSign1::from_slice(&bytes).unwrap();
+        assert_eq!(parsed.signature, sign1.signature);
+    }
+}

--- a/crates/arkavo-permit/tests/vectors/ed25519-parent-chain.json
+++ b/crates/arkavo-permit/tests/vectors/ed25519-parent-chain.json
@@ -1,0 +1,36 @@
+{
+  "algorithm": "EdDSA",
+  "claims": {
+    "agent_workload_id": "spiffe://arkavo-edge/ns/default/sa/edge-agent-001",
+    "argument_hash_hex": "e02c6eb385256fdf6d3a61f6ed673c499463dbcce85095aee694edfe6a4ad656",
+    "arguments": {
+      "agent": "spiffe://arkavo-edge/ns/default/sa/edge-agent-002",
+      "task": "summarize"
+    },
+    "budget": {
+      "cost_micro_usd": 250000,
+      "max_invocations": 5,
+      "token_ceiling": 100000
+    },
+    "data_classifications": [
+      "tdf:classification:confidential",
+      "tdf:region:us"
+    ],
+    "exp": 1700000300,
+    "iat": 1700000000,
+    "iss": "https://permit-issuer.arkavo.example",
+    "nbf": 1700000000,
+    "parent_permit_hex": "c71dcec671887873e530e4b45968dffcb5ecd0b60c57b415ce99b6fae7ea56a8",
+    "policy_bundle_hash_hex": "438c3a1bf4d4708cf8084ea5b889279b7e3992dac8dc42e1e62e50915e869a5e",
+    "sequence_state_hash_hex": "3fcb0977a9a08cd4c8f829a837f4157be009926babec23a8039fb480bb631cbc",
+    "sub": "did:example:human-alice",
+    "tool_name": "arkavo.a2a.delegate"
+  },
+  "cwt_hex": "d83dd28446a2012703183da05901b6ae01782468747470733a2f2f7065726d69742d6973737565722e61726b61766f2e6578616d706c6502776469643a6578616d706c653a68756d616e2d616c696365041a6553f22c051a6553f100061a6553f10008a101a401010327200621582017cb79fb2b4120f2b1ec65e4198d6e08b28e813feb01e4a400839b85e18080ce3a0001117078317370696666653a2f2f61726b61766f2d656467652f6e732f64656661756c742f73612f656467652d6167656e742d3030313a000111715820438c3a1bf4d4708cf8084ea5b889279b7e3992dac8dc42e1e62e50915e869a5e3a000111727361726b61766f2e6132612e64656c65676174653a000111735820e02c6eb385256fdf6d3a61f6ed673c499463dbcce85095aee694edfe6a4ad6563a0001117482781f7464663a636c617373696669636174696f6e3a636f6e666964656e7469616c6d7464663a726567696f6e3a75733a00011175a30105021a000186a0031a0003d0903a0001117658203fcb0977a9a08cd4c8f829a837f4157be009926babec23a8039fb480bb631cbc3a000111775820c71dcec671887873e530e4b45968dffcb5ecd0b60c57b415ce99b6fae7ea56a8584073b0209142a1a36651ff2157b48e7d147394f971f60a638bd883b11b18133ad6f967788f76bda4ce197aea4e82285a3a8018989af32614f1e7dcd4414466250d",
+  "description": "Signed CWT permit test vector for arkavo-permit; regenerate with `cargo run -p arkavo-permit --example generate_vectors`",
+  "hash_algorithm": "sha256",
+  "name": "ed25519-parent-chain",
+  "now_for_verification": 1700000060,
+  "public_key_hex": "17cb79fb2b4120f2b1ec65e4198d6e08b28e813feb01e4a400839b85e18080ce",
+  "secret_key_hex": "3333333333333333333333333333333333333333333333333333333333333333"
+}

--- a/crates/arkavo-permit/tests/vectors/ed25519-sha256.json
+++ b/crates/arkavo-permit/tests/vectors/ed25519-sha256.json
@@ -1,0 +1,36 @@
+{
+  "algorithm": "EdDSA",
+  "claims": {
+    "agent_workload_id": "spiffe://arkavo-edge/ns/default/sa/edge-agent-001",
+    "argument_hash_hex": "b88f8c77e0f36012c73b89f37e022b2aee0e2c7199251bb813a9a2d7e12111ab",
+    "arguments": {
+      "max_bytes": 4096,
+      "path": "/tmp/data.csv"
+    },
+    "budget": {
+      "cost_micro_usd": 250000,
+      "max_invocations": 5,
+      "token_ceiling": 100000
+    },
+    "data_classifications": [
+      "tdf:classification:confidential",
+      "tdf:region:us"
+    ],
+    "exp": 1700000300,
+    "iat": 1700000000,
+    "iss": "https://permit-issuer.arkavo.example",
+    "nbf": 1700000000,
+    "parent_permit_hex": null,
+    "policy_bundle_hash_hex": "438c3a1bf4d4708cf8084ea5b889279b7e3992dac8dc42e1e62e50915e869a5e",
+    "sequence_state_hash_hex": "3fcb0977a9a08cd4c8f829a837f4157be009926babec23a8039fb480bb631cbc",
+    "sub": "did:example:human-alice",
+    "tool_name": "arkavo.fs.read_file"
+  },
+  "cwt_hex": "d83dd28446a2012703183da059018fad01782468747470733a2f2f7065726d69742d6973737565722e61726b61766f2e6578616d706c6502776469643a6578616d706c653a68756d616e2d616c696365041a6553f22c051a6553f100061a6553f10008a101a4010103272006215820d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c97787373a0001117078317370696666653a2f2f61726b61766f2d656467652f6e732f64656661756c742f73612f656467652d6167656e742d3030313a000111715820438c3a1bf4d4708cf8084ea5b889279b7e3992dac8dc42e1e62e50915e869a5e3a000111727361726b61766f2e66732e726561645f66696c653a000111735820b88f8c77e0f36012c73b89f37e022b2aee0e2c7199251bb813a9a2d7e12111ab3a0001117482781f7464663a636c617373696669636174696f6e3a636f6e666964656e7469616c6d7464663a726567696f6e3a75733a00011175a30105021a000186a0031a0003d0903a0001117658203fcb0977a9a08cd4c8f829a837f4157be009926babec23a8039fb480bb631cbc58405c09813a7e8e7c8f5a8980e97b88838a1f18194618dd3ddda45bd294ecdea4deb0882bc27bef13c83e666c70e4959cf89b5fba9c1cc22d1abd1a3158d3e18100",
+  "description": "Signed CWT permit test vector for arkavo-permit; regenerate with `cargo run -p arkavo-permit --example generate_vectors`",
+  "hash_algorithm": "sha256",
+  "name": "ed25519-sha256",
+  "now_for_verification": 1700000060,
+  "public_key_hex": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+  "secret_key_hex": "1111111111111111111111111111111111111111111111111111111111111111"
+}

--- a/crates/arkavo-permit/tests/vectors/es256-blake3.json
+++ b/crates/arkavo-permit/tests/vectors/es256-blake3.json
@@ -1,0 +1,40 @@
+{
+  "algorithm": "ES256",
+  "claims": {
+    "agent_workload_id": "spiffe://arkavo-edge/ns/default/sa/edge-agent-001",
+    "argument_hash_hex": "3a468fc4e706f9cfc585d32e344e913825e8175b80648d3427cafe17dbd9d328",
+    "arguments": {
+      "argv": [
+        "ls",
+        "-la"
+      ],
+      "cwd": "/tmp",
+      "timeout_ms": 5000
+    },
+    "budget": {
+      "cost_micro_usd": 250000,
+      "max_invocations": 5,
+      "token_ceiling": 100000
+    },
+    "data_classifications": [
+      "tdf:classification:confidential",
+      "tdf:region:us"
+    ],
+    "exp": 1700000300,
+    "iat": 1700000000,
+    "iss": "https://permit-issuer.arkavo.example",
+    "nbf": 1700000000,
+    "parent_permit_hex": null,
+    "policy_bundle_hash_hex": "fc7098491f29851e0e80cbf6f858e9a15a9ffc0b2a050ac7a0fac32b1962a468",
+    "sequence_state_hash_hex": "c1483b47c4fd43849682d6f70b6004f187353e22ccc7b7eb8e044227b55cc022",
+    "sub": "did:example:human-alice",
+    "tool_name": "arkavo.shell.exec"
+  },
+  "cwt_hex": "d83dd28446a2012603183da05901b0ad01782468747470733a2f2f7065726d69742d6973737565722e61726b61766f2e6578616d706c6502776469643a6578616d706c653a68756d616e2d616c696365041a6553f22c051a6553f100061a6553f10008a101a5010203262001215820d65a93977caa3d1b081852ff57a79e465f1660577304baead505dd3a48589cf322582050185e895372df6221ea3a137557e473fddb6755f05bd507c3c533fce9c912853a0001117078317370696666653a2f2f61726b61766f2d656467652f6e732f64656661756c742f73612f656467652d6167656e742d3030313a000111715820fc7098491f29851e0e80cbf6f858e9a15a9ffc0b2a050ac7a0fac32b1962a4683a000111727161726b61766f2e7368656c6c2e657865633a0001117358203a468fc4e706f9cfc585d32e344e913825e8175b80648d3427cafe17dbd9d3283a0001117482781f7464663a636c617373696669636174696f6e3a636f6e666964656e7469616c6d7464663a726567696f6e3a75733a00011175a30105021a000186a0031a0003d0903a000111765820c1483b47c4fd43849682d6f70b6004f187353e22ccc7b7eb8e044227b55cc02258409366ef3be1737b09dd1189f5dd7889488aedf06eb2938e58de25c5bfcd2f8555f954924dcf815ffaf3b96de6b572518276f1715c65da3e066ff97e85cd1a8d4c",
+  "description": "Signed CWT permit test vector for arkavo-permit; regenerate with `cargo run -p arkavo-permit --example generate_vectors`",
+  "hash_algorithm": "blake3",
+  "name": "es256-blake3",
+  "now_for_verification": 1700000060,
+  "public_key_hex": "04d65a93977caa3d1b081852ff57a79e465f1660577304baead505dd3a48589cf350185e895372df6221ea3a137557e473fddb6755f05bd507c3c533fce9c91285",
+  "secret_key_hex": "2222222222222222222222222222222222222222222222222222222222222222"
+}

--- a/crates/arkavo-permit/tests/vectors_test.rs
+++ b/crates/arkavo-permit/tests/vectors_test.rs
@@ -1,0 +1,178 @@
+//! Validates the published test vectors in `tests/vectors/` against the
+//! implementation. Vectors are regenerated with
+//! `cargo run -p arkavo-permit --example generate_vectors`.
+
+use std::path::PathBuf;
+
+use arkavo_permit::{Budget, HashAlgorithm, verify};
+use serde_json::Value;
+
+fn load_vector(name: &str) -> Value {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/vectors")
+        .join(format!("{name}.json"));
+    let text =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn hex_decode(value: &Value, field: &str) -> Vec<u8> {
+    let text = value
+        .as_str()
+        .unwrap_or_else(|| panic!("{field} must be a string"));
+    hex::decode(text).unwrap_or_else(|e| panic!("{field} hex: {e}"))
+}
+
+fn check_vector(vector: &Value) {
+    let name = vector["name"].as_str().unwrap();
+    let hash_algorithm = HashAlgorithm::from_name(vector["hash_algorithm"].as_str().unwrap())
+        .expect("known hash algorithm");
+    let cwt = hex_decode(&vector["cwt_hex"], "cwt_hex");
+    let now = vector["now_for_verification"].as_i64().unwrap();
+    let expected = &vector["claims"];
+
+    let permit = verify(&cwt, now).unwrap_or_else(|e| panic!("{name}: verify: {e}"));
+    let claims = &permit.claims;
+
+    assert_eq!(
+        claims.issuer,
+        expected["iss"].as_str().unwrap(),
+        "{name} iss"
+    );
+    assert_eq!(
+        claims.subject,
+        expected["sub"].as_str().unwrap(),
+        "{name} sub"
+    );
+    assert_eq!(
+        claims.agent_workload_id,
+        expected["agent_workload_id"].as_str().unwrap(),
+        "{name} agent_workload_id"
+    );
+    assert_eq!(
+        claims.policy_bundle_hash,
+        hex_decode(
+            &expected["policy_bundle_hash_hex"],
+            "policy_bundle_hash_hex"
+        ),
+        "{name} policy_bundle_hash"
+    );
+    assert_eq!(
+        claims.tool_name,
+        expected["tool_name"].as_str().unwrap(),
+        "{name} tool_name"
+    );
+    assert_eq!(
+        claims.argument_hash,
+        hex_decode(&expected["argument_hash_hex"], "argument_hash_hex"),
+        "{name} argument_hash"
+    );
+    let classifications: Vec<String> = expected["data_classifications"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c.as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        claims.data_classifications, classifications,
+        "{name} data_classifications"
+    );
+    let budget = &expected["budget"];
+    assert_eq!(
+        claims.budget,
+        Budget {
+            max_invocations: budget["max_invocations"].as_u64().unwrap(),
+            token_ceiling: budget["token_ceiling"].as_u64(),
+            cost_micro_usd: budget["cost_micro_usd"].as_u64(),
+        },
+        "{name} budget"
+    );
+    assert_eq!(
+        claims.sequence_state_hash,
+        hex_decode(
+            &expected["sequence_state_hash_hex"],
+            "sequence_state_hash_hex"
+        ),
+        "{name} sequence_state_hash"
+    );
+    assert_eq!(
+        claims.issued_at,
+        expected["iat"].as_i64().unwrap(),
+        "{name} iat"
+    );
+    assert_eq!(
+        claims.not_before,
+        expected["nbf"].as_i64().unwrap(),
+        "{name} nbf"
+    );
+    assert_eq!(
+        claims.expires_at,
+        expected["exp"].as_i64().unwrap(),
+        "{name} exp"
+    );
+    match &expected["parent_permit_hex"] {
+        Value::Null => assert_eq!(claims.parent_permit, None, "{name} parent_permit"),
+        value => assert_eq!(
+            claims.parent_permit.as_deref(),
+            Some(hex_decode(value, "parent_permit_hex").as_slice()),
+            "{name} parent_permit"
+        ),
+    }
+
+    // The confirmation key in the permit must equal the published public key.
+    assert_eq!(
+        permit.confirmation_key.public_key_bytes(),
+        hex_decode(&vector["public_key_hex"], "public_key_hex"),
+        "{name} cnf public key"
+    );
+
+    // The recorded invocation must match the permit binding.
+    claims
+        .verify_invocation(
+            expected["tool_name"].as_str().unwrap(),
+            &expected["arguments"],
+            hash_algorithm,
+        )
+        .unwrap_or_else(|e| panic!("{name}: invocation binding: {e}"));
+
+    // Expired permits must be rejected.
+    assert!(
+        verify(&cwt, claims.expires_at).is_err(),
+        "{name}: expired permit accepted"
+    );
+}
+
+#[test]
+fn vector_ed25519_sha256() {
+    check_vector(&load_vector("ed25519-sha256"));
+}
+
+#[test]
+fn vector_es256_blake3() {
+    check_vector(&load_vector("es256-blake3"));
+}
+
+#[test]
+fn vector_ed25519_parent_chain() {
+    let child = load_vector("ed25519-parent-chain");
+    check_vector(&child);
+
+    // The child permit's parent_permit claim must hash the parent's CWT.
+    let parent = load_vector("ed25519-sha256");
+    let parent_cwt = hex_decode(&parent["cwt_hex"], "cwt_hex");
+    let expected_hash = HashAlgorithm::Sha256.digest(&parent_cwt);
+    assert_eq!(
+        child["claims"]["parent_permit_hex"].as_str().unwrap(),
+        hex::encode(expected_hash)
+    );
+}
+
+#[test]
+fn tampered_vector_rejected() {
+    let vector = load_vector("ed25519-sha256");
+    let mut cwt = hex_decode(&vector["cwt_hex"], "cwt_hex");
+    let now = vector["now_for_verification"].as_i64().unwrap();
+    let last = cwt.len() - 1;
+    cwt[last] ^= 0x01;
+    assert!(verify(&cwt, now).is_err(), "tampered CWT accepted");
+}

--- a/docs/permit-cwt-schema.md
+++ b/docs/permit-cwt-schema.md
@@ -1,0 +1,144 @@
+# CWT Permit Schema for Permit-Bound Tool Execution
+
+A permit is a CBOR Web Token (RFC 8392) signed as COSE_Sign1 (RFC 8152) that
+binds a single tool invocation — tool name plus canonicalized arguments — to
+an agent workload, a policy bundle, an execution budget, and a
+proof-of-possession key. The `arkavo-permit` crate (`crates/arkavo-permit`)
+implements this schema.
+
+## Wire Format
+
+```
+CWT = #6.61( COSE_Sign1 )        ; CBOR tag 61 wrapping tag 18
+COSE_Sign1 payload = claims set  ; CBOR map, labels below
+```
+
+The COSE_Sign1 protected header carries:
+
+- `alg` (1): `EdDSA` (-8) or `ES256` (-7). No other algorithms are accepted.
+- `content type` (3): `application/cwt` (CoAP content format 61).
+
+## Claims
+
+Standard claims use their RFC 8392 / RFC 8747 keys. Arkavo claims use
+private-use keys below -65536 (RFC 8392 section 4).
+
+| Key | Name | Type | Req | Semantics |
+|-----|------|------|-----|-----------|
+| 1 | iss | tstr | required | Permit issuer identity (URI or DID). |
+| 2 | sub | tstr | required | Delegator: the human identity on whose behalf the agent acts. |
+| 4 | exp | uint | required | Expiration, seconds since UNIX epoch. Permits are rejected at `now >= exp`. |
+| 5 | nbf | uint | required | Not-before, seconds since UNIX epoch. Must satisfy `nbf < exp`. |
+| 6 | iat | uint | required | Issued-at, seconds since UNIX epoch. Permits with `iat > now` are rejected. |
+| 8 | cnf | map | required | RFC 8747 confirmation claim: `{1: COSE_Key}` — the proof-of-possession key the signature is verified against. |
+| -70001 | agent_workload_id | tstr | required | Agent workload identity (SPIFFE-style workload ID). |
+| -70002 | policy_bundle_hash | bstr | required | Hash of the policy bundle authorizing this permit. |
+| -70003 | tool_name | tstr | required | Fully-qualified tool name this permit authorizes. |
+| -70004 | argument_hash | bstr | required | Hash of the canonicalized tool arguments (see canonicalization below). |
+| -70005 | data_classifications | [+ tstr] | required | TDF data-classification attributes the invocation may touch. May be an empty array. |
+| -70006 | budget | map | required | Execution budget; sub-keys below. |
+| -70007 | sequence_state_hash | bstr | required | Hash of the sequence state (replay/ordering anchor). |
+| -70008 | parent_permit | bstr | optional | Hash of the parent permit's CWT bytes for A2A delegation chains. |
+
+Budget map (claim -70006) sub-keys:
+
+| Key | Name | Type | Req | Semantics |
+|-----|------|------|-----|-----------|
+| 1 | max_invocations | uint | required | Maximum number of tool invocations; must be >= 1. |
+| 2 | token_ceiling | uint | optional | Ceiling on total tokens consumed across invocations. |
+| 3 | cost_micro_usd | uint | optional | Cost ceiling in micro-USD (10^-6 USD). |
+
+Unknown claims are ignored for forward compatibility; every required claim
+must be present and correctly typed or the permit is rejected (fail closed).
+
+## Confirmation Key (`cnf`)
+
+The `cnf` claim follows RFC 8747: a map with key `1` holding a COSE_Key.
+Supported key types:
+
+- `OKP` (1) with curve `Ed25519` (6) and the `x` parameter (-2): the 32-byte
+  public key. Used with `EdDSA`.
+- `EC2` (2) with curve `P-256` (1) and `x` (-2) / `y` (-3) parameters: 32-byte
+  affine coordinates. Used with `ES256`.
+
+The COSE_Key's key type and curve must agree with the `alg` in the protected
+header, and the COSE_Sign1 signature must verify against this key. A permit
+therefore proves possession of the confirmation key at mint time; verifiers
+never need out-of-band key lookup to check the signature, and policy layers
+can pin the `cnf` key to a registered workload identity.
+
+## Canonicalization of Tool Arguments
+
+`argument_hash` (-70004) commits the permit to one exact tool invocation.
+Arguments are canonicalized before hashing so that semantically identical
+JSON produced by different serializers hashes identically:
+
+- UTF-8 output with no insignificant whitespace.
+- Object keys sorted by Unicode code point, recursively.
+- Strings escaped per RFC 8259 section 7: short escapes (`\"`, `\\`, `\b`,
+  `\f`, `\n`, `\r`, `\t`) where defined, `\u00XX` for other control
+  characters; all other characters emitted as raw UTF-8.
+- Numbers rendered with `serde_json::Number`'s shortest representation
+  (integers without fraction, floats shortest round-trip).
+
+Example: `{"max_bytes":4096,"path":"/tmp/data.csv"}` is the canonical form of
+any key ordering and whitespace layout of that object.
+
+## Hash Algorithms
+
+Permit-bound hashes (policy bundle, arguments, sequence state, parent permit)
+are computed with a pluggable algorithm:
+
+- `sha256` (default)
+- `blake3` (permitted alternative)
+
+The algorithm is not recorded in the token: hashes are opaque byte strings,
+and the relying party knows which algorithm its policy requires. Mixing
+algorithms across the claims of one permit is discouraged.
+
+## Signing Algorithms
+
+- `EdDSA` over Ed25519 is the primary choice: compact keys (32 bytes),
+  deterministic signatures, and no ECDSA nonce concerns.
+- `ES256` over P-256 is supported for environments that require NIST curves
+  (e.g. iOS Secure Enclave). ES256 signature values use the IEEE P1363
+  fixed-size `r || s` encoding (64 bytes) required by RFC 8152 section 8.1.
+
+## Expiry Guidance
+
+Permits are single-purpose and short-lived: `exp - nbf` should be on the
+order of seconds to a few minutes (the test vectors use 300 s), just long
+enough to cover minting, transport, and execution. Long-lived authority
+belongs in the referenced policy bundle (-70002), not in the permit itself.
+Verifiers must check `nbf <= now < exp` and `iat <= now`, and must reject
+`nbf >= exp` structurally.
+
+## A2A Delegation Chains (`parent_permit`)
+
+When an agent delegates work to another agent (A2A), the delegated permit
+carries `parent_permit` (-70008): the hash of the parent permit's complete
+CWT bytes (tag 61 included). This binds the child to the exact parent token,
+so a verifier can:
+
+- fetch the parent CWT, hash it, and compare against the claim;
+- recursively verify the parent (signature, window, budget);
+- enforce attenuation: the child's tool, classifications, and budget must be
+  a subset of the parent's authority.
+
+Chain length limits and attenuation rules are policy decisions enforced
+above this crate; the schema only provides the cryptographic link.
+
+## Test Vectors
+
+`crates/arkavo-permit/tests/vectors/` holds reproducible vectors (Ed25519 +
+SHA-256, ES256 + BLAKE3, and a parent-chained A2A permit), each containing
+the signed CWT (hex), the expected claims, the public key, and the secret
+key. Regenerate with:
+
+```bash
+cargo run -p arkavo-permit --example generate_vectors
+```
+
+Generation is deterministic (fixed keys and timestamps), so regeneration
+must leave the committed files unchanged. `tests/vectors_test.rs` verifies
+each vector end to end.

--- a/docs/permit-cwt-schema.md
+++ b/docs/permit-cwt-schema.md
@@ -13,6 +13,11 @@ CWT = #6.61( COSE_Sign1 )        ; CBOR tag 61 wrapping tag 18
 COSE_Sign1 payload = claims set  ; CBOR map, labels below
 ```
 
+Untrusted `decode`/`verify` input is rejected if it exceeds 16 KiB
+(`MAX_PERMIT_BYTES`) before COSE/CBOR parse. Permit-bound hashes
+(`policy_bundle_hash`, `argument_hash`, `sequence_state_hash`,
+`parent_permit`) must be exactly 32 bytes (SHA-256 / BLAKE3 default output).
+
 The COSE_Sign1 protected header carries:
 
 - `alg` (1): `EdDSA` (-8) or `ES256` (-7). No other algorithms are accepted.


### PR DESCRIPTION
## What

New crate `crates/arkavo-permit` implementing the CWT permit schema for permit-bound tool execution (EPIC 3.1):

- Permits are **CBOR Web Tokens (RFC 8392)** signed as **COSE_Sign1 (RFC 8152)** — not JWT/DPoP — transported as CBOR tag 61 wrapping tag 18.
- Every permit carries an RFC 8747 **`cnf` confirmation claim** holding a COSE_Key proof-of-possession key; the signature is verified against that key, so no out-of-band key lookup is needed and permits fail closed on any malformed claim.
- Required claims: `iss`, `sub` (delegator/human), agent workload ID, policy-bundle hash, tool name + canonical-argument hash, TDF data-classification attributes, budget (max invocations + optional token/cost ceilings), sequence-state hash, `exp`/`iat`/`nbf`; optional `parent_permit` for A2A delegation chains. Private-use claim keys (-70001..-70008) documented in `docs/permit-cwt-schema.md`.
- Canonicalization: sorted JSON keys, UTF-8, no whitespace (documented in the spec, covered by tests).
- Signing: **Ed25519/EdDSA primary** (reuses `arkavo-crypto::AgentKeypair`), **ES256/P-256 supported** (reuses `P256SigningKeypair`; DER signatures converted to the RFC 8152 P1363 `r||s` form).
- Hash algorithm pluggable via `HashAlgorithm` enum: SHA-256 default, BLAKE3 permitted.
- API: `mint` / `decode` / `verify` (signature + expiry window + structural validation), plus `PermitClaims::verify_invocation` for the tool/argument binding check.

## New dependencies (for review)

- `coset 0.3` — COSE/CWT structures (pure Rust, Apache-2.0)
- `ciborium 0.2` — CBOR serialization (pure Rust, Apache-2.0)
- `blake3 1.5` — already used by `arkavo-swarmkit`; optional hash algorithm

No OpenSSL, no C++; builds on Windows without C++.

## Tests

- 41 inline unit tests + 4 integration tests: round-trip (EdDSA and ES256), tampered signature/payload rejected, expired / not-yet-valid / future-iat rejected, wrong `cnf` key rejected, canonical-argument-hash mismatch rejected, unknown-claim tolerance, parent-chain binding.
- Reproducible test vectors in `crates/arkavo-permit/tests/vectors/` (Ed25519+SHA-256, ES256+BLAKE3, A2A parent-chained), regenerated deterministically by `cargo run -p arkavo-permit --example generate_vectors` and verified by `tests/vectors_test.rs`.
- `cargo nextest run -p arkavo-permit`: 45/45 pass. `cargo clippy -p arkavo-permit --all-targets -- -D warnings`: clean. `cargo fmt --check`: clean.
- Version bumped to 0.89.6 with `Cargo.lock` committed (several open PRs already claim 0.89.5).