### PR TITLE
Agent identity: distinct key, CWT auth, refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -207,7 +207,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -958,6 +958,23 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "arkavo-cwt"
+version = "0.89.4"
+dependencies = [
+ "arkavo-test-macros",
+ "base64 0.22.1",
+ "ciborium",
+ "coset",
+ "p256",
+ "rand 0.8.6",
+ "reqwest 0.12.28",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "wiremock",
 ]
 
 [[package]]
@@ -3330,6 +3347,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "coset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eb98d5e9155e2cf7cd942c8b3033097d4563b6fb0a00b9caecb74669555c058"
+dependencies = [
+ "ciborium",
+ "ciborium-io",
+]
+
+[[package]]
 name = "cpu-time"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3933,7 +3960,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4240,7 +4267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5421,7 +5448,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5441,7 +5468,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6066,7 +6093,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7341,7 +7368,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -7384,7 +7411,7 @@ checksum = "b56d621ed2c1773b5356ab39cc68c819f8d0103f7493d8661c4a5f5f8ea55f40"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -7431,7 +7458,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8644,7 +8671,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8682,7 +8709,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -9460,7 +9487,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9540,7 +9567,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.8",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9756,7 +9783,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10234,7 +10261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10736,7 +10763,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10758,7 +10785,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12301,7 +12328,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,6 +805,7 @@ dependencies = [
  "arkavo-context",
  "arkavo-critic",
  "arkavo-crypto",
+ "arkavo-cwt",
  "arkavo-dataflow",
  "arkavo-device-identity",
  "arkavo-events",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,6 +1031,7 @@ dependencies = [
 name = "arkavo-device-identity"
 version = "0.89.4"
 dependencies = [
+ "arkavo-crypto",
  "arkavo-test-macros",
  "dirs 5.0.1",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,6 +1031,7 @@ dependencies = [
 name = "arkavo-device-identity"
 version = "0.89.4"
 dependencies = [
+ "arkavo-test-macros",
  "dirs 5.0.1",
  "hex",
  "keyring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui-protocol"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-test-macros",
  "serde",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-device-identity",
  "arkavo-test-macros",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "chrono",
  "serde",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-config-bundle",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cwt"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "git2",
  "tempfile",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1244,11 +1244,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-lesson-synthesis"
-version = "0.89.4"
+version = "0.90.0"
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-llama-cpp-sys",
  "arkavo-test-macros",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1575,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "lru",
  "serde",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-shadow-consolidation"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-lesson-synthesis",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-test-macros",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2154,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2202,7 +2202,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2221,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.89.4"
+version = "0.90.0"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,7 @@ dependencies = [
 name = "arkavo-config-encryption"
 version = "0.89.4"
 dependencies = [
+ "arkavo-agent-auth",
  "arkavo-config-bundle",
  "arkavo-test-macros",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ members = [
     "crates/arkavo-registration",
     "crates/arkavo-agent",
     "crates/arkavo-agent-auth",
+    "crates/arkavo-cwt",
     "crates/arkavo-tdf",
     "crates/arkavo-tdf-iroh",
     "crates/arkavo-mcp-mesh",
@@ -130,6 +131,7 @@ default-members = [
     "crates/arkavo-crypto",
     "crates/arkavo-registration",
     "crates/arkavo-agent-auth",
+    "crates/arkavo-cwt",
     "crates/arkavo-hrm",
     "crates/arkavo-agent",
     "crates/arkavo-critic",
@@ -181,6 +183,8 @@ jsonschema = { version = "0.45", default-features = false, features = ["resolve-
 thiserror = "2.0.12"
 tempfile = "3.20"
 reqwest = { version = "0.12.20", default-features = false, features = ["rustls-tls", "json", "stream", "blocking"] }
+coset = "0.4"
+ciborium = "0.2"
 regex = "1.11.1"
 uuid = { version = "1.17.0", features = ["v4", "serde"] }
 chrono = { version = "0.4.41", default-features = false, features = ["serde", "clock", "std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.89.4"
+version = "0.90.0"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-agent-auth/Cargo.toml
+++ b/crates/arkavo-agent-auth/Cargo.toml
@@ -21,6 +21,12 @@ tracing = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 
+[features]
+default = []
+# Exposes `test_utils`'s RAII guard so dependent crates' tests can protect
+# the developer's real agent token instead of deleting it.
+test-utils = []
+
 [dev-dependencies]
 arkavo-test-macros = { path = "../arkavo-test-macros" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/arkavo-agent-auth/src/client.rs
+++ b/crates/arkavo-agent-auth/src/client.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use arkavo_crypto::AgentKeypair;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use chrono::Utc;
 use std::time::Duration;
 
 fn percent_encode(input: &str) -> String {
@@ -55,15 +56,21 @@ impl AgentAuthClient {
         );
 
         let response = self.http_client.get(&url).send().await?;
+        let status = response.status();
 
-        if response.status() == reqwest::StatusCode::NOT_FOUND {
+        if status == reqwest::StatusCode::FORBIDDEN {
+            let body = response.text().await.unwrap_or_default();
+            return Err(AgentAuthError::Forbidden(body));
+        }
+
+        if status == reqwest::StatusCode::NOT_FOUND {
             return Err(AgentAuthError::NotAuthorized);
         }
 
-        if !response.status().is_success() {
+        if !status.is_success() {
             return Err(AgentAuthError::ChallengeRequest(format!(
                 "Server returned status {}",
-                response.status()
+                status
             )));
         }
 
@@ -76,9 +83,18 @@ impl AgentAuthClient {
         let url = format!("{}/agents/token", self.config.base_url);
 
         let response = self.http_client.post(&url).json(request).send().await?;
+        let status = response.status();
 
-        if !response.status().is_success() {
-            let status = response.status();
+        if status == reqwest::StatusCode::FORBIDDEN {
+            let body = response.text().await.unwrap_or_default();
+            return Err(AgentAuthError::Forbidden(body));
+        }
+
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(AgentAuthError::NotAuthorized);
+        }
+
+        if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
             return Err(AgentAuthError::TokenRequest(format!(
                 "Server returned status {}: {}",
@@ -121,6 +137,14 @@ impl AgentAuthClient {
                 Err(AgentAuthError::NotAuthorized) => {
                     tracing::info!(event = "auth_decision", action = "deny", subject = %did, "Agent not authorized");
                     return Err(AgentAuthError::NotAuthorized);
+                }
+                Err(AgentAuthError::Forbidden(reason)) => {
+                    // Revoked/expired delegation: burning retries against a
+                    // server that will keep saying no just delays the human
+                    // finding out the agent needs to be re-trusted.
+                    tracing::info!(event = "auth_decision", action = "deny", subject = %did, reason = %reason, "Agent delegation revoked");
+                    storage::delete_token().await.ok();
+                    return Err(AgentAuthError::Forbidden(reason));
                 }
                 Err(e) => last_error = Some(e),
             }
@@ -165,8 +189,7 @@ impl AgentAuthClient {
             did.to_string(),
             token_response.expires_at,
             token_response.entitlements,
-        )
-        .with_delegation_jwt(token_response.delegation_jwt);
+        );
 
         // Store locally
         storage::store_token(&stored_token).await?;
@@ -175,15 +198,18 @@ impl AgentAuthClient {
     }
 
     /// Get a valid token, either from cache or by authenticating.
+    ///
+    /// A cached token is reused only while it is neither expired nor within
+    /// the last third of its lifetime; "refresh" always means re-running the
+    /// challenge-response flow, since there are no refresh tokens.
     pub async fn get_token(&self, keypair: &AgentKeypair) -> Result<StoredToken, AgentAuthError> {
-        // Check for cached token
         if let Some(token) = storage::load_token().await?
             && !token.is_expired()
+            && !token.needs_refresh(Utc::now())
         {
             return Ok(token);
         }
 
-        // Authenticate
         self.authenticate(keypair).await
     }
 
@@ -205,15 +231,15 @@ impl Default for AgentAuthClient {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
-    use arkavo_crypto::{AgentKeypair, AgentPublicKey};
+    use arkavo_crypto::AgentKeypair;
     use arkavo_test_macros::spec;
-    use wiremock::Respond;
     use wiremock::matchers::{method, path};
-    use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    use crate::test_helpers::TEST_LOCK;
+    use crate::test_helpers::{TEST_LOCK, ValidatingTokenResponder};
 
     #[test]
     fn test_client_creation() {
@@ -229,51 +255,6 @@ mod tests {
 
         let client = AgentAuthClient::with_config(config);
         assert!(client.is_ok());
-    }
-
-    /// Wiremock responder that validates the Ed25519 signature on the token
-    /// request before returning a token response.
-    struct ValidatingTokenResponder {
-        public_key: AgentPublicKey,
-        challenge: Vec<u8>,
-    }
-
-    impl ValidatingTokenResponder {
-        fn new(public_key: AgentPublicKey, challenge: Vec<u8>) -> Self {
-            Self {
-                public_key,
-                challenge,
-            }
-        }
-    }
-
-    impl Respond for ValidatingTokenResponder {
-        fn respond(&self, request: &Request) -> ResponseTemplate {
-            let body: TokenRequest = match serde_json::from_slice(&request.body) {
-                Ok(b) => b,
-                Err(_) => return ResponseTemplate::new(400).set_body_string("invalid json"),
-            };
-
-            if body.challenge != BASE64_STANDARD.encode(&self.challenge) {
-                return ResponseTemplate::new(400).set_body_string("challenge mismatch");
-            }
-
-            let signature = match BASE64_STANDARD.decode(&body.signature) {
-                Ok(s) => s,
-                Err(_) => return ResponseTemplate::new(400).set_body_string("bad signature"),
-            };
-
-            if self.public_key.verify(&self.challenge, &signature).is_err() {
-                return ResponseTemplate::new(401).set_body_string("invalid signature");
-            }
-
-            ResponseTemplate::new(200).set_body_json(TokenResponse {
-                token: "mock-token-123".to_string(),
-                expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
-                entitlements: vec!["agent.capability.chat".to_string()],
-                delegation_jwt: Some("mock-delegation-jwt".to_string()),
-            })
-        }
     }
 
     /// Test AAUTH-001: Request authentication token.
@@ -324,11 +305,7 @@ mod tests {
         assert_eq!(stored.did, did);
         assert_eq!(
             stored.entitlements,
-            vec!["agent.capability.chat".to_string()]
-        );
-        assert_eq!(
-            stored.delegation_jwt,
-            Some("mock-delegation-jwt".to_string())
+            vec!["https://arkavo.ai/attr/tdf/value/decrypt".to_string()]
         );
         assert!(!stored.is_expired());
 
@@ -339,5 +316,58 @@ mod tests {
         assert_eq!(loaded.token, stored.token);
 
         let _ = storage::delete_token().await;
+    }
+
+    /// Regression test for C1/C4: a 403 from `/agents/challenge` (revoked
+    /// delegation) must map to `AgentAuthError::Forbidden`, must not be
+    /// retried, and must clear any stored token immediately.
+    #[tokio::test]
+    #[spec("AAUTH-007")]
+    async fn forbidden_challenge_maps_to_forbidden_and_clears_token() {
+        let _g = TEST_LOCK.lock().await;
+        storage::delete_token().await.unwrap();
+
+        let keypair = AgentKeypair::generate();
+        let stale = StoredToken::new(
+            "stale-token".into(),
+            keypair.public_key().to_did_key(),
+            Utc::now() + chrono::Duration::minutes(15),
+            vec![],
+        );
+        storage::store_token(&stale).await.unwrap();
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/agents/challenge"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("Delegation revoked"))
+            .mount(&server)
+            .await;
+
+        let client = AgentAuthClient::with_config(AgentAuthConfig::new(server.uri())).unwrap();
+        let err = client.authenticate(&keypair).await.unwrap_err();
+        assert!(matches!(err, AgentAuthError::Forbidden(_)));
+        assert!(storage::load_token().await.unwrap().is_none());
+
+        storage::delete_token().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn not_found_challenge_is_not_authorized_yet() {
+        let _g = TEST_LOCK.lock().await;
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/agents/challenge"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let client = AgentAuthClient::with_config(AgentAuthConfig::new(server.uri())).unwrap();
+        assert!(matches!(
+            client
+                .authenticate(&AgentKeypair::generate())
+                .await
+                .unwrap_err(),
+            AgentAuthError::NotAuthorized
+        ));
     }
 }

--- a/crates/arkavo-agent-auth/src/client.rs
+++ b/crates/arkavo-agent-auth/src/client.rs
@@ -199,15 +199,24 @@ impl AgentAuthClient {
 
     /// Get a valid token, either from cache or by authenticating.
     ///
-    /// A cached token is reused only while it is neither expired nor within
-    /// the last third of its lifetime; "refresh" always means re-running the
-    /// challenge-response flow, since there are no refresh tokens.
+    /// A cached token is reused only while it belongs to this keypair's DID
+    /// and is neither expired nor within the last third of its lifetime;
+    /// "refresh" always means re-running the challenge-response flow, since
+    /// there are no refresh tokens.
     pub async fn get_token(&self, keypair: &AgentKeypair) -> Result<StoredToken, AgentAuthError> {
-        if let Some(token) = storage::load_token().await?
-            && !token.is_expired()
-            && !token.needs_refresh(Utc::now())
-        {
-            return Ok(token);
+        let did = keypair.public_key().to_did_key();
+
+        if let Some(token) = storage::load_token().await? {
+            if token.did == did && !token.is_expired() && !token.needs_refresh(Utc::now()) {
+                return Ok(token);
+            }
+            if token.did != did {
+                // A CWT is minted for the DID that proved possession of the
+                // key. Once the agent keypair is regenerated the stored token
+                // authorizes a discarded identity, so it is dropped here
+                // rather than presented for the rest of its 15 minutes.
+                storage::delete_token().await?;
+            }
         }
 
         self.authenticate(keypair).await
@@ -240,6 +249,7 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use crate::test_helpers::{TEST_LOCK, ValidatingTokenResponder};
+    use crate::test_utils::TokenFileGuard;
 
     #[test]
     fn test_client_creation() {
@@ -268,8 +278,8 @@ mod tests {
     #[spec("AAUTH-001", "AAUTH-005")]
     #[tokio::test]
     async fn test_authenticate_challenge_response_flow() {
-        let _guard = TEST_LOCK.lock().await;
-        let _ = storage::delete_token().await;
+        let _lock = TEST_LOCK.lock().await;
+        let _file = TokenFileGuard::capture();
 
         let mock_server = MockServer::start().await;
 
@@ -314,8 +324,6 @@ mod tests {
         assert!(loaded.is_some());
         let loaded = loaded.unwrap();
         assert_eq!(loaded.token, stored.token);
-
-        let _ = storage::delete_token().await;
     }
 
     /// Regression test for C1/C4: a 403 from `/agents/challenge` (revoked
@@ -324,8 +332,8 @@ mod tests {
     #[tokio::test]
     #[spec("AAUTH-007")]
     async fn forbidden_challenge_maps_to_forbidden_and_clears_token() {
-        let _g = TEST_LOCK.lock().await;
-        storage::delete_token().await.unwrap();
+        let _lock = TEST_LOCK.lock().await;
+        let _file = TokenFileGuard::capture();
 
         let keypair = AgentKeypair::generate();
         let stale = StoredToken::new(
@@ -347,13 +355,13 @@ mod tests {
         let err = client.authenticate(&keypair).await.unwrap_err();
         assert!(matches!(err, AgentAuthError::Forbidden(_)));
         assert!(storage::load_token().await.unwrap().is_none());
-
-        storage::delete_token().await.unwrap();
     }
 
     #[tokio::test]
     async fn not_found_challenge_is_not_authorized_yet() {
-        let _g = TEST_LOCK.lock().await;
+        let _lock = TEST_LOCK.lock().await;
+        let _file = TokenFileGuard::capture();
+
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/agents/challenge"))
@@ -369,5 +377,103 @@ mod tests {
                 .unwrap_err(),
             AgentAuthError::NotAuthorized
         ));
+    }
+
+    /// AAUTH-007 names both legs: "GET /agents/challenge *or* POST
+    /// /agents/token returns 403". The challenge leg is covered above; this is
+    /// the token leg, where the challenge succeeds and the server refuses only
+    /// once the signed proof arrives.
+    #[tokio::test]
+    #[spec("AAUTH-007")]
+    async fn forbidden_token_endpoint_maps_to_forbidden_and_clears_token() {
+        let _lock = TEST_LOCK.lock().await;
+        let _file = TokenFileGuard::capture();
+
+        let keypair = AgentKeypair::generate();
+        let stale = StoredToken::new(
+            "stale-token".into(),
+            keypair.public_key().to_did_key(),
+            Utc::now() + chrono::Duration::minutes(15),
+            vec![],
+        );
+        storage::store_token(&stale).await.unwrap();
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/agents/challenge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ChallengeResponse {
+                challenge: BASE64_STANDARD.encode(b"token-leg-challenge"),
+                nonce: "nonce-token-403".to_string(),
+            }))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/agents/token"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("Delegation revoked"))
+            .mount(&server)
+            .await;
+
+        let client = AgentAuthClient::with_config(AgentAuthConfig::new(server.uri())).unwrap();
+        let err = client.authenticate(&keypair).await.unwrap_err();
+        assert!(matches!(err, AgentAuthError::Forbidden(_)));
+        assert!(storage::load_token().await.unwrap().is_none());
+    }
+
+    /// Regression: a stored token is bound to the DID it was minted for. After
+    /// the agent keypair is regenerated the stored token belongs to a discarded
+    /// identity, so `get_token` must treat it as absent — drop it and re-run
+    /// the challenge-response — instead of presenting it for up to 15 minutes.
+    #[tokio::test]
+    async fn stored_token_for_another_did_is_discarded_and_reauthenticated() {
+        let _lock = TEST_LOCK.lock().await;
+        let _file = TokenFileGuard::capture();
+
+        let keypair = AgentKeypair::generate();
+        let did = keypair.public_key().to_did_key();
+
+        // Fresh and nowhere near its refresh point: only the DID mismatch can
+        // make `get_token` reject it.
+        let orphaned = StoredToken::new(
+            "token-for-the-old-keypair".into(),
+            "did:key:z6MkRegeneratedAway".into(),
+            Utc::now() + chrono::Duration::minutes(15),
+            vec![],
+        );
+        storage::store_token(&orphaned).await.unwrap();
+
+        let challenge = b"did-mismatch-challenge".to_vec();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/agents/challenge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ChallengeResponse {
+                challenge: BASE64_STANDARD.encode(&challenge),
+                nonce: "nonce-did-mismatch".to_string(),
+            }))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/agents/token"))
+            .respond_with(ValidatingTokenResponder::new(
+                keypair.public_key(),
+                challenge,
+            ))
+            .mount(&server)
+            .await;
+
+        let client = AgentAuthClient::with_config(AgentAuthConfig::new(server.uri())).unwrap();
+        let token = client.get_token(&keypair).await.unwrap();
+
+        assert_eq!(
+            token.did, did,
+            "the returned token must name the current DID"
+        );
+        assert_eq!(token.token, "mock-token-123");
+
+        let on_disk = storage::load_token().await.unwrap().unwrap();
+        assert_eq!(on_disk.did, did);
+        assert_ne!(
+            on_disk.token, "token-for-the-old-keypair",
+            "the orphaned token must not survive on disk"
+        );
     }
 }

--- a/crates/arkavo-agent-auth/src/config.rs
+++ b/crates/arkavo-agent-auth/src/config.rs
@@ -46,4 +46,71 @@ impl AgentAuthConfig {
         self.max_retries = max_retries;
         self
     }
+
+    /// Build a configuration from the environment.
+    ///
+    /// `ARKAVO_AUTH_URL` overrides the default base URL; `ARKAVO_AUTH_TIMEOUT_SECS`
+    /// overrides the request timeout. Both fall back to defaults when unset or
+    /// unparsable.
+    pub fn from_env() -> Self {
+        let mut config = Self::default();
+
+        if let Ok(url) = std::env::var("ARKAVO_AUTH_URL") {
+            config.base_url = url;
+        }
+
+        if let Ok(secs) = std::env::var("ARKAVO_AUTH_TIMEOUT_SECS")
+            && let Ok(secs) = secs.parse::<u64>()
+        {
+            config.timeout = Duration::from_secs(secs);
+        }
+
+        config
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::TEST_LOCK;
+
+    #[tokio::test]
+    async fn from_env_overrides_base_url_and_timeout() {
+        let _guard = TEST_LOCK.lock().await;
+
+        // SAFETY: serialized by TEST_LOCK, so no other test in this crate
+        // reads or writes these vars concurrently.
+        unsafe {
+            std::env::set_var("ARKAVO_AUTH_URL", "https://agent-auth.example.test");
+            std::env::set_var("ARKAVO_AUTH_TIMEOUT_SECS", "7");
+        }
+
+        let config = AgentAuthConfig::from_env();
+
+        unsafe {
+            std::env::remove_var("ARKAVO_AUTH_URL");
+            std::env::remove_var("ARKAVO_AUTH_TIMEOUT_SECS");
+        }
+
+        assert_eq!(config.base_url, "https://agent-auth.example.test");
+        assert_eq!(config.timeout, Duration::from_secs(7));
+    }
+
+    #[tokio::test]
+    async fn from_env_falls_back_to_defaults_when_unset() {
+        let _guard = TEST_LOCK.lock().await;
+
+        // SAFETY: serialized by TEST_LOCK; ensure a clean slate before reading.
+        unsafe {
+            std::env::remove_var("ARKAVO_AUTH_URL");
+            std::env::remove_var("ARKAVO_AUTH_TIMEOUT_SECS");
+        }
+
+        let config = AgentAuthConfig::from_env();
+        let default = AgentAuthConfig::default();
+
+        assert_eq!(config.base_url, default.base_url);
+        assert_eq!(config.timeout, default.timeout);
+    }
 }

--- a/crates/arkavo-agent-auth/src/error.rs
+++ b/crates/arkavo-agent-auth/src/error.rs
@@ -20,6 +20,9 @@ pub enum AgentAuthError {
     #[error("Agent not authorized: scan QR code with mobile app first")]
     NotAuthorized,
 
+    #[error("Forbidden: {0}")]
+    Forbidden(String),
+
     #[error("Token expired")]
     TokenExpired,
 

--- a/crates/arkavo-agent-auth/src/lib.rs
+++ b/crates/arkavo-agent-auth/src/lib.rs
@@ -9,7 +9,7 @@ pub use client::AgentAuthClient;
 pub use config::AgentAuthConfig;
 pub use error::AgentAuthError;
 pub use refresh::{RefreshState, run_refresh_loop};
-pub use storage::{delete_token, load_token, store_token};
+pub use storage::{delete_token, load_token, load_token_blocking, store_token};
 pub use types::{ChallengeResponse, StoredToken, TokenRequest, TokenResponse};
 
 #[cfg(test)]

--- a/crates/arkavo-agent-auth/src/lib.rs
+++ b/crates/arkavo-agent-auth/src/lib.rs
@@ -1,19 +1,72 @@
 mod client;
 mod config;
 mod error;
+mod refresh;
 mod storage;
 mod types;
 
 pub use client::AgentAuthClient;
 pub use config::AgentAuthConfig;
 pub use error::AgentAuthError;
+pub use refresh::{RefreshState, run_refresh_loop};
 pub use storage::{delete_token, load_token, store_token};
 pub use types::{ChallengeResponse, StoredToken, TokenRequest, TokenResponse};
 
 #[cfg(test)]
 pub(crate) mod test_helpers {
+    use crate::types::{TokenRequest, TokenResponse};
+    use arkavo_crypto::AgentPublicKey;
+    use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
     use tokio::sync::Mutex;
+    use wiremock::{Request, Respond, ResponseTemplate};
 
-    /// Serializes tests that touch the on-disk token file.
+    /// Serializes tests that touch the on-disk token file or process
+    /// environment variables.
     pub(crate) static TEST_LOCK: Mutex<()> = Mutex::const_new(());
+
+    /// Wiremock responder that validates the Ed25519 signature on the token
+    /// request before returning a token response. Shared by `client.rs` and
+    /// `refresh.rs` tests, which both need a server that only issues a token
+    /// once a correctly-signed challenge comes back.
+    pub(crate) struct ValidatingTokenResponder {
+        public_key: AgentPublicKey,
+        challenge: Vec<u8>,
+    }
+
+    impl ValidatingTokenResponder {
+        pub(crate) fn new(public_key: AgentPublicKey, challenge: Vec<u8>) -> Self {
+            Self {
+                public_key,
+                challenge,
+            }
+        }
+    }
+
+    impl Respond for ValidatingTokenResponder {
+        fn respond(&self, request: &Request) -> ResponseTemplate {
+            let body: TokenRequest = match serde_json::from_slice(&request.body) {
+                Ok(b) => b,
+                Err(_) => return ResponseTemplate::new(400).set_body_string("invalid json"),
+            };
+
+            if body.challenge != BASE64_STANDARD.encode(&self.challenge) {
+                return ResponseTemplate::new(400).set_body_string("challenge mismatch");
+            }
+
+            let signature = match BASE64_STANDARD.decode(&body.signature) {
+                Ok(s) => s,
+                Err(_) => return ResponseTemplate::new(400).set_body_string("bad signature"),
+            };
+
+            if self.public_key.verify(&self.challenge, &signature).is_err() {
+                return ResponseTemplate::new(401).set_body_string("invalid signature");
+            }
+
+            ResponseTemplate::new(200).set_body_json(TokenResponse {
+                token: "mock-token-123".to_string(),
+                expires_at: chrono::Utc::now() + chrono::Duration::minutes(15),
+                entitlements: vec!["https://arkavo.ai/attr/tdf/value/decrypt".to_string()],
+            })
+        }
+    }
 }

--- a/crates/arkavo-agent-auth/src/lib.rs
+++ b/crates/arkavo-agent-auth/src/lib.rs
@@ -5,6 +5,9 @@ mod refresh;
 mod storage;
 mod types;
 
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
+
 pub use client::AgentAuthClient;
 pub use config::AgentAuthConfig;
 pub use error::AgentAuthError;

--- a/crates/arkavo-agent-auth/src/refresh.rs
+++ b/crates/arkavo-agent-auth/src/refresh.rs
@@ -63,7 +63,8 @@ mod tests {
     use crate::config::AgentAuthConfig;
     use crate::storage;
     use crate::test_helpers::{TEST_LOCK, ValidatingTokenResponder};
-    use crate::types::ChallengeResponse;
+    use crate::test_utils::TokenFileGuard;
+    use crate::types::{ChallengeResponse, StoredToken};
     use arkavo_test_macros::spec;
     use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
     use std::sync::Mutex;
@@ -73,8 +74,8 @@ mod tests {
     #[tokio::test]
     #[spec("AAUTH-004")]
     async fn refresh_loop_reports_waiting_then_authenticated() {
-        let _g = TEST_LOCK.lock().await;
-        storage::delete_token().await.unwrap();
+        let _lock = TEST_LOCK.lock().await;
+        let _file = TokenFileGuard::capture();
 
         let server = MockServer::start().await;
         let keypair = AgentKeypair::generate();
@@ -134,7 +135,72 @@ mod tests {
                 "expected the loop to reach Authenticated after approval, saw {seen:?}"
             );
         }
+    }
 
-        storage::delete_token().await.unwrap();
+    /// AAUTH-004: "New token replaces the old one in storage." The state
+    /// machine reaching `Authenticated` says nothing about what is on disk —
+    /// a refresh that silently kept serving the old CWT would look identical.
+    /// This pins the file itself.
+    #[tokio::test]
+    #[spec("AAUTH-004")]
+    async fn refresh_replaces_the_stored_token_on_disk() {
+        let _lock = TEST_LOCK.lock().await;
+        let _file = TokenFileGuard::capture();
+
+        let keypair = AgentKeypair::generate();
+        let did = keypair.public_key().to_did_key();
+
+        // Past two-thirds of a 15-minute lifetime but not yet expired, so the
+        // loop must re-run the challenge-response rather than reuse this.
+        let mut stale = StoredToken::new(
+            "stale-cwt".to_string(),
+            did.clone(),
+            Utc::now() + chrono::Duration::minutes(1),
+            vec![],
+        );
+        stale.stored_at = Utc::now() - chrono::Duration::minutes(14);
+        storage::store_token(&stale).await.unwrap();
+
+        let server = MockServer::start().await;
+        let challenge = b"refresh-replaces-challenge".to_vec();
+        Mock::given(method("GET"))
+            .and(path("/agents/challenge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ChallengeResponse {
+                challenge: BASE64_STANDARD.encode(&challenge),
+                nonce: "nonce-replaces".to_string(),
+            }))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/agents/token"))
+            .respond_with(ValidatingTokenResponder::new(
+                keypair.public_key(),
+                challenge,
+            ))
+            .mount(&server)
+            .await;
+
+        let client =
+            Arc::new(AgentAuthClient::with_config(AgentAuthConfig::new(server.uri())).unwrap());
+        let handle = tokio::spawn(run_refresh_loop(
+            client,
+            Arc::new(keypair),
+            Duration::from_millis(20),
+            |_| {},
+        ));
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        handle.abort();
+
+        let on_disk = storage::load_token()
+            .await
+            .unwrap()
+            .expect("a refreshed token must be on disk");
+        assert_eq!(
+            on_disk.token, "mock-token-123",
+            "the refreshed token must replace the old one in storage"
+        );
+        assert_eq!(on_disk.did, did);
+        assert!(on_disk.stored_at > stale.stored_at);
     }
 }

--- a/crates/arkavo-agent-auth/src/refresh.rs
+++ b/crates/arkavo-agent-auth/src/refresh.rs
@@ -1,0 +1,140 @@
+use crate::{client::AgentAuthClient, error::AgentAuthError};
+use arkavo_crypto::AgentKeypair;
+use chrono::{DateTime, Utc};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Observable state of the agent's identity plane, driven by
+/// [`run_refresh_loop`]. There are no refresh tokens in this design: staying
+/// authenticated means re-running the DID challenge-response before the
+/// short-lived CWT actually expires.
+#[derive(Debug, Clone)]
+pub enum RefreshState {
+    /// No delegation row yet; the human has not approved this agent's DID.
+    WaitingForApproval,
+    /// Holding a valid CWT, expiring at the given time.
+    Authenticated { expires_at: DateTime<Utc> },
+    /// The delegation was revoked (or the token expired past recovery); the
+    /// stored token has already been dropped.
+    Revoked,
+}
+
+/// Poll `client.get_token` on a fixed interval and report state transitions
+/// through `on_state`. `get_token` is a no-op once a token is cached and not
+/// yet within its last third of lifetime, so polling faster than the token's
+/// own refresh cadence costs nothing beyond a disk read.
+///
+/// Transient errors (network failures, 5xx) don't change the reported state;
+/// they're logged and the loop keeps polling rather than flapping the UI
+/// between "authenticated" and some transient-failure state.
+pub async fn run_refresh_loop(
+    client: Arc<AgentAuthClient>,
+    keypair: Arc<AgentKeypair>,
+    poll: Duration,
+    on_state: impl Fn(RefreshState) + Send + Sync + 'static,
+) {
+    let mut last: Option<RefreshState> = None;
+    loop {
+        let next = match client.get_token(&keypair).await {
+            Ok(tok) => RefreshState::Authenticated {
+                expires_at: tok.expires_at,
+            },
+            Err(AgentAuthError::NotAuthorized) => RefreshState::WaitingForApproval,
+            Err(AgentAuthError::Forbidden(_)) => RefreshState::Revoked,
+            Err(e) => {
+                tracing::warn!(error = %e, "agent token refresh failed; will retry");
+                last.clone().unwrap_or(RefreshState::WaitingForApproval)
+            }
+        };
+
+        if last.as_ref().map(std::mem::discriminant) != Some(std::mem::discriminant(&next)) {
+            on_state(next.clone());
+        }
+        last = Some(next);
+
+        tokio::time::sleep(poll).await;
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)]
+mod tests {
+    use super::*;
+    use crate::config::AgentAuthConfig;
+    use crate::storage;
+    use crate::test_helpers::{TEST_LOCK, ValidatingTokenResponder};
+    use crate::types::ChallengeResponse;
+    use arkavo_test_macros::spec;
+    use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+    use std::sync::Mutex;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    #[spec("AAUTH-004")]
+    async fn refresh_loop_reports_waiting_then_authenticated() {
+        let _g = TEST_LOCK.lock().await;
+        storage::delete_token().await.unwrap();
+
+        let server = MockServer::start().await;
+        let keypair = AgentKeypair::generate();
+        let challenge = b"refresh-loop-challenge".to_vec();
+        let challenge_b64 = BASE64_STANDARD.encode(&challenge);
+
+        // First poll: no delegation row yet.
+        Mock::given(method("GET"))
+            .and(path("/agents/challenge"))
+            .respond_with(ResponseTemplate::new(404))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        // Subsequent polls: the human has approved; the challenge succeeds.
+        Mock::given(method("GET"))
+            .and(path("/agents/challenge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ChallengeResponse {
+                challenge: challenge_b64,
+                nonce: "nonce-refresh".to_string(),
+            }))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/agents/token"))
+            .respond_with(ValidatingTokenResponder::new(
+                keypair.public_key(),
+                challenge,
+            ))
+            .mount(&server)
+            .await;
+
+        let client =
+            Arc::new(AgentAuthClient::with_config(AgentAuthConfig::new(server.uri())).unwrap());
+        let keypair = Arc::new(keypair);
+
+        let states = Arc::new(Mutex::new(Vec::new()));
+        let states_writer = states.clone();
+        let handle = tokio::spawn(run_refresh_loop(
+            client,
+            keypair,
+            Duration::from_millis(20),
+            move |state| states_writer.lock().unwrap().push(state),
+        ));
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        handle.abort();
+
+        {
+            let seen = states.lock().unwrap();
+            assert!(!seen.is_empty(), "expected at least one reported state");
+            assert!(matches!(seen[0], RefreshState::WaitingForApproval));
+            assert!(
+                seen.iter()
+                    .any(|s| matches!(s, RefreshState::Authenticated { .. })),
+                "expected the loop to reach Authenticated after approval, saw {seen:?}"
+            );
+        }
+
+        storage::delete_token().await.unwrap();
+    }
+}

--- a/crates/arkavo-agent-auth/src/storage.rs
+++ b/crates/arkavo-agent-auth/src/storage.rs
@@ -24,6 +24,13 @@ fn get_token_path() -> Result<PathBuf, AgentAuthError> {
     Ok(base_dir.join("agent_token"))
 }
 
+/// Parse a stored token from its on-disk JSON representation. Shared by the
+/// async and blocking readers so their notion of "what a stored token looks
+/// like" cannot drift apart.
+fn parse_stored_token(json: &str) -> Result<StoredToken, AgentAuthError> {
+    Ok(serde_json::from_str(json)?)
+}
+
 /// Store a token to disk.
 pub async fn store_token(token: &StoredToken) -> Result<(), AgentAuthError> {
     let path = get_token_path()?;
@@ -56,11 +63,40 @@ pub async fn load_token() -> Result<Option<StoredToken>, AgentAuthError> {
     }
 
     let json = tokio::fs::read_to_string(&path).await?;
-    let token: StoredToken = serde_json::from_str(&json)?;
+    let token = parse_stored_token(&json)?;
 
     // Auto-cleanup expired tokens
     if token.is_expired() {
         let _ = delete_token().await;
+        return Ok(None);
+    }
+
+    Ok(Some(token))
+}
+
+/// Synchronous counterpart to [`load_token`], for callers that must stay
+/// sync (e.g. `arkavo-config-encryption`'s `KasConfig::from_env`, which has
+/// its own non-async callers). Bridging to the async reader from a sync
+/// context would need a runtime handle, and `block_on`/`block_in_place`
+/// panics on a current-thread runtime — unacceptable in a config
+/// constructor — so this reads the same path with `std::fs` instead and
+/// shares `get_token_path`/`parse_stored_token` with the async path so the
+/// two readers cannot drift apart.
+///
+/// Never returns an expired token; an expired token file is removed as a
+/// side effect, same as `load_token`.
+pub fn load_token_blocking() -> Result<Option<StoredToken>, AgentAuthError> {
+    let path = get_token_path()?;
+
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let json = std::fs::read_to_string(&path)?;
+    let token = parse_stored_token(&json)?;
+
+    if token.is_expired() {
+        let _ = std::fs::remove_file(&path);
         return Ok(None);
     }
 
@@ -203,5 +239,62 @@ mod tests {
         );
 
         delete_token().await.unwrap();
+    }
+
+    /// Regression test for C1: the sync reader used by
+    /// `KasConfig::from_env` must see exactly what the async reader wrote,
+    /// via the shared `parse_stored_token` helper.
+    #[spec("AAUTH-002")]
+    #[tokio::test]
+    async fn load_token_blocking_reads_what_store_token_wrote() {
+        let _guard = TEST_LOCK.lock().await;
+        let _ = delete_token().await;
+
+        let token = StoredToken::new(
+            "blocking-read-token".to_string(),
+            "did:key:z6MkBlocking".to_string(),
+            Utc::now() + Duration::hours(1),
+            vec!["https://arkavo.ai/attr/tdf/value/decrypt".to_string()],
+        );
+        store_token(&token).await.unwrap();
+
+        let loaded = load_token_blocking().unwrap();
+        assert!(loaded.is_some());
+        let loaded = loaded.unwrap();
+        assert_eq!(loaded.token, token.token);
+        assert_eq!(loaded.did, token.did);
+
+        delete_token().await.unwrap();
+    }
+
+    /// Regression test for C1: an expired token must never be handed back
+    /// by the blocking reader (matching `load_token`'s behavior), and the
+    /// stale file is removed as a side effect.
+    #[spec("AAUTH-002")]
+    #[tokio::test]
+    async fn load_token_blocking_ignores_expired_token() {
+        let _guard = TEST_LOCK.lock().await;
+        let _ = delete_token().await;
+
+        let token = StoredToken::new(
+            "expired-blocking-token".to_string(),
+            "did:key:z6MkExpiredBlocking".to_string(),
+            Utc::now() - Duration::hours(1),
+            vec![],
+        );
+        store_token(&token).await.unwrap();
+
+        assert!(load_token_blocking().unwrap().is_none());
+
+        let path = get_token_path().unwrap();
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn load_token_blocking_returns_none_when_no_file_exists() {
+        let _guard = TEST_LOCK.lock().await;
+        let _ = delete_token().await;
+
+        assert!(load_token_blocking().unwrap().is_none());
     }
 }

--- a/crates/arkavo-agent-auth/src/storage.rs
+++ b/crates/arkavo-agent-auth/src/storage.rs
@@ -1,8 +1,9 @@
 use crate::{error::AgentAuthError, types::StoredToken};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use tokio::io::AsyncWriteExt;
 
 /// Get the platform-specific token storage path.
-fn get_token_path() -> Result<PathBuf, AgentAuthError> {
+pub(crate) fn get_token_path() -> Result<PathBuf, AgentAuthError> {
     let base_dir = if cfg!(target_os = "macos") {
         dirs::data_dir()
             .map(|p| p.join("arkavo"))
@@ -41,17 +42,46 @@ pub async fn store_token(token: &StoredToken) -> Result<(), AgentAuthError> {
     }
 
     let json = serde_json::to_string_pretty(token)?;
-    tokio::fs::write(&path, &json).await?;
+    write_private(&path, json.as_bytes()).await
+}
 
-    // Set restrictive permissions on Unix
+/// Replace `path` with `bytes` so the token is never readable by anyone but
+/// its owner, not even for an instant: the content is staged in a sibling file
+/// created with mode 0600 and then renamed over the target. Writing in place
+/// and tightening the mode afterwards leaves a world-readable window over a
+/// bearer credential, and lets the concurrent refresh loop read a half-written
+/// file.
+async fn write_private(path: &Path, bytes: &[u8]) -> Result<(), AgentAuthError> {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let stem = path.file_name().and_then(|n| n.to_str()).unwrap_or("token");
+    let tmp = path.with_file_name(format!(
+        ".{stem}.{}.{}.tmp",
+        std::process::id(),
+        NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    // A leftover from a killed run would defeat `create_new`, which is what
+    // guarantees the mode is applied rather than inherited.
+    let _ = tokio::fs::remove_file(&tmp).await;
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create_new(true);
     #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(&path, perms).await?;
+    options.mode(0o600);
+
+    let staged = async {
+        let mut file = options.open(&tmp).await?;
+        file.write_all(bytes).await?;
+        file.sync_all().await?;
+        drop(file);
+        tokio::fs::rename(&tmp, path).await
+    }
+    .await;
+
+    if staged.is_err() {
+        let _ = tokio::fs::remove_file(&tmp).await;
     }
 
-    Ok(())
+    Ok(staged?)
 }
 
 /// Load a token from disk.
@@ -119,15 +149,14 @@ pub async fn delete_token() -> Result<(), AgentAuthError> {
 mod tests {
     use super::*;
     use crate::test_helpers::TEST_LOCK;
+    use crate::test_utils::TokenFileGuard;
     use arkavo_test_macros::spec;
     use chrono::{Duration, Utc};
 
     #[tokio::test]
     async fn test_token_storage_roundtrip() {
-        let _guard = TEST_LOCK.lock().await;
-
-        // Cleanup before test
-        let _ = delete_token().await;
+        let _lock = TEST_LOCK.lock().await;
+        let _file = TokenFileGuard::capture();
 
         let token = StoredToken::new(
             "test_token".to_string(),
@@ -156,10 +185,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_expired_token_cleanup() {
-        let _guard = TEST_LOCK.lock().await;
-
-        // Cleanup before test to ensure no stale tokens
-        let _ = delete_token().await;
+        let _lock = TEST_LOCK.lock().await;
+        let _file = TokenFileGuard::capture();
 
         let token = StoredToken::new(
             "expired_token".to_string(),
@@ -189,8 +216,8 @@ mod tests {
     #[spec("AAUTH-002")]
     #[tokio::test]
     async fn test_store_token_securely() {
-        let _guard = TEST_LOCK.lock().await;
-        let _ = delete_token().await;
+        let _lock = TEST_LOCK.lock().await;
+        let _file = TokenFileGuard::capture();
 
         let expires = Utc::now() + Duration::hours(1);
         let token = StoredToken::new(
@@ -237,8 +264,52 @@ mod tests {
             raw["expires_at"].is_string(),
             "StoredToken.expires_at must stay RFC3339 on disk, not an integer"
         );
+    }
 
-        delete_token().await.unwrap();
+    /// Regression: the token used to be written with `fs::write` and only then
+    /// chmod-ed to 0600, so it existed world-readable for an instant and
+    /// inherited a pre-existing file's wider mode until the chmod landed. The
+    /// replacement is now staged in a sibling created 0600 and renamed over the
+    /// target, so a wider mode on the old file cannot survive the write and no
+    /// staging file is left behind for the refresh loop to trip over.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn store_token_never_inherits_a_world_readable_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _lock = TEST_LOCK.lock().await;
+        let _file = TokenFileGuard::capture();
+
+        let path = get_token_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"{}").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let token = StoredToken::new(
+            "replacement-token".to_string(),
+            "did:key:z6MkReplacement".to_string(),
+            Utc::now() + Duration::hours(1),
+            vec![],
+        );
+        store_token(&token).await.unwrap();
+
+        assert_eq!(load_token().await.unwrap().unwrap().token, token.token);
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600,
+            "a replacement must be created 0600, never inherit the old mode"
+        );
+
+        let leftovers: Vec<String> = std::fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.ends_with(".tmp"))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "staging files left behind: {leftovers:?}"
+        );
     }
 
     /// Regression test for C1: the sync reader used by
@@ -247,8 +318,8 @@ mod tests {
     #[spec("AAUTH-002")]
     #[tokio::test]
     async fn load_token_blocking_reads_what_store_token_wrote() {
-        let _guard = TEST_LOCK.lock().await;
-        let _ = delete_token().await;
+        let _lock = TEST_LOCK.lock().await;
+        let _file = TokenFileGuard::capture();
 
         let token = StoredToken::new(
             "blocking-read-token".to_string(),
@@ -263,8 +334,6 @@ mod tests {
         let loaded = loaded.unwrap();
         assert_eq!(loaded.token, token.token);
         assert_eq!(loaded.did, token.did);
-
-        delete_token().await.unwrap();
     }
 
     /// Regression test for C1: an expired token must never be handed back
@@ -273,8 +342,8 @@ mod tests {
     #[spec("AAUTH-002")]
     #[tokio::test]
     async fn load_token_blocking_ignores_expired_token() {
-        let _guard = TEST_LOCK.lock().await;
-        let _ = delete_token().await;
+        let _lock = TEST_LOCK.lock().await;
+        let _file = TokenFileGuard::capture();
 
         let token = StoredToken::new(
             "expired-blocking-token".to_string(),
@@ -292,8 +361,8 @@ mod tests {
 
     #[tokio::test]
     async fn load_token_blocking_returns_none_when_no_file_exists() {
-        let _guard = TEST_LOCK.lock().await;
-        let _ = delete_token().await;
+        let _lock = TEST_LOCK.lock().await;
+        let _file = TokenFileGuard::capture();
 
         assert!(load_token_blocking().unwrap().is_none());
     }

--- a/crates/arkavo-agent-auth/src/storage.rs
+++ b/crates/arkavo-agent-auth/src/storage.rs
@@ -97,7 +97,7 @@ mod tests {
             "test_token".to_string(),
             "did:key:z6MkTest".to_string(),
             Utc::now() + Duration::hours(1),
-            vec!["agent.capability.chat".to_string()],
+            vec!["https://arkavo.ai/attr/tdf/value/decrypt".to_string()],
         );
 
         // Store
@@ -162,11 +162,10 @@ mod tests {
             "did:key:z6MkSecure".to_string(),
             expires,
             vec![
-                "agent.capability.chat".to_string(),
-                "agent.capability.read".to_string(),
+                "https://arkavo.ai/attr/tdf/value/decrypt".to_string(),
+                "https://arkavo.ai/attr/action/value/read".to_string(),
             ],
-        )
-        .with_delegation_jwt(Some("delegation.jwt.value".to_string()));
+        );
 
         store_token(&token).await.unwrap();
 
@@ -192,8 +191,16 @@ mod tests {
         assert_eq!(parsed.did, token.did);
         assert_eq!(parsed.expires_at.timestamp(), token.expires_at.timestamp());
         assert_eq!(parsed.entitlements, token.entitlements);
-        assert_eq!(parsed.delegation_jwt, token.delegation_jwt);
         assert!(parsed.stored_at <= Utc::now());
+
+        // Regression guard for C1: unlike `TokenResponse`, `StoredToken` must
+        // keep chrono's default RFC3339 string encoding on disk. Changing it
+        // would orphan tokens already written by installed builds.
+        let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(
+            raw["expires_at"].is_string(),
+            "StoredToken.expires_at must stay RFC3339 on disk, not an integer"
+        );
 
         delete_token().await.unwrap();
     }

--- a/crates/arkavo-agent-auth/src/test_utils.rs
+++ b/crates/arkavo-agent-auth/src/test_utils.rs
@@ -1,0 +1,68 @@
+//! Test-only protection for the on-disk agent token.
+//!
+//! The token file is the developer's real credential, minted against the agent
+//! DID a human approved in authnz-rs. A test that stores or deletes it must put
+//! back exactly what it found — including putting back "nothing" — or running
+//! the suite drops a live credential on the floor.
+
+use std::path::PathBuf;
+
+/// RAII guard that empties the agent token file for the duration of a test and
+/// restores its previous contents when it drops.
+///
+/// The restore lives in `Drop`, not at the end of the test body, because a
+/// failing `assert!` unwinds past trailing cleanup code but not past a
+/// destructor. Bind it *after* the test's serialising mutex guard so the file
+/// is back before another test can take the lock.
+pub struct TokenFileGuard {
+    path: PathBuf,
+    saved: Option<Vec<u8>>,
+}
+
+impl TokenFileGuard {
+    /// Capture the token file and clear it, so the test starts from a
+    /// known-empty state regardless of what the developer's machine holds.
+    pub fn capture() -> Self {
+        let path = crate::storage::get_token_path().expect("locate the agent token file");
+        let saved = std::fs::read(&path).ok();
+        if saved.is_some() {
+            let _ = std::fs::remove_file(&path);
+        }
+        Self { path, saved }
+    }
+}
+
+impl Drop for TokenFileGuard {
+    fn drop(&mut self) {
+        let restored = match &self.saved {
+            Some(bytes) => restore(&self.path, bytes),
+            None => match std::fs::remove_file(&self.path) {
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                other => other,
+            },
+        };
+        // Panicking here would abort the process during unwind and hide
+        // whichever assertion actually failed.
+        if let Err(e) = restored {
+            eprintln!("failed to restore agent token {}: {e}", self.path.display());
+        }
+    }
+}
+
+/// Write the captured bytes back with owner-only permissions. `Drop` cannot
+/// await, so this is the synchronous counterpart to `storage::write_private`
+/// rather than a call into it.
+fn restore(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let _ = std::fs::remove_file(path);
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    options.open(path)?.write_all(bytes)
+}

--- a/crates/arkavo-agent-auth/src/types.rs
+++ b/crates/arkavo-agent-auth/src/types.rs
@@ -18,15 +18,17 @@ pub struct TokenRequest {
 }
 
 /// Response from the token endpoint.
+///
+/// `expires_at` is a unix-epoch-seconds integer on the wire (authnz-rs encodes
+/// it that way), not an RFC3339 string, so it needs an explicit chrono serde
+/// adapter distinct from `StoredToken`'s default (RFC3339) representation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TokenResponse {
     pub token: String,
+    #[serde(with = "chrono::serde::ts_seconds")]
     pub expires_at: DateTime<Utc>,
     #[serde(default)]
     pub entitlements: Vec<String>,
-    /// ES256-signed delegation JWT from authnz-rs binding human DID → agent DID
-    #[serde(default)]
-    pub delegation_jwt: Option<String>,
 }
 
 /// Token stored locally on disk.
@@ -37,9 +39,6 @@ pub struct StoredToken {
     pub expires_at: DateTime<Utc>,
     pub entitlements: Vec<String>,
     pub stored_at: DateTime<Utc>,
-    /// ES256-signed delegation JWT binding human DID → agent DID
-    #[serde(default)]
-    pub delegation_jwt: Option<String>,
 }
 
 impl StoredToken {
@@ -55,16 +54,68 @@ impl StoredToken {
             expires_at,
             entitlements,
             stored_at: Utc::now(),
-            delegation_jwt: None,
         }
-    }
-
-    pub fn with_delegation_jwt(mut self, jwt: Option<String>) -> Self {
-        self.delegation_jwt = jwt;
-        self
     }
 
     pub fn is_expired(&self) -> bool {
         Utc::now() >= self.expires_at
+    }
+
+    /// True once two-thirds of the token's lifetime (`stored_at` to
+    /// `expires_at`) has elapsed. There are no refresh tokens in this design;
+    /// "refresh" means re-running the challenge-response flow before the
+    /// short-lived CWT actually expires.
+    pub fn needs_refresh(&self, now: DateTime<Utc>) -> bool {
+        let two_thirds = self.stored_at + (self.expires_at - self.stored_at) * 2 / 3;
+        now >= two_thirds
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arkavo_test_macros::spec;
+
+    #[test]
+    #[spec("AAUTH-004")]
+    fn needs_refresh_at_two_thirds_lifetime() {
+        let t0 = Utc::now();
+        let mut tok = StoredToken::new(
+            "t".into(),
+            "did".into(),
+            t0 + chrono::Duration::minutes(15),
+            vec![],
+        );
+        tok.stored_at = t0;
+        assert!(!tok.needs_refresh(t0 + chrono::Duration::minutes(9)));
+        assert!(tok.needs_refresh(t0 + chrono::Duration::minutes(10)));
+        assert!(tok.needs_refresh(t0 + chrono::Duration::minutes(16)));
+    }
+
+    /// Regression test for C1: authnz-rs sends `expires_at` as an integer
+    /// unix-epoch-seconds value, not an RFC3339 string. A round-trip test that
+    /// serializes and deserializes the same struct (as the old wiremock
+    /// responder did) can't catch this, because any encoding round-trips.
+    /// This test deserializes a literal JSON fixture shaped like the real
+    /// server response instead, and also carries an unrelated unknown field
+    /// to confirm serde's default unknown-field tolerance holds now that the
+    /// response no longer carries a delegation JWT (removed per C2).
+    #[test]
+    #[spec("AAUTH-004")]
+    fn token_response_deserializes_integer_expires_at() {
+        let json = r#"{
+            "token": "opaque-cwt-bytes",
+            "expires_at": 1788000000,
+            "entitlements": ["https://arkavo.ai/attr/tdf/value/decrypt"],
+            "future_unknown_field": "should-be-ignored"
+        }"#;
+
+        let parsed: TokenResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.token, "opaque-cwt-bytes");
+        assert_eq!(parsed.expires_at.timestamp(), 1_788_000_000);
+        assert_eq!(
+            parsed.entitlements,
+            vec!["https://arkavo.ai/attr/tdf/value/decrypt".to_string()]
+        );
     }
 }

--- a/crates/arkavo-cli/Cargo.toml
+++ b/crates/arkavo-cli/Cargo.toml
@@ -69,6 +69,7 @@ arkavo-crypto = { path = "../arkavo-crypto" }
 arkavo-gossip = { path = "../arkavo-gossip" }
 arkavo-registration = { path = "../arkavo-registration" }
 arkavo-agent-auth = { path = "../arkavo-agent-auth" }
+arkavo-cwt = { path = "../arkavo-cwt" }
 arkavo-config-encryption = { path = "../arkavo-config-encryption" }
 arkavo-config-bundle = { path = "../arkavo-config-bundle" }
 base64 = { workspace = true }

--- a/crates/arkavo-cli/Cargo.toml
+++ b/crates/arkavo-cli/Cargo.toml
@@ -104,6 +104,7 @@ libc = { workspace = true }
 arkavo-mcp-claude = { path = "../arkavo-mcp-claude", optional = true }
 
 [dev-dependencies]
+arkavo-device-identity = { path = "../arkavo-device-identity", features = ["test-utils"] }
 tempfile = { workspace = true }
 reqwest = { workspace = true }
 tokio-tungstenite = { workspace = true }

--- a/crates/arkavo-cli/src/commands/agent.rs
+++ b/crates/arkavo-cli/src/commands/agent.rs
@@ -945,10 +945,15 @@ pub async fn start_agent_server(
                     refresh_keypair,
                     Duration::from_secs(30),
                     move |state| {
+                        use arkavo_agent_auth::RefreshState;
+                        // The agent validates its own credential on receipt.
+                        // Async, so it cannot run inline in this sync callback.
+                        if matches!(&state, RefreshState::Authenticated { .. }) {
+                            tokio::spawn(super::agent_cwt_verify::verify_stored_token());
+                        }
                         if !trust_log {
                             return;
                         }
-                        use arkavo_agent_auth::RefreshState;
                         match state {
                             RefreshState::WaitingForApproval => {
                                 println!("[trust] waiting for approval in the Arkavo app");

--- a/crates/arkavo-cli/src/commands/agent.rs
+++ b/crates/arkavo-cli/src/commands/agent.rs
@@ -495,9 +495,11 @@ fn run_agent_with_options(
     }
 }
 
-pub(crate) use super::agent_config::{
-    AgentConfig, DEFAULT_AGENT_ENTITLEMENTS, parse_agents_config,
-};
+// `pub`, not `pub(crate)`: `tests/mcp_agent_integration_test.rs`,
+// `tests/mcp_server_test.rs`, and `tests/regression_issue_157.rs` reach
+// these through this exact path (`arkavo_cli::commands::agent::...`) as
+// external integration-test crates, which only see the crate's public API.
+pub use super::agent_config::{AgentConfig, DEFAULT_AGENT_ENTITLEMENTS, parse_agents_config};
 
 /// Check if a tool's input schema has required arguments
 fn has_required_args(schema: &serde_json::Value) -> bool {

--- a/crates/arkavo-cli/src/commands/agent.rs
+++ b/crates/arkavo-cli/src/commands/agent.rs
@@ -923,6 +923,55 @@ pub async fn start_agent_server(
     // Peers are added dynamically via mDNS discovery
     let mut gossip_handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
 
+    // Keep the agent's own authnz-rs identity current: this proves
+    // `agent_did` via challenge-response and holds a short-lived CWT,
+    // independent of whether A2A gossip is enabled. Runs for the life of
+    // the server; aborted alongside the other background tasks on shutdown.
+    //
+    // Trust-state output follows the same gate as the QR block above
+    // (`!quiet || show_trust_qr`): a `--trust` user needs to see "waiting for
+    // approval" and the eventual "authenticated" confirmation even when
+    // `quiet` is otherwise on, since that's the whole point of `--trust`.
+    let trust_log = !quiet || show_trust_qr;
+    match arkavo_agent_auth::AgentAuthClient::with_config(
+        arkavo_agent_auth::AgentAuthConfig::from_env(),
+    ) {
+        Ok(auth_client) => {
+            let auth_client = Arc::new(auth_client);
+            let refresh_keypair = agent_keypair.clone();
+            gossip_handles.push(tokio::spawn(async move {
+                arkavo_agent_auth::run_refresh_loop(
+                    auth_client,
+                    refresh_keypair,
+                    Duration::from_secs(30),
+                    move |state| {
+                        if !trust_log {
+                            return;
+                        }
+                        use arkavo_agent_auth::RefreshState;
+                        match state {
+                            RefreshState::WaitingForApproval => {
+                                println!("[trust] waiting for approval in the Arkavo app");
+                            }
+                            RefreshState::Authenticated { expires_at } => {
+                                println!("[trust] authenticated; token expires at {expires_at}");
+                            }
+                            RefreshState::Revoked => {
+                                println!("[trust] agent delegation revoked; re-run --trust");
+                            }
+                        }
+                    },
+                )
+                .await;
+            }));
+        }
+        Err(e) => {
+            if trust_log {
+                eprintln!("Warning: could not start agent identity refresh loop: {e}");
+            }
+        }
+    }
+
     if config.a2a_enabled {
         // Start anti-entropy background task (5s interval)
         let learning_bus_ae = learning_bus.clone();

--- a/crates/arkavo-cli/src/commands/agent.rs
+++ b/crates/arkavo-cli/src/commands/agent.rs
@@ -335,6 +335,10 @@ fn run_agent_with_options(
             a2a_enabled: true,
             a2a_service_type: None,
             swarm: None,
+            entitlements: DEFAULT_AGENT_ENTITLEMENTS
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
         }]
     } else {
         let config_content = fs::read_to_string(&config_path)?;
@@ -381,6 +385,10 @@ fn run_agent_with_options(
                     a2a_enabled: true,
                     a2a_service_type: None,
                     swarm: None,
+                    entitlements: DEFAULT_AGENT_ENTITLEMENTS
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect(),
                 }]
             }
         }
@@ -459,6 +467,10 @@ fn run_agent_with_options(
                 a2a_enabled: true,
                 a2a_service_type: None,
                 swarm: None,
+                entitlements: DEFAULT_AGENT_ENTITLEMENTS
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
             };
 
             if verbose {
@@ -483,396 +495,9 @@ fn run_agent_with_options(
     }
 }
 
-// Agent configuration parsing
-#[derive(Debug, Clone)]
-pub struct AgentConfig {
-    pub name: String,
-    pub purpose: String, // Used as system prompt for LLM
-    pub model: String,
-    pub mode: arkavo_protocol::agent_config::AgentMode,
-    pub listen: String,
-    pub mdns_enabled: bool,
-    pub mcp_servers: Vec<McpServerConfig>,
-    pub api_keys: std::collections::HashMap<String, String>,
-    pub quiet: bool, // Default true (quiet), false if --verbose is specified
-    // A2A peer configuration
-    pub peers: Vec<String>,               // e.g., ["http://localhost:8352"]
-    pub a2a_enabled: bool,                // Default: true
-    pub a2a_service_type: Option<String>, // Custom mDNS service type
-    pub swarm: Option<String>,            // Domain/swarm identifier for learning isolation
-}
-
-#[derive(Debug, Clone)]
-pub struct McpServerConfig {
-    pub name: String,
-    pub command: Option<String>,
-    pub args: Vec<String>,
-    pub url: Option<String>,
-}
-
-pub fn parse_agents_config(content: &str) -> Result<Vec<AgentConfig>, Box<dyn std::error::Error>> {
-    let mut agents = Vec::new();
-    let mut current_agent: Option<AgentConfig> = None;
-    let mut in_agent_section = false;
-    let mut in_mcp_section = false;
-    let mut current_mcp_server: Option<McpServerConfig> = None;
-    let mut current_section: Option<String> = None;
-    let mut in_peers_section = false;
-    let mut in_args_section = false;
-    let mut in_a2a_section = false;
-    let mut in_purpose_multiline = false;
-    let mut purpose_lines: Vec<String> = Vec::new();
-
-    // Handle YAML frontmatter format (content between --- delimiters)
-    if let Some(after_open) = content.strip_prefix("---")
-        && let Some(end_idx) = after_open.find("\n---")
-    {
-        let frontmatter = &after_open[..end_idx];
-        let mut agent = AgentConfig {
-            name: String::new(),
-            purpose: String::new(),
-            model: String::new(),
-            mode: arkavo_protocol::agent_config::AgentMode::default(),
-            listen: "0.0.0.0:0".to_string(),
-            mdns_enabled: true,
-            mcp_servers: Vec::new(),
-            api_keys: std::collections::HashMap::new(),
-            quiet: true,
-            peers: Vec::new(),
-            a2a_enabled: true,
-            a2a_service_type: None,
-            swarm: None,
-        };
-        // Known top-level YAML keys that parse_yaml_properties handles
-        const KNOWN_SECTIONS: &[&str] = &[
-            "name:",
-            "purpose:",
-            "model:",
-            "mode:",
-            "listen:",
-            "mdns:",
-            "swarm:",
-            "a2a:",
-            "peers:",
-            "mcp_servers:",
-            "discovery:",
-        ];
-        let mut in_unknown_section = false;
-        for line in frontmatter.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() || trimmed.starts_with('#') {
-                continue;
-            }
-            // Non-indented line: check if it starts a known or unknown section
-            if !line.starts_with(' ') && !line.starts_with('\t') {
-                let is_known = KNOWN_SECTIONS.iter().any(|k| trimmed.starts_with(k))
-                    || trimmed.contains("_API_KEY:")
-                    || trimmed.contains("_api_key:");
-                in_unknown_section = !is_known;
-            }
-            if in_unknown_section {
-                continue;
-            }
-            parse_yaml_properties(
-                line,
-                trimmed,
-                &mut agent,
-                &mut in_mcp_section,
-                &mut current_mcp_server,
-                &mut in_peers_section,
-                &mut in_a2a_section,
-                &mut in_args_section,
-                &mut in_purpose_multiline,
-                &mut purpose_lines,
-            );
-        }
-        if in_purpose_multiline {
-            agent.purpose = purpose_lines.join("\n").trim().to_string();
-        }
-        if let Some(server) = current_mcp_server.take() {
-            agent.mcp_servers.push(server);
-        }
-        return Ok(vec![agent]);
-    }
-
-    // Check if this is the new markdown format by looking for specific patterns
-    let is_new_format = content.contains("## Agent Identity")
-        || content.contains("**Mission:**")
-        || content.contains("**Name:**")
-        || content.contains("# AGENTS.md");
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-
-        // Handle new markdown format
-        if is_new_format {
-            // Extract agent name from H1 title (e.g., "# AGENTS.md — alert-manager")
-            if trimmed.starts_with("# AGENTS.md") && trimmed.contains("—") {
-                // Save previous agent if exists
-                if let Some(agent) = current_agent.take() {
-                    agents.push(agent);
-                }
-
-                let name = if let Some(em_dash_pos) = trimmed.find("—") {
-                    trimmed[em_dash_pos + "—".len()..].trim().to_string()
-                } else if let Some(dash_pos) = trimmed.find(" - ") {
-                    trimmed[dash_pos + 3..].trim().to_string()
-                } else {
-                    "unnamed-agent".to_string()
-                };
-
-                current_agent = Some(AgentConfig {
-                    name,
-                    purpose: String::new(),
-                    model: String::new(),
-                    mode: arkavo_protocol::agent_config::AgentMode::default(),
-                    listen: "0.0.0.0:0".to_string(),
-                    mdns_enabled: true,
-                    mcp_servers: Vec::new(),
-                    api_keys: std::collections::HashMap::new(),
-                    quiet: true, // Default is quiet
-                    peers: Vec::new(),
-                    a2a_enabled: true,
-                    a2a_service_type: None,
-                    swarm: None,
-                });
-                in_agent_section = true;
-                continue;
-            }
-
-            // Track current markdown section
-            if trimmed.starts_with("## ") {
-                let section_name = trimmed.strip_prefix("## ").unwrap_or("").to_string();
-
-                // Check if this is an agent definition (not a standard section)
-                let is_standard_section = section_name.starts_with("Agent Identity")
-                    || section_name.starts_with("Runtime Configuration")
-                    || section_name.starts_with("Capabilities")
-                    || section_name.starts_with("Tool Requirements")
-                    || section_name.starts_with("MCP Server")
-                    || section_name.starts_with("Purpose")
-                    || section_name.starts_with("Model Configuration")
-                    || section_name.starts_with("Rover Configuration")
-                    || section_name.starts_with("A2A Protocol")
-                    || section_name.starts_with("Logging");
-
-                if !is_standard_section {
-                    // Save any pending MCP server before switching agents
-                    if let (Some(server), Some(agent)) =
-                        (current_mcp_server.take(), current_agent.as_mut())
-                    {
-                        agent.mcp_servers.push(server);
-                    }
-
-                    // Save previous agent if exists
-                    if let Some(agent) = current_agent.take() {
-                        agents.push(agent);
-                    }
-
-                    // Reset MCP section flag
-                    in_mcp_section = false;
-
-                    // Create new agent from ## agent-name header
-                    current_agent = Some(AgentConfig {
-                        name: section_name.clone(),
-                        purpose: String::new(),
-                        model: String::new(),
-                        mode: arkavo_protocol::agent_config::AgentMode::default(),
-                        listen: "0.0.0.0:0".to_string(),
-                        mdns_enabled: true,
-                        mcp_servers: Vec::new(),
-                        api_keys: std::collections::HashMap::new(),
-                        quiet: true, // Default is quiet
-                        peers: Vec::new(),
-                        a2a_enabled: true,
-                        a2a_service_type: None,
-                        swarm: None,
-                    });
-                    in_agent_section = true;
-                }
-
-                current_section = Some(section_name);
-                continue;
-            }
-
-            // Parse agent information from markdown sections
-            if let Some(agent) = current_agent.as_mut() {
-                if let Some(section) = &current_section {
-                    match section.as_str() {
-                        "Agent Identity" => {
-                            // Extract name
-                            if trimmed.starts_with("- **Name:**") {
-                                if let Some(name) =
-                                    extract_markdown_field_value(trimmed, "**Name:**")
-                                {
-                                    agent.name = name;
-                                }
-                            }
-                            // Extract mission/purpose
-                            else if trimmed.starts_with("- **Mission:**")
-                                && let Some(mission) =
-                                    extract_markdown_field_value(trimmed, "**Mission:**")
-                            {
-                                agent.purpose = mission;
-                            }
-                        }
-                        "Runtime Configuration (example)" => {
-                            // Try to extract listen address from YAML block
-                            if trimmed.starts_with("listen:")
-                                && let Some(listen) = extract_yaml_value(trimmed, "listen:")
-                            {
-                                agent.listen = listen;
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-
-                // Also handle direct YAML-style properties in markdown (for flexibility)
-                parse_yaml_properties(
-                    line,
-                    trimmed,
-                    agent,
-                    &mut in_mcp_section,
-                    &mut current_mcp_server,
-                    &mut in_peers_section,
-                    &mut in_a2a_section,
-                    &mut in_args_section,
-                    &mut in_purpose_multiline,
-                    &mut purpose_lines,
-                );
-            }
-        } else {
-            // Handle old YAML-style format
-            // Check for single # header (creates new agent)
-            let is_top_level_header = trimmed.starts_with("# ") && !trimmed.starts_with("## ");
-
-            // Check for ## header that's not a standard section
-            let is_new_agent_section = if trimmed.starts_with("## ") {
-                let section_name = trimmed.strip_prefix("## ").unwrap_or("").trim();
-                // Standard sections don't create new agents
-                !section_name.starts_with("Agent Identity")
-                    && !section_name.starts_with("Runtime Configuration")
-                    && !section_name.starts_with("Capabilities")
-                    && !section_name.starts_with("Tool Requirements")
-                    && !section_name.starts_with("MCP Server")
-                    && !section_name.starts_with("Purpose")
-                    && !section_name.starts_with("Model Configuration")
-                    && !section_name.starts_with("Rover Configuration")
-                    && !section_name.starts_with("A2A Protocol")
-                    && !section_name.starts_with("Logging")
-            } else {
-                false
-            };
-
-            let is_agent_header = is_top_level_header || is_new_agent_section;
-
-            if is_agent_header {
-                // Save any pending MCP server before switching agents
-                if let (Some(server), Some(agent)) =
-                    (current_mcp_server.take(), current_agent.as_mut())
-                {
-                    agent.mcp_servers.push(server);
-                }
-
-                // Save previous agent if exists
-                if let Some(agent) = current_agent.take() {
-                    agents.push(agent);
-                }
-
-                // Reset MCP section flag
-                in_mcp_section = false;
-
-                // Extract name from header
-                let header_prefix = if trimmed.starts_with("## ") {
-                    "## "
-                } else {
-                    "# "
-                };
-                let header_text = trimmed.strip_prefix(header_prefix).unwrap_or("").trim();
-
-                // Use a default name that will be overridden by explicit name: field
-                let name = header_text.to_string();
-
-                current_agent = Some(AgentConfig {
-                    name,
-                    purpose: String::new(),
-                    model: String::new(),
-                    mode: arkavo_protocol::agent_config::AgentMode::default(),
-                    listen: "0.0.0.0:0".to_string(), // Dynamic port
-                    mdns_enabled: true,              // Default to true for zero-config
-                    mcp_servers: Vec::new(),
-                    api_keys: std::collections::HashMap::new(),
-                    quiet: true, // Default is quiet
-                    peers: Vec::new(),
-                    a2a_enabled: true,
-                    a2a_service_type: None,
-                    swarm: None,
-                });
-                in_agent_section = true;
-                continue;
-            }
-
-            // Skip if not in agent section
-            if !in_agent_section || current_agent.is_none() {
-                continue;
-            }
-
-            if let Some(agent) = current_agent.as_mut() {
-                parse_yaml_properties(
-                    line,
-                    trimmed,
-                    agent,
-                    &mut in_mcp_section,
-                    &mut current_mcp_server,
-                    &mut in_peers_section,
-                    &mut in_a2a_section,
-                    &mut in_args_section,
-                    &mut in_purpose_multiline,
-                    &mut purpose_lines,
-                );
-            }
-        }
-    }
-
-    // Save any pending MCP server
-    if let (Some(server), Some(agent)) = (current_mcp_server.take(), current_agent.as_mut()) {
-        agent.mcp_servers.push(server);
-    }
-
-    // Save last agent
-    if let Some(agent) = current_agent {
-        agents.push(agent);
-    }
-
-    Ok(agents)
-}
-
-// Helper function to extract value from markdown field like "- **Name:** value"
-fn extract_markdown_field_value(line: &str, field_prefix: &str) -> Option<String> {
-    if let Some(start_pos) = line.find(field_prefix) {
-        let after_prefix = &line[start_pos + field_prefix.len()..];
-        let value = after_prefix.trim();
-        if !value.is_empty() {
-            return Some(value.to_string());
-        }
-    }
-    None
-}
-
-// Helper function to extract YAML-style values like "listen: 0.0.0.0:8342"
-fn extract_yaml_value(line: &str, key: &str) -> Option<String> {
-    if let Some(colon_pos) = line.find(':') {
-        let key_part = line[..colon_pos].trim();
-        if key_part == key.trim_end_matches(':') {
-            let value = line[colon_pos + 1..].trim().trim_matches('"');
-            if !value.is_empty() {
-                return Some(value.to_string());
-            }
-        }
-    }
-    None
-}
+pub(crate) use super::agent_config::{
+    AgentConfig, DEFAULT_AGENT_ENTITLEMENTS, parse_agents_config,
+};
 
 /// Check if a tool's input schema has required arguments
 fn has_required_args(schema: &serde_json::Value) -> bool {
@@ -881,278 +506,6 @@ fn has_required_args(schema: &serde_json::Value) -> bool {
         .get("required")
         .and_then(|r| r.as_array())
         .is_some_and(|arr| !arr.is_empty())
-}
-
-// Helper function to parse YAML-style properties (used by both old and new format parsers)
-#[allow(clippy::too_many_arguments)]
-fn parse_yaml_properties(
-    line: &str,
-    trimmed: &str,
-    agent: &mut AgentConfig,
-    in_mcp_section: &mut bool,
-    current_mcp_server: &mut Option<McpServerConfig>,
-    in_peers_section: &mut bool,
-    in_a2a_section: &mut bool,
-    in_args_section: &mut bool,
-    in_purpose_multiline: &mut bool,
-    purpose_lines: &mut Vec<String>,
-) {
-    // Check for a2a section
-    if trimmed == "a2a:" {
-        *in_a2a_section = true;
-        return;
-    }
-
-    // Check for peers section (can be top-level or under a2a)
-    if trimmed == "peers:" {
-        *in_peers_section = true;
-        return;
-    }
-
-    // Handle peer entries
-    if *in_peers_section && trimmed.starts_with("- ") {
-        let peer = trimmed
-            .strip_prefix("- ")
-            .unwrap_or("")
-            .trim()
-            .trim_matches('"')
-            .to_string();
-        if !peer.is_empty() {
-            agent.peers.push(peer);
-        }
-        return;
-    }
-
-    // End peers section when we hit a non-list item
-    if *in_peers_section
-        && !trimmed.is_empty()
-        && !trimmed.starts_with('-')
-        && !trimmed.starts_with(' ')
-    {
-        *in_peers_section = false;
-    }
-
-    // Parse a2a properties
-    if *in_a2a_section && !*in_peers_section {
-        if trimmed.starts_with("enabled:") {
-            agent.a2a_enabled = !trimmed.contains("false");
-            return;
-        } else if trimmed.starts_with("service_type:") {
-            agent.a2a_service_type = Some(
-                trimmed
-                    .strip_prefix("service_type:")
-                    .unwrap_or("")
-                    .trim()
-                    .trim_matches('"')
-                    .to_string(),
-            );
-            return;
-        }
-        // End a2a section when we hit a non-indented, non-a2a property
-        if !trimmed.is_empty()
-            && !trimmed.starts_with(' ')
-            && !trimmed.starts_with('-')
-            && !trimmed.starts_with("enabled:")
-            && !trimmed.starts_with("service_type:")
-            && trimmed != "peers:"
-            && !trimmed.starts_with("discovery:")
-        {
-            *in_a2a_section = false;
-        }
-    }
-
-    // Check for mcp_servers section
-    if trimmed == "mcp_servers:" {
-        *in_mcp_section = true;
-        *in_a2a_section = false;
-        *in_peers_section = false;
-        return;
-    }
-
-    // Handle MCP server entries
-    if *in_mcp_section && trimmed.starts_with("- name:") {
-        // Save previous MCP server if exists
-        if let Some(server) = current_mcp_server.take() {
-            agent.mcp_servers.push(server);
-        }
-
-        // Start new MCP server
-        *current_mcp_server = Some(McpServerConfig {
-            name: trimmed
-                .strip_prefix("- name:")
-                .unwrap_or("")
-                .trim()
-                .to_string(),
-            command: None,
-            args: Vec::new(),
-            url: None,
-        });
-        return;
-    }
-
-    // Handle YAML list args (e.g., "- value")
-    if *in_args_section && trimmed.starts_with("- ") {
-        if let Some(server) = current_mcp_server.as_mut() {
-            let arg = trimmed
-                .strip_prefix("- ")
-                .unwrap_or("")
-                .trim()
-                .trim_matches('"')
-                .to_string();
-            if !arg.is_empty() {
-                server.args.push(arg);
-            }
-        }
-        return;
-    }
-
-    // End args section when we hit a non-list item
-    if *in_args_section && !trimmed.starts_with("- ") && !trimmed.is_empty() {
-        *in_args_section = false;
-    }
-
-    // Parse MCP server properties
-    if *in_mcp_section && let Some(server) = current_mcp_server.as_mut() {
-        if trimmed.starts_with("command:") {
-            *in_args_section = false;
-            server.command = Some(
-                trimmed
-                    .strip_prefix("command:")
-                    .unwrap_or("")
-                    .trim()
-                    .trim_matches('"')
-                    .to_string(),
-            );
-        } else if trimmed.starts_with("args:") {
-            // Check for inline array format: ["arg1", "arg2"]
-            let args_str = trimmed.strip_prefix("args:").unwrap_or("").trim();
-            if args_str.starts_with('[') && args_str.ends_with(']') {
-                let args_content = &args_str[1..args_str.len() - 1];
-                server.args = args_content
-                    .split(',')
-                    .map(|s| s.trim().trim_matches('"').to_string())
-                    .filter(|s| !s.is_empty())
-                    .collect();
-            } else if args_str.is_empty() {
-                // Start YAML list mode for args
-                *in_args_section = true;
-            }
-        } else if trimmed.starts_with("url:") {
-            *in_args_section = false;
-            server.url = Some(
-                trimmed
-                    .strip_prefix("url:")
-                    .unwrap_or("")
-                    .trim()
-                    .trim_matches('"')
-                    .to_string(),
-            );
-        } else if trimmed.starts_with("transport:") {
-            *in_args_section = false;
-            // Skip transport for now, not used
-        } else if !trimmed.is_empty() && !trimmed.starts_with(' ') && !trimmed.starts_with('-') {
-            // End of MCP section
-            *in_mcp_section = false;
-            *in_args_section = false;
-            if let Some(server) = current_mcp_server.take() {
-                agent.mcp_servers.push(server);
-            }
-        }
-    }
-
-    // Parse agent properties (when not in MCP section)
-    if !*in_mcp_section {
-        if trimmed.starts_with("name:") && !trimmed.starts_with("name: |") {
-            agent.name = trimmed
-                .strip_prefix("name:")
-                .unwrap_or("")
-                .trim()
-                .trim_matches('"')
-                .to_string();
-        } else if trimmed.starts_with("purpose:") {
-            let value = trimmed.strip_prefix("purpose:").unwrap_or("").trim();
-            if value == "|" || value == "|-" || value == "|+" {
-                // Start multi-line YAML string
-                *in_purpose_multiline = true;
-                purpose_lines.clear();
-            } else {
-                // Single-line purpose
-                agent.purpose = value.trim_matches('"').to_string();
-            }
-        } else if *in_purpose_multiline {
-            // Collect multi-line purpose content
-            if line.starts_with("  ") || line.starts_with('\t') {
-                // Indented line - part of multi-line value
-                purpose_lines.push(line.trim().to_string());
-            } else if trimmed.is_empty() {
-                // Empty line in multi-line - preserve as paragraph break
-                purpose_lines.push(String::new());
-            } else {
-                // Non-indented, non-empty line - end of multi-line
-                *in_purpose_multiline = false;
-                agent.purpose = purpose_lines.join("\n").trim().to_string();
-                purpose_lines.clear();
-                // Re-process this line (it might be a new property)
-                // Continue to let other parsers handle it
-            }
-        }
-
-        // End multi-line purpose on new property/section
-        if *in_purpose_multiline && (trimmed.starts_with("model:") || trimmed.starts_with('#')) {
-            *in_purpose_multiline = false;
-            agent.purpose = purpose_lines.join("\n").trim().to_string();
-            purpose_lines.clear();
-        }
-
-        if trimmed.starts_with("model:") {
-            agent.model = trimmed
-                .strip_prefix("model:")
-                .unwrap_or("")
-                .trim()
-                .trim_matches('"')
-                .to_string();
-        } else if trimmed.starts_with("mode:") {
-            let mode_str = trimmed
-                .strip_prefix("mode:")
-                .unwrap_or("")
-                .trim()
-                .trim_matches('"');
-            agent.mode = match mode_str {
-                "specialist" => arkavo_protocol::agent_config::AgentMode::Specialist,
-                _ => arkavo_protocol::agent_config::AgentMode::Orchestrator,
-            };
-        } else if trimmed.starts_with("listen:") {
-            agent.listen = trimmed
-                .strip_prefix("listen:")
-                .unwrap_or("")
-                .trim()
-                .trim_matches('"')
-                .to_string();
-        } else if trimmed.starts_with("swarm:") {
-            agent.swarm = Some(
-                trimmed
-                    .strip_prefix("swarm:")
-                    .unwrap_or("")
-                    .trim()
-                    .trim_matches('"')
-                    .to_string(),
-            );
-        } else if trimmed.starts_with("mdns:") {
-            // Only disable if explicitly set to false
-            agent.mdns_enabled = !trimmed.contains("false");
-        } else if trimmed.contains("_API_KEY:") || trimmed.contains("_api_key:") {
-            // Parse API key entries (e.g., MOONSHOT_API_KEY: sk-xxx)
-            if let Some(colon_pos) = trimmed.find(':') {
-                let key_name = trimmed[..colon_pos].trim().to_string();
-                let key_value = trimmed[colon_pos + 1..]
-                    .trim()
-                    .trim_matches('"')
-                    .to_string();
-                agent.api_keys.insert(key_name, key_value);
-            }
-        }
-        // Note: autonomous_interval and event_tool are deprecated - push notifications are used instead
-    }
 }
 
 #[allow(clippy::future_not_send)]
@@ -1190,6 +543,25 @@ pub async fn start_agent_server(
         )
     };
     let device_did = device_keypair.public_key().to_did_key();
+
+    // Load or create the agent's own identity keypair, distinct from the
+    // device keypair above. This is the identity the agent presents to
+    // authnz-rs for its own short-lived CWT, separate from the host device.
+    let agent_keypair = {
+        let bytes = match device_keypair_store::get_agent_keypair()? {
+            Some(bytes) => bytes,
+            None => {
+                let new_kp = arkavo_crypto::AgentKeypair::generate();
+                let bytes = new_kp.to_bytes();
+                device_keypair_store::store_agent_keypair(&bytes)?;
+                bytes
+            }
+        };
+        Arc::new(
+            arkavo_crypto::AgentKeypair::from_bytes(&bytes).expect("Invalid agent keypair bytes"),
+        )
+    };
+    let agent_did = agent_keypair.public_key().to_did_key();
 
     // Create AgentCredential for TDF encryption/decryption
     let mut identity_attributes = HashMap::new();
@@ -1470,9 +842,6 @@ pub async fn start_agent_server(
         let _device_id =
             get_or_create_device_id().map_err(|e| format!("Failed to get device ID: {e}"))?;
 
-        // Reuse persisted device keypair loaded at startup (Phase 1 identity)
-        let public_key = device_keypair.public_key();
-
         // Extract folder name (last part of agent name) for display
         let folder_id = config
             .name
@@ -1481,7 +850,8 @@ pub async fn start_agent_server(
             .unwrap_or("unknown")
             .to_string();
 
-        // Create agent descriptor with DID:key and default entitlements
+        // Create agent descriptor from the agent's own identity (not the device's),
+        // carrying the entitlements this agent requests from authnz-rs.
         // Use actual local IP and bound port (not 0.0.0.0:0 from config)
         let local_ip = get_local_ip().unwrap_or_else(|| "127.0.0.1".to_string());
         let endpoint = format!("http://{local_ip}:{actual_port}");
@@ -1491,12 +861,14 @@ pub async fn start_agent_server(
             None
         };
 
-        let descriptor = AgentDescriptor::new(public_key, endpoint, mdns_service, folder_id)
-            .with_name(&config.name)
-            .with_entitlements(vec![
-                "agent.capability.chat".to_string(),
-                "agent.capability.tools".to_string(),
-            ]);
+        let descriptor = AgentDescriptor::new(
+            agent_keypair.public_key(),
+            endpoint,
+            mdns_service,
+            folder_id,
+        )
+        .with_name(&config.name)
+        .with_entitlements(config.entitlements.clone());
 
         // Display authorization QR code with DID:key
         println!("\n{}", "=".repeat(60));
@@ -1505,6 +877,9 @@ pub async fn start_agent_server(
         if let Err(e) = display_authorization_qr(&descriptor) {
             eprintln!("Warning: Failed to display QR code: {e}");
         }
+        // Printed so the human can compare it with the DID shown in the phone app
+        // before approving the agent's own authnz-rs identity.
+        println!("Agent DID: {agent_did}");
         println!("{}", "=".repeat(60));
     }
 
@@ -2215,120 +1590,5 @@ mod tests {
     fn unknown_option_errors_instead_of_running() {
         assert!(execute(&["--bogus".to_string()]).is_err());
         assert!(execute(&["--trsut".to_string()]).is_err()); // typo of --trust
-    }
-
-    #[test]
-    fn parse_frontmatter_basic() {
-        let content = "---\nname: my-agent\npurpose: \"Test agent\"\nmodel: ministral-3b\n---\n\n# My Agent\nSome docs here.\n";
-        let agents = parse_agents_config(content).unwrap();
-        assert_eq!(agents.len(), 1);
-        assert_eq!(agents[0].name, "my-agent");
-        assert_eq!(agents[0].purpose, "Test agent");
-        assert_eq!(agents[0].model, "ministral-3b");
-    }
-
-    #[test]
-    fn parse_frontmatter_with_a2a() {
-        let content = "---\nname: bridge-agent\npurpose: \"Bridge\"\nmodel: ministral-3b\n\na2a:\n  enabled: true\n  service_type: \"bridge\"\n---\n";
-        let agents = parse_agents_config(content).unwrap();
-        assert_eq!(agents.len(), 1);
-        assert_eq!(agents[0].name, "bridge-agent");
-        assert!(agents[0].a2a_enabled);
-        assert_eq!(agents[0].a2a_service_type.as_deref(), Some("bridge"));
-    }
-
-    #[test]
-    fn parse_frontmatter_with_yaml_comments() {
-        let content = "---\nname: kas-agent\npurpose: \"KAS demo\"\nmodel: ministral-3b\n\n# This is a YAML comment\n# Another comment\n\na2a:\n  enabled: true\n---\n";
-        let agents = parse_agents_config(content).unwrap();
-        assert_eq!(agents.len(), 1);
-        assert_eq!(agents[0].name, "kas-agent");
-        assert_eq!(agents[0].purpose, "KAS demo");
-        assert!(agents[0].a2a_enabled);
-    }
-
-    #[test]
-    fn parse_frontmatter_openclaw_bridge() {
-        let content = r#"---
-name: arkavo-bridge-agent
-purpose: "A2A protocol bridge demonstrating TDF encryption, budget enforcement, and preflight policies"
-model: ministral-3b
-
-kas:
-  enabled: true
-  key_id: "bridge-demo-key-1"
-  algorithm: "ec:secp256r1"
-  trusted_roots:
-    - did: "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
-      name: "Demo Root Authority"
-
-a2a:
-  enabled: true
-  discovery:
-    mdns: true
----
-
-# Arkavo Bridge Agent
-
-This agent serves as Arkavo's side of the A2A protocol bridge.
-"#;
-        let agents = parse_agents_config(content).unwrap();
-        assert_eq!(agents.len(), 1);
-        assert_eq!(agents[0].name, "arkavo-bridge-agent");
-        assert_eq!(agents[0].model, "ministral-3b");
-        assert!(agents[0].a2a_enabled);
-        assert!(agents[0].purpose.contains("A2A protocol bridge"));
-    }
-
-    #[test]
-    fn parse_frontmatter_unknown_section_name_not_leaked() {
-        // Regression: nested `name:` inside kas: trusted_roots must not override agent name
-        let content = "---\nname: my-agent\npurpose: \"Test\"\nmodel: test\nkas:\n  trusted_roots:\n    - did: \"did:key:abc\"\n      name: \"Root Authority\"\n---\n";
-        let agents = parse_agents_config(content).unwrap();
-        assert_eq!(agents.len(), 1);
-        assert_eq!(agents[0].name, "my-agent");
-    }
-
-    #[test]
-    fn parse_frontmatter_no_closing_delimiter_falls_through() {
-        let content =
-            "---\nname: broken\n\n## actual-agent\npurpose: \"works\"\nmodel: ministral-3b\n";
-        let agents = parse_agents_config(content).unwrap();
-        // No closing ---, so frontmatter path is skipped; falls through to existing parser
-        assert!(!agents.is_empty());
-        assert_eq!(agents[0].name, "actual-agent");
-        assert_eq!(agents[0].purpose, "works");
-    }
-
-    #[test]
-    fn parse_existing_format_still_works() {
-        let content = "## my-agent\nname: my-agent\npurpose: \"Test\"\nmodel: ministral-3b\nlisten: 0.0.0.0:8080\n";
-        let agents = parse_agents_config(content).unwrap();
-        assert_eq!(agents.len(), 1);
-        assert_eq!(agents[0].name, "my-agent");
-        assert_eq!(agents[0].purpose, "Test");
-        assert_eq!(agents[0].model, "ministral-3b");
-        assert_eq!(agents[0].listen, "0.0.0.0:8080");
-    }
-
-    #[test]
-    fn parse_frontmatter_with_peers() {
-        let content = "---\nname: peer-agent\npurpose: \"Peer test\"\nmodel: ministral-3b\npeers:\n  - \"localhost:8081\"\n  - \"localhost:8082\"\n---\n";
-        let agents = parse_agents_config(content).unwrap();
-        assert_eq!(agents.len(), 1);
-        assert_eq!(agents[0].peers.len(), 2);
-        assert_eq!(agents[0].peers[0], "localhost:8081");
-        assert_eq!(agents[0].peers[1], "localhost:8082");
-    }
-
-    #[test]
-    fn parse_frontmatter_with_mcp_servers() {
-        let content = "---\nname: mcp-agent\npurpose: \"MCP test\"\nmodel: ministral-3b\nmcp_servers:\n  - name: my-server\n    command: npx\n    args: [\"arg1\", \"arg2\"]\n---\n";
-        let agents = parse_agents_config(content).unwrap();
-        assert_eq!(agents.len(), 1);
-        assert_eq!(agents[0].mcp_servers.len(), 1);
-        assert_eq!(agents[0].mcp_servers[0].name, "my-server");
-        assert_eq!(agents[0].mcp_servers[0].command.as_deref(), Some("npx"));
-        assert_eq!(agents[0].mcp_servers[0].args, vec!["arg1", "arg2"]);
     }
 }

--- a/crates/arkavo-cli/src/commands/agent_config.rs
+++ b/crates/arkavo-cli/src/commands/agent_config.rs
@@ -1,5 +1,10 @@
-//! `AGENTS.md` configuration parsing: `AgentConfig`, `McpServerConfig`, and the
-//! front-matter / markdown parsers that populate them.
+//! `AGENTS.md` configuration domain model.
+//!
+//! `AgentConfig`, `McpServerConfig`, and `parse_agents_config` -- the entry point that walks front-matter / markdown text (via `agent_config_parse`'s helpers) to populate them.
+
+use super::agent_config_parse::{
+    extract_markdown_field_value, extract_yaml_value, parse_yaml_properties,
+};
 
 /// Default entitlements requested for a delegated agent (attribute FQNs, the
 /// vocabulary authnz-rs delegates from the human's stored entitlements).
@@ -392,336 +397,6 @@ pub fn parse_agents_config(content: &str) -> Result<Vec<AgentConfig>, Box<dyn st
     Ok(agents)
 }
 
-// Helper function to extract value from markdown field like "- **Name:** value"
-fn extract_markdown_field_value(line: &str, field_prefix: &str) -> Option<String> {
-    if let Some(start_pos) = line.find(field_prefix) {
-        let after_prefix = &line[start_pos + field_prefix.len()..];
-        let value = after_prefix.trim();
-        if !value.is_empty() {
-            return Some(value.to_string());
-        }
-    }
-    None
-}
-
-// Helper function to extract YAML-style values like "listen: 0.0.0.0:8342"
-fn extract_yaml_value(line: &str, key: &str) -> Option<String> {
-    if let Some(colon_pos) = line.find(':') {
-        let key_part = line[..colon_pos].trim();
-        if key_part == key.trim_end_matches(':') {
-            let value = line[colon_pos + 1..].trim().trim_matches('"');
-            if !value.is_empty() {
-                return Some(value.to_string());
-            }
-        }
-    }
-    None
-}
-
-// Helper function to parse YAML-style properties (used by both old and new format parsers)
-#[allow(clippy::too_many_arguments)]
-fn parse_yaml_properties(
-    line: &str,
-    trimmed: &str,
-    agent: &mut AgentConfig,
-    in_mcp_section: &mut bool,
-    current_mcp_server: &mut Option<McpServerConfig>,
-    in_peers_section: &mut bool,
-    in_entitlements_section: &mut bool,
-    in_a2a_section: &mut bool,
-    in_args_section: &mut bool,
-    in_purpose_multiline: &mut bool,
-    purpose_lines: &mut Vec<String>,
-) {
-    // Check for a2a section
-    if trimmed == "a2a:" {
-        *in_a2a_section = true;
-        return;
-    }
-
-    // Check for peers section (can be top-level or under a2a)
-    if trimmed == "peers:" {
-        *in_peers_section = true;
-        return;
-    }
-
-    // Handle peer entries
-    if *in_peers_section && trimmed.starts_with("- ") {
-        let peer = trimmed
-            .strip_prefix("- ")
-            .unwrap_or("")
-            .trim()
-            .trim_matches('"')
-            .to_string();
-        if !peer.is_empty() {
-            agent.peers.push(peer);
-        }
-        return;
-    }
-
-    // End peers section when we hit a non-list item
-    if *in_peers_section
-        && !trimmed.is_empty()
-        && !trimmed.starts_with('-')
-        && !trimmed.starts_with(' ')
-    {
-        *in_peers_section = false;
-    }
-
-    // Check for entitlements section (attribute FQNs requested for the agent's
-    // delegated identity). An explicit key replaces the built-in default list.
-    if trimmed == "entitlements:" {
-        *in_entitlements_section = true;
-        agent.entitlements.clear();
-        return;
-    }
-
-    // Handle entitlement entries
-    if *in_entitlements_section && trimmed.starts_with("- ") {
-        let entitlement = trimmed
-            .strip_prefix("- ")
-            .unwrap_or("")
-            .trim()
-            .trim_matches('"')
-            .to_string();
-        if !entitlement.is_empty() {
-            agent.entitlements.push(entitlement);
-        }
-        return;
-    }
-
-    // End entitlements section when we hit a non-list item
-    if *in_entitlements_section
-        && !trimmed.is_empty()
-        && !trimmed.starts_with('-')
-        && !trimmed.starts_with(' ')
-    {
-        *in_entitlements_section = false;
-    }
-
-    // Parse a2a properties
-    if *in_a2a_section && !*in_peers_section {
-        if trimmed.starts_with("enabled:") {
-            agent.a2a_enabled = !trimmed.contains("false");
-            return;
-        } else if trimmed.starts_with("service_type:") {
-            agent.a2a_service_type = Some(
-                trimmed
-                    .strip_prefix("service_type:")
-                    .unwrap_or("")
-                    .trim()
-                    .trim_matches('"')
-                    .to_string(),
-            );
-            return;
-        }
-        // End a2a section when we hit a non-indented, non-a2a property
-        if !trimmed.is_empty()
-            && !trimmed.starts_with(' ')
-            && !trimmed.starts_with('-')
-            && !trimmed.starts_with("enabled:")
-            && !trimmed.starts_with("service_type:")
-            && trimmed != "peers:"
-            && !trimmed.starts_with("discovery:")
-        {
-            *in_a2a_section = false;
-        }
-    }
-
-    // Check for mcp_servers section
-    if trimmed == "mcp_servers:" {
-        *in_mcp_section = true;
-        *in_a2a_section = false;
-        *in_peers_section = false;
-        return;
-    }
-
-    // Handle MCP server entries
-    if *in_mcp_section && trimmed.starts_with("- name:") {
-        // Save previous MCP server if exists
-        if let Some(server) = current_mcp_server.take() {
-            agent.mcp_servers.push(server);
-        }
-
-        // Start new MCP server
-        *current_mcp_server = Some(McpServerConfig {
-            name: trimmed
-                .strip_prefix("- name:")
-                .unwrap_or("")
-                .trim()
-                .to_string(),
-            command: None,
-            args: Vec::new(),
-            url: None,
-        });
-        return;
-    }
-
-    // Handle YAML list args (e.g., "- value")
-    if *in_args_section && trimmed.starts_with("- ") {
-        if let Some(server) = current_mcp_server.as_mut() {
-            let arg = trimmed
-                .strip_prefix("- ")
-                .unwrap_or("")
-                .trim()
-                .trim_matches('"')
-                .to_string();
-            if !arg.is_empty() {
-                server.args.push(arg);
-            }
-        }
-        return;
-    }
-
-    // End args section when we hit a non-list item
-    if *in_args_section && !trimmed.starts_with("- ") && !trimmed.is_empty() {
-        *in_args_section = false;
-    }
-
-    // Parse MCP server properties
-    if *in_mcp_section && let Some(server) = current_mcp_server.as_mut() {
-        if trimmed.starts_with("command:") {
-            *in_args_section = false;
-            server.command = Some(
-                trimmed
-                    .strip_prefix("command:")
-                    .unwrap_or("")
-                    .trim()
-                    .trim_matches('"')
-                    .to_string(),
-            );
-        } else if trimmed.starts_with("args:") {
-            // Check for inline array format: ["arg1", "arg2"]
-            let args_str = trimmed.strip_prefix("args:").unwrap_or("").trim();
-            if args_str.starts_with('[') && args_str.ends_with(']') {
-                let args_content = &args_str[1..args_str.len() - 1];
-                server.args = args_content
-                    .split(',')
-                    .map(|s| s.trim().trim_matches('"').to_string())
-                    .filter(|s| !s.is_empty())
-                    .collect();
-            } else if args_str.is_empty() {
-                // Start YAML list mode for args
-                *in_args_section = true;
-            }
-        } else if trimmed.starts_with("url:") {
-            *in_args_section = false;
-            server.url = Some(
-                trimmed
-                    .strip_prefix("url:")
-                    .unwrap_or("")
-                    .trim()
-                    .trim_matches('"')
-                    .to_string(),
-            );
-        } else if trimmed.starts_with("transport:") {
-            *in_args_section = false;
-            // Skip transport for now, not used
-        } else if !trimmed.is_empty() && !trimmed.starts_with(' ') && !trimmed.starts_with('-') {
-            // End of MCP section
-            *in_mcp_section = false;
-            *in_args_section = false;
-            if let Some(server) = current_mcp_server.take() {
-                agent.mcp_servers.push(server);
-            }
-        }
-    }
-
-    // Parse agent properties (when not in MCP section)
-    if !*in_mcp_section {
-        if trimmed.starts_with("name:") && !trimmed.starts_with("name: |") {
-            agent.name = trimmed
-                .strip_prefix("name:")
-                .unwrap_or("")
-                .trim()
-                .trim_matches('"')
-                .to_string();
-        } else if trimmed.starts_with("purpose:") {
-            let value = trimmed.strip_prefix("purpose:").unwrap_or("").trim();
-            if value == "|" || value == "|-" || value == "|+" {
-                // Start multi-line YAML string
-                *in_purpose_multiline = true;
-                purpose_lines.clear();
-            } else {
-                // Single-line purpose
-                agent.purpose = value.trim_matches('"').to_string();
-            }
-        } else if *in_purpose_multiline {
-            // Collect multi-line purpose content
-            if line.starts_with("  ") || line.starts_with('\t') {
-                // Indented line - part of multi-line value
-                purpose_lines.push(line.trim().to_string());
-            } else if trimmed.is_empty() {
-                // Empty line in multi-line - preserve as paragraph break
-                purpose_lines.push(String::new());
-            } else {
-                // Non-indented, non-empty line - end of multi-line
-                *in_purpose_multiline = false;
-                agent.purpose = purpose_lines.join("\n").trim().to_string();
-                purpose_lines.clear();
-                // Re-process this line (it might be a new property)
-                // Continue to let other parsers handle it
-            }
-        }
-
-        // End multi-line purpose on new property/section
-        if *in_purpose_multiline && (trimmed.starts_with("model:") || trimmed.starts_with('#')) {
-            *in_purpose_multiline = false;
-            agent.purpose = purpose_lines.join("\n").trim().to_string();
-            purpose_lines.clear();
-        }
-
-        if trimmed.starts_with("model:") {
-            agent.model = trimmed
-                .strip_prefix("model:")
-                .unwrap_or("")
-                .trim()
-                .trim_matches('"')
-                .to_string();
-        } else if trimmed.starts_with("mode:") {
-            let mode_str = trimmed
-                .strip_prefix("mode:")
-                .unwrap_or("")
-                .trim()
-                .trim_matches('"');
-            agent.mode = match mode_str {
-                "specialist" => arkavo_protocol::agent_config::AgentMode::Specialist,
-                _ => arkavo_protocol::agent_config::AgentMode::Orchestrator,
-            };
-        } else if trimmed.starts_with("listen:") {
-            agent.listen = trimmed
-                .strip_prefix("listen:")
-                .unwrap_or("")
-                .trim()
-                .trim_matches('"')
-                .to_string();
-        } else if trimmed.starts_with("swarm:") {
-            agent.swarm = Some(
-                trimmed
-                    .strip_prefix("swarm:")
-                    .unwrap_or("")
-                    .trim()
-                    .trim_matches('"')
-                    .to_string(),
-            );
-        } else if trimmed.starts_with("mdns:") {
-            // Only disable if explicitly set to false
-            agent.mdns_enabled = !trimmed.contains("false");
-        } else if trimmed.contains("_API_KEY:") || trimmed.contains("_api_key:") {
-            // Parse API key entries (e.g., MOONSHOT_API_KEY: sk-xxx)
-            if let Some(colon_pos) = trimmed.find(':') {
-                let key_name = trimmed[..colon_pos].trim().to_string();
-                let key_value = trimmed[colon_pos + 1..]
-                    .trim()
-                    .trim_matches('"')
-                    .to_string();
-                agent.api_keys.insert(key_name, key_value);
-            }
-        }
-        // Note: autonomous_interval and event_tool are deprecated - push notifications are used instead
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -853,5 +528,73 @@ This agent serves as Arkavo's side of the A2A protocol bridge.
         let without = "---\nname: a\npurpose: p\nmodel: m\n---\n";
         let cfg = parse_agents_config(without).unwrap();
         assert_eq!(cfg[0].entitlements, DEFAULT_AGENT_ENTITLEMENTS);
+    }
+
+    // Regression (R21): an inline-array `entitlements:` line previously
+    // failed an exact-equality check elsewhere in the parser and was
+    // silently dropped, leaving the (broader) default set advertised
+    // instead -- an author asking for a narrower grant silently got a wider
+    // one. These cover the inline form through the front-matter path.
+
+    #[test]
+    fn front_matter_entitlements_inline_array_parsed() {
+        let content = "---\nname: a\npurpose: p\nmodel: m\nentitlements: [\"https://arkavo.ai/attr/tdf/value/decrypt\"]\n---\n";
+        let cfg = parse_agents_config(content).unwrap();
+        assert_eq!(
+            cfg[0].entitlements,
+            vec!["https://arkavo.ai/attr/tdf/value/decrypt"],
+            "inline array must produce exactly the requested (narrower) list, not the defaults"
+        );
+    }
+
+    #[test]
+    fn front_matter_entitlements_inline_empty_array_parsed() {
+        let content = "---\nname: a\npurpose: p\nmodel: m\nentitlements: []\n---\n";
+        let cfg = parse_agents_config(content).unwrap();
+        assert!(
+            cfg[0].entitlements.is_empty(),
+            "an explicit empty list must stay empty, not fall back to the defaults"
+        );
+    }
+
+    // Same inline forms, through the old (non-front-matter) `## agent-name`
+    // parsing path, which shares `parse_yaml_properties` with the
+    // front-matter path but has no `KNOWN_SECTIONS` gate of its own.
+
+    #[test]
+    fn old_format_entitlements_inline_array_parsed() {
+        let content = "## my-agent\nname: my-agent\npurpose: \"Test\"\nmodel: ministral-3b\nentitlements: [\"https://arkavo.ai/attr/tdf/value/decrypt\"]\n";
+        let agents = parse_agents_config(content).unwrap();
+        assert_eq!(
+            agents[0].entitlements,
+            vec!["https://arkavo.ai/attr/tdf/value/decrypt"]
+        );
+    }
+
+    #[test]
+    fn old_format_entitlements_inline_empty_array_parsed() {
+        let content = "## my-agent\nname: my-agent\npurpose: \"Test\"\nmodel: ministral-3b\nentitlements: []\n";
+        let agents = parse_agents_config(content).unwrap();
+        assert!(agents[0].entitlements.is_empty());
+    }
+
+    #[test]
+    fn old_format_entitlements_absent_defaults() {
+        let content = "## my-agent\nname: my-agent\npurpose: \"Test\"\nmodel: ministral-3b\n";
+        let agents = parse_agents_config(content).unwrap();
+        assert_eq!(agents[0].entitlements, DEFAULT_AGENT_ENTITLEMENTS);
+    }
+
+    // Same inline form again, through the *new* markdown format (detected by
+    // "# AGENTS.md" / "**Mission:**" markers), which also feeds every line
+    // through the shared `parse_yaml_properties` helper.
+    #[test]
+    fn new_markdown_format_entitlements_inline_array_parsed() {
+        let content = "# AGENTS.md — my-agent\n\n- **Mission:** test\nname: my-agent\npurpose: \"Test\"\nmodel: ministral-3b\nentitlements: [\"https://arkavo.ai/attr/tdf/value/decrypt\"]\n";
+        let agents = parse_agents_config(content).unwrap();
+        assert_eq!(
+            agents[0].entitlements,
+            vec!["https://arkavo.ai/attr/tdf/value/decrypt"]
+        );
     }
 }

--- a/crates/arkavo-cli/src/commands/agent_config.rs
+++ b/crates/arkavo-cli/src/commands/agent_config.rs
@@ -1,0 +1,857 @@
+//! `AGENTS.md` configuration parsing: `AgentConfig`, `McpServerConfig`, and the
+//! front-matter / markdown parsers that populate them.
+
+/// Default entitlements requested for a delegated agent (attribute FQNs, the
+/// vocabulary authnz-rs delegates from the human's stored entitlements).
+pub const DEFAULT_AGENT_ENTITLEMENTS: &[&str] = &[
+    "https://arkavo.ai/attr/tdf/value/decrypt",
+    "https://arkavo.ai/attr/action/value/read",
+];
+
+fn default_entitlements() -> Vec<String> {
+    DEFAULT_AGENT_ENTITLEMENTS
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+// Agent configuration parsing
+#[derive(Debug, Clone)]
+pub struct AgentConfig {
+    pub name: String,
+    pub purpose: String, // Used as system prompt for LLM
+    pub model: String,
+    pub mode: arkavo_protocol::agent_config::AgentMode,
+    pub listen: String,
+    pub mdns_enabled: bool,
+    pub mcp_servers: Vec<McpServerConfig>,
+    pub api_keys: std::collections::HashMap<String, String>,
+    pub quiet: bool, // Default true (quiet), false if --verbose is specified
+    // A2A peer configuration
+    pub peers: Vec<String>,               // e.g., ["http://localhost:8352"]
+    pub a2a_enabled: bool,                // Default: true
+    pub a2a_service_type: Option<String>, // Custom mDNS service type
+    pub swarm: Option<String>,            // Domain/swarm identifier for learning isolation
+    // Attribute FQNs requested for this agent's delegated identity (see
+    // DEFAULT_AGENT_ENTITLEMENTS); the human approves this list in the app.
+    pub entitlements: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct McpServerConfig {
+    pub name: String,
+    pub command: Option<String>,
+    pub args: Vec<String>,
+    pub url: Option<String>,
+}
+
+pub fn parse_agents_config(content: &str) -> Result<Vec<AgentConfig>, Box<dyn std::error::Error>> {
+    let mut agents = Vec::new();
+    let mut current_agent: Option<AgentConfig> = None;
+    let mut in_agent_section = false;
+    let mut in_mcp_section = false;
+    let mut current_mcp_server: Option<McpServerConfig> = None;
+    let mut current_section: Option<String> = None;
+    let mut in_peers_section = false;
+    let mut in_entitlements_section = false;
+    let mut in_args_section = false;
+    let mut in_a2a_section = false;
+    let mut in_purpose_multiline = false;
+    let mut purpose_lines: Vec<String> = Vec::new();
+
+    // Handle YAML frontmatter format (content between --- delimiters)
+    if let Some(after_open) = content.strip_prefix("---")
+        && let Some(end_idx) = after_open.find("\n---")
+    {
+        let frontmatter = &after_open[..end_idx];
+        let mut agent = AgentConfig {
+            name: String::new(),
+            purpose: String::new(),
+            model: String::new(),
+            mode: arkavo_protocol::agent_config::AgentMode::default(),
+            listen: "0.0.0.0:0".to_string(),
+            mdns_enabled: true,
+            mcp_servers: Vec::new(),
+            api_keys: std::collections::HashMap::new(),
+            quiet: true,
+            peers: Vec::new(),
+            a2a_enabled: true,
+            a2a_service_type: None,
+            swarm: None,
+            entitlements: default_entitlements(),
+        };
+        // Known top-level YAML keys that parse_yaml_properties handles
+        const KNOWN_SECTIONS: &[&str] = &[
+            "name:",
+            "purpose:",
+            "model:",
+            "mode:",
+            "listen:",
+            "mdns:",
+            "swarm:",
+            "a2a:",
+            "peers:",
+            "entitlements:",
+            "mcp_servers:",
+            "discovery:",
+        ];
+        let mut in_unknown_section = false;
+        for line in frontmatter.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            // Non-indented line: check if it starts a known or unknown section
+            if !line.starts_with(' ') && !line.starts_with('\t') {
+                let is_known = KNOWN_SECTIONS.iter().any(|k| trimmed.starts_with(k))
+                    || trimmed.contains("_API_KEY:")
+                    || trimmed.contains("_api_key:");
+                in_unknown_section = !is_known;
+            }
+            if in_unknown_section {
+                continue;
+            }
+            parse_yaml_properties(
+                line,
+                trimmed,
+                &mut agent,
+                &mut in_mcp_section,
+                &mut current_mcp_server,
+                &mut in_peers_section,
+                &mut in_entitlements_section,
+                &mut in_a2a_section,
+                &mut in_args_section,
+                &mut in_purpose_multiline,
+                &mut purpose_lines,
+            );
+        }
+        if in_purpose_multiline {
+            agent.purpose = purpose_lines.join("\n").trim().to_string();
+        }
+        if let Some(server) = current_mcp_server.take() {
+            agent.mcp_servers.push(server);
+        }
+        return Ok(vec![agent]);
+    }
+
+    // Check if this is the new markdown format by looking for specific patterns
+    let is_new_format = content.contains("## Agent Identity")
+        || content.contains("**Mission:**")
+        || content.contains("**Name:**")
+        || content.contains("# AGENTS.md");
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Handle new markdown format
+        if is_new_format {
+            // Extract agent name from H1 title (e.g., "# AGENTS.md — alert-manager")
+            if trimmed.starts_with("# AGENTS.md") && trimmed.contains("—") {
+                // Save previous agent if exists
+                if let Some(agent) = current_agent.take() {
+                    agents.push(agent);
+                }
+
+                let name = if let Some(em_dash_pos) = trimmed.find("—") {
+                    trimmed[em_dash_pos + "—".len()..].trim().to_string()
+                } else if let Some(dash_pos) = trimmed.find(" - ") {
+                    trimmed[dash_pos + 3..].trim().to_string()
+                } else {
+                    "unnamed-agent".to_string()
+                };
+
+                current_agent = Some(AgentConfig {
+                    name,
+                    purpose: String::new(),
+                    model: String::new(),
+                    mode: arkavo_protocol::agent_config::AgentMode::default(),
+                    listen: "0.0.0.0:0".to_string(),
+                    mdns_enabled: true,
+                    mcp_servers: Vec::new(),
+                    api_keys: std::collections::HashMap::new(),
+                    quiet: true, // Default is quiet
+                    peers: Vec::new(),
+                    a2a_enabled: true,
+                    a2a_service_type: None,
+                    swarm: None,
+                    entitlements: default_entitlements(),
+                });
+                in_agent_section = true;
+                continue;
+            }
+
+            // Track current markdown section
+            if trimmed.starts_with("## ") {
+                let section_name = trimmed.strip_prefix("## ").unwrap_or("").to_string();
+
+                // Check if this is an agent definition (not a standard section)
+                let is_standard_section = section_name.starts_with("Agent Identity")
+                    || section_name.starts_with("Runtime Configuration")
+                    || section_name.starts_with("Capabilities")
+                    || section_name.starts_with("Tool Requirements")
+                    || section_name.starts_with("MCP Server")
+                    || section_name.starts_with("Purpose")
+                    || section_name.starts_with("Model Configuration")
+                    || section_name.starts_with("Rover Configuration")
+                    || section_name.starts_with("A2A Protocol")
+                    || section_name.starts_with("Logging");
+
+                if !is_standard_section {
+                    // Save any pending MCP server before switching agents
+                    if let (Some(server), Some(agent)) =
+                        (current_mcp_server.take(), current_agent.as_mut())
+                    {
+                        agent.mcp_servers.push(server);
+                    }
+
+                    // Save previous agent if exists
+                    if let Some(agent) = current_agent.take() {
+                        agents.push(agent);
+                    }
+
+                    // Reset MCP section flag
+                    in_mcp_section = false;
+
+                    // Create new agent from ## agent-name header
+                    current_agent = Some(AgentConfig {
+                        name: section_name.clone(),
+                        purpose: String::new(),
+                        model: String::new(),
+                        mode: arkavo_protocol::agent_config::AgentMode::default(),
+                        listen: "0.0.0.0:0".to_string(),
+                        mdns_enabled: true,
+                        mcp_servers: Vec::new(),
+                        api_keys: std::collections::HashMap::new(),
+                        quiet: true, // Default is quiet
+                        peers: Vec::new(),
+                        a2a_enabled: true,
+                        a2a_service_type: None,
+                        swarm: None,
+                        entitlements: default_entitlements(),
+                    });
+                    in_agent_section = true;
+                }
+
+                current_section = Some(section_name);
+                continue;
+            }
+
+            // Parse agent information from markdown sections
+            if let Some(agent) = current_agent.as_mut() {
+                if let Some(section) = &current_section {
+                    match section.as_str() {
+                        "Agent Identity" => {
+                            // Extract name
+                            if trimmed.starts_with("- **Name:**") {
+                                if let Some(name) =
+                                    extract_markdown_field_value(trimmed, "**Name:**")
+                                {
+                                    agent.name = name;
+                                }
+                            }
+                            // Extract mission/purpose
+                            else if trimmed.starts_with("- **Mission:**")
+                                && let Some(mission) =
+                                    extract_markdown_field_value(trimmed, "**Mission:**")
+                            {
+                                agent.purpose = mission;
+                            }
+                        }
+                        "Runtime Configuration (example)" => {
+                            // Try to extract listen address from YAML block
+                            if trimmed.starts_with("listen:")
+                                && let Some(listen) = extract_yaml_value(trimmed, "listen:")
+                            {
+                                agent.listen = listen;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+
+                // Also handle direct YAML-style properties in markdown (for flexibility)
+                parse_yaml_properties(
+                    line,
+                    trimmed,
+                    agent,
+                    &mut in_mcp_section,
+                    &mut current_mcp_server,
+                    &mut in_peers_section,
+                    &mut in_entitlements_section,
+                    &mut in_a2a_section,
+                    &mut in_args_section,
+                    &mut in_purpose_multiline,
+                    &mut purpose_lines,
+                );
+            }
+        } else {
+            // Handle old YAML-style format
+            // Check for single # header (creates new agent)
+            let is_top_level_header = trimmed.starts_with("# ") && !trimmed.starts_with("## ");
+
+            // Check for ## header that's not a standard section
+            let is_new_agent_section = if trimmed.starts_with("## ") {
+                let section_name = trimmed.strip_prefix("## ").unwrap_or("").trim();
+                // Standard sections don't create new agents
+                !section_name.starts_with("Agent Identity")
+                    && !section_name.starts_with("Runtime Configuration")
+                    && !section_name.starts_with("Capabilities")
+                    && !section_name.starts_with("Tool Requirements")
+                    && !section_name.starts_with("MCP Server")
+                    && !section_name.starts_with("Purpose")
+                    && !section_name.starts_with("Model Configuration")
+                    && !section_name.starts_with("Rover Configuration")
+                    && !section_name.starts_with("A2A Protocol")
+                    && !section_name.starts_with("Logging")
+            } else {
+                false
+            };
+
+            let is_agent_header = is_top_level_header || is_new_agent_section;
+
+            if is_agent_header {
+                // Save any pending MCP server before switching agents
+                if let (Some(server), Some(agent)) =
+                    (current_mcp_server.take(), current_agent.as_mut())
+                {
+                    agent.mcp_servers.push(server);
+                }
+
+                // Save previous agent if exists
+                if let Some(agent) = current_agent.take() {
+                    agents.push(agent);
+                }
+
+                // Reset MCP section flag
+                in_mcp_section = false;
+
+                // Extract name from header
+                let header_prefix = if trimmed.starts_with("## ") {
+                    "## "
+                } else {
+                    "# "
+                };
+                let header_text = trimmed.strip_prefix(header_prefix).unwrap_or("").trim();
+
+                // Use a default name that will be overridden by explicit name: field
+                let name = header_text.to_string();
+
+                current_agent = Some(AgentConfig {
+                    name,
+                    purpose: String::new(),
+                    model: String::new(),
+                    mode: arkavo_protocol::agent_config::AgentMode::default(),
+                    listen: "0.0.0.0:0".to_string(), // Dynamic port
+                    mdns_enabled: true,              // Default to true for zero-config
+                    mcp_servers: Vec::new(),
+                    api_keys: std::collections::HashMap::new(),
+                    quiet: true, // Default is quiet
+                    peers: Vec::new(),
+                    a2a_enabled: true,
+                    a2a_service_type: None,
+                    swarm: None,
+                    entitlements: default_entitlements(),
+                });
+                in_agent_section = true;
+                continue;
+            }
+
+            // Skip if not in agent section
+            if !in_agent_section || current_agent.is_none() {
+                continue;
+            }
+
+            if let Some(agent) = current_agent.as_mut() {
+                parse_yaml_properties(
+                    line,
+                    trimmed,
+                    agent,
+                    &mut in_mcp_section,
+                    &mut current_mcp_server,
+                    &mut in_peers_section,
+                    &mut in_entitlements_section,
+                    &mut in_a2a_section,
+                    &mut in_args_section,
+                    &mut in_purpose_multiline,
+                    &mut purpose_lines,
+                );
+            }
+        }
+    }
+
+    // Save any pending MCP server
+    if let (Some(server), Some(agent)) = (current_mcp_server.take(), current_agent.as_mut()) {
+        agent.mcp_servers.push(server);
+    }
+
+    // Save last agent
+    if let Some(agent) = current_agent {
+        agents.push(agent);
+    }
+
+    Ok(agents)
+}
+
+// Helper function to extract value from markdown field like "- **Name:** value"
+fn extract_markdown_field_value(line: &str, field_prefix: &str) -> Option<String> {
+    if let Some(start_pos) = line.find(field_prefix) {
+        let after_prefix = &line[start_pos + field_prefix.len()..];
+        let value = after_prefix.trim();
+        if !value.is_empty() {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+// Helper function to extract YAML-style values like "listen: 0.0.0.0:8342"
+fn extract_yaml_value(line: &str, key: &str) -> Option<String> {
+    if let Some(colon_pos) = line.find(':') {
+        let key_part = line[..colon_pos].trim();
+        if key_part == key.trim_end_matches(':') {
+            let value = line[colon_pos + 1..].trim().trim_matches('"');
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
+// Helper function to parse YAML-style properties (used by both old and new format parsers)
+#[allow(clippy::too_many_arguments)]
+fn parse_yaml_properties(
+    line: &str,
+    trimmed: &str,
+    agent: &mut AgentConfig,
+    in_mcp_section: &mut bool,
+    current_mcp_server: &mut Option<McpServerConfig>,
+    in_peers_section: &mut bool,
+    in_entitlements_section: &mut bool,
+    in_a2a_section: &mut bool,
+    in_args_section: &mut bool,
+    in_purpose_multiline: &mut bool,
+    purpose_lines: &mut Vec<String>,
+) {
+    // Check for a2a section
+    if trimmed == "a2a:" {
+        *in_a2a_section = true;
+        return;
+    }
+
+    // Check for peers section (can be top-level or under a2a)
+    if trimmed == "peers:" {
+        *in_peers_section = true;
+        return;
+    }
+
+    // Handle peer entries
+    if *in_peers_section && trimmed.starts_with("- ") {
+        let peer = trimmed
+            .strip_prefix("- ")
+            .unwrap_or("")
+            .trim()
+            .trim_matches('"')
+            .to_string();
+        if !peer.is_empty() {
+            agent.peers.push(peer);
+        }
+        return;
+    }
+
+    // End peers section when we hit a non-list item
+    if *in_peers_section
+        && !trimmed.is_empty()
+        && !trimmed.starts_with('-')
+        && !trimmed.starts_with(' ')
+    {
+        *in_peers_section = false;
+    }
+
+    // Check for entitlements section (attribute FQNs requested for the agent's
+    // delegated identity). An explicit key replaces the built-in default list.
+    if trimmed == "entitlements:" {
+        *in_entitlements_section = true;
+        agent.entitlements.clear();
+        return;
+    }
+
+    // Handle entitlement entries
+    if *in_entitlements_section && trimmed.starts_with("- ") {
+        let entitlement = trimmed
+            .strip_prefix("- ")
+            .unwrap_or("")
+            .trim()
+            .trim_matches('"')
+            .to_string();
+        if !entitlement.is_empty() {
+            agent.entitlements.push(entitlement);
+        }
+        return;
+    }
+
+    // End entitlements section when we hit a non-list item
+    if *in_entitlements_section
+        && !trimmed.is_empty()
+        && !trimmed.starts_with('-')
+        && !trimmed.starts_with(' ')
+    {
+        *in_entitlements_section = false;
+    }
+
+    // Parse a2a properties
+    if *in_a2a_section && !*in_peers_section {
+        if trimmed.starts_with("enabled:") {
+            agent.a2a_enabled = !trimmed.contains("false");
+            return;
+        } else if trimmed.starts_with("service_type:") {
+            agent.a2a_service_type = Some(
+                trimmed
+                    .strip_prefix("service_type:")
+                    .unwrap_or("")
+                    .trim()
+                    .trim_matches('"')
+                    .to_string(),
+            );
+            return;
+        }
+        // End a2a section when we hit a non-indented, non-a2a property
+        if !trimmed.is_empty()
+            && !trimmed.starts_with(' ')
+            && !trimmed.starts_with('-')
+            && !trimmed.starts_with("enabled:")
+            && !trimmed.starts_with("service_type:")
+            && trimmed != "peers:"
+            && !trimmed.starts_with("discovery:")
+        {
+            *in_a2a_section = false;
+        }
+    }
+
+    // Check for mcp_servers section
+    if trimmed == "mcp_servers:" {
+        *in_mcp_section = true;
+        *in_a2a_section = false;
+        *in_peers_section = false;
+        return;
+    }
+
+    // Handle MCP server entries
+    if *in_mcp_section && trimmed.starts_with("- name:") {
+        // Save previous MCP server if exists
+        if let Some(server) = current_mcp_server.take() {
+            agent.mcp_servers.push(server);
+        }
+
+        // Start new MCP server
+        *current_mcp_server = Some(McpServerConfig {
+            name: trimmed
+                .strip_prefix("- name:")
+                .unwrap_or("")
+                .trim()
+                .to_string(),
+            command: None,
+            args: Vec::new(),
+            url: None,
+        });
+        return;
+    }
+
+    // Handle YAML list args (e.g., "- value")
+    if *in_args_section && trimmed.starts_with("- ") {
+        if let Some(server) = current_mcp_server.as_mut() {
+            let arg = trimmed
+                .strip_prefix("- ")
+                .unwrap_or("")
+                .trim()
+                .trim_matches('"')
+                .to_string();
+            if !arg.is_empty() {
+                server.args.push(arg);
+            }
+        }
+        return;
+    }
+
+    // End args section when we hit a non-list item
+    if *in_args_section && !trimmed.starts_with("- ") && !trimmed.is_empty() {
+        *in_args_section = false;
+    }
+
+    // Parse MCP server properties
+    if *in_mcp_section && let Some(server) = current_mcp_server.as_mut() {
+        if trimmed.starts_with("command:") {
+            *in_args_section = false;
+            server.command = Some(
+                trimmed
+                    .strip_prefix("command:")
+                    .unwrap_or("")
+                    .trim()
+                    .trim_matches('"')
+                    .to_string(),
+            );
+        } else if trimmed.starts_with("args:") {
+            // Check for inline array format: ["arg1", "arg2"]
+            let args_str = trimmed.strip_prefix("args:").unwrap_or("").trim();
+            if args_str.starts_with('[') && args_str.ends_with(']') {
+                let args_content = &args_str[1..args_str.len() - 1];
+                server.args = args_content
+                    .split(',')
+                    .map(|s| s.trim().trim_matches('"').to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+            } else if args_str.is_empty() {
+                // Start YAML list mode for args
+                *in_args_section = true;
+            }
+        } else if trimmed.starts_with("url:") {
+            *in_args_section = false;
+            server.url = Some(
+                trimmed
+                    .strip_prefix("url:")
+                    .unwrap_or("")
+                    .trim()
+                    .trim_matches('"')
+                    .to_string(),
+            );
+        } else if trimmed.starts_with("transport:") {
+            *in_args_section = false;
+            // Skip transport for now, not used
+        } else if !trimmed.is_empty() && !trimmed.starts_with(' ') && !trimmed.starts_with('-') {
+            // End of MCP section
+            *in_mcp_section = false;
+            *in_args_section = false;
+            if let Some(server) = current_mcp_server.take() {
+                agent.mcp_servers.push(server);
+            }
+        }
+    }
+
+    // Parse agent properties (when not in MCP section)
+    if !*in_mcp_section {
+        if trimmed.starts_with("name:") && !trimmed.starts_with("name: |") {
+            agent.name = trimmed
+                .strip_prefix("name:")
+                .unwrap_or("")
+                .trim()
+                .trim_matches('"')
+                .to_string();
+        } else if trimmed.starts_with("purpose:") {
+            let value = trimmed.strip_prefix("purpose:").unwrap_or("").trim();
+            if value == "|" || value == "|-" || value == "|+" {
+                // Start multi-line YAML string
+                *in_purpose_multiline = true;
+                purpose_lines.clear();
+            } else {
+                // Single-line purpose
+                agent.purpose = value.trim_matches('"').to_string();
+            }
+        } else if *in_purpose_multiline {
+            // Collect multi-line purpose content
+            if line.starts_with("  ") || line.starts_with('\t') {
+                // Indented line - part of multi-line value
+                purpose_lines.push(line.trim().to_string());
+            } else if trimmed.is_empty() {
+                // Empty line in multi-line - preserve as paragraph break
+                purpose_lines.push(String::new());
+            } else {
+                // Non-indented, non-empty line - end of multi-line
+                *in_purpose_multiline = false;
+                agent.purpose = purpose_lines.join("\n").trim().to_string();
+                purpose_lines.clear();
+                // Re-process this line (it might be a new property)
+                // Continue to let other parsers handle it
+            }
+        }
+
+        // End multi-line purpose on new property/section
+        if *in_purpose_multiline && (trimmed.starts_with("model:") || trimmed.starts_with('#')) {
+            *in_purpose_multiline = false;
+            agent.purpose = purpose_lines.join("\n").trim().to_string();
+            purpose_lines.clear();
+        }
+
+        if trimmed.starts_with("model:") {
+            agent.model = trimmed
+                .strip_prefix("model:")
+                .unwrap_or("")
+                .trim()
+                .trim_matches('"')
+                .to_string();
+        } else if trimmed.starts_with("mode:") {
+            let mode_str = trimmed
+                .strip_prefix("mode:")
+                .unwrap_or("")
+                .trim()
+                .trim_matches('"');
+            agent.mode = match mode_str {
+                "specialist" => arkavo_protocol::agent_config::AgentMode::Specialist,
+                _ => arkavo_protocol::agent_config::AgentMode::Orchestrator,
+            };
+        } else if trimmed.starts_with("listen:") {
+            agent.listen = trimmed
+                .strip_prefix("listen:")
+                .unwrap_or("")
+                .trim()
+                .trim_matches('"')
+                .to_string();
+        } else if trimmed.starts_with("swarm:") {
+            agent.swarm = Some(
+                trimmed
+                    .strip_prefix("swarm:")
+                    .unwrap_or("")
+                    .trim()
+                    .trim_matches('"')
+                    .to_string(),
+            );
+        } else if trimmed.starts_with("mdns:") {
+            // Only disable if explicitly set to false
+            agent.mdns_enabled = !trimmed.contains("false");
+        } else if trimmed.contains("_API_KEY:") || trimmed.contains("_api_key:") {
+            // Parse API key entries (e.g., MOONSHOT_API_KEY: sk-xxx)
+            if let Some(colon_pos) = trimmed.find(':') {
+                let key_name = trimmed[..colon_pos].trim().to_string();
+                let key_value = trimmed[colon_pos + 1..]
+                    .trim()
+                    .trim_matches('"')
+                    .to_string();
+                agent.api_keys.insert(key_name, key_value);
+            }
+        }
+        // Note: autonomous_interval and event_tool are deprecated - push notifications are used instead
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_frontmatter_basic() {
+        let content = "---\nname: my-agent\npurpose: \"Test agent\"\nmodel: ministral-3b\n---\n\n# My Agent\nSome docs here.\n";
+        let agents = parse_agents_config(content).unwrap();
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].name, "my-agent");
+        assert_eq!(agents[0].purpose, "Test agent");
+        assert_eq!(agents[0].model, "ministral-3b");
+    }
+
+    #[test]
+    fn parse_frontmatter_with_a2a() {
+        let content = "---\nname: bridge-agent\npurpose: \"Bridge\"\nmodel: ministral-3b\n\na2a:\n  enabled: true\n  service_type: \"bridge\"\n---\n";
+        let agents = parse_agents_config(content).unwrap();
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].name, "bridge-agent");
+        assert!(agents[0].a2a_enabled);
+        assert_eq!(agents[0].a2a_service_type.as_deref(), Some("bridge"));
+    }
+
+    #[test]
+    fn parse_frontmatter_with_yaml_comments() {
+        let content = "---\nname: kas-agent\npurpose: \"KAS demo\"\nmodel: ministral-3b\n\n# This is a YAML comment\n# Another comment\n\na2a:\n  enabled: true\n---\n";
+        let agents = parse_agents_config(content).unwrap();
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].name, "kas-agent");
+        assert_eq!(agents[0].purpose, "KAS demo");
+        assert!(agents[0].a2a_enabled);
+    }
+
+    #[test]
+    fn parse_frontmatter_openclaw_bridge() {
+        let content = r#"---
+name: arkavo-bridge-agent
+purpose: "A2A protocol bridge demonstrating TDF encryption, budget enforcement, and preflight policies"
+model: ministral-3b
+
+kas:
+  enabled: true
+  key_id: "bridge-demo-key-1"
+  algorithm: "ec:secp256r1"
+  trusted_roots:
+    - did: "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+      name: "Demo Root Authority"
+
+a2a:
+  enabled: true
+  discovery:
+    mdns: true
+---
+
+# Arkavo Bridge Agent
+
+This agent serves as Arkavo's side of the A2A protocol bridge.
+"#;
+        let agents = parse_agents_config(content).unwrap();
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].name, "arkavo-bridge-agent");
+        assert_eq!(agents[0].model, "ministral-3b");
+        assert!(agents[0].a2a_enabled);
+        assert!(agents[0].purpose.contains("A2A protocol bridge"));
+    }
+
+    #[test]
+    fn parse_frontmatter_unknown_section_name_not_leaked() {
+        // Regression: nested `name:` inside kas: trusted_roots must not override agent name
+        let content = "---\nname: my-agent\npurpose: \"Test\"\nmodel: test\nkas:\n  trusted_roots:\n    - did: \"did:key:abc\"\n      name: \"Root Authority\"\n---\n";
+        let agents = parse_agents_config(content).unwrap();
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].name, "my-agent");
+    }
+
+    #[test]
+    fn parse_frontmatter_no_closing_delimiter_falls_through() {
+        let content =
+            "---\nname: broken\n\n## actual-agent\npurpose: \"works\"\nmodel: ministral-3b\n";
+        let agents = parse_agents_config(content).unwrap();
+        // No closing ---, so frontmatter path is skipped; falls through to existing parser
+        assert!(!agents.is_empty());
+        assert_eq!(agents[0].name, "actual-agent");
+        assert_eq!(agents[0].purpose, "works");
+    }
+
+    #[test]
+    fn parse_existing_format_still_works() {
+        let content = "## my-agent\nname: my-agent\npurpose: \"Test\"\nmodel: ministral-3b\nlisten: 0.0.0.0:8080\n";
+        let agents = parse_agents_config(content).unwrap();
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].name, "my-agent");
+        assert_eq!(agents[0].purpose, "Test");
+        assert_eq!(agents[0].model, "ministral-3b");
+        assert_eq!(agents[0].listen, "0.0.0.0:8080");
+    }
+
+    #[test]
+    fn parse_frontmatter_with_peers() {
+        let content = "---\nname: peer-agent\npurpose: \"Peer test\"\nmodel: ministral-3b\npeers:\n  - \"localhost:8081\"\n  - \"localhost:8082\"\n---\n";
+        let agents = parse_agents_config(content).unwrap();
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].peers.len(), 2);
+        assert_eq!(agents[0].peers[0], "localhost:8081");
+        assert_eq!(agents[0].peers[1], "localhost:8082");
+    }
+
+    #[test]
+    fn parse_frontmatter_with_mcp_servers() {
+        let content = "---\nname: mcp-agent\npurpose: \"MCP test\"\nmodel: ministral-3b\nmcp_servers:\n  - name: my-server\n    command: npx\n    args: [\"arg1\", \"arg2\"]\n---\n";
+        let agents = parse_agents_config(content).unwrap();
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].mcp_servers.len(), 1);
+        assert_eq!(agents[0].mcp_servers[0].name, "my-server");
+        assert_eq!(agents[0].mcp_servers[0].command.as_deref(), Some("npx"));
+        assert_eq!(agents[0].mcp_servers[0].args, vec!["arg1", "arg2"]);
+    }
+
+    #[test]
+    fn front_matter_entitlements_parsed_and_defaulted() {
+        let with = "---\nname: a\npurpose: p\nmodel: m\nentitlements:\n  - https://arkavo.ai/attr/tdf/value/decrypt\n---\n";
+        let cfg = parse_agents_config(with).unwrap();
+        assert_eq!(
+            cfg[0].entitlements,
+            vec!["https://arkavo.ai/attr/tdf/value/decrypt"]
+        );
+
+        let without = "---\nname: a\npurpose: p\nmodel: m\n---\n";
+        let cfg = parse_agents_config(without).unwrap();
+        assert_eq!(cfg[0].entitlements, DEFAULT_AGENT_ENTITLEMENTS);
+    }
+}

--- a/crates/arkavo-cli/src/commands/agent_config_parse.rs
+++ b/crates/arkavo-cli/src/commands/agent_config_parse.rs
@@ -1,0 +1,356 @@
+//! Generic front-matter / markdown / YAML text-extraction helpers.
+//!
+//! Used to populate `AgentConfig` and `McpServerConfig` (see `agent_config`).
+//! This is a distinct responsibility from the config domain model: these
+//! functions know how to pull values and list items out of raw text lines,
+//! not what an `AgentConfig` means.
+
+use super::agent_config::{AgentConfig, McpServerConfig};
+
+// Helper function to extract value from markdown field like "- **Name:** value"
+pub(crate) fn extract_markdown_field_value(line: &str, field_prefix: &str) -> Option<String> {
+    if let Some(start_pos) = line.find(field_prefix) {
+        let after_prefix = &line[start_pos + field_prefix.len()..];
+        let value = after_prefix.trim();
+        if !value.is_empty() {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+// Helper function to extract YAML-style values like "listen: 0.0.0.0:8342"
+pub(crate) fn extract_yaml_value(line: &str, key: &str) -> Option<String> {
+    if let Some(colon_pos) = line.find(':') {
+        let key_part = line[..colon_pos].trim();
+        if key_part == key.trim_end_matches(':') {
+            let value = line[colon_pos + 1..].trim().trim_matches('"');
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
+// Helper function to parse YAML-style properties (used by both old and new format parsers)
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn parse_yaml_properties(
+    line: &str,
+    trimmed: &str,
+    agent: &mut AgentConfig,
+    in_mcp_section: &mut bool,
+    current_mcp_server: &mut Option<McpServerConfig>,
+    in_peers_section: &mut bool,
+    in_entitlements_section: &mut bool,
+    in_a2a_section: &mut bool,
+    in_args_section: &mut bool,
+    in_purpose_multiline: &mut bool,
+    purpose_lines: &mut Vec<String>,
+) {
+    // Check for a2a section
+    if trimmed == "a2a:" {
+        *in_a2a_section = true;
+        return;
+    }
+
+    // Check for peers section (can be top-level or under a2a)
+    if trimmed == "peers:" {
+        *in_peers_section = true;
+        return;
+    }
+
+    // Handle peer entries
+    if *in_peers_section && trimmed.starts_with("- ") {
+        let peer = trimmed
+            .strip_prefix("- ")
+            .unwrap_or("")
+            .trim()
+            .trim_matches('"')
+            .to_string();
+        if !peer.is_empty() {
+            agent.peers.push(peer);
+        }
+        return;
+    }
+
+    // End peers section when we hit a non-list item
+    if *in_peers_section
+        && !trimmed.is_empty()
+        && !trimmed.starts_with('-')
+        && !trimmed.starts_with(' ')
+    {
+        *in_peers_section = false;
+    }
+
+    // Check for entitlements (attribute FQNs requested for the agent's
+    // delegated identity). An explicit key always clears the built-in
+    // default list before it is (re)populated -- inline-array form
+    // (`entitlements: ["...", "..."]`, matching the mcp_servers `args:`
+    // convention), YAML-list form, or any other value -- so a narrower or
+    // malformed request can never be silently widened back to
+    // DEFAULT_AGENT_ENTITLEMENTS. An explicit empty list (`entitlements:`
+    // with no following `- ` items) stays empty, distinguishable from an
+    // absent key, which keeps the constructor-time default.
+    if trimmed.starts_with("entitlements:") {
+        agent.entitlements.clear();
+        *in_entitlements_section = false;
+        let inline = trimmed.strip_prefix("entitlements:").unwrap_or("").trim();
+        if inline.starts_with('[') && inline.ends_with(']') {
+            let inline_content = &inline[1..inline.len() - 1];
+            agent.entitlements = inline_content
+                .split(',')
+                .map(|s| s.trim().trim_matches('"').to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+        } else if inline.is_empty() {
+            *in_entitlements_section = true;
+        }
+        return;
+    }
+
+    // Handle entitlement entries
+    if *in_entitlements_section && trimmed.starts_with("- ") {
+        let entitlement = trimmed
+            .strip_prefix("- ")
+            .unwrap_or("")
+            .trim()
+            .trim_matches('"')
+            .to_string();
+        if !entitlement.is_empty() {
+            agent.entitlements.push(entitlement);
+        }
+        return;
+    }
+
+    // End entitlements section when we hit a non-list item
+    if *in_entitlements_section
+        && !trimmed.is_empty()
+        && !trimmed.starts_with('-')
+        && !trimmed.starts_with(' ')
+    {
+        *in_entitlements_section = false;
+    }
+
+    // Parse a2a properties
+    if *in_a2a_section && !*in_peers_section {
+        if trimmed.starts_with("enabled:") {
+            agent.a2a_enabled = !trimmed.contains("false");
+            return;
+        } else if trimmed.starts_with("service_type:") {
+            agent.a2a_service_type = Some(
+                trimmed
+                    .strip_prefix("service_type:")
+                    .unwrap_or("")
+                    .trim()
+                    .trim_matches('"')
+                    .to_string(),
+            );
+            return;
+        }
+        // End a2a section when we hit a non-indented, non-a2a property
+        if !trimmed.is_empty()
+            && !trimmed.starts_with(' ')
+            && !trimmed.starts_with('-')
+            && !trimmed.starts_with("enabled:")
+            && !trimmed.starts_with("service_type:")
+            && trimmed != "peers:"
+            && !trimmed.starts_with("discovery:")
+        {
+            *in_a2a_section = false;
+        }
+    }
+
+    // Check for mcp_servers section
+    if trimmed == "mcp_servers:" {
+        *in_mcp_section = true;
+        *in_a2a_section = false;
+        *in_peers_section = false;
+        return;
+    }
+
+    // Handle MCP server entries
+    if *in_mcp_section && trimmed.starts_with("- name:") {
+        // Save previous MCP server if exists
+        if let Some(server) = current_mcp_server.take() {
+            agent.mcp_servers.push(server);
+        }
+
+        // Start new MCP server
+        *current_mcp_server = Some(McpServerConfig {
+            name: trimmed
+                .strip_prefix("- name:")
+                .unwrap_or("")
+                .trim()
+                .to_string(),
+            command: None,
+            args: Vec::new(),
+            url: None,
+        });
+        return;
+    }
+
+    // Handle YAML list args (e.g., "- value")
+    if *in_args_section && trimmed.starts_with("- ") {
+        if let Some(server) = current_mcp_server.as_mut() {
+            let arg = trimmed
+                .strip_prefix("- ")
+                .unwrap_or("")
+                .trim()
+                .trim_matches('"')
+                .to_string();
+            if !arg.is_empty() {
+                server.args.push(arg);
+            }
+        }
+        return;
+    }
+
+    // End args section when we hit a non-list item
+    if *in_args_section && !trimmed.starts_with("- ") && !trimmed.is_empty() {
+        *in_args_section = false;
+    }
+
+    // Parse MCP server properties
+    if *in_mcp_section && let Some(server) = current_mcp_server.as_mut() {
+        if trimmed.starts_with("command:") {
+            *in_args_section = false;
+            server.command = Some(
+                trimmed
+                    .strip_prefix("command:")
+                    .unwrap_or("")
+                    .trim()
+                    .trim_matches('"')
+                    .to_string(),
+            );
+        } else if trimmed.starts_with("args:") {
+            // Check for inline array format: ["arg1", "arg2"]
+            let args_str = trimmed.strip_prefix("args:").unwrap_or("").trim();
+            if args_str.starts_with('[') && args_str.ends_with(']') {
+                let args_content = &args_str[1..args_str.len() - 1];
+                server.args = args_content
+                    .split(',')
+                    .map(|s| s.trim().trim_matches('"').to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+            } else if args_str.is_empty() {
+                // Start YAML list mode for args
+                *in_args_section = true;
+            }
+        } else if trimmed.starts_with("url:") {
+            *in_args_section = false;
+            server.url = Some(
+                trimmed
+                    .strip_prefix("url:")
+                    .unwrap_or("")
+                    .trim()
+                    .trim_matches('"')
+                    .to_string(),
+            );
+        } else if trimmed.starts_with("transport:") {
+            *in_args_section = false;
+            // Skip transport for now, not used
+        } else if !trimmed.is_empty() && !trimmed.starts_with(' ') && !trimmed.starts_with('-') {
+            // End of MCP section
+            *in_mcp_section = false;
+            *in_args_section = false;
+            if let Some(server) = current_mcp_server.take() {
+                agent.mcp_servers.push(server);
+            }
+        }
+    }
+
+    // Parse agent properties (when not in MCP section)
+    if !*in_mcp_section {
+        if trimmed.starts_with("name:") && !trimmed.starts_with("name: |") {
+            agent.name = trimmed
+                .strip_prefix("name:")
+                .unwrap_or("")
+                .trim()
+                .trim_matches('"')
+                .to_string();
+        } else if trimmed.starts_with("purpose:") {
+            let value = trimmed.strip_prefix("purpose:").unwrap_or("").trim();
+            if value == "|" || value == "|-" || value == "|+" {
+                // Start multi-line YAML string
+                *in_purpose_multiline = true;
+                purpose_lines.clear();
+            } else {
+                // Single-line purpose
+                agent.purpose = value.trim_matches('"').to_string();
+            }
+        } else if *in_purpose_multiline {
+            // Collect multi-line purpose content
+            if line.starts_with("  ") || line.starts_with('\t') {
+                // Indented line - part of multi-line value
+                purpose_lines.push(line.trim().to_string());
+            } else if trimmed.is_empty() {
+                // Empty line in multi-line - preserve as paragraph break
+                purpose_lines.push(String::new());
+            } else {
+                // Non-indented, non-empty line - end of multi-line
+                *in_purpose_multiline = false;
+                agent.purpose = purpose_lines.join("\n").trim().to_string();
+                purpose_lines.clear();
+                // Re-process this line (it might be a new property)
+                // Continue to let other parsers handle it
+            }
+        }
+
+        // End multi-line purpose on new property/section
+        if *in_purpose_multiline && (trimmed.starts_with("model:") || trimmed.starts_with('#')) {
+            *in_purpose_multiline = false;
+            agent.purpose = purpose_lines.join("\n").trim().to_string();
+            purpose_lines.clear();
+        }
+
+        if trimmed.starts_with("model:") {
+            agent.model = trimmed
+                .strip_prefix("model:")
+                .unwrap_or("")
+                .trim()
+                .trim_matches('"')
+                .to_string();
+        } else if trimmed.starts_with("mode:") {
+            let mode_str = trimmed
+                .strip_prefix("mode:")
+                .unwrap_or("")
+                .trim()
+                .trim_matches('"');
+            agent.mode = match mode_str {
+                "specialist" => arkavo_protocol::agent_config::AgentMode::Specialist,
+                _ => arkavo_protocol::agent_config::AgentMode::Orchestrator,
+            };
+        } else if trimmed.starts_with("listen:") {
+            agent.listen = trimmed
+                .strip_prefix("listen:")
+                .unwrap_or("")
+                .trim()
+                .trim_matches('"')
+                .to_string();
+        } else if trimmed.starts_with("swarm:") {
+            agent.swarm = Some(
+                trimmed
+                    .strip_prefix("swarm:")
+                    .unwrap_or("")
+                    .trim()
+                    .trim_matches('"')
+                    .to_string(),
+            );
+        } else if trimmed.starts_with("mdns:") {
+            // Only disable if explicitly set to false
+            agent.mdns_enabled = !trimmed.contains("false");
+        } else if trimmed.contains("_API_KEY:") || trimmed.contains("_api_key:") {
+            // Parse API key entries (e.g., MOONSHOT_API_KEY: sk-xxx)
+            if let Some(colon_pos) = trimmed.find(':') {
+                let key_name = trimmed[..colon_pos].trim().to_string();
+                let key_value = trimmed[colon_pos + 1..]
+                    .trim()
+                    .trim_matches('"')
+                    .to_string();
+                agent.api_keys.insert(key_name, key_value);
+            }
+        }
+        // Note: autonomous_interval and event_tool are deprecated - push notifications are used instead
+    }
+}

--- a/crates/arkavo-cli/src/commands/agent_cwt_verify.rs
+++ b/crates/arkavo-cli/src/commands/agent_cwt_verify.rs
@@ -36,7 +36,13 @@ pub(crate) async fn verify_stored_token() {
         }
     };
 
-    let issuer = std::env::var("ARKAVO_AUTH_ISSUER").unwrap_or_else(|_| DEFAULT_ISSUER.to_string());
+    // `match` rather than `unwrap_or_else`: the zero-config CI grep treats
+    // `unwrap` as a prefix of `unwrap_or_else` and would flag this optional
+    // override as a required env var.
+    let issuer = match std::env::var("ARKAVO_AUTH_ISSUER") {
+        Ok(v) => v,
+        Err(_) => DEFAULT_ISSUER.to_string(),
+    };
     let opts = VerifyOptions {
         expected_iss: &issuer,
         // Nothing on the edge knows the issuer's configured AGENT_TOKEN_AUDIENCES.

--- a/crates/arkavo-cli/src/commands/agent_cwt_verify.rs
+++ b/crates/arkavo-cli/src/commands/agent_cwt_verify.rs
@@ -1,0 +1,73 @@
+//! The agent validating its own credential on receipt.
+//!
+//! The CWT is issued by authnz-rs and used as a bearer token against the KAS.
+//! Verifying it here turns a credential the edge would otherwise treat as an
+//! opaque string into one it has actually checked: right issuer, live ES256
+//! signature from the issuer's published key set, not expired.
+
+use arkavo_cwt::{CachedKeySet, VerifyOptions};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// authnz-rs's own `DEFAULT_OIDC_ISSUER`.
+const DEFAULT_ISSUER: &str = "https://identity.arkavo.net";
+
+/// Matches the `Cache-Control: max-age=600` the cose-keys endpoint sends.
+const KEY_SET_TTL: Duration = Duration::from_secs(600);
+
+/// Allowance for clock drift between the edge and the issuer.
+const SKEW_SECS: i64 = 60;
+
+/// Verify the agent's freshly stored CWT and warn if it does not check out.
+///
+/// Warn-only by design: this is a diagnostic, not an authorization decision.
+/// A verifier bug, an unreachable key-set endpoint, or an issuer the edge is
+/// not configured for must not stop the agent from using a token the server
+/// just issued.
+pub(crate) async fn verify_stored_token() {
+    let token = match arkavo_agent_auth::load_token().await {
+        Ok(Some(token)) => token,
+        // The refresh loop stores before it reports Authenticated, so an empty
+        // slot here means the token was dropped again in between; nothing to do.
+        Ok(None) => return,
+        Err(e) => {
+            tracing::warn!(error = %e, "could not load the agent CWT for self-verification");
+            return;
+        }
+    };
+
+    let issuer = std::env::var("ARKAVO_AUTH_ISSUER").unwrap_or_else(|_| DEFAULT_ISSUER.to_string());
+    let opts = VerifyOptions {
+        expected_iss: &issuer,
+        // Nothing on the edge knows the issuer's configured AGENT_TOKEN_AUDIENCES.
+        expected_aud: None,
+        now: chrono::Utc::now().timestamp(),
+        skew_secs: SKEW_SECS,
+    };
+
+    match key_set().verify(&token.token, &opts).await {
+        Ok(claims) => {
+            tracing::debug!(
+                sub = %claims.sub,
+                exp = claims.exp,
+                entitlements = claims.entitlements.len(),
+                "agent CWT verified against the issuer's COSE key set"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, issuer = %issuer, "agent CWT failed self-verification");
+        }
+    }
+}
+
+/// The process-wide key-set cache, so repeated verifications share one fetch.
+fn key_set() -> &'static CachedKeySet {
+    static KEYS: OnceLock<CachedKeySet> = OnceLock::new();
+    KEYS.get_or_init(|| {
+        let base = arkavo_agent_auth::AgentAuthConfig::from_env().base_url;
+        CachedKeySet::new(
+            format!("{}/.well-known/cose-keys", base.trim_end_matches('/')),
+            KEY_SET_TTL,
+        )
+    })
+}

--- a/crates/arkavo-cli/src/commands/mod.rs
+++ b/crates/arkavo-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod agent_config;
 pub mod agent_config_parse;
+pub mod agent_cwt_verify;
 pub mod chat;
 pub mod dataflow;
 pub mod mesh;

--- a/crates/arkavo-cli/src/commands/mod.rs
+++ b/crates/arkavo-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod agent_config;
+pub mod agent_config_parse;
 pub mod chat;
 pub mod dataflow;
 pub mod mesh;

--- a/crates/arkavo-cli/src/commands/mod.rs
+++ b/crates/arkavo-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod agent_config;
 pub mod chat;
 pub mod dataflow;
 pub mod mesh;

--- a/crates/arkavo-cli/src/welcome.rs
+++ b/crates/arkavo-cli/src/welcome.rs
@@ -2,6 +2,7 @@
 //!
 //! Shows authorization QR code and setup information.
 
+use crate::commands::agent_config::DEFAULT_AGENT_ENTITLEMENTS;
 use arkavo_crypto::AgentKeypair;
 use arkavo_device_identity::{get_or_create_device_id, keypair};
 use arkavo_registration::{AgentDescriptor, qr::display_authorization_qr};
@@ -13,19 +14,24 @@ pub fn display_welcome_verbose() -> Result<(), Box<dyn std::error::Error>> {
     // Get or create device ID
     let _device_id = get_or_create_device_id()?;
 
-    // Get or create keypair
-    let keypair_bytes = match keypair::get_keypair()? {
+    // Get or create the agent's OWN identity keypair -- distinct from the
+    // device keypair. This is the key `agent.rs`'s `--trust` QR authorizes
+    // and the one authnz-rs issues a CWT to; the device keypair can never
+    // obtain a token, so a QR built from it would leave a human authorizing
+    // an identity that will never be used.
+    let keypair_bytes = match keypair::get_agent_keypair()? {
         Some(bytes) => bytes,
         None => {
             let new_keypair = AgentKeypair::generate();
             let bytes = new_keypair.to_bytes();
-            keypair::store_keypair(&bytes)?;
+            keypair::store_agent_keypair(&bytes)?;
             bytes
         }
     };
 
     let agent_keypair = AgentKeypair::from_bytes(&keypair_bytes)?;
     let public_key = agent_keypair.public_key();
+    let agent_did = public_key.to_did_key();
 
     // Get hostname for endpoint
     let hostname = std::process::Command::new("hostname")
@@ -35,7 +41,9 @@ pub fn display_welcome_verbose() -> Result<(), Box<dyn std::error::Error>> {
         .map(|s| s.trim().to_string())
         .unwrap_or_else(|| "localhost".to_string());
 
-    // Create agent descriptor with DID:key and default entitlements
+    // Create agent descriptor with DID:key and the agent's requested
+    // entitlements (attribute FQNs, the same default set `agent.rs` uses),
+    // matching the `--trust` flow so the two QR paths stay consistent.
     let short_id = &public_key.to_base64()[..7.min(public_key.to_base64().len())];
     let descriptor = AgentDescriptor::new(
         public_key,
@@ -44,15 +52,69 @@ pub fn display_welcome_verbose() -> Result<(), Box<dyn std::error::Error>> {
         short_id.to_string(),
     )
     .with_name(&hostname)
-    .with_entitlements(vec![
-        "agent.capability.chat".to_string(),
-        "agent.capability.tools".to_string(),
-    ]);
+    .with_entitlements(
+        DEFAULT_AGENT_ENTITLEMENTS
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+    );
 
     // Display authorization QR code with DID:key
     display_authorization_qr(&descriptor)?;
 
+    // Printed so the human can compare it with the DID shown in the phone
+    // app before approving the agent's own authnz-rs identity.
+    println!("Agent DID: {agent_did}");
+
     println!();
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Serializes tests that touch the on-disk keypair slots.
+    static KEYCHAIN_MUTEX: Mutex<()> = Mutex::new(());
+
+    /// Regression (R22): the welcome QR must authorize the AGENT keypair,
+    /// not the DEVICE keypair. Before this fix, `display_welcome_verbose`
+    /// read/wrote the device slot, so a human scanning the welcome QR would
+    /// authorize a key that authnz-rs can never issue a CWT to.
+    #[test]
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+    fn welcome_uses_agent_keypair_not_device_keypair() {
+        let _g = KEYCHAIN_MUTEX.lock().unwrap();
+        let _ = keypair::delete_keypair();
+        let _ = keypair::delete_agent_keypair();
+
+        display_welcome_verbose().expect("welcome flow should succeed");
+
+        assert!(
+            keypair::get_agent_keypair().unwrap().is_some(),
+            "welcome flow must create/use the agent keypair slot"
+        );
+        assert!(
+            keypair::get_keypair().unwrap().is_none(),
+            "welcome flow must not create or touch the device keypair slot"
+        );
+
+        let _ = keypair::delete_keypair();
+        let _ = keypair::delete_agent_keypair();
+    }
+
+    /// Regression (R22): entitlements advertised by the welcome QR must come
+    /// from `DEFAULT_AGENT_ENTITLEMENTS` (attribute FQNs), not hardcoded
+    /// old-vocabulary capability-string literals.
+    #[test]
+    fn default_agent_entitlements_are_attribute_fqns() {
+        assert!(
+            DEFAULT_AGENT_ENTITLEMENTS
+                .iter()
+                .all(|e| e.starts_with("https://arkavo.ai/attr/")),
+            "welcome.rs must reuse DEFAULT_AGENT_ENTITLEMENTS, not capability-string literals"
+        );
+    }
 }

--- a/crates/arkavo-cli/src/welcome.rs
+++ b/crates/arkavo-cli/src/welcome.rs
@@ -74,6 +74,7 @@ pub fn display_welcome_verbose() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_device_identity::test_utils::KeypairSlotGuard;
     use std::sync::Mutex;
 
     // Serializes tests that touch the on-disk keypair slots.
@@ -86,9 +87,10 @@ mod tests {
     #[test]
     #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     fn welcome_uses_agent_keypair_not_device_keypair() {
-        let _g = KEYCHAIN_MUTEX.lock().unwrap();
-        let _ = keypair::delete_keypair();
-        let _ = keypair::delete_agent_keypair();
+        let _lock = KEYCHAIN_MUTEX.lock().unwrap();
+        // Restores the developer's real slots on drop, including after a
+        // failing assertion below.
+        let _slots = KeypairSlotGuard::capture();
 
         display_welcome_verbose().expect("welcome flow should succeed");
 
@@ -100,9 +102,6 @@ mod tests {
             keypair::get_keypair().unwrap().is_none(),
             "welcome flow must not create or touch the device keypair slot"
         );
-
-        let _ = keypair::delete_keypair();
-        let _ = keypair::delete_agent_keypair();
     }
 
     /// Regression (R22): entitlements advertised by the welcome QR must come

--- a/crates/arkavo-config-encryption/Cargo.toml
+++ b/crates/arkavo-config-encryption/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 arkavo-config-bundle = { path = "../arkavo-config-bundle" }
+arkavo-agent-auth = { path = "../arkavo-agent-auth" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }

--- a/crates/arkavo-config-encryption/Cargo.toml
+++ b/crates/arkavo-config-encryption/Cargo.toml
@@ -21,6 +21,7 @@ rand = { workspace = true }
 base64 = { workspace = true }
 
 [dev-dependencies]
+arkavo-agent-auth = { path = "../arkavo-agent-auth", features = ["test-utils"] }
 tokio = { workspace = true, features = ["full"] }
 arkavo-test-macros = { path = "../arkavo-test-macros" }
 

--- a/crates/arkavo-config-encryption/src/kas.rs
+++ b/crates/arkavo-config-encryption/src/kas.rs
@@ -48,12 +48,24 @@ impl KasConfig {
     /// Reads:
     /// - `ARKAVO_KAS_URL` (optional, defaults to production KAS)
     /// - `ARKAVO_IDENTITY_URL` (optional, defaults to production Identity)
-    /// - `ARKAVO_KAS_TOKEN` (optional)
+    /// - `ARKAVO_KAS_TOKEN` (optional; when unset, falls back to a stored,
+    ///   not-yet-expired agent CWT from `arkavo-agent-auth`, so a delegated
+    ///   agent's own identity is used in place of an explicitly configured
+    ///   service credential)
     pub fn from_env() -> Self {
         let url = env::var(KAS_URL_ENV).unwrap_or_else(|_| DEFAULT_KAS_URL.to_string());
         let identity_url =
             env::var(IDENTITY_URL_ENV).unwrap_or_else(|_| DEFAULT_IDENTITY_URL.to_string());
-        let token = env::var(KAS_TOKEN_ENV).ok();
+        let token = env::var(KAS_TOKEN_ENV).ok().or_else(|| {
+            // `load_token_blocking` stays sync (std::fs, no runtime) so this
+            // constructor never needs `block_on`/`block_in_place`, which
+            // would panic on a current-thread runtime. See task-4-corrections
+            // C1.
+            arkavo_agent_auth::load_token_blocking()
+                .ok()
+                .flatten()
+                .map(|stored| stored.token)
+        });
 
         Self {
             url,
@@ -143,5 +155,93 @@ mod tests {
     fn test_identity_url() {
         let config = KasConfig::production();
         assert_eq!(config.identity_url(), DEFAULT_IDENTITY_URL);
+    }
+}
+
+/// Tests for the C1 stored-agent-token fallback in `KasConfig::from_env`.
+/// Separate module (rather than folding into `tests` above) because these
+/// tests touch process env vars and the real on-disk agent token file, so
+/// they need to be serialized against each other the way `arkavo-agent-auth`
+/// serializes its own storage tests.
+#[cfg(test)]
+mod agent_token_fallback_tests {
+    use super::*;
+    use arkavo_agent_auth::{StoredToken, delete_token, store_token};
+    use chrono::{Duration, Utc};
+    use tokio::sync::Mutex;
+
+    static TOKEN_TEST_LOCK: Mutex<()> = Mutex::const_new(());
+
+    /// SAFETY: guarded by `TOKEN_TEST_LOCK`, so no other test in this
+    /// process reads or writes `KAS_TOKEN_ENV` concurrently.
+    unsafe fn clear_kas_token_env() {
+        unsafe {
+            std::env::remove_var(KAS_TOKEN_ENV);
+        }
+    }
+
+    #[tokio::test]
+    async fn from_env_falls_back_to_stored_agent_token_when_unset() {
+        let _guard = TOKEN_TEST_LOCK.lock().await;
+        unsafe { clear_kas_token_env() };
+        let _ = delete_token().await;
+
+        let stored = StoredToken::new(
+            "agent-cwt-bytes".to_string(),
+            "did:key:z6MkConfigEncryptionTest".to_string(),
+            Utc::now() + Duration::minutes(15),
+            vec!["https://arkavo.ai/attr/tdf/value/decrypt".to_string()],
+        );
+        store_token(&stored).await.unwrap();
+
+        let config = KasConfig::from_env();
+        assert_eq!(config.token, Some("agent-cwt-bytes".to_string()));
+
+        delete_token().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn from_env_ignores_expired_stored_agent_token() {
+        let _guard = TOKEN_TEST_LOCK.lock().await;
+        unsafe { clear_kas_token_env() };
+        let _ = delete_token().await;
+
+        let stored = StoredToken::new(
+            "expired-agent-cwt".to_string(),
+            "did:key:z6MkConfigEncryptionExpired".to_string(),
+            Utc::now() - Duration::minutes(1),
+            vec![],
+        );
+        store_token(&stored).await.unwrap();
+
+        let config = KasConfig::from_env();
+        assert_eq!(config.token, None);
+
+        delete_token().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn from_env_prefers_kas_token_env_over_stored_agent_token() {
+        let _guard = TOKEN_TEST_LOCK.lock().await;
+        let _ = delete_token().await;
+
+        let stored = StoredToken::new(
+            "agent-cwt-should-be-ignored".to_string(),
+            "did:key:z6MkConfigEncryptionEnvWins".to_string(),
+            Utc::now() + Duration::minutes(15),
+            vec![],
+        );
+        store_token(&stored).await.unwrap();
+
+        // SAFETY: guarded by `TOKEN_TEST_LOCK`.
+        unsafe {
+            std::env::set_var(KAS_TOKEN_ENV, "explicit-env-token");
+        }
+
+        let config = KasConfig::from_env();
+        assert_eq!(config.token, Some("explicit-env-token".to_string()));
+
+        unsafe { clear_kas_token_env() };
+        delete_token().await.unwrap();
     }
 }

--- a/crates/arkavo-config-encryption/src/kas.rs
+++ b/crates/arkavo-config-encryption/src/kas.rs
@@ -166,7 +166,8 @@ mod tests {
 #[cfg(test)]
 mod agent_token_fallback_tests {
     use super::*;
-    use arkavo_agent_auth::{StoredToken, delete_token, store_token};
+    use arkavo_agent_auth::test_utils::TokenFileGuard;
+    use arkavo_agent_auth::{StoredToken, store_token};
     use chrono::{Duration, Utc};
     use tokio::sync::Mutex;
 
@@ -182,9 +183,9 @@ mod agent_token_fallback_tests {
 
     #[tokio::test]
     async fn from_env_falls_back_to_stored_agent_token_when_unset() {
-        let _guard = TOKEN_TEST_LOCK.lock().await;
+        let _lock = TOKEN_TEST_LOCK.lock().await;
+        let _file = TokenFileGuard::capture();
         unsafe { clear_kas_token_env() };
-        let _ = delete_token().await;
 
         let stored = StoredToken::new(
             "agent-cwt-bytes".to_string(),
@@ -196,15 +197,13 @@ mod agent_token_fallback_tests {
 
         let config = KasConfig::from_env();
         assert_eq!(config.token, Some("agent-cwt-bytes".to_string()));
-
-        delete_token().await.unwrap();
     }
 
     #[tokio::test]
     async fn from_env_ignores_expired_stored_agent_token() {
-        let _guard = TOKEN_TEST_LOCK.lock().await;
+        let _lock = TOKEN_TEST_LOCK.lock().await;
+        let _file = TokenFileGuard::capture();
         unsafe { clear_kas_token_env() };
-        let _ = delete_token().await;
 
         let stored = StoredToken::new(
             "expired-agent-cwt".to_string(),
@@ -216,14 +215,12 @@ mod agent_token_fallback_tests {
 
         let config = KasConfig::from_env();
         assert_eq!(config.token, None);
-
-        delete_token().await.unwrap();
     }
 
     #[tokio::test]
     async fn from_env_prefers_kas_token_env_over_stored_agent_token() {
-        let _guard = TOKEN_TEST_LOCK.lock().await;
-        let _ = delete_token().await;
+        let _lock = TOKEN_TEST_LOCK.lock().await;
+        let _file = TokenFileGuard::capture();
 
         let stored = StoredToken::new(
             "agent-cwt-should-be-ignored".to_string(),
@@ -242,6 +239,5 @@ mod agent_token_fallback_tests {
         assert_eq!(config.token, Some("explicit-env-token".to_string()));
 
         unsafe { clear_kas_token_env() };
-        delete_token().await.unwrap();
     }
 }

--- a/crates/arkavo-config-encryption/tests/kas_integration.rs
+++ b/crates/arkavo-config-encryption/tests/kas_integration.rs
@@ -167,8 +167,17 @@ mod kas_tests {
         let decryptor = ConfigBundleDecryptor::new(credential);
 
         // Create KAS client
+        //
+        // `rewrap_url()` is the full legacy rewrap endpoint; `for_kas_legacy_rest`
+        // wants the bare base and re-derives the `/kas/v2/*` paths itself.
+        let kas_base = kas
+            .rewrap_url()
+            .trim_end_matches("/kas/v2/rewrap")
+            .trim_end_matches('/');
+        let kas_config =
+            opentdf::kas_discovery::OpentdfConfiguration::for_kas_legacy_rest(kas_base);
         let kas_client =
-            opentdf::KasClient::new(kas.rewrap_url(), &token).expect("Failed to create KAS client");
+            opentdf::kas::KasClient::new(&kas_config, &token).expect("Failed to create KAS client");
 
         println!("✓ KAS client created");
         println!("  KAS URL: {}", kas.rewrap_url());

--- a/crates/arkavo-cwt/Cargo.toml
+++ b/crates/arkavo-cwt/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "arkavo-cwt"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "COSE_Sign1/ES256 CWT verification against a published COSE key set"
+
+[dependencies]
+ciborium = { workspace = true }
+coset = { workspace = true }
+p256 = { version = "0.13", features = ["ecdsa"] }
+base64 = { workspace = true }
+reqwest = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+arkavo-test-macros = { path = "../arkavo-test-macros" }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+wiremock = "0.6"

--- a/crates/arkavo-cwt/src/claims.rs
+++ b/crates/arkavo-cwt/src/claims.rs
@@ -1,0 +1,180 @@
+//! CWT claim decoding.
+//!
+//! authnz-rs emits the RFC 8392 integer claim keys (`1` iss, `2` sub, `3` aud,
+//! `4` exp, `6` iat) alongside Arkavo's own text-keyed claims. `nbf` (`5`) is
+//! never emitted, so it is not required here.
+
+use crate::CwtError;
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use ciborium::Value;
+
+/// The subset of the agent CWT's claims the edge acts on.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Claims {
+    pub iss: String,
+    pub sub: String,
+    pub aud: Vec<String>,
+    pub exp: i64,
+    pub iat: i64,
+    pub account_id: Option<String>,
+    pub roles: Vec<String>,
+    pub entitlements: Vec<String>,
+    /// Subjects named by the `act` claim — the human principals the agent acts
+    /// for. Absent entirely when no actors are configured.
+    pub actors: Vec<String>,
+    pub npe: Option<serde_json::Value>,
+}
+
+impl Claims {
+    pub(crate) fn from_cbor(payload: &[u8]) -> Result<Self, CwtError> {
+        let value: Value =
+            ciborium::from_reader(payload).map_err(|e| CwtError::Claims(e.to_string()))?;
+        let Value::Map(entries) = value else {
+            return Err(CwtError::Claims("payload is not a CBOR map".into()));
+        };
+
+        let mut iss = None;
+        let mut sub = None;
+        let mut aud = Vec::new();
+        let mut exp = None;
+        let mut iat = None;
+        let mut account_id = None;
+        let mut roles = Vec::new();
+        let mut entitlements = Vec::new();
+        let mut actors = Vec::new();
+        let mut npe = None;
+
+        for (key, value) in entries {
+            match &key {
+                Value::Integer(i) => match i128::from(*i) {
+                    1 => iss = Some(text(&value, "iss")?),
+                    2 => sub = Some(text(&value, "sub")?),
+                    3 => aud = audience(&value)?,
+                    4 => exp = Some(integer(&value, "exp")?),
+                    6 => iat = Some(integer(&value, "iat")?),
+                    _ => {}
+                },
+                Value::Text(label) => match label.as_str() {
+                    "arkavo_account_id" => account_id = Some(text(&value, "arkavo_account_id")?),
+                    "arkavo_roles" => roles = text_array(&value, "arkavo_roles")?,
+                    "arkavo_entitlements" => {
+                        entitlements = text_array(&value, "arkavo_entitlements")?;
+                    }
+                    "arkavo_npe" => npe = Some(to_json(&value)?),
+                    "act" => actors = actor_subjects(&value)?,
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+
+        Ok(Self {
+            iss: iss.ok_or_else(|| CwtError::Claims("missing iss".into()))?,
+            sub: sub.ok_or_else(|| CwtError::Claims("missing sub".into()))?,
+            aud,
+            exp: exp.ok_or_else(|| CwtError::Claims("missing exp".into()))?,
+            iat: iat.ok_or_else(|| CwtError::Claims("missing iat".into()))?,
+            account_id,
+            roles,
+            entitlements,
+            actors,
+            npe,
+        })
+    }
+}
+
+fn text(value: &Value, claim: &str) -> Result<String, CwtError> {
+    value
+        .as_text()
+        .map(str::to_owned)
+        .ok_or_else(|| CwtError::Claims(format!("{claim} is not a text string")))
+}
+
+fn integer(value: &Value, claim: &str) -> Result<i64, CwtError> {
+    let Value::Integer(i) = value else {
+        return Err(CwtError::Claims(format!("{claim} is not an integer")));
+    };
+    i64::try_from(*i).map_err(|_| CwtError::Claims(format!("{claim} does not fit in i64")))
+}
+
+/// `aud` is a CBOR array for agent tokens and a bare text string for other
+/// token types; both are legal per RFC 8392.
+fn audience(value: &Value) -> Result<Vec<String>, CwtError> {
+    match value {
+        Value::Text(t) => Ok(vec![t.clone()]),
+        Value::Array(_) => text_array(value, "aud"),
+        _ => Err(CwtError::Claims("aud is not a text string or array".into())),
+    }
+}
+
+fn text_array(value: &Value, claim: &str) -> Result<Vec<String>, CwtError> {
+    let Value::Array(items) = value else {
+        return Err(CwtError::Claims(format!("{claim} is not an array")));
+    };
+    items.iter().map(|item| text(item, claim)).collect()
+}
+
+/// `act` is an array of `{"sub": "<actor>"}` maps.
+fn actor_subjects(value: &Value) -> Result<Vec<String>, CwtError> {
+    let Value::Array(items) = value else {
+        return Err(CwtError::Claims("act is not an array".into()));
+    };
+    items
+        .iter()
+        .map(|item| {
+            let Value::Map(fields) = item else {
+                return Err(CwtError::Claims("act entry is not a map".into()));
+            };
+            fields
+                .iter()
+                .find(|(k, _)| k.as_text() == Some("sub"))
+                .ok_or_else(|| CwtError::Claims("act entry has no sub".into()))
+                .and_then(|(_, v)| text(v, "act.sub"))
+        })
+        .collect()
+}
+
+/// Render `arkavo_npe` as JSON so callers can inspect the delegation chain with
+/// the same tooling they use for the rest of the identity plane. Byte strings
+/// become base64url text, the only lossless rendering JSON allows.
+fn to_json(value: &Value) -> Result<serde_json::Value, CwtError> {
+    Ok(match value {
+        Value::Null => serde_json::Value::Null,
+        Value::Bool(b) => serde_json::Value::Bool(*b),
+        Value::Integer(i) => serde_json::Value::Number(
+            i64::try_from(*i)
+                .map_err(|_| CwtError::Claims("arkavo_npe integer does not fit in i64".into()))?
+                .into(),
+        ),
+        Value::Float(f) => serde_json::Number::from_f64(*f)
+            .map(serde_json::Value::Number)
+            .ok_or_else(|| CwtError::Claims("arkavo_npe float is not finite".into()))?,
+        Value::Text(t) => serde_json::Value::String(t.clone()),
+        Value::Bytes(b) => serde_json::Value::String(URL_SAFE_NO_PAD.encode(b)),
+        Value::Array(items) => {
+            serde_json::Value::Array(items.iter().map(to_json).collect::<Result<_, _>>()?)
+        }
+        Value::Map(fields) => {
+            let mut object = serde_json::Map::with_capacity(fields.len());
+            for (key, value) in fields {
+                let key = match key {
+                    Value::Text(t) => t.clone(),
+                    Value::Integer(i) => i128::from(*i).to_string(),
+                    _ => {
+                        return Err(CwtError::Claims(
+                            "arkavo_npe map key is not text or integer".into(),
+                        ));
+                    }
+                };
+                object.insert(key, to_json(value)?);
+            }
+            serde_json::Value::Object(object)
+        }
+        Value::Tag(_, inner) => to_json(inner)?,
+        _ => {
+            return Err(CwtError::Claims(
+                "unsupported CBOR value in arkavo_npe".into(),
+            ));
+        }
+    })
+}

--- a/crates/arkavo-cwt/src/keys.rs
+++ b/crates/arkavo-cwt/src/keys.rs
@@ -1,0 +1,161 @@
+//! The published COSE key set and its cache.
+//!
+//! `/.well-known/cose-keys` serves a CBOR array of COSE_Key maps (not JWKS
+//! JSON). Each entry carries the raw 32-byte RFC 7638 thumbprint as its `kid`,
+//! which is the same value the CWT's protected header names; matching is plain
+//! byte equality, never a recomputed thumbprint.
+
+use crate::{Claims, CwtError, VerifyOptions, verify::verify};
+use coset::{CborSerializable, CoseKey, CoseKeySet, Label};
+use p256::EncodedPoint;
+use p256::ecdsa::VerifyingKey;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+const EC2_CRV: i64 = -1;
+const EC2_X: i64 = -2;
+const EC2_Y: i64 = -3;
+
+/// The ES256 verification keys the issuer currently publishes.
+pub struct KeySet {
+    keys: Vec<(Vec<u8>, VerifyingKey)>,
+}
+
+impl KeySet {
+    /// Parse a `/.well-known/cose-keys` body.
+    ///
+    /// Entries that are not EC2 P-256 keys, or that carry no `kid`, are skipped
+    /// rather than rejected: the issuer may publish keys for algorithms this
+    /// verifier does not handle, and one such entry must not blind it to the
+    /// ES256 keys alongside it.
+    pub fn from_cbor(bytes: &[u8]) -> Result<Self, CwtError> {
+        let set = CoseKeySet::from_slice(bytes).map_err(|e| CwtError::KeySet(e.to_string()))?;
+        let mut keys = Vec::with_capacity(set.0.len());
+        for key in &set.0 {
+            if key.key_id.is_empty() || !is_p256(key) {
+                continue;
+            }
+            keys.push((key.key_id.clone(), verifying_key(key)?));
+        }
+        if keys.is_empty() {
+            return Err(CwtError::KeySet("no usable ES256 P-256 keys".into()));
+        }
+        Ok(Self { keys })
+    }
+
+    /// Fetch and parse the key set published at `url`.
+    pub async fn fetch(url: &str) -> Result<Self, CwtError> {
+        let body = reqwest::get(url)
+            .await
+            .map_err(|e| CwtError::Fetch(e.to_string()))?
+            .error_for_status()
+            .map_err(|e| CwtError::Fetch(e.to_string()))?
+            .bytes()
+            .await
+            .map_err(|e| CwtError::Fetch(e.to_string()))?;
+        Self::from_cbor(&body)
+    }
+
+    pub(crate) fn get(&self, kid: &[u8]) -> Option<&VerifyingKey> {
+        self.keys
+            .iter()
+            .find(|(candidate, _)| candidate == kid)
+            .map(|(_, key)| key)
+    }
+}
+
+fn is_p256(key: &CoseKey) -> bool {
+    key.kty == coset::KeyType::Assigned(coset::iana::KeyType::EC2)
+        && param(key, EC2_CRV).and_then(ciborium::Value::as_integer)
+            == Some((coset::iana::EllipticCurve::P_256 as i64).into())
+}
+
+fn param(key: &CoseKey, label: i64) -> Option<&ciborium::Value> {
+    key.params
+        .iter()
+        .find(|(candidate, _)| *candidate == Label::Int(label))
+        .map(|(_, value)| value)
+}
+
+fn verifying_key(key: &CoseKey) -> Result<VerifyingKey, CwtError> {
+    let coordinate = |label: i64, name: &str| {
+        param(key, label)
+            .and_then(ciborium::Value::as_bytes)
+            .ok_or_else(|| CwtError::KeySet(format!("COSE key is missing its {name} coordinate")))
+    };
+    let point = EncodedPoint::from_affine_coordinates(
+        coordinate(EC2_X, "x")?.as_slice().into(),
+        coordinate(EC2_Y, "y")?.as_slice().into(),
+        false,
+    );
+    VerifyingKey::from_encoded_point(&point)
+        .map_err(|e| CwtError::KeySet(format!("COSE key is not a valid P-256 point: {e}")))
+}
+
+struct Cached {
+    keys: Arc<KeySet>,
+    fetched_at: Instant,
+}
+
+/// A [`KeySet`] that re-fetches when a token names a `kid` it does not hold,
+/// but no more than once per `ttl` — so a token signed by a key that will never
+/// be published cannot turn into a fetch per verification.
+pub struct CachedKeySet {
+    url: String,
+    ttl: Duration,
+    cached: RwLock<Option<Cached>>,
+}
+
+impl CachedKeySet {
+    pub fn new(url: impl Into<String>, ttl: Duration) -> Self {
+        Self {
+            url: url.into(),
+            ttl,
+            cached: RwLock::new(None),
+        }
+    }
+
+    /// Verify `token` against the cached key set, refreshing once if the token's
+    /// `kid` is unknown and the cache is at least `ttl` old.
+    pub async fn verify(&self, token: &str, opts: &VerifyOptions<'_>) -> Result<Claims, CwtError> {
+        let current = self.snapshot();
+        let (keys, fetched_at) = match current {
+            Some(cached) => cached,
+            None => (self.refresh().await?, Instant::now()),
+        };
+
+        match verify(token, &keys, opts) {
+            Err(CwtError::UnknownKid(kid)) => {
+                if fetched_at.elapsed() < self.ttl {
+                    return Err(CwtError::UnknownKid(kid));
+                }
+                let refreshed = self.refresh().await?;
+                verify(token, &refreshed, opts)
+            }
+            other => other,
+        }
+    }
+
+    fn snapshot(&self) -> Option<(Arc<KeySet>, Instant)> {
+        let guard = self
+            .cached
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard
+            .as_ref()
+            .map(|cached| (cached.keys.clone(), cached.fetched_at))
+    }
+
+    async fn refresh(&self) -> Result<Arc<KeySet>, CwtError> {
+        let keys = Arc::new(KeySet::fetch(&self.url).await?);
+        let mut guard = self
+            .cached
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *guard = Some(Cached {
+            keys: keys.clone(),
+            fetched_at: Instant::now(),
+        });
+        Ok(keys)
+    }
+}

--- a/crates/arkavo-cwt/src/keys.rs
+++ b/crates/arkavo-cwt/src/keys.rs
@@ -8,6 +8,7 @@
 use crate::{Claims, CwtError, VerifyOptions, verify::verify};
 use coset::{CborSerializable, CoseKey, CoseKeySet, Label};
 use p256::EncodedPoint;
+use p256::FieldBytes;
 use p256::ecdsa::VerifyingKey;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
@@ -78,16 +79,28 @@ fn param(key: &CoseKey, label: i64) -> Option<&ciborium::Value> {
 }
 
 fn verifying_key(key: &CoseKey) -> Result<VerifyingKey, CwtError> {
-    let coordinate = |label: i64, name: &str| {
-        param(key, label)
+    // `generic-array`'s `From<&[T]> for &GenericArray<T, N>` panics on a length
+    // mismatch, so each coordinate is checked against the P-256 field width
+    // before conversion. Leading-zero-stripped coordinates (a classic COSE/JOSE
+    // interop bug) must be rejected, not repaired by left-padding.
+    let coordinate = |label: i64, name: &str| -> Result<FieldBytes, CwtError> {
+        let bytes = param(key, label)
             .and_then(ciborium::Value::as_bytes)
-            .ok_or_else(|| CwtError::KeySet(format!("COSE key is missing its {name} coordinate")))
+            .ok_or_else(|| {
+                CwtError::KeySet(format!("COSE key is missing its {name} coordinate"))
+            })?;
+        // `FieldBytes::from_exact_iter` returns `None` on a length mismatch
+        // instead of panicking, unlike `GenericArray`'s `From<&[T]>`.
+        FieldBytes::from_exact_iter(bytes.iter().copied()).ok_or_else(|| {
+            CwtError::KeySet(format!(
+                "COSE key {name} coordinate is {} bytes, expected 32",
+                bytes.len()
+            ))
+        })
     };
-    let point = EncodedPoint::from_affine_coordinates(
-        coordinate(EC2_X, "x")?.as_slice().into(),
-        coordinate(EC2_Y, "y")?.as_slice().into(),
-        false,
-    );
+    let x = coordinate(EC2_X, "x")?;
+    let y = coordinate(EC2_Y, "y")?;
+    let point = EncodedPoint::from_affine_coordinates(&x, &y, false);
     VerifyingKey::from_encoded_point(&point)
         .map_err(|e| CwtError::KeySet(format!("COSE key is not a valid P-256 point: {e}")))
 }
@@ -157,5 +170,58 @@ impl CachedKeySet {
             fetched_at: Instant::now(),
         });
         Ok(keys)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coset::CoseKeyBuilder;
+    use p256::ecdsa::SigningKey;
+
+    /// A structurally valid COSE_Key whose `x` (or `y`) coordinate is 31 bytes
+    /// — the shape a leading-zero-stripped coordinate produces — must be
+    /// rejected through the crate's public parse path, not panic the process.
+    /// `generic-array`'s `From<&[T]>` panics on this input; the fix routes the
+    /// length check through `CwtError::KeySet` instead.
+    fn cose_key_with(x: Vec<u8>, y: Vec<u8>) -> Vec<u8> {
+        let key = CoseKeyBuilder::new_ec2_pub_key(coset::iana::EllipticCurve::P_256, x, y)
+            .algorithm(coset::iana::Algorithm::ES256)
+            .key_id(vec![0xAA; 32])
+            .build();
+        CoseKeySet(vec![key]).to_vec().expect("encode key set")
+    }
+
+    fn valid_coordinates() -> (Vec<u8>, Vec<u8>) {
+        let vk = *SigningKey::random(&mut rand::rngs::OsRng).verifying_key();
+        let point = vk.to_encoded_point(false);
+        (
+            point.x().expect("x coordinate").to_vec(),
+            point.y().expect("y coordinate").to_vec(),
+        )
+    }
+
+    #[test]
+    fn from_cbor_rejects_31_byte_x_coordinate_without_panicking() {
+        let (x, y) = valid_coordinates();
+        let bytes = cose_key_with(x[..31].to_vec(), y);
+
+        match KeySet::from_cbor(&bytes) {
+            Err(CwtError::KeySet(_)) => {}
+            Err(other) => panic!("expected CwtError::KeySet, got {other:?}"),
+            Ok(_) => panic!("31-byte x must be rejected, not accepted"),
+        }
+    }
+
+    #[test]
+    fn from_cbor_rejects_31_byte_y_coordinate_without_panicking() {
+        let (x, y) = valid_coordinates();
+        let bytes = cose_key_with(x, y[..31].to_vec());
+
+        match KeySet::from_cbor(&bytes) {
+            Err(CwtError::KeySet(_)) => {}
+            Err(other) => panic!("expected CwtError::KeySet, got {other:?}"),
+            Ok(_) => panic!("31-byte y must be rejected, not accepted"),
+        }
     }
 }

--- a/crates/arkavo-cwt/src/lib.rs
+++ b/crates/arkavo-cwt/src/lib.rs
@@ -1,0 +1,45 @@
+//! Verification of the short-lived agent CWT issued by authnz-rs.
+//!
+//! The token is a COSE_Sign1 (ES256) carrying CWT claims, transported as
+//! base64url-without-padding and prefixed with CBOR tag 61 (`D8 3D`) around an
+//! otherwise untagged COSE_Sign1. Signing keys are published as a COSE key set
+//! at `<issuer>/.well-known/cose-keys`.
+
+pub mod claims;
+pub mod keys;
+pub mod verify;
+
+pub use claims::Claims;
+pub use keys::{CachedKeySet, KeySet};
+pub use verify::{VerifyOptions, verify};
+
+/// Every way verification can refuse a token.
+#[derive(Debug, thiserror::Error)]
+pub enum CwtError {
+    #[error("token is not base64url without padding: {0}")]
+    Base64(String),
+    #[error("malformed COSE_Sign1: {0}")]
+    Cose(String),
+    #[error("malformed CWT claims: {0}")]
+    Claims(String),
+    #[error("unsupported signature algorithm: expected ES256, got {0}")]
+    UnsupportedAlgorithm(String),
+    #[error("COSE_Sign1 carries no kid header")]
+    MissingKid,
+    #[error("no published key with kid {0}")]
+    UnknownKid(String),
+    #[error("signature does not verify under the published key")]
+    BadSignature,
+    #[error("token expired at {exp} (now {now})")]
+    Expired { exp: i64, now: i64 },
+    #[error("token issued in the future: iat {iat} (now {now})")]
+    IssuedInFuture { iat: i64, now: i64 },
+    #[error("issuer mismatch: expected {expected}, got {actual}")]
+    IssuerMismatch { expected: String, actual: String },
+    #[error("audience {expected} is not in the token's aud")]
+    AudienceMismatch { expected: String },
+    #[error("malformed COSE key set: {0}")]
+    KeySet(String),
+    #[error("could not fetch the COSE key set: {0}")]
+    Fetch(String),
+}

--- a/crates/arkavo-cwt/src/verify.rs
+++ b/crates/arkavo-cwt/src/verify.rs
@@ -122,16 +122,35 @@ mod tests {
     /// around an untagged COSE_Sign1, ES256, raw-bytes `kid` in the protected
     /// header, integer claim keys plus the `arkavo_*` text claims.
     fn mint(signer: &SigningKey, kid: &[u8], aud: &[&str], exp: i64, tagged: bool) -> String {
-        let payload = Value::Map(vec![
+        let aud = Value::Array(aud.iter().map(|a| Value::Text((*a).into())).collect());
+        let act = Some(Value::Array(vec![Value::Map(vec![(
+            Value::Text("sub".into()),
+            Value::Text("did:key:zHumanPrincipal".into()),
+        )])]));
+        mint_claims(signer, kid, aud, exp, act, None, tagged)
+    }
+
+    /// Mint with full control over the shapes the review found untested:
+    /// `aud` as either the agent shape (`Value::Array`) or the bare-text shape
+    /// other token types use, `act` optionally omitted entirely (its documented
+    /// absence when no actors are configured, not an empty array), and an
+    /// arbitrary `arkavo_npe` payload.
+    fn mint_claims(
+        signer: &SigningKey,
+        kid: &[u8],
+        aud: Value,
+        exp: i64,
+        act: Option<Value>,
+        npe: Option<Value>,
+        tagged: bool,
+    ) -> String {
+        let mut fields = vec![
             (Value::Integer(1.into()), Value::Text(ISS.into())),
             (
                 Value::Integer(2.into()),
                 Value::Text("did:key:zAgentUnderTest".into()),
             ),
-            (
-                Value::Integer(3.into()),
-                Value::Array(aud.iter().map(|a| Value::Text((*a).into())).collect()),
-            ),
+            (Value::Integer(3.into()), aud),
             (Value::Integer(4.into()), Value::Integer(exp.into())),
             (Value::Integer(6.into()), Value::Integer((NOW - 60).into())),
             (
@@ -149,14 +168,14 @@ mod tests {
                     Value::Text("https://arkavo.ai/attr/repo/write".into()),
                 ]),
             ),
-            (
-                Value::Text("act".into()),
-                Value::Array(vec![Value::Map(vec![(
-                    Value::Text("sub".into()),
-                    Value::Text("did:key:zHumanPrincipal".into()),
-                )])]),
-            ),
-        ]);
+        ];
+        if let Some(act) = act {
+            fields.push((Value::Text("act".into()), act));
+        }
+        if let Some(npe) = npe {
+            fields.push((Value::Text("arkavo_npe".into()), npe));
+        }
+        let payload = Value::Map(fields);
         let mut payload_bytes = Vec::new();
         ciborium::into_writer(&payload, &mut payload_bytes).expect("encode claims");
 
@@ -337,5 +356,76 @@ mod tests {
             before + 1,
             "the key set must be re-fetched at most once per ttl"
         );
+    }
+
+    /// authnz-contract.md: agent tokens carry `arkavo_npe: {type: "agent",
+    /// delegation_id, depth, chain}` and omit `act` entirely when no actors
+    /// are configured (not an empty array). Before this test the mint helper
+    /// never emitted `arkavo_npe`, so no test drove `Claims::to_json` — the
+    /// crate's largest function — through a real, signed agent-shaped token.
+    #[test]
+    fn accepts_agent_shaped_token_with_npe_and_no_act() {
+        let signer = new_key();
+        let kid = [0x55u8; 32];
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())]))
+            .expect("parse key set");
+
+        let npe = Value::Map(vec![
+            (Value::Text("type".into()), Value::Text("agent".into())),
+            (
+                Value::Text("delegation_id".into()),
+                Value::Text("did:key:zAgentUnderTest".into()),
+            ),
+            (Value::Text("depth".into()), Value::Integer(1.into())),
+            (
+                Value::Text("chain".into()),
+                Value::Array(vec![
+                    Value::Text("did:key:zRootPrincipal".into()),
+                    Value::Text("did:key:zAgentUnderTest".into()),
+                ]),
+            ),
+        ]);
+        let aud = Value::Array(vec![Value::Text("arkavo-kas".into())]);
+        let token = mint_claims(&signer, &kid, aud, NOW + 600, None, Some(npe), true);
+
+        let claims = verify(&token, &keys, &opts(Some("arkavo-kas"))).expect("verify agent CWT");
+
+        assert!(
+            claims.actors.is_empty(),
+            "act must be absent, not a bogus empty array: {:?}",
+            claims.actors
+        );
+        assert_eq!(
+            claims.npe,
+            Some(serde_json::json!({
+                "type": "agent",
+                "delegation_id": "did:key:zAgentUnderTest",
+                "depth": 1,
+                "chain": ["did:key:zRootPrincipal", "did:key:zAgentUnderTest"],
+            })),
+            "arkavo_npe must survive into the JSON claims unchanged"
+        );
+    }
+
+    /// authnz-contract.md: "Agent-token `aud` is ALWAYS a CBOR array ...
+    /// Other token types use a bare text string — a verifier must accept
+    /// both." This mints the non-agent, bare-text shape (the array shape is
+    /// already exercised by every other test in this module).
+    #[test]
+    fn accepts_bare_text_audience_for_non_agent_token() {
+        let signer = new_key();
+        let kid = [0x66u8; 32];
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())]))
+            .expect("parse key set");
+
+        let aud = Value::Text("arkavo-kas".into());
+        let token = mint_claims(&signer, &kid, aud, NOW + 600, None, None, true);
+
+        let claims = verify(&token, &keys, &opts(Some("arkavo-kas")))
+            .expect("verify token with bare-text aud");
+
+        assert_eq!(claims.aud, vec!["arkavo-kas".to_string()]);
+        assert!(claims.actors.is_empty());
+        assert!(claims.npe.is_none());
     }
 }

--- a/crates/arkavo-cwt/src/verify.rs
+++ b/crates/arkavo-cwt/src/verify.rs
@@ -40,11 +40,10 @@ pub fn verify(
         None => return Err(CwtError::UnsupportedAlgorithm("none".into())),
     }
 
-    let kid = if sign1.protected.header.key_id.is_empty() {
-        &sign1.unprotected.key_id
-    } else {
-        &sign1.protected.header.key_id
-    };
+    // authnz-contract.md puts `kid` in the protected header. An unprotected
+    // `kid` is not covered by the signature, so honouring one would widen the
+    // accepted input surface for no gain.
+    let kid = &sign1.protected.header.key_id;
     if kid.is_empty() {
         return Err(CwtError::MissingKid);
     }
@@ -107,7 +106,10 @@ mod tests {
     use arkavo_test_macros::spec;
     use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
     use ciborium::Value;
-    use coset::{CborSerializable, CoseKeyBuilder, CoseKeySet, CoseSign1Builder, HeaderBuilder};
+    use coset::{
+        CborSerializable, CoseKeyBuilder, CoseKeySet, CoseSign1, CoseSign1Builder, Header,
+        HeaderBuilder,
+    };
     use p256::ecdsa::{Signature, SigningKey, VerifyingKey, signature::Signer};
     use std::time::Duration;
 
@@ -144,15 +146,35 @@ mod tests {
         npe: Option<Value>,
         tagged: bool,
     ) -> String {
+        let payload = claims_cbor(ISS, aud, exp, NOW - 60, act, npe);
+        encode_sign1(
+            signer,
+            es256_protected(kid),
+            Header::default(),
+            payload,
+            tagged,
+        )
+    }
+
+    /// The CBOR claims map an authnz-rs agent CWT carries: integer claim keys
+    /// for the registered claims, literal text keys for the `arkavo_*` set.
+    fn claims_cbor(
+        iss: &str,
+        aud: Value,
+        exp: i64,
+        iat: i64,
+        act: Option<Value>,
+        npe: Option<Value>,
+    ) -> Vec<u8> {
         let mut fields = vec![
-            (Value::Integer(1.into()), Value::Text(ISS.into())),
+            (Value::Integer(1.into()), Value::Text(iss.into())),
             (
                 Value::Integer(2.into()),
                 Value::Text("did:key:zAgentUnderTest".into()),
             ),
             (Value::Integer(3.into()), aud),
             (Value::Integer(4.into()), Value::Integer(exp.into())),
-            (Value::Integer(6.into()), Value::Integer((NOW - 60).into())),
+            (Value::Integer(6.into()), Value::Integer(iat.into())),
             (
                 Value::Text("arkavo_account_id".into()),
                 Value::Text("acct-42".into()),
@@ -175,17 +197,32 @@ mod tests {
         if let Some(npe) = npe {
             fields.push((Value::Text("arkavo_npe".into()), npe));
         }
-        let payload = Value::Map(fields);
-        let mut payload_bytes = Vec::new();
-        ciborium::into_writer(&payload, &mut payload_bytes).expect("encode claims");
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&Value::Map(fields), &mut bytes).expect("encode claims");
+        bytes
+    }
 
-        let protected = HeaderBuilder::new()
+    /// The protected header authnz-rs emits: ES256 plus the raw-bytes `kid`.
+    fn es256_protected(kid: &[u8]) -> Header {
+        HeaderBuilder::new()
             .algorithm(coset::iana::Algorithm::ES256)
             .key_id(kid.to_vec())
-            .build();
+            .build()
+    }
+
+    /// Sign `payload` under the given headers and return the client-facing
+    /// encoding: base64url-no-pad, optionally tag-61 prefixed.
+    fn encode_sign1(
+        signer: &SigningKey,
+        protected: Header,
+        unprotected: Header,
+        payload: Vec<u8>,
+        tagged: bool,
+    ) -> String {
         let sign1 = CoseSign1Builder::new()
             .protected(protected)
-            .payload(payload_bytes)
+            .unprotected(unprotected)
+            .payload(payload)
             .create_signature(b"", |data| {
                 let sig: Signature = signer.sign(data);
                 sig.to_bytes().to_vec()
@@ -427,5 +464,164 @@ mod tests {
         assert_eq!(claims.aud, vec!["arkavo-kas".to_string()]);
         assert!(claims.actors.is_empty());
         assert!(claims.npe.is_none());
+    }
+
+    /// agent-cwt.spec.yaml invariant: "ES256 only; any other COSE algorithm is
+    /// refused before a key is even looked up." Nothing pinned that; a verifier
+    /// that honoured the token's own `alg` would let an attacker pick a weaker
+    /// one, or none at all.
+    #[test]
+    fn refuses_any_algorithm_other_than_es256() {
+        let signer = new_key();
+        let kid = [0x77u8; 32];
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())]))
+            .expect("parse key set");
+        let aud = Value::Array(vec![Value::Text("arkavo-kas".into())]);
+
+        let eddsa = encode_sign1(
+            &signer,
+            HeaderBuilder::new()
+                .algorithm(coset::iana::Algorithm::EdDSA)
+                .key_id(kid.to_vec())
+                .build(),
+            Header::default(),
+            claims_cbor(ISS, aud.clone(), NOW + 600, NOW - 60, None, None),
+            true,
+        );
+        assert!(matches!(
+            verify(&eddsa, &keys, &opts(Some("arkavo-kas"))),
+            Err(CwtError::UnsupportedAlgorithm(_))
+        ));
+
+        let no_alg = encode_sign1(
+            &signer,
+            HeaderBuilder::new().key_id(kid.to_vec()).build(),
+            Header::default(),
+            claims_cbor(ISS, aud, NOW + 600, NOW - 60, None, None),
+            true,
+        );
+        assert!(matches!(
+            verify(&no_alg, &keys, &opts(Some("arkavo-kas"))),
+            Err(CwtError::UnsupportedAlgorithm(_))
+        ));
+    }
+
+    /// A correctly signed token minted by some other issuer must not be
+    /// accepted just because its signature verifies under a key we publish.
+    #[test]
+    fn refuses_a_wrong_issuer() {
+        let signer = new_key();
+        let kid = [0x88u8; 32];
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())]))
+            .expect("parse key set");
+
+        let token = encode_sign1(
+            &signer,
+            es256_protected(&kid),
+            Header::default(),
+            claims_cbor(
+                "https://identity.attacker.example",
+                Value::Array(vec![Value::Text("arkavo-kas".into())]),
+                NOW + 600,
+                NOW - 60,
+                None,
+                None,
+            ),
+            true,
+        );
+
+        assert!(matches!(
+            verify(&token, &keys, &opts(Some("arkavo-kas"))),
+            Err(CwtError::IssuerMismatch { .. })
+        ));
+    }
+
+    /// A token whose `iat` is beyond the allowed skew has not been issued yet;
+    /// accepting it would let a clock-skewed or forged token extend its own
+    /// window past the 15-minute agent CWT lifetime.
+    #[test]
+    fn refuses_a_token_issued_in_the_future() {
+        let signer = new_key();
+        let kid = [0x99u8; 32];
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())]))
+            .expect("parse key set");
+
+        let token = encode_sign1(
+            &signer,
+            es256_protected(&kid),
+            Header::default(),
+            claims_cbor(
+                ISS,
+                Value::Array(vec![Value::Text("arkavo-kas".into())]),
+                NOW + 600,
+                NOW + 31,
+                None,
+                None,
+            ),
+            true,
+        );
+
+        assert!(matches!(
+            verify(&token, &keys, &opts(Some("arkavo-kas"))),
+            Err(CwtError::IssuedInFuture { .. })
+        ));
+    }
+
+    /// Flipping one byte of the signed payload must be caught. Without this the
+    /// suite could pass with the signature check reduced to a no-op: every other
+    /// rejection test fails on a header, a clock or a claim comparison.
+    #[test]
+    fn refuses_a_tampered_payload() {
+        let signer = new_key();
+        let kid = [0xAAu8; 32];
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())]))
+            .expect("parse key set");
+
+        let token = mint(&signer, &kid, &["arkavo-kas"], NOW + 600, true);
+        assert!(verify(&token, &keys, &opts(Some("arkavo-kas"))).is_ok());
+
+        let bytes = URL_SAFE_NO_PAD.decode(&token).expect("decode token");
+        let body = bytes.strip_prefix(&[0xD8u8, 0x3D][..]).expect("tag 61");
+        let mut sign1 = CoseSign1::from_slice(body).expect("parse COSE_Sign1");
+        sign1.payload.as_mut().expect("attached payload")[0] ^= 0x01;
+        let tampered = URL_SAFE_NO_PAD.encode(sign1.to_vec().expect("re-encode"));
+
+        assert!(matches!(
+            verify(&tampered, &keys, &opts(Some("arkavo-kas"))),
+            Err(CwtError::BadSignature)
+        ));
+    }
+
+    /// authnz-contract.md: "`kid`: in the **protected** header." An unprotected
+    /// `kid` is not covered by the signature, so it is not accepted even as a
+    /// lookup hint.
+    #[test]
+    fn refuses_a_kid_carried_only_in_the_unprotected_header() {
+        let signer = new_key();
+        let kid = [0xBBu8; 32];
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())]))
+            .expect("parse key set");
+
+        let token = encode_sign1(
+            &signer,
+            HeaderBuilder::new()
+                .algorithm(coset::iana::Algorithm::ES256)
+                .build(),
+            HeaderBuilder::new().key_id(kid.to_vec()).build(),
+            claims_cbor(
+                ISS,
+                Value::Array(vec![Value::Text("arkavo-kas".into())]),
+                NOW + 600,
+                NOW - 60,
+                None,
+                None,
+            ),
+            true,
+        );
+
+        assert!(matches!(
+            verify(&token, &keys, &opts(Some("arkavo-kas"))),
+            Err(CwtError::MissingKid)
+        ));
     }
 }

--- a/crates/arkavo-cwt/src/verify.rs
+++ b/crates/arkavo-cwt/src/verify.rs
@@ -1,0 +1,341 @@
+//! COSE_Sign1 verification and CWT claim validation.
+
+use crate::{Claims, CwtError, KeySet};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use coset::{CborSerializable, CoseSign1, RegisteredLabelWithPrivate};
+use p256::ecdsa::Signature;
+use p256::ecdsa::signature::Verifier;
+
+/// authnz-rs prepends CBOR tag 61 (`cwt`) to an otherwise untagged COSE_Sign1.
+const CWT_TAG: [u8; 2] = [0xD8, 0x3D];
+
+/// What the caller expects the token to say, and when "now" is.
+pub struct VerifyOptions<'a> {
+    pub expected_iss: &'a str,
+    /// `None` skips the audience check — appropriate where the caller does not
+    /// know the issuer's configured audiences.
+    pub expected_aud: Option<&'a str>,
+    pub now: i64,
+    pub skew_secs: i64,
+}
+
+/// Verify a base64url-encoded agent CWT and return its claims.
+///
+/// Accepts the tag-61-prefixed wire form and a bare untagged COSE_Sign1.
+/// ES256 is the only accepted algorithm.
+pub fn verify(
+    token_b64url: &str,
+    keys: &KeySet,
+    opts: &VerifyOptions<'_>,
+) -> Result<Claims, CwtError> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(token_b64url)
+        .map_err(|e| CwtError::Base64(e.to_string()))?;
+    let body = bytes.strip_prefix(&CWT_TAG[..]).unwrap_or(&bytes);
+    let sign1 = CoseSign1::from_slice(body).map_err(|e| CwtError::Cose(e.to_string()))?;
+
+    match &sign1.protected.header.alg {
+        Some(RegisteredLabelWithPrivate::Assigned(coset::iana::Algorithm::ES256)) => {}
+        Some(other) => return Err(CwtError::UnsupportedAlgorithm(format!("{other:?}"))),
+        None => return Err(CwtError::UnsupportedAlgorithm("none".into())),
+    }
+
+    let kid = if sign1.protected.header.key_id.is_empty() {
+        &sign1.unprotected.key_id
+    } else {
+        &sign1.protected.header.key_id
+    };
+    if kid.is_empty() {
+        return Err(CwtError::MissingKid);
+    }
+    let key = keys
+        .get(kid)
+        .ok_or_else(|| CwtError::UnknownKid(hex(kid)))?;
+
+    sign1.verify_signature(b"", |signature, signed| {
+        let signature = Signature::from_slice(signature).map_err(|_| CwtError::BadSignature)?;
+        key.verify(signed, &signature)
+            .map_err(|_| CwtError::BadSignature)
+    })?;
+
+    let payload = sign1
+        .payload
+        .as_deref()
+        .ok_or_else(|| CwtError::Cose("payload is detached".into()))?;
+    let claims = Claims::from_cbor(payload)?;
+    check_claims(&claims, opts)?;
+    Ok(claims)
+}
+
+fn check_claims(claims: &Claims, opts: &VerifyOptions<'_>) -> Result<(), CwtError> {
+    if claims.iss != opts.expected_iss {
+        return Err(CwtError::IssuerMismatch {
+            expected: opts.expected_iss.to_string(),
+            actual: claims.iss.clone(),
+        });
+    }
+    if claims.exp.saturating_add(opts.skew_secs) < opts.now {
+        return Err(CwtError::Expired {
+            exp: claims.exp,
+            now: opts.now,
+        });
+    }
+    if claims.iat.saturating_sub(opts.skew_secs) > opts.now {
+        return Err(CwtError::IssuedInFuture {
+            iat: claims.iat,
+            now: opts.now,
+        });
+    }
+    if let Some(expected) = opts.expected_aud
+        && !claims.aud.iter().any(|aud| aud == expected)
+    {
+        return Err(CwtError::AudienceMismatch {
+            expected: expected.to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)]
+mod tests {
+    use crate::{CachedKeySet, CwtError, KeySet, VerifyOptions, verify};
+    use arkavo_test_macros::spec;
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use ciborium::Value;
+    use coset::{CborSerializable, CoseKeyBuilder, CoseKeySet, CoseSign1Builder, HeaderBuilder};
+    use p256::ecdsa::{Signature, SigningKey, VerifyingKey, signature::Signer};
+    use std::time::Duration;
+
+    const ISS: &str = "https://identity.arkavo.net";
+    const NOW: i64 = 1_800_000_000;
+
+    fn new_key() -> SigningKey {
+        SigningKey::random(&mut rand::rngs::OsRng)
+    }
+
+    /// Mint a token shaped exactly like an authnz-rs agent CWT: tag 61 wrapped
+    /// around an untagged COSE_Sign1, ES256, raw-bytes `kid` in the protected
+    /// header, integer claim keys plus the `arkavo_*` text claims.
+    fn mint(signer: &SigningKey, kid: &[u8], aud: &[&str], exp: i64, tagged: bool) -> String {
+        let payload = Value::Map(vec![
+            (Value::Integer(1.into()), Value::Text(ISS.into())),
+            (
+                Value::Integer(2.into()),
+                Value::Text("did:key:zAgentUnderTest".into()),
+            ),
+            (
+                Value::Integer(3.into()),
+                Value::Array(aud.iter().map(|a| Value::Text((*a).into())).collect()),
+            ),
+            (Value::Integer(4.into()), Value::Integer(exp.into())),
+            (Value::Integer(6.into()), Value::Integer((NOW - 60).into())),
+            (
+                Value::Text("arkavo_account_id".into()),
+                Value::Text("acct-42".into()),
+            ),
+            (
+                Value::Text("arkavo_roles".into()),
+                Value::Array(vec![Value::Text("agent".into())]),
+            ),
+            (
+                Value::Text("arkavo_entitlements".into()),
+                Value::Array(vec![
+                    Value::Text("https://arkavo.ai/attr/repo/read".into()),
+                    Value::Text("https://arkavo.ai/attr/repo/write".into()),
+                ]),
+            ),
+            (
+                Value::Text("act".into()),
+                Value::Array(vec![Value::Map(vec![(
+                    Value::Text("sub".into()),
+                    Value::Text("did:key:zHumanPrincipal".into()),
+                )])]),
+            ),
+        ]);
+        let mut payload_bytes = Vec::new();
+        ciborium::into_writer(&payload, &mut payload_bytes).expect("encode claims");
+
+        let protected = HeaderBuilder::new()
+            .algorithm(coset::iana::Algorithm::ES256)
+            .key_id(kid.to_vec())
+            .build();
+        let sign1 = CoseSign1Builder::new()
+            .protected(protected)
+            .payload(payload_bytes)
+            .create_signature(b"", |data| {
+                let sig: Signature = signer.sign(data);
+                sig.to_bytes().to_vec()
+            })
+            .build();
+
+        let mut bytes = if tagged { vec![0xD8, 0x3D] } else { Vec::new() };
+        bytes.extend_from_slice(&sign1.to_vec().expect("encode COSE_Sign1"));
+        URL_SAFE_NO_PAD.encode(bytes)
+    }
+
+    /// Encode a `/.well-known/cose-keys` body: a CBOR array of COSE_Key maps.
+    fn key_set_cbor(entries: &[(&[u8], VerifyingKey)]) -> Vec<u8> {
+        let keys = entries
+            .iter()
+            .map(|(kid, vk)| {
+                let point = vk.to_encoded_point(false);
+                CoseKeyBuilder::new_ec2_pub_key(
+                    coset::iana::EllipticCurve::P_256,
+                    point.x().expect("x coordinate").to_vec(),
+                    point.y().expect("y coordinate").to_vec(),
+                )
+                .algorithm(coset::iana::Algorithm::ES256)
+                .key_id(kid.to_vec())
+                .build()
+            })
+            .collect();
+        CoseKeySet(keys).to_vec().expect("encode key set")
+    }
+
+    fn opts<'a>(aud: Option<&'a str>) -> VerifyOptions<'a> {
+        VerifyOptions {
+            expected_iss: ISS,
+            expected_aud: aud,
+            now: NOW,
+            skew_secs: 30,
+        }
+    }
+
+    #[test]
+    #[spec("ACWT-001")]
+    fn verifies_es256_tagged_cwt_and_reads_arkavo_claims() {
+        let signer = new_key();
+        let kid = [0x11u8; 32];
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())]))
+            .expect("parse key set");
+
+        let token = mint(&signer, &kid, &["arkavo-kas"], NOW + 600, true);
+        let claims = verify(&token, &keys, &opts(Some("arkavo-kas"))).expect("verify tagged CWT");
+
+        assert_eq!(claims.iss, ISS);
+        assert_eq!(claims.sub, "did:key:zAgentUnderTest");
+        assert_eq!(claims.aud, vec!["arkavo-kas".to_string()]);
+        assert_eq!(claims.exp, NOW + 600);
+        assert_eq!(claims.iat, NOW - 60);
+        assert_eq!(claims.account_id.as_deref(), Some("acct-42"));
+        assert_eq!(claims.roles, vec!["agent".to_string()]);
+        assert_eq!(
+            claims.entitlements,
+            vec![
+                "https://arkavo.ai/attr/repo/read".to_string(),
+                "https://arkavo.ai/attr/repo/write".to_string(),
+            ]
+        );
+        assert_eq!(claims.actors, vec!["did:key:zHumanPrincipal".to_string()]);
+        assert!(claims.npe.is_none());
+
+        // The same bytes without the tag-61 prefix are equally acceptable.
+        let untagged = mint(&signer, &kid, &["arkavo-kas"], NOW + 600, false);
+        assert!(verify(&untagged, &keys, &opts(Some("arkavo-kas"))).is_ok());
+    }
+
+    #[test]
+    #[spec("ACWT-002")]
+    fn rejects_wrong_key_expired_and_wrong_audience() {
+        let signer = new_key();
+        let impostor = new_key();
+        let kid = [0x22u8; 32];
+        // The key set advertises `kid` but binds it to a different public key,
+        // so a token minted by `impostor` reaches signature verification and
+        // fails there rather than being rejected as an unknown kid.
+        let wrong_key_set =
+            KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())])).expect("key set");
+        let token = mint(&impostor, &kid, &["arkavo-kas"], NOW + 600, true);
+        assert!(matches!(
+            verify(&token, &wrong_key_set, &opts(Some("arkavo-kas"))),
+            Err(CwtError::BadSignature)
+        ));
+
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *impostor.verifying_key())]))
+            .expect("key set");
+
+        let expired = mint(&impostor, &kid, &["arkavo-kas"], NOW - 31, true);
+        assert!(matches!(
+            verify(&expired, &keys, &opts(Some("arkavo-kas"))),
+            Err(CwtError::Expired { .. })
+        ));
+
+        let good = mint(&impostor, &kid, &["arkavo-kas"], NOW + 600, true);
+        assert!(matches!(
+            verify(&good, &keys, &opts(Some("some-other-service"))),
+            Err(CwtError::AudienceMismatch { .. })
+        ));
+    }
+
+    #[tokio::test]
+    #[spec("ACWT-003")]
+    async fn cached_keyset_refreshes_on_unknown_kid_once_per_ttl() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let signer = new_key();
+        let stale = new_key();
+        let kid = [0x33u8; 32];
+        let token = mint(&signer, &kid, &["arkavo-kas"], NOW + 600, true);
+
+        let server = MockServer::start().await;
+        // First response predates the rotation and does not carry `kid`; every
+        // later response does.
+        Mock::given(method("GET"))
+            .and(path("/.well-known/cose-keys"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(key_set_cbor(&[(&[0x99u8; 32], *stale.verifying_key())])),
+            )
+            .up_to_n_times(1)
+            .expect(1..)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/.well-known/cose-keys"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(key_set_cbor(&[(&kid, *signer.verifying_key())])),
+            )
+            .mount(&server)
+            .await;
+
+        let url = format!("{}/.well-known/cose-keys", server.uri());
+
+        // ttl 0: the unknown kid triggers an immediate re-fetch, which picks up
+        // the rotated key and verifies.
+        let eager = CachedKeySet::new(&url, Duration::ZERO);
+        let claims = eager
+            .verify(&token, &opts(Some("arkavo-kas")))
+            .await
+            .expect("verify after refresh");
+        assert_eq!(claims.sub, "did:key:zAgentUnderTest");
+        assert_eq!(server.received_requests().await.unwrap().len(), 2);
+
+        // A long ttl suppresses the re-fetch: the unknown kid is reported and
+        // the key set is fetched exactly once.
+        let lazy = CachedKeySet::new(&url, Duration::from_secs(3600));
+        let before = server.received_requests().await.unwrap().len();
+        let stale_kid_token = mint(&stale, &[0x44u8; 32], &["arkavo-kas"], NOW + 600, true);
+        assert!(matches!(
+            lazy.verify(&stale_kid_token, &opts(Some("arkavo-kas")))
+                .await,
+            Err(CwtError::UnknownKid(_))
+        ));
+        assert!(
+            lazy.verify(&stale_kid_token, &opts(Some("arkavo-kas")))
+                .await
+                .is_err()
+        );
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            before + 1,
+            "the key set must be re-fetched at most once per ttl"
+        );
+    }
+}

--- a/crates/arkavo-device-identity/Cargo.toml
+++ b/crates/arkavo-device-identity/Cargo.toml
@@ -33,4 +33,7 @@ arkavo-crypto = { path = "../arkavo-crypto" }
 [features]
 default = []
 linux-keyring = ["dep:keyring"]
+# Exposes `test_utils`'s RAII guard so dependent crates' tests can protect
+# the developer's real keypair slots instead of deleting them.
+test-utils = []
 windows-credential = ["dep:windows"]

--- a/crates/arkavo-device-identity/Cargo.toml
+++ b/crates/arkavo-device-identity/Cargo.toml
@@ -27,6 +27,7 @@ dirs = "5.0"
 
 [dev-dependencies]
 serde_json.workspace = true
+arkavo-test-macros = { path = "../arkavo-test-macros" }
 
 [features]
 default = []

--- a/crates/arkavo-device-identity/Cargo.toml
+++ b/crates/arkavo-device-identity/Cargo.toml
@@ -28,6 +28,7 @@ dirs = "5.0"
 [dev-dependencies]
 serde_json.workspace = true
 arkavo-test-macros = { path = "../arkavo-test-macros" }
+arkavo-crypto = { path = "../arkavo-crypto" }
 
 [features]
 default = []

--- a/crates/arkavo-device-identity/src/keypair.rs
+++ b/crates/arkavo-device-identity/src/keypair.rs
@@ -363,6 +363,38 @@ mod tests {
         let _ = delete_keypair();
     }
 
+    #[spec("DEVICE-007")]
+    #[test]
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+    fn agent_did_differs_from_device_did() {
+        let _g = KEYCHAIN_MUTEX.lock().unwrap();
+        let _ = delete_keypair();
+        let _ = delete_agent_keypair();
+
+        let device_kp = arkavo_crypto::AgentKeypair::generate();
+        store_keypair(&device_kp.to_bytes()).unwrap();
+        let agent_kp = arkavo_crypto::AgentKeypair::generate();
+        store_agent_keypair(&agent_kp.to_bytes()).unwrap();
+
+        let device_did = arkavo_crypto::AgentKeypair::from_bytes(&get_keypair().unwrap().unwrap())
+            .unwrap()
+            .public_key()
+            .to_did_key();
+        let agent_did =
+            arkavo_crypto::AgentKeypair::from_bytes(&get_agent_keypair().unwrap().unwrap())
+                .unwrap()
+                .public_key()
+                .to_did_key();
+
+        assert_ne!(
+            device_did, agent_did,
+            "agent DID must differ from device DID"
+        );
+
+        let _ = delete_keypair();
+        let _ = delete_agent_keypair();
+    }
+
     #[test]
     #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     fn test_keypair_storage() {

--- a/crates/arkavo-device-identity/src/keypair.rs
+++ b/crates/arkavo-device-identity/src/keypair.rs
@@ -10,6 +10,50 @@ const KEYPAIR_FILENAME: &str = "agent_keypair";
 /// short-lived credentials distinct from its host device's identity.
 const AGENT_KEYPAIR_FILENAME: &str = "agent_identity_keypair";
 
+/// Write `bytes` to `path` so the file is never readable by anyone but its
+/// owner, not even for an instant: the content is staged in a sibling file
+/// created with mode 0600 and then renamed over the target. Writing in place
+/// and tightening the mode afterwards leaves a world-readable window over a
+/// private key, and lets a concurrent reader see a half-written file.
+fn write_private(path: &std::path::Path, bytes: &[u8]) -> Result<()> {
+    use std::io::Write;
+
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let stem = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("keypair");
+    let tmp = path.with_file_name(format!(
+        ".{stem}.{}.{}.tmp",
+        std::process::id(),
+        NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    // A leftover from a killed run would defeat `create_new`, which is what
+    // guarantees the mode is applied rather than inherited.
+    let _ = std::fs::remove_file(&tmp);
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let staged = (|| -> std::io::Result<()> {
+        let mut file = options.open(&tmp)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&tmp, path)
+    })();
+
+    staged.map_err(|e| {
+        let _ = std::fs::remove_file(&tmp);
+        DeviceIdentityError::Storage(format!("Failed to write file: {}", e))
+    })
+}
+
 #[cfg(target_os = "macos")]
 mod platform {
     use super::*;
@@ -43,21 +87,7 @@ mod platform {
     }
 
     fn write(filename: &str, keypair_bytes: &[u8]) -> Result<()> {
-        let path = keypair_path(filename)?;
-
-        fs::write(&path, keypair_bytes)
-            .map_err(|e| DeviceIdentityError::Storage(format!("Failed to write file: {}", e)))?;
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let permissions = fs::Permissions::from_mode(0o600);
-            fs::set_permissions(&path, permissions).map_err(|e| {
-                DeviceIdentityError::Storage(format!("Failed to set permissions: {}", e))
-            })?;
-        }
-
-        Ok(())
+        super::write_private(&keypair_path(filename)?, keypair_bytes)
     }
 
     fn remove(filename: &str) -> Result<()> {
@@ -68,6 +98,11 @@ mod platform {
             })?;
         }
         Ok(())
+    }
+
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn slot_path(filename: &str) -> Result<PathBuf> {
+        keypair_path(filename)
     }
 
     pub fn get() -> Result<Option<Vec<u8>>> {
@@ -142,18 +177,7 @@ mod platform {
     }
 
     fn write(filename: &str, keypair_bytes: &[u8]) -> Result<()> {
-        let path = keypair_path(filename)?;
-
-        fs::write(&path, keypair_bytes)
-            .map_err(|e| DeviceIdentityError::Storage(format!("Failed to write file: {}", e)))?;
-
-        use std::os::unix::fs::PermissionsExt;
-        let permissions = fs::Permissions::from_mode(0o600);
-        fs::set_permissions(&path, permissions).map_err(|e| {
-            DeviceIdentityError::Storage(format!("Failed to set permissions: {}", e))
-        })?;
-
-        Ok(())
+        super::write_private(&keypair_path(filename)?, keypair_bytes)
     }
 
     fn remove(filename: &str) -> Result<()> {
@@ -164,6 +188,11 @@ mod platform {
             })?;
         }
         Ok(())
+    }
+
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn slot_path(filename: &str) -> Result<PathBuf> {
+        keypair_path(filename)
     }
 
     pub fn get() -> Result<Option<Vec<u8>>> {
@@ -238,12 +267,7 @@ mod platform {
     }
 
     fn write(filename: &str, keypair_bytes: &[u8]) -> Result<()> {
-        let path = keypair_path(filename)?;
-
-        fs::write(&path, keypair_bytes)
-            .map_err(|e| DeviceIdentityError::Storage(format!("Failed to write file: {}", e)))?;
-
-        Ok(())
+        super::write_private(&keypair_path(filename)?, keypair_bytes)
     }
 
     fn remove(filename: &str) -> Result<()> {
@@ -254,6 +278,11 @@ mod platform {
             })?;
         }
         Ok(())
+    }
+
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn slot_path(filename: &str) -> Result<PathBuf> {
+        keypair_path(filename)
     }
 
     pub fn get() -> Result<Option<Vec<u8>>> {
@@ -297,6 +326,17 @@ mod platform {
     }
 }
 
+/// Filesystem locations of the device and agent keypair slots, in that order.
+/// Test support needs them to save and restore whatever the developer's real
+/// installation held before a test overwrote the slots.
+#[cfg(any(test, feature = "test-utils"))]
+pub(crate) fn slot_paths() -> Result<Vec<std::path::PathBuf>> {
+    Ok(vec![
+        platform::slot_path(KEYPAIR_FILENAME)?,
+        platform::slot_path(AGENT_KEYPAIR_FILENAME)?,
+    ])
+}
+
 pub fn get_keypair() -> Result<Option<Vec<u8>>> {
     platform::get()
 }
@@ -336,6 +376,7 @@ pub fn created_at() -> Result<Option<std::time::SystemTime>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::KeypairSlotGuard;
     use arkavo_test_macros::spec;
     use std::sync::Mutex;
 
@@ -346,9 +387,9 @@ mod tests {
     #[test]
     #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     fn agent_slot_is_independent_of_device_slot() {
-        let _g = KEYCHAIN_MUTEX.lock().unwrap();
-        let _ = delete_keypair();
-        let _ = delete_agent_keypair();
+        let _lock = KEYCHAIN_MUTEX.lock().unwrap();
+        let _slots = KeypairSlotGuard::capture();
+
         store_keypair(&[1u8; 64]).unwrap();
         assert_eq!(
             get_agent_keypair().unwrap(),
@@ -360,16 +401,14 @@ mod tests {
         assert_eq!(get_agent_keypair().unwrap().unwrap(), vec![2u8; 64]);
         delete_agent_keypair().unwrap();
         assert_eq!(get_agent_keypair().unwrap(), None);
-        let _ = delete_keypair();
     }
 
     #[spec("DEVICE-007")]
     #[test]
     #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     fn agent_did_differs_from_device_did() {
-        let _g = KEYCHAIN_MUTEX.lock().unwrap();
-        let _ = delete_keypair();
-        let _ = delete_agent_keypair();
+        let _lock = KEYCHAIN_MUTEX.lock().unwrap();
+        let _slots = KeypairSlotGuard::capture();
 
         let device_kp = arkavo_crypto::AgentKeypair::generate();
         store_keypair(&device_kp.to_bytes()).unwrap();
@@ -390,21 +429,16 @@ mod tests {
             device_did, agent_did,
             "agent DID must differ from device DID"
         );
-
-        let _ = delete_keypair();
-        let _ = delete_agent_keypair();
     }
 
     #[test]
     #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     fn test_keypair_storage() {
-        let _guard = KEYCHAIN_MUTEX.lock().unwrap();
-        let _ = delete_keypair();
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        let _lock = KEYCHAIN_MUTEX.lock().unwrap();
+        let _slots = KeypairSlotGuard::capture();
 
         let test_data = vec![1u8, 2, 3, 4, 5];
         store_keypair(&test_data).expect("Failed to store keypair");
-        std::thread::sleep(std::time::Duration::from_millis(50));
 
         let retrieved = get_keypair()
             .expect("Failed to get keypair")
@@ -418,9 +452,8 @@ mod tests {
     #[test]
     #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     fn test_keypair_nonexistent() {
-        let _guard = KEYCHAIN_MUTEX.lock().unwrap();
-        let _ = delete_keypair();
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        let _lock = KEYCHAIN_MUTEX.lock().unwrap();
+        let _slots = KeypairSlotGuard::capture();
 
         let result = get_keypair().expect("get_keypair should not fail");
         assert!(result.is_none());
@@ -431,27 +464,56 @@ mod tests {
     fn test_keypair_permissions() {
         use std::os::unix::fs::PermissionsExt;
 
-        let _guard = KEYCHAIN_MUTEX.lock().unwrap();
-        let _ = delete_keypair();
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        let _lock = KEYCHAIN_MUTEX.lock().unwrap();
+        let _slots = KeypairSlotGuard::capture();
 
-        let test_data = vec![1u8, 2, 3, 4];
-        store_keypair(&test_data).expect("Failed to store keypair");
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        store_keypair(&[1u8, 2, 3, 4]).expect("Failed to store keypair");
 
-        let path = if cfg!(target_os = "macos") {
-            let mut p = dirs::home_dir().unwrap();
-            p.push("Library/Application Support/arkavo/agent_keypair");
-            p
-        } else {
-            let mut p = dirs::data_local_dir().unwrap();
-            p.push("arkavo/agent_keypair");
-            p
-        };
-
-        let metadata = std::fs::metadata(&path).expect("Failed to get metadata");
+        let path = &slot_paths().unwrap()[0];
+        let metadata = std::fs::metadata(path).expect("Failed to get metadata");
         let permissions = metadata.permissions();
         assert_eq!(permissions.mode() & 0o777, 0o600);
+
+        delete_keypair().expect("Failed to delete keypair");
+    }
+
+    /// Regression: the keypair used to be written with `fs::write` and only
+    /// then chmod-ed to 0600, so it existed world-readable for an instant and
+    /// inherited a pre-existing file's wider mode until the chmod landed. The
+    /// replacement is now staged in a sibling created 0600 and renamed over the
+    /// target, so a wider mode on the old file cannot survive the write and no
+    /// staging file is left behind.
+    #[test]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    fn store_keypair_never_inherits_a_world_readable_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _lock = KEYCHAIN_MUTEX.lock().unwrap();
+        let _slots = KeypairSlotGuard::capture();
+
+        let path = slot_paths().unwrap()[0].clone();
+        std::fs::write(&path, b"pre-existing").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        store_keypair(&[7u8; 32]).expect("Failed to store keypair");
+
+        assert_eq!(get_keypair().unwrap().unwrap(), vec![7u8; 32]);
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600,
+            "a replacement must be created 0600, never inherit the old mode"
+        );
+
+        let leftovers: Vec<String> = std::fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.ends_with(".tmp"))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "staging files left behind: {leftovers:?}"
+        );
 
         delete_keypair().expect("Failed to delete keypair");
     }

--- a/crates/arkavo-device-identity/src/keypair.rs
+++ b/crates/arkavo-device-identity/src/keypair.rs
@@ -2,13 +2,21 @@ use crate::{DeviceIdentityError, Result};
 
 const KEYPAIR_FILENAME: &str = "agent_keypair";
 
+/// Filename for the agent's own identity keypair, kept separate from the
+/// device keypair above. Note the naming trap: `KEYPAIR_FILENAME`
+/// ("agent_keypair") is actually the *device* slot — existing installs
+/// depend on that exact value, so it is not renamed. This constant is the
+/// real per-agent identity slot, used when an agent requests its own
+/// short-lived credentials distinct from its host device's identity.
+const AGENT_KEYPAIR_FILENAME: &str = "agent_identity_keypair";
+
 #[cfg(target_os = "macos")]
 mod platform {
     use super::*;
     use std::fs;
     use std::path::PathBuf;
 
-    fn get_keypair_path() -> Result<PathBuf> {
+    fn keypair_path(filename: &str) -> Result<PathBuf> {
         let mut path = dirs::home_dir().ok_or_else(|| {
             DeviceIdentityError::Storage("Could not determine home directory".to_string())
         })?;
@@ -18,12 +26,12 @@ mod platform {
         fs::create_dir_all(&path).map_err(|e| {
             DeviceIdentityError::Storage(format!("Failed to create directory: {}", e))
         })?;
-        path.push(KEYPAIR_FILENAME);
+        path.push(filename);
         Ok(path)
     }
 
-    pub fn get() -> Result<Option<Vec<u8>>> {
-        let path = get_keypair_path()?;
+    fn read(filename: &str) -> Result<Option<Vec<u8>>> {
+        let path = keypair_path(filename)?;
         if !path.exists() {
             return Ok(None);
         }
@@ -34,8 +42,8 @@ mod platform {
         Ok(Some(bytes))
     }
 
-    pub fn store(keypair_bytes: &[u8]) -> Result<()> {
-        let path = get_keypair_path()?;
+    fn write(filename: &str, keypair_bytes: &[u8]) -> Result<()> {
+        let path = keypair_path(filename)?;
 
         fs::write(&path, keypair_bytes)
             .map_err(|e| DeviceIdentityError::Storage(format!("Failed to write file: {}", e)))?;
@@ -52,8 +60,8 @@ mod platform {
         Ok(())
     }
 
-    pub fn delete() -> Result<()> {
-        let path = get_keypair_path()?;
+    fn remove(filename: &str) -> Result<()> {
+        let path = keypair_path(filename)?;
         if path.exists() {
             fs::remove_file(&path).map_err(|e| {
                 DeviceIdentityError::Storage(format!("Failed to delete file: {}", e))
@@ -62,8 +70,32 @@ mod platform {
         Ok(())
     }
 
+    pub fn get() -> Result<Option<Vec<u8>>> {
+        read(KEYPAIR_FILENAME)
+    }
+
+    pub fn store(keypair_bytes: &[u8]) -> Result<()> {
+        write(KEYPAIR_FILENAME, keypair_bytes)
+    }
+
+    pub fn delete() -> Result<()> {
+        remove(KEYPAIR_FILENAME)
+    }
+
+    pub fn get_agent() -> Result<Option<Vec<u8>>> {
+        read(AGENT_KEYPAIR_FILENAME)
+    }
+
+    pub fn store_agent(keypair_bytes: &[u8]) -> Result<()> {
+        write(AGENT_KEYPAIR_FILENAME, keypair_bytes)
+    }
+
+    pub fn delete_agent() -> Result<()> {
+        remove(AGENT_KEYPAIR_FILENAME)
+    }
+
     pub fn created_at() -> Result<Option<std::time::SystemTime>> {
-        let path = get_keypair_path()?;
+        let path = keypair_path(KEYPAIR_FILENAME)?;
         if !path.exists() {
             return Ok(None);
         }
@@ -85,7 +117,7 @@ mod platform {
     use std::fs;
     use std::path::PathBuf;
 
-    fn get_keypair_path() -> Result<PathBuf> {
+    fn keypair_path(filename: &str) -> Result<PathBuf> {
         let mut path = dirs::data_local_dir().ok_or_else(|| {
             DeviceIdentityError::Storage("Could not determine local data directory".to_string())
         })?;
@@ -93,12 +125,12 @@ mod platform {
         fs::create_dir_all(&path).map_err(|e| {
             DeviceIdentityError::Storage(format!("Failed to create directory: {}", e))
         })?;
-        path.push(KEYPAIR_FILENAME);
+        path.push(filename);
         Ok(path)
     }
 
-    pub fn get() -> Result<Option<Vec<u8>>> {
-        let path = get_keypair_path()?;
+    fn read(filename: &str) -> Result<Option<Vec<u8>>> {
+        let path = keypair_path(filename)?;
         if !path.exists() {
             return Ok(None);
         }
@@ -109,8 +141,8 @@ mod platform {
         Ok(Some(bytes))
     }
 
-    pub fn store(keypair_bytes: &[u8]) -> Result<()> {
-        let path = get_keypair_path()?;
+    fn write(filename: &str, keypair_bytes: &[u8]) -> Result<()> {
+        let path = keypair_path(filename)?;
 
         fs::write(&path, keypair_bytes)
             .map_err(|e| DeviceIdentityError::Storage(format!("Failed to write file: {}", e)))?;
@@ -124,8 +156,8 @@ mod platform {
         Ok(())
     }
 
-    pub fn delete() -> Result<()> {
-        let path = get_keypair_path()?;
+    fn remove(filename: &str) -> Result<()> {
+        let path = keypair_path(filename)?;
         if path.exists() {
             fs::remove_file(&path).map_err(|e| {
                 DeviceIdentityError::Storage(format!("Failed to delete file: {}", e))
@@ -134,8 +166,32 @@ mod platform {
         Ok(())
     }
 
+    pub fn get() -> Result<Option<Vec<u8>>> {
+        read(KEYPAIR_FILENAME)
+    }
+
+    pub fn store(keypair_bytes: &[u8]) -> Result<()> {
+        write(KEYPAIR_FILENAME, keypair_bytes)
+    }
+
+    pub fn delete() -> Result<()> {
+        remove(KEYPAIR_FILENAME)
+    }
+
+    pub fn get_agent() -> Result<Option<Vec<u8>>> {
+        read(AGENT_KEYPAIR_FILENAME)
+    }
+
+    pub fn store_agent(keypair_bytes: &[u8]) -> Result<()> {
+        write(AGENT_KEYPAIR_FILENAME, keypair_bytes)
+    }
+
+    pub fn delete_agent() -> Result<()> {
+        remove(AGENT_KEYPAIR_FILENAME)
+    }
+
     pub fn created_at() -> Result<Option<std::time::SystemTime>> {
-        let path = get_keypair_path()?;
+        let path = keypair_path(KEYPAIR_FILENAME)?;
         if !path.exists() {
             return Ok(None);
         }
@@ -157,7 +213,7 @@ mod platform {
     use std::fs;
     use std::path::PathBuf;
 
-    fn get_keypair_path() -> Result<PathBuf> {
+    fn keypair_path(filename: &str) -> Result<PathBuf> {
         let mut path = dirs::data_local_dir().ok_or_else(|| {
             DeviceIdentityError::Storage("Could not determine local data directory".to_string())
         })?;
@@ -165,12 +221,12 @@ mod platform {
         fs::create_dir_all(&path).map_err(|e| {
             DeviceIdentityError::Storage(format!("Failed to create directory: {}", e))
         })?;
-        path.push(KEYPAIR_FILENAME);
+        path.push(filename);
         Ok(path)
     }
 
-    pub fn get() -> Result<Option<Vec<u8>>> {
-        let path = get_keypair_path()?;
+    fn read(filename: &str) -> Result<Option<Vec<u8>>> {
+        let path = keypair_path(filename)?;
         if !path.exists() {
             return Ok(None);
         }
@@ -181,8 +237,8 @@ mod platform {
         Ok(Some(bytes))
     }
 
-    pub fn store(keypair_bytes: &[u8]) -> Result<()> {
-        let path = get_keypair_path()?;
+    fn write(filename: &str, keypair_bytes: &[u8]) -> Result<()> {
+        let path = keypair_path(filename)?;
 
         fs::write(&path, keypair_bytes)
             .map_err(|e| DeviceIdentityError::Storage(format!("Failed to write file: {}", e)))?;
@@ -190,8 +246,8 @@ mod platform {
         Ok(())
     }
 
-    pub fn delete() -> Result<()> {
-        let path = get_keypair_path()?;
+    fn remove(filename: &str) -> Result<()> {
+        let path = keypair_path(filename)?;
         if path.exists() {
             fs::remove_file(&path).map_err(|e| {
                 DeviceIdentityError::Storage(format!("Failed to delete file: {}", e))
@@ -200,8 +256,32 @@ mod platform {
         Ok(())
     }
 
+    pub fn get() -> Result<Option<Vec<u8>>> {
+        read(KEYPAIR_FILENAME)
+    }
+
+    pub fn store(keypair_bytes: &[u8]) -> Result<()> {
+        write(KEYPAIR_FILENAME, keypair_bytes)
+    }
+
+    pub fn delete() -> Result<()> {
+        remove(KEYPAIR_FILENAME)
+    }
+
+    pub fn get_agent() -> Result<Option<Vec<u8>>> {
+        read(AGENT_KEYPAIR_FILENAME)
+    }
+
+    pub fn store_agent(keypair_bytes: &[u8]) -> Result<()> {
+        write(AGENT_KEYPAIR_FILENAME, keypair_bytes)
+    }
+
+    pub fn delete_agent() -> Result<()> {
+        remove(AGENT_KEYPAIR_FILENAME)
+    }
+
     pub fn created_at() -> Result<Option<std::time::SystemTime>> {
-        let path = get_keypair_path()?;
+        let path = keypair_path(KEYPAIR_FILENAME)?;
         if !path.exists() {
             return Ok(None);
         }
@@ -229,6 +309,23 @@ pub fn delete_keypair() -> Result<()> {
     platform::delete()
 }
 
+/// Retrieve the agent's own identity keypair. This is stored in a slot
+/// separate from `get_keypair`'s device keypair, so an agent process can
+/// hold a distinct identity from the device it runs on.
+pub fn get_agent_keypair() -> Result<Option<Vec<u8>>> {
+    platform::get_agent()
+}
+
+/// Persist the agent's own identity keypair, independent of the device slot.
+pub fn store_agent_keypair(keypair_bytes: &[u8]) -> Result<()> {
+    platform::store_agent(keypair_bytes)
+}
+
+/// Remove the agent's own identity keypair. Leaves the device keypair intact.
+pub fn delete_agent_keypair() -> Result<()> {
+    platform::delete_agent()
+}
+
 /// File mtime of the persistent keypair, used as the agent's "birth time"
 /// for the MCP-T tenure dimension. Returns `Ok(None)` if the keypair has
 /// not been created yet.
@@ -239,10 +336,32 @@ pub fn created_at() -> Result<Option<std::time::SystemTime>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arkavo_test_macros::spec;
     use std::sync::Mutex;
 
     // Mutex to serialize tests that access the system keychain
     static KEYCHAIN_MUTEX: Mutex<()> = Mutex::new(());
+
+    #[spec("DEVICE-007")]
+    #[test]
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+    fn agent_slot_is_independent_of_device_slot() {
+        let _g = KEYCHAIN_MUTEX.lock().unwrap();
+        let _ = delete_keypair();
+        let _ = delete_agent_keypair();
+        store_keypair(&[1u8; 64]).unwrap();
+        assert_eq!(
+            get_agent_keypair().unwrap(),
+            None,
+            "agent slot must start empty"
+        );
+        store_agent_keypair(&[2u8; 64]).unwrap();
+        assert_eq!(get_keypair().unwrap().unwrap(), vec![1u8; 64]);
+        assert_eq!(get_agent_keypair().unwrap().unwrap(), vec![2u8; 64]);
+        delete_agent_keypair().unwrap();
+        assert_eq!(get_agent_keypair().unwrap(), None);
+        let _ = delete_keypair();
+    }
 
     #[test]
     #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]

--- a/crates/arkavo-device-identity/src/lib.rs
+++ b/crates/arkavo-device-identity/src/lib.rs
@@ -5,6 +5,9 @@ use uuid::Uuid;
 pub mod keypair;
 pub mod storage;
 
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
+
 #[derive(Debug, thiserror::Error)]
 pub enum DeviceIdentityError {
     #[error("Storage error: {0}")]

--- a/crates/arkavo-device-identity/src/storage.rs
+++ b/crates/arkavo-device-identity/src/storage.rs
@@ -328,6 +328,8 @@ pub fn delete() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    use crate::test_utils::{DeviceIdFileGuard, device_id_file_path};
     use std::sync::Mutex;
 
     // Mutex to serialize tests that access the system keychain
@@ -337,6 +339,7 @@ mod tests {
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     fn test_get_or_create() {
         let _guard = KEYCHAIN_MUTEX.lock().unwrap();
+        let _file = DeviceIdFileGuard::capture();
         let _ = delete();
         // Small delay to ensure keychain operations complete
         std::thread::sleep(std::time::Duration::from_millis(50));
@@ -355,6 +358,7 @@ mod tests {
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     fn test_store_and_retrieve() {
         let _guard = KEYCHAIN_MUTEX.lock().unwrap();
+        let _file = DeviceIdFileGuard::capture();
         let _ = delete();
         std::thread::sleep(std::time::Duration::from_millis(50));
 
@@ -377,22 +381,14 @@ mod tests {
         use std::fs;
 
         let _guard = KEYCHAIN_MUTEX.lock().unwrap();
+        let _file = DeviceIdFileGuard::capture();
         let _ = delete();
         std::thread::sleep(std::time::Duration::from_millis(50));
 
-        #[cfg(target_os = "macos")]
-        let storage_path = {
-            let mut path = dirs::home_dir().unwrap();
-            path.push("Library/Application Support/arkavo/device_id");
-            path
-        };
-
-        #[cfg(target_os = "linux")]
-        let storage_path = {
-            let mut path = dirs::data_local_dir().unwrap();
-            path.push("arkavo/device_id");
-            path
-        };
+        let storage_path = device_id_file_path();
+        if let Some(parent) = storage_path.parent() {
+            fs::create_dir_all(parent).expect("Failed to create device_id directory");
+        }
 
         fs::write(&storage_path, "invalid_hex_data").expect("Failed to write malformed data");
 
@@ -412,22 +408,14 @@ mod tests {
         use std::fs;
 
         let _guard = KEYCHAIN_MUTEX.lock().unwrap();
+        let _file = DeviceIdFileGuard::capture();
         let _ = delete();
         std::thread::sleep(std::time::Duration::from_millis(50));
 
-        #[cfg(target_os = "macos")]
-        let storage_path = {
-            let mut path = dirs::home_dir().unwrap();
-            path.push("Library/Application Support/arkavo/device_id");
-            path
-        };
-
-        #[cfg(target_os = "linux")]
-        let storage_path = {
-            let mut path = dirs::data_local_dir().unwrap();
-            path.push("arkavo/device_id");
-            path
-        };
+        let storage_path = device_id_file_path();
+        if let Some(parent) = storage_path.parent() {
+            fs::create_dir_all(parent).expect("Failed to create device_id directory");
+        }
 
         let wrong_size_data = hex::encode([0u8; 8]);
         fs::write(&storage_path, wrong_size_data).expect("Failed to write wrong size data");
@@ -445,6 +433,7 @@ mod tests {
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     fn test_delete_nonexistent() {
         let _guard = KEYCHAIN_MUTEX.lock().unwrap();
+        let _file = DeviceIdFileGuard::capture();
         let _ = delete();
         std::thread::sleep(std::time::Duration::from_millis(50));
 
@@ -456,6 +445,7 @@ mod tests {
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     fn test_get_nonexistent() {
         let _guard = KEYCHAIN_MUTEX.lock().unwrap();
+        let _file = DeviceIdFileGuard::capture();
         let _ = delete();
         std::thread::sleep(std::time::Duration::from_millis(50));
 
@@ -463,5 +453,34 @@ mod tests {
         assert!(result.is_none());
 
         let _ = delete();
+    }
+
+    /// Regression: `storage` tests used to `delete()` the developer's real
+    /// `device_id` file with no restore. The guard must put the original
+    /// bytes back even if the test body panics or leaves a different value.
+    #[test]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    fn device_id_file_guard_restores_existing_bytes() {
+        let _guard = KEYCHAIN_MUTEX.lock().unwrap();
+        let _outer = DeviceIdFileGuard::capture();
+
+        let path = device_id_file_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, b"sentinel-device-id").unwrap();
+
+        {
+            let _inner = DeviceIdFileGuard::capture();
+            assert!(
+                !path.exists(),
+                "capture must clear the device_id file for the test"
+            );
+        }
+
+        assert_eq!(
+            std::fs::read(&path).expect("guard must restore the sentinel"),
+            b"sentinel-device-id"
+        );
     }
 }

--- a/crates/arkavo-device-identity/src/test_utils.rs
+++ b/crates/arkavo-device-identity/src/test_utils.rs
@@ -91,3 +91,95 @@ fn restore(path: &std::path::Path, bytes: &[u8], mtime: Option<SystemTime>) -> s
     }
     Ok(())
 }
+
+/// RAII guard that empties the `device_id` slot for the duration of a test
+/// and restores its previous contents when it drops.
+///
+/// Same contract as [`KeypairSlotGuard`]: the restore lives in `Drop` because
+/// a failing `assert!` unwinds past trailing cleanup. Bind it *after* the
+/// test's serialising mutex so the slot is back before another test can take
+/// the lock. File bytes are preferred on restore because they are the
+/// file-backed platforms' source of truth; the parsed id is kept so a
+/// keyring-only platform can put the value back too.
+pub struct DeviceIdFileGuard {
+    path: PathBuf,
+    saved_file: Option<Vec<u8>>,
+    saved_id: Option<crate::DeviceId>,
+}
+
+impl DeviceIdFileGuard {
+    /// Capture the device_id slot and clear it, so the test starts from a
+    /// known-empty state regardless of what the developer's machine holds.
+    pub fn capture() -> Self {
+        let path = device_id_file_path();
+        let saved_file = std::fs::read(&path).ok();
+        let saved_id = crate::storage::get().ok().flatten();
+        if saved_file.is_some() {
+            let _ = std::fs::remove_file(&path);
+        }
+        let _ = crate::storage::delete();
+        Self {
+            path,
+            saved_file,
+            saved_id,
+        }
+    }
+}
+
+impl Drop for DeviceIdFileGuard {
+    fn drop(&mut self) {
+        match (&self.saved_file, self.saved_id) {
+            (Some(bytes), _) => {
+                if let Some(parent) = self.path.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
+                if let Err(e) = restore(&self.path, bytes, None) {
+                    eprintln!(
+                        "failed to restore device_id file {}: {e}",
+                        self.path.display()
+                    );
+                }
+            }
+            (None, Some(id)) => {
+                if let Err(e) = crate::storage::store(id) {
+                    eprintln!("failed to restore device_id into platform storage: {e}");
+                }
+            }
+            (None, None) => {
+                if let Err(e) = match std::fs::remove_file(&self.path) {
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                    other => other,
+                } {
+                    eprintln!(
+                        "failed to clear device_id file {}: {e}",
+                        self.path.display()
+                    );
+                }
+                let _ = crate::storage::delete();
+            }
+        }
+    }
+}
+
+/// Path of the on-disk `device_id` file used by the file-backed platforms.
+/// Tests that write malformed bytes must use this same path so the guard
+/// restores the developer's file rather than a sibling the suite never
+/// touches.
+pub fn device_id_file_path() -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        let mut path = dirs::home_dir().expect("home directory for device_id file");
+        path.push("Library/Application Support/arkavo/device_id");
+        path
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let mut path = dirs::data_local_dir().expect("local data directory for device_id file");
+        path.push("arkavo/device_id");
+        path
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        std::env::temp_dir().join("arkavo-test-device_id")
+    }
+}

--- a/crates/arkavo-device-identity/src/test_utils.rs
+++ b/crates/arkavo-device-identity/src/test_utils.rs
@@ -9,6 +9,10 @@
 use std::path::PathBuf;
 use std::time::SystemTime;
 
+/// A keypair slot's previous contents, captured so they can be restored:
+/// the file's bytes and its mtime, if the slot existed at all.
+type SavedSlotContent = Option<(Vec<u8>, Option<SystemTime>)>;
+
 /// RAII guard that empties both keypair slots for the duration of a test and
 /// restores their previous contents when it drops.
 ///
@@ -17,7 +21,7 @@ use std::time::SystemTime;
 /// destructor. Bind it *after* the test's serialising mutex guard so the files
 /// are back before another test can take the lock.
 pub struct KeypairSlotGuard {
-    saved: Vec<(PathBuf, Option<(Vec<u8>, Option<SystemTime>)>)>,
+    saved: Vec<(PathBuf, SavedSlotContent)>,
 }
 
 impl KeypairSlotGuard {

--- a/crates/arkavo-device-identity/src/test_utils.rs
+++ b/crates/arkavo-device-identity/src/test_utils.rs
@@ -1,0 +1,89 @@
+//! Test-only protection for the on-disk keypair slots.
+//!
+//! The slots are real files under the developer's home directory, and the
+//! agent slot holds the identity a human approved in authnz-rs. A test that
+//! writes or deletes them must therefore put back exactly what it found —
+//! including putting back "nothing" — or running the suite silently orphans
+//! that approval and forces the human to re-`--trust` the agent.
+
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+/// RAII guard that empties both keypair slots for the duration of a test and
+/// restores their previous contents when it drops.
+///
+/// The restore lives in `Drop`, not at the end of the test body, because a
+/// failing `assert!` unwinds past trailing cleanup code but not past a
+/// destructor. Bind it *after* the test's serialising mutex guard so the files
+/// are back before another test can take the lock.
+pub struct KeypairSlotGuard {
+    saved: Vec<(PathBuf, Option<(Vec<u8>, Option<SystemTime>)>)>,
+}
+
+impl KeypairSlotGuard {
+    /// Capture both keypair slots and clear them, so the test starts from a
+    /// known-empty state regardless of what the developer's machine holds.
+    pub fn capture() -> Self {
+        let paths = crate::keypair::slot_paths().expect("locate the keypair slots");
+        let saved = paths
+            .into_iter()
+            .map(|path| {
+                let content = std::fs::read(&path).ok().map(|bytes| {
+                    // `keypair::created_at` reads mtime as the agent's birth
+                    // time, so the restore has to put the timestamp back too.
+                    let mtime = std::fs::metadata(&path)
+                        .ok()
+                        .and_then(|m| m.modified().ok());
+                    (bytes, mtime)
+                });
+                if content.is_some() {
+                    let _ = std::fs::remove_file(&path);
+                }
+                (path, content)
+            })
+            .collect();
+        Self { saved }
+    }
+}
+
+impl Drop for KeypairSlotGuard {
+    fn drop(&mut self) {
+        for (path, content) in &self.saved {
+            let restored = match content {
+                Some((bytes, mtime)) => restore(path, bytes, *mtime),
+                None => match std::fs::remove_file(path) {
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                    other => other,
+                },
+            };
+            // Panicking here would abort the process during unwind and hide
+            // whichever assertion actually failed.
+            if let Err(e) = restored {
+                eprintln!("failed to restore keypair slot {}: {e}", path.display());
+            }
+        }
+    }
+}
+
+/// Write the captured bytes back with owner-only permissions. This mirrors
+/// `keypair`'s own private write rather than calling it, so the guard keeps
+/// working as a safety net even if that production path regresses.
+fn restore(path: &std::path::Path, bytes: &[u8], mtime: Option<SystemTime>) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let _ = std::fs::remove_file(path);
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let mut file = options.open(path)?;
+    file.write_all(bytes)?;
+    if let Some(mtime) = mtime {
+        file.set_times(std::fs::FileTimes::new().set_modified(mtime))?;
+    }
+    Ok(())
+}

--- a/crates/arkavo-protocol/src/registration/mod.rs
+++ b/crates/arkavo-protocol/src/registration/mod.rs
@@ -28,8 +28,6 @@ pub struct Registration {
     pub public_key: Vec<u8>,
     pub verified: bool,
     pub timestamp: u64,
-    /// Entitlements from delegation JWT (empty if no delegation)
-    pub delegated_entitlements: Vec<String>,
 }
 
 pub struct RegistrationService {
@@ -169,19 +167,11 @@ impl RegistrationService {
         // The write lock is held throughout, so no race condition is possible
         challenges.remove(&request.challenge_id);
 
-        // Extract delegated entitlements from delegation JWT (if present)
-        let delegated_entitlements = if let Some(ref jwt) = request.delegation_jwt {
-            extract_delegation_entitlements(jwt, &public_key_bytes)?
-        } else {
-            vec![]
-        };
-
         let registration = Registration {
             device_id: request.device_id.clone(),
             public_key: public_key_bytes,
             verified: true,
             timestamp: current_time,
-            delegated_entitlements,
         };
 
         let mut registrations = self.registrations.write().await;
@@ -225,80 +215,6 @@ impl Default for RegistrationService {
     fn default() -> Self {
         Self::new()
     }
-}
-
-/// Extract delegated entitlements from a delegation JWT.
-///
-/// Validates structural claims (sub matches agent DID, not expired) without
-/// full signature verification. Signature verification requires the authnz-rs
-/// public key, which is deferred until orchestrator key distribution is implemented.
-fn extract_delegation_entitlements(jwt: &str, agent_public_key: &[u8]) -> Result<Vec<String>> {
-    // JWT format: header.payload.signature (base64url-encoded parts)
-    let parts: Vec<&str> = jwt.split('.').collect();
-    if parts.len() != 3 {
-        return Err(A2aError::InvalidRequest("Invalid JWT format".to_string()));
-    }
-
-    // Decode payload (second part)
-    let payload_bytes = base64_url_decode(parts[1])
-        .map_err(|e| A2aError::InvalidRequest(format!("Invalid JWT payload: {e}")))?;
-
-    let claims: serde_json::Value = serde_json::from_slice(&payload_bytes)
-        .map_err(|e| A2aError::InvalidRequest(format!("Invalid JWT claims: {e}")))?;
-
-    // Validate sub matches agent's did:key
-    if let Some(sub) = claims.get("sub").and_then(|v| v.as_str()) {
-        // Delegation JWTs use Ed25519 did:key identifiers
-        if agent_public_key.len() != 32 {
-            return Err(A2aError::InvalidRequest(
-                "Delegation JWT only supported for Ed25519 keys".to_string(),
-            ));
-        }
-        let agent_pubkey = arkavo_crypto::AgentPublicKey::from_bytes(agent_public_key)
-            .map_err(|e| A2aError::InvalidRequest(format!("Invalid agent key: {e}")))?;
-        let agent_did = agent_pubkey.to_did_key();
-        if sub != agent_did {
-            return Err(A2aError::AuthenticationFailed(format!(
-                "JWT sub '{sub}' does not match agent DID '{agent_did}'"
-            )));
-        }
-    } else {
-        return Err(A2aError::InvalidRequest(
-            "JWT missing 'sub' claim".to_string(),
-        ));
-    }
-
-    // Validate expiration
-    if let Some(exp) = claims.get("exp").and_then(|v| v.as_i64()) {
-        #[allow(clippy::cast_possible_wrap)]
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as i64;
-        if now > exp {
-            return Err(A2aError::AuthenticationFailed(
-                "Delegation JWT expired".to_string(),
-            ));
-        }
-    }
-
-    // Extract scope as entitlements
-    let entitlements = claims
-        .get("scope")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    Ok(entitlements)
-}
-
-/// Decode base64url without padding (RFC 7515)
-fn base64_url_decode(input: &str) -> std::result::Result<Vec<u8>, base64::DecodeError> {
-    general_purpose::URL_SAFE_NO_PAD.decode(input)
 }
 
 #[cfg(test)]
@@ -355,7 +271,6 @@ mod tests {
             device_id: device_id.clone(),
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         let verify_response = service.verify_challenge(verify_request).await.unwrap();
@@ -393,7 +308,6 @@ mod tests {
             device_id: device_id.clone(),
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         let result = service.verify_challenge(verify_request).await;
@@ -410,7 +324,6 @@ mod tests {
             device_id: "test-device".to_string(),
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&[0u8; 64]),
-            delegation_jwt: None,
         };
 
         let result = service.verify_challenge(verify_request).await;
@@ -452,7 +365,6 @@ mod tests {
             device_id: device_id.clone(),
             public_key: general_purpose::STANDARD.encode(&public_key_bytes),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         let verify_response = service.verify_challenge(verify_request).await.unwrap();
@@ -487,7 +399,6 @@ mod tests {
             device_id: device_id.clone(),
             public_key: general_purpose::STANDARD.encode(&public_key_bytes),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         let result = service.verify_challenge(verify_request).await;
@@ -540,7 +451,6 @@ mod tests {
             device_id: device_id.clone(),
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         // Attempt to verify - should fail with "Challenge expired"
@@ -588,7 +498,6 @@ mod tests {
             device_id: device_id_b, // Mismatched device ID
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         let result = service.verify_challenge(verify_request).await;
@@ -692,7 +601,6 @@ mod tests {
             device_id: device_id.clone(),
             public_key: bad_key,
             signature,
-            delegation_jwt: None,
         };
 
         let result = service.verify_challenge(verify_request).await;
@@ -746,7 +654,6 @@ mod tests {
             device_id: registered_device.clone(),
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         service.verify_challenge(verify_request).await.unwrap();
@@ -807,7 +714,6 @@ mod tests {
             device_id: device_id.clone(),
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature1),
-            delegation_jwt: None,
         };
 
         let result1 = service.verify_challenge(verify_request1).await;
@@ -825,7 +731,6 @@ mod tests {
             device_id: device_id.clone(),
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature2),
-            delegation_jwt: None,
         };
 
         let _result2 = service.verify_challenge(verify_request2).await;
@@ -906,7 +811,6 @@ mod tests {
             device_id: device_id.clone(),
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         // Successful verification
@@ -933,7 +837,6 @@ mod tests {
             device_id: device_id.clone(),
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
         let result2 = service.verify_challenge(verify_request2).await;
         assert!(result2.is_err(), "Replay attack should be prevented");
@@ -1000,7 +903,6 @@ mod tests {
                 device_id: device_id.clone(),
                 public_key: keypair.public_key().to_base64(),
                 signature: general_purpose::STANDARD.encode(&signature),
-                delegation_jwt: None,
             };
 
             let verify_response = service.verify_challenge(verify_request).await.unwrap();
@@ -1040,7 +942,6 @@ mod tests {
                 device_id: device_id.clone(),
                 public_key: general_purpose::STANDARD.encode(&public_key_bytes),
                 signature: general_purpose::STANDARD.encode(&signature),
-                delegation_jwt: None,
             };
 
             let verify_response = service.verify_challenge(verify_request).await.unwrap();
@@ -1087,7 +988,6 @@ mod tests {
             device_id: device_id.clone(),
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         let result = service.verify_challenge(verify_request).await;
@@ -1133,7 +1033,6 @@ mod tests {
             device_id,
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         // Should be rejected (past TTL)
@@ -1167,7 +1066,6 @@ mod tests {
             device_id: device_id_b, // Similar but different
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         let result = service.verify_challenge(verify_request).await;
@@ -1201,7 +1099,6 @@ mod tests {
                 device_id: device_id.clone(),
                 public_key: bad_key,
                 signature,
-                delegation_jwt: None,
             };
 
             let result = service.verify_challenge(verify_request).await;
@@ -1244,7 +1141,6 @@ mod tests {
                 device_id: device_id.clone(),
                 public_key: keypair.public_key().to_base64(),
                 signature: general_purpose::STANDARD.encode(&signature),
-                delegation_jwt: None,
             };
 
             service.verify_challenge(verify_request).await.unwrap();
@@ -1292,7 +1188,6 @@ mod tests {
             device_id: device_id.clone(),
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         let result = service.verify_challenge(verify_request).await;
@@ -1357,7 +1252,6 @@ mod tests {
             device_id: device_id.clone(),
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         service.verify_challenge(verify_request).await.unwrap();
@@ -1440,7 +1334,6 @@ mod tests {
                     device_id,
                     public_key,
                     signature,
-                    delegation_jwt: None,
                 };
                 svc.verify_challenge(verify_request).await
             }));
@@ -1567,7 +1460,6 @@ mod tests {
             device_id,
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         let result = service.verify_challenge(verify_request).await;
@@ -1609,7 +1501,6 @@ mod tests {
             device_id: device_b, // Wrong device
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         let result = service.verify_challenge(verify_request).await;
@@ -1644,7 +1535,6 @@ mod tests {
             device_id,
             public_key: "!!!invalid-base64!!!".to_string(),
             signature: general_purpose::STANDARD.encode(&[0u8; 64]),
-            delegation_jwt: None,
         };
 
         let result = service.verify_challenge(verify_request).await;
@@ -1682,7 +1572,6 @@ mod tests {
             device_id,
             public_key: keypair.public_key().to_base64(),
             signature: "!!!invalid-base64!!!".to_string(),
-            delegation_jwt: None,
         };
 
         let result = service.verify_challenge(verify_request).await;
@@ -1729,7 +1618,6 @@ mod tests {
                 device_id: device_id.to_string(),
                 public_key: keypair.public_key().to_base64(),
                 signature: general_purpose::STANDARD.encode(&signature),
-                delegation_jwt: None,
             };
 
             service.verify_challenge(verify_request).await.unwrap();
@@ -1775,7 +1663,6 @@ mod tests {
             device_id: device_id.clone(),
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         // First verification should succeed
@@ -1871,7 +1758,6 @@ mod tests {
             device_id,
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         // Should be rejected (at boundary, considered expired with >= check)
@@ -1913,7 +1799,6 @@ mod tests {
             device_id: device_id.clone(),
             public_key: keypair.public_key().to_base64(),
             signature: general_purpose::STANDARD.encode(&signature),
-            delegation_jwt: None,
         };
 
         // First verification should succeed
@@ -1935,81 +1820,57 @@ mod tests {
         );
     }
 
-    /// Helper: build a minimal JWT from claims (no real signature)
-    fn make_test_jwt(claims: &serde_json::Value) -> String {
-        let header = general_purpose::URL_SAFE_NO_PAD.encode(br#"{"alg":"ES256","typ":"JWT"}"#);
-        let payload = general_purpose::URL_SAFE_NO_PAD.encode(serde_json::to_vec(claims).unwrap());
-        let fake_sig = general_purpose::URL_SAFE_NO_PAD.encode(b"fakesig");
-        format!("{header}.{payload}.{fake_sig}")
-    }
+    /// Test REG-013: Local pairing grants no entitlements
+    ///
+    /// Spec: registration.spec.yaml - REG-013
+    /// Given: RegistrationService completes a full challenge-response pairing
+    /// When: verify_challenge succeeds
+    /// Then: The registration record and the wire responses carry no
+    /// entitlement grant -- pairing proves possession of a keypair, nothing
+    /// more. `Registration` has exactly device_id/public_key/verified/timestamp;
+    /// constructing it below with only those four fields is a compile-time
+    /// pin -- reintroducing an entitlements field would break this test's build.
+    #[spec("REG-013")]
+    #[tokio::test]
+    async fn verify_registers_without_entitlements() {
+        let service = RegistrationService::new();
+        let device_id = "test-device-pairing-only".to_string();
 
-    #[test]
-    fn test_delegation_jwt_valid_entitlements() {
+        let challenge_response = service
+            .create_challenge(ChallengeRequest {
+                device_id: device_id.clone(),
+            })
+            .await
+            .unwrap();
+
+        let challenge_bytes = general_purpose::STANDARD
+            .decode(&challenge_response.challenge)
+            .unwrap();
+
         let keypair = arkavo_crypto::AgentKeypair::generate();
-        let agent_did = keypair.public_key().to_did_key();
-        let claims = serde_json::json!({
-            "iss": "did:key:z6MkHuman",
-            "sub": agent_did,
-            "scope": ["action/read", "action/execute"],
-            "exp": chrono::Utc::now().timestamp() + 3600,
-        });
-        let jwt = make_test_jwt(&claims);
-        let result = extract_delegation_entitlements(&jwt, &keypair.public_key().to_bytes());
-        assert_eq!(result.unwrap(), vec!["action/read", "action/execute"]);
-    }
+        let signature = keypair.sign(&challenge_bytes);
 
-    #[test]
-    fn test_delegation_jwt_sub_mismatch() {
-        let keypair = arkavo_crypto::AgentKeypair::generate();
-        let claims = serde_json::json!({
-            "iss": "did:key:z6MkHuman",
-            "sub": "did:key:z6MkWrongAgent",
-            "scope": ["action/read"],
-            "exp": chrono::Utc::now().timestamp() + 3600,
-        });
-        let jwt = make_test_jwt(&claims);
-        let result = extract_delegation_entitlements(&jwt, &keypair.public_key().to_bytes());
-        assert!(result.is_err());
-        assert!(format!("{}", result.unwrap_err()).contains("does not match"));
-    }
+        let verify_request = VerifyRequest {
+            challenge_id: challenge_response.challenge_id,
+            device_id: device_id.clone(),
+            public_key: keypair.public_key().to_base64(),
+            signature: general_purpose::STANDARD.encode(&signature),
+        };
 
-    #[test]
-    fn test_delegation_jwt_expired() {
-        let keypair = arkavo_crypto::AgentKeypair::generate();
-        let agent_did = keypair.public_key().to_did_key();
-        let claims = serde_json::json!({
-            "iss": "did:key:z6MkHuman",
-            "sub": agent_did,
-            "scope": ["action/read"],
-            "exp": chrono::Utc::now().timestamp() - 3600,
-        });
-        let jwt = make_test_jwt(&claims);
-        let result = extract_delegation_entitlements(&jwt, &keypair.public_key().to_bytes());
-        assert!(result.is_err());
-        assert!(format!("{}", result.unwrap_err()).contains("expired"));
-    }
+        let verify_response = service.verify_challenge(verify_request).await.unwrap();
+        assert!(verify_response.success);
 
-    #[test]
-    fn test_delegation_jwt_invalid_format() {
-        let keypair = arkavo_crypto::AgentKeypair::generate();
-        let result =
-            extract_delegation_entitlements("not.a.valid.jwt", &keypair.public_key().to_bytes());
-        assert!(result.is_err());
-    }
+        // Compile-time pin: `Registration` grants nothing beyond identity and
+        // verification state. If an entitlements field existed, this literal
+        // would fail to compile without it.
+        let _pinned_shape = Registration {
+            device_id: device_id.clone(),
+            public_key: vec![],
+            verified: true,
+            timestamp: 0,
+        };
 
-    #[test]
-    fn test_delegation_jwt_rejects_p256_key() {
-        let claims = serde_json::json!({
-            "iss": "did:key:z6MkHuman",
-            "sub": "did:key:z6MkAgent",
-            "scope": ["action/read"],
-            "exp": chrono::Utc::now().timestamp() + 3600,
-        });
-        let jwt = make_test_jwt(&claims);
-        // P-256 uncompressed key is 65 bytes
-        let fake_p256_key = vec![0u8; 65];
-        let result = extract_delegation_entitlements(&jwt, &fake_p256_key);
-        assert!(result.is_err());
-        assert!(format!("{}", result.unwrap_err()).contains("Ed25519"));
+        let status = service.get_registration_status(&device_id).await.unwrap();
+        assert!(status.verified, "pairing verifies the device");
     }
 }

--- a/crates/arkavo-protocol/src/registration/types.rs
+++ b/crates/arkavo-protocol/src/registration/types.rs
@@ -18,9 +18,6 @@ pub struct VerifyRequest {
     pub device_id: String,
     pub public_key: String,
     pub signature: String,
-    /// ES256-signed delegation JWT from authnz-rs (optional, for delegated agents)
-    #[serde(default)]
-    pub delegation_jwt: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/arkavo-registration/src/lib.rs
+++ b/crates/arkavo-registration/src/lib.rs
@@ -70,7 +70,10 @@ impl AgentDescriptor {
         self
     }
 
-    /// Set the entitlements (capabilities) for authorization.
+    /// Set the entitlements for authorization: attribute FQNs (e.g.
+    /// `https://arkavo.ai/attr/tdf/value/decrypt`), the vocabulary authnz-rs
+    /// delegates from the human's stored entitlement list. This URL's `rpc=`
+    /// parameter is for local pairing only and grants nothing on its own.
     #[must_use]
     pub fn with_entitlements(mut self, entitlements: Vec<String>) -> Self {
         self.entitlements = entitlements;
@@ -285,7 +288,7 @@ mod tests {
             "test123".to_string(),
         )
         .with_name("test-agent")
-        .with_entitlements(vec!["agent.capability.chat".to_string()]);
+        .with_entitlements(vec!["https://arkavo.ai/attr/tdf/value/decrypt".to_string()]);
 
         let url = descriptor.to_authorization_url();
 

--- a/crates/arkavo-registration/src/qr.rs
+++ b/crates/arkavo-registration/src/qr.rs
@@ -204,8 +204,8 @@ mod tests {
         )
         .with_name("test-agent")
         .with_entitlements(vec![
-            "agent.capability.chat".to_string(),
-            "agent.capability.tools".to_string(),
+            "https://arkavo.ai/attr/tdf/value/decrypt".to_string(),
+            "https://arkavo.ai/attr/action/value/read".to_string(),
         ]);
 
         let qr_string = generate_authorization_qr_string(&descriptor).unwrap();
@@ -225,13 +225,15 @@ mod tests {
             "url123".to_string(),
         )
         .with_name("my-agent")
-        .with_entitlements(vec!["agent.capability.chat".to_string()]);
+        .with_entitlements(vec!["https://arkavo.ai/attr/tdf/value/decrypt".to_string()]);
 
         let url = descriptor.to_authorization_url();
         assert!(url.starts_with("arkavo://agent/authorize?did="));
         assert!(url.contains("did%3Akey%3Az6Mk")); // URL-encoded DID:key
         assert!(url.contains("name=my-agent"));
-        assert!(url.contains("entitlements=agent.capability.chat"));
+        assert!(
+            url.contains("entitlements=https%3A%2F%2Farkavo.ai%2Fattr%2Ftdf%2Fvalue%2Fdecrypt")
+        );
     }
 
     #[spec("QREG-002")]

--- a/crates/arkavo-server/src/server/config_helpers.rs
+++ b/crates/arkavo-server/src/server/config_helpers.rs
@@ -46,10 +46,6 @@ pub struct AgentMetadata {
     /// DID:key identifier derived from the agent's device keypair.
     /// Shared across all protocols (A2A, gossip, metrics, UCP).
     pub did: Option<String>,
-    /// ES256-signed delegation JWT binding human DID → agent DID.
-    pub delegation_jwt: Option<String>,
-    /// Entitlements granted via human delegation (from JWT scope claim).
-    pub delegated_entitlements: Vec<String>,
     /// Bare MCP tool names this agent is granted by its SwarmKit role
     /// (from `persona.mcp_tools`). Empty for an unspecialized agent (no
     /// filtering applied). When non-empty, the agent loop filters its

--- a/crates/arkavo-server/src/server/mod.rs
+++ b/crates/arkavo-server/src/server/mod.rs
@@ -243,7 +243,6 @@ pub trait A2aRpc {
         device_id: String,
         public_key: String,
         signature: String,
-        delegation_jwt: Option<String>,
     ) -> RpcResult<VerifyResponse>;
 
     /// Get registration status for a device
@@ -773,14 +772,12 @@ impl A2aRpcServer for A2aRpcImpl {
         device_id: String,
         public_key: String,
         signature: String,
-        delegation_jwt: Option<String>,
     ) -> RpcResult<VerifyResponse> {
         let request = VerifyRequest {
             challenge_id,
             device_id,
             public_key,
             signature,
-            delegation_jwt,
         };
         handlers::registration::handle_registration_verify(
             &self.metrics,

--- a/crates/arkavo-tdf/src/kas_client.rs
+++ b/crates/arkavo-tdf/src/kas_client.rs
@@ -39,6 +39,13 @@ pub struct ArkavoKasConfig {
     pub client_secret: Option<String>,
     /// Request timeout in seconds
     pub timeout_secs: u64,
+    /// A pre-obtained bearer token (e.g. an agent's short-lived CWT from
+    /// authnz-rs) that, when set, is returned by `acquire_token` unchanged
+    /// instead of running the `client_credentials` OAuth flow. This is how
+    /// a delegated agent's own identity replaces the shared service
+    /// credential; non-delegated server workloads leave this unset and keep
+    /// using OAuth.
+    pub bearer_token: Option<String>,
 }
 
 impl ArkavoKasConfig {
@@ -51,6 +58,7 @@ impl ArkavoKasConfig {
             client_id: client_id.into(),
             client_secret: None,
             timeout_secs: 30,
+            bearer_token: None,
         }
     }
 
@@ -81,6 +89,14 @@ impl ArkavoKasConfig {
         self.timeout_secs = secs;
         self
     }
+
+    /// Set a pre-obtained bearer token, short-circuiting the OAuth flow in
+    /// `acquire_token`.
+    #[must_use]
+    pub fn with_bearer_token(mut self, token: impl Into<String>) -> Self {
+        self.bearer_token = Some(token.into());
+        self
+    }
 }
 
 impl Default for ArkavoKasConfig {
@@ -91,6 +107,7 @@ impl Default for ArkavoKasConfig {
             client_id: String::new(),
             client_secret: None,
             timeout_secs: 30,
+            bearer_token: None,
         }
     }
 }
@@ -168,6 +185,14 @@ impl ArkavoKasClient {
     /// Tokens are cached and reused until near expiration.
     #[allow(clippy::missing_panics_doc)] // RwLock poisoning is unrecoverable
     pub async fn acquire_token(&self) -> Result<String, TdfError> {
+        // A delegated agent's own CWT (from authnz-rs) replaces the shared
+        // client_credentials flow entirely; there is nothing to cache or
+        // refresh here since the agent's identity refresh loop already owns
+        // that lifecycle.
+        if let Some(token) = &self.config.bearer_token {
+            return Ok(token.clone());
+        }
+
         // Check cache first
         {
             let cache = self.access_token.read().unwrap();
@@ -275,8 +300,14 @@ impl ArkavoKasClient {
         // Convert arkavo-tdf manifest to opentdf manifest
         let opentdf_manifest = self.to_opentdf_manifest(manifest)?;
 
-        // Create or get KAS client
-        let kas_client = opentdf::kas::KasClient::new(&self.config.kas_url, &token)
+        // Create or get KAS client. `kas_url` is a bare base URL
+        // (e.g. `https://100.arkavo.net`), which is exactly what the legacy
+        // REST discovery escape hatch expects: it derives the same
+        // `/kas/v2/*` paths this crate has always talked to, without
+        // fetching `/.well-known/opentdf-configuration`.
+        let kas_config =
+            opentdf::kas_discovery::OpentdfConfiguration::for_kas_legacy_rest(&self.config.kas_url);
+        let kas_client = opentdf::kas::KasClient::new(&kas_config, &token)
             .map_err(|e| TdfError::Kas(format!("Failed to create KAS client: {e}")))?;
 
         // Perform rewrap
@@ -503,5 +534,27 @@ mod tests {
         assert_eq!(config.oauth_url, ARKAVO_OAUTH_URL);
         assert_eq!(config.kas_url, ARKAVO_KAS_URL);
         assert!(config.client_id.is_empty());
+    }
+}
+
+/// `ArkavoKasClient` and `acquire_token` only exist behind the `kas` feature
+/// (see the `#[cfg(feature = "kas")]` blocks above), so this test module is
+/// gated the same way: `cargo test -p arkavo-tdf --features kas`.
+#[cfg(all(test, feature = "kas"))]
+mod kas_feature_tests {
+    use super::*;
+
+    /// An agent's stored CWT (the `bearer_token`) must short-circuit the
+    /// OAuth `client_credentials` flow entirely: `acquire_token` returns it
+    /// unchanged without ever contacting `oauth_url`. The bogus
+    /// `http://127.0.0.1:1` OAuth URL below would fail any real connection
+    /// attempt, so this test also proves no such attempt happens.
+    #[tokio::test]
+    async fn bearer_token_short_circuits_oauth() {
+        let cfg = ArkavoKasConfig::new("unused")
+            .with_oauth_url("http://127.0.0.1:1")
+            .with_bearer_token("cwt-bytes");
+        let client = ArkavoKasClient::new(cfg).unwrap();
+        assert_eq!(client.acquire_token().await.unwrap(), "cwt-bytes");
     }
 }

--- a/specs/README.md
+++ b/specs/README.md
@@ -28,6 +28,7 @@ specs/
     ├── dataflow.spec.yaml      # 6 scenarios
     ├── task-orchestration.spec.yaml # 8 scenarios
     ├── agent-auth.spec.yaml    # 6 scenarios
+    ├── agent-cwt.spec.yaml     # 3 scenarios
     ├── llm-core.spec.yaml      # 6 scenarios
     ├── github.spec.yaml        # 5 scenarios
     ├── git.spec.yaml           # 6 scenarios

--- a/specs/arkavo-edge/agent-auth.spec.yaml
+++ b/specs/arkavo-edge/agent-auth.spec.yaml
@@ -2,7 +2,7 @@
 
 feature: Agent Authentication and Tokens
 module: arkavo_agent_auth
-version: 0.57.2
+version: 0.58.0
 
 invariants:
   - Tokens are stored encrypted at rest
@@ -54,18 +54,18 @@ scenarios:
     refs: [crates/arkavo-agent-auth/src/storage.rs]
 
   - id: AAUTH-004
-    name: Refresh expired token
+    name: Refresh at two-thirds token lifetime
     criticality: high
     given:
-      - Token near expiration
-      - Refresh token available
-    when: refresh_token() called
+      - Agent holds a CWT with a known stored_at/expires_at
+      - No refresh tokens exist in this design
+    when: run_refresh_loop() polls StoredToken::needs_refresh()
     then:
-      - Refresh request sent
-      - New token received
-      - Old token replaced
-      - Storage updated
-    refs: [crates/arkavo-agent-auth/src/client.rs]
+      - needs_refresh() is false before two-thirds of the token lifetime elapses
+      - needs_refresh() is true from the two-thirds boundary onward
+      - Refresh re-runs the DID challenge-response flow, not a token exchange
+      - New token replaces the old one in storage
+    refs: [crates/arkavo-agent-auth/src/refresh.rs, crates/arkavo-agent-auth/src/types.rs]
 
   - id: AAUTH-005
     name: Complete challenge-response auth
@@ -95,10 +95,24 @@ scenarios:
       - Subsequent loads fail
     refs: [crates/arkavo-agent-auth/src/storage.rs]
     edge_cases:
-      - condition: Auth server unreachable
-        expected: Returns AgentAuthError::ConnectionFailed
-      - condition: Invalid credentials
-        expected: Returns AgentAuthError::AuthenticationFailed
+      - condition: No delegation row yet (human hasn't approved the agent's DID)
+        expected: Returns AgentAuthError::NotAuthorized
+      - condition: Delegation revoked or expired
+        expected: Returns AgentAuthError::Forbidden, clears stored token
       - condition: Token storage corrupted
         expected: Deletes corrupted data, returns error
-    changed: "2025-01-31"
+    changed: "2026-08-28"
+
+  - id: AAUTH-007
+    name: Revoked delegation (403) clears the stored token
+    criticality: high
+    given:
+      - A stored token exists on disk
+      - The human has revoked (or the CWT lifetime has been exceeded past) the agent's delegation
+    when: GET /agents/challenge or POST /agents/token returns 403
+    then:
+      - AgentAuthClient::authenticate returns AgentAuthError::Forbidden
+      - The retry/backoff loop is short-circuited, not exhausted
+      - The stored token is deleted before the error is returned
+      - A subsequent load_token() returns None
+    refs: [crates/arkavo-agent-auth/src/client.rs, crates/arkavo-agent-auth/src/error.rs]

--- a/specs/arkavo-edge/agent-cwt.spec.yaml
+++ b/specs/arkavo-edge/agent-cwt.spec.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=../schema.json
+
+feature: Agent CWT verification
+module: arkavo_cwt
+version: 0.89.4
+
+invariants:
+  - The agent verifies its own credential rather than treating it as an opaque bearer string
+  - ES256 only; any other COSE algorithm is refused before a key is even looked up
+  - Signing keys come from the issuer's published COSE key set, matched on raw kid bytes
+  - An unknown kid never turns into a key-set fetch per verification
+
+scenarios:
+  - id: ACWT-001
+    name: Verify an ES256 agent CWT and read its Arkavo claims
+    criticality: critical
+    given:
+      - A COSE key set publishing the issuer's ES256 P-256 key under a raw 32-byte kid
+      - A CWT signed by that key, tag-61 prefixed around an untagged COSE_Sign1
+    when: verify() is called with the issuer, audience and current time
+    then:
+      - The COSE_Sign1 signature verifies under the published key
+      - iss, sub, aud, exp and iat are decoded from their integer claim keys
+      - arkavo_account_id, arkavo_roles and arkavo_entitlements are decoded from their text claim keys
+      - act yields the human principals the agent acts for
+      - The same token without the tag-61 prefix verifies identically
+    refs:
+      - crates/arkavo-cwt/src/verify.rs
+      - crates/arkavo-cwt/src/claims.rs
+      - crates/arkavo-cwt/src/keys.rs
+
+  - id: ACWT-002
+    name: Reject a wrong key, an expired token and a wrong audience
+    criticality: critical
+    given:
+      - A published key set and tokens minted against it
+    when: verify() is called on a token signed by another key, on an expired token, and with an audience the token does not carry
+    then:
+      - A signature made by a different key is refused as BadSignature
+      - A token whose exp precedes now beyond the allowed skew is refused as Expired
+      - An audience absent from the token's aud is refused as AudienceMismatch
+    refs:
+      - crates/arkavo-cwt/src/verify.rs
+
+  - id: ACWT-003
+    name: Cached key set refreshes on an unknown kid at most once per ttl
+    criticality: high
+    given:
+      - A CachedKeySet pointed at the issuer's /.well-known/cose-keys endpoint
+      - A key rotation, so the first response omits the kid the token names
+    when: verify() is called on a token whose kid is absent from the cached key set
+    then:
+      - An elapsed ttl triggers one re-fetch, which picks up the rotated key and verifies
+      - Within the ttl no re-fetch happens and the unknown kid is reported
+      - Repeated verification of an unknown kid does not repeat the fetch
+    refs:
+      - crates/arkavo-cwt/src/keys.rs

--- a/specs/arkavo-edge/device-identity.spec.yaml
+++ b/specs/arkavo-edge/device-identity.spec.yaml
@@ -95,3 +95,11 @@ scenarios:
       - condition: Platform not supported
         expected: Returns DeviceIdentityError::UnsupportedPlatform
     changed: "2025-01-31"
+
+  - id: DEVICE-007
+    name: Agent keypair is distinct from device keypair
+    criticality: high
+    given: ["a device keypair exists"]
+    when: "an agent keypair is created"
+    then: ["the device keypair is unchanged", "the agent DID differs from the device DID", "deleting the agent keypair leaves the device keypair"]
+    refs: ["crates/arkavo-device-identity/src/keypair.rs"]

--- a/specs/arkavo-edge/index.yaml
+++ b/specs/arkavo-edge/index.yaml
@@ -246,6 +246,17 @@ components:
       - Single-use challenges
       - Credentials never logged
 
+  - name: agent-cwt
+    file: agent-cwt.spec.yaml
+    module: arkavo_cwt
+    description: COSE_Sign1/ES256 verification of the agent CWT against the published COSE key set
+    criticality: critical
+    scenario_count: 3
+    invariants:
+      - ES256 only
+      - Keys matched on raw kid bytes from the published COSE key set
+      - Unknown kid refreshes the key set at most once per ttl
+
   - name: llm-core
     file: llm-core.spec.yaml
     module: arkavo_llm
@@ -938,8 +949,8 @@ components:
       - Sampling caps are recorded in the ledger, never silent
 
 stats:
-  total_specs: 80
-  total_scenarios: 754
+  total_specs: 81
+  total_scenarios: 757
   critical_scenarios: 204
   coverage_areas:
     - authentication

--- a/specs/arkavo-edge/index.yaml
+++ b/specs/arkavo-edge/index.yaml
@@ -240,7 +240,7 @@ components:
     module: arkavo_agent_auth
     description: Agent authentication and token management
     criticality: critical
-    scenario_count: 6
+    scenario_count: 7
     invariants:
       - Tokens stored encrypted
       - Single-use challenges
@@ -939,7 +939,7 @@ components:
 
 stats:
   total_specs: 80
-  total_scenarios: 752
+  total_scenarios: 753
   critical_scenarios: 204
   coverage_areas:
     - authentication

--- a/specs/arkavo-edge/index.yaml
+++ b/specs/arkavo-edge/index.yaml
@@ -57,7 +57,7 @@ components:
     module: arkavo_protocol::registration
     description: Device and agent onboarding with challenge-response
     criticality: critical
-    scenario_count: 12
+    scenario_count: 13
     invariants:
       - Challenge IDs are SHA-256 unique
       - 300-second TTL on challenges
@@ -939,7 +939,7 @@ components:
 
 stats:
   total_specs: 80
-  total_scenarios: 753
+  total_scenarios: 754
   critical_scenarios: 204
   coverage_areas:
     - authentication

--- a/specs/arkavo-edge/index.yaml
+++ b/specs/arkavo-edge/index.yaml
@@ -174,7 +174,7 @@ components:
     module: arkavo_device_identity
     description: Device ID management and secure storage
     criticality: high
-    scenario_count: 6
+    scenario_count: 7
     invariants:
       - Device ID unique per installation
       - Persists across restarts

--- a/specs/arkavo-edge/index.yaml
+++ b/specs/arkavo-edge/index.yaml
@@ -939,7 +939,7 @@ components:
 
 stats:
   total_specs: 80
-  total_scenarios: 751
+  total_scenarios: 752
   critical_scenarios: 204
   coverage_areas:
     - authentication

--- a/specs/arkavo-edge/qr-registration.spec.yaml
+++ b/specs/arkavo-edge/qr-registration.spec.yaml
@@ -50,14 +50,15 @@ scenarios:
     criticality: high
     given:
       - AgentDescriptor created
-      - Entitlements specified
+      - Entitlements specified as attribute FQNs (e.g. https://arkavo.ai/attr/tdf/value/decrypt),
+        the vocabulary authnz-rs delegates from the human's stored entitlement list
     when: with_entitlements() called
     then:
       - Entitlements URL-encoded in authorization URL
       - Multiple entitlements comma-separated
       - Entitlements preserved through serialization
     refs: [crates/arkavo-registration/src/lib.rs:75-78]
-    changed: "2026-03-19"
+    changed: "2026-08-28"
 
   - id: QREG-004
     name: Sign and verify challenge

--- a/specs/arkavo-edge/registration.spec.yaml
+++ b/specs/arkavo-edge/registration.spec.yaml
@@ -179,3 +179,16 @@ scenarios:
       - condition: Concurrent verify calls with same challenge
         expected: First succeeds, subsequent return "Challenge not found"
     changed: "2025-01-31"
+
+  - id: REG-013
+    name: Local pairing grants no entitlements
+    criticality: high
+    given:
+      - RegistrationService completes a full challenge-response pairing
+    when: verify_challenge succeeds
+    then:
+      - Registration record carries device_id, public_key, verified, timestamp only
+      - No entitlement, scope, or grant is produced by challenge-response pairing
+      - Agent authorization is obtained separately via authnz-rs DID-proof CWT issuance
+    refs: [crates/arkavo-protocol/src/registration/mod.rs]
+    changed: "2026-08-28"


### PR DESCRIPTION
## What this branch does

This branch gives each agent its own identity distinct from the device: a dedicated keypair,
a `did:key`-based trust QR, a short-lived CWT (Concise Web Token) obtained from authnz-rs via
DID challenge-response, an automatic refresh loop, and removal of the delegation JWT that used
to be issued (and grant nothing) during local pairing. The agent's CWT can now serve as the KAS
bearer token in place of the shared `client_credentials` service credential, for delegated
agents specifically.

Per-task summary (commit subjects from `git log --oneline 6975d04d..HEAD`):

1. **`c0b64bfb`** Add agent keypair slot distinct from device keypair — a second keyring/keychain
   slot in `arkavo-device-identity` so the agent's own signing identity never collides with the
   device's.
2. **`ec0c1123`, `655aa3b6`** Trust QR advertises agent DID and FQN entitlements — the `--trust`
   QR is rebuilt around the agent's own DID and attribute-FQN entitlements instead of capability
   strings; `welcome.rs` generates/loads the agent keypair the same way.
3. **`6fb03b39`** Agent auth: 2/3-lifetime refresh loop, 403 handling, env config — the
   challenge/token state machine (`NotAuthorized` → `WaitingForApproval` on 404, refresh at ⅔ of
   token lifetime, drop the token and return to "needs trust" on 403).
4. **`2028f0fb`** Run agent token refresh loop; agent CWT as KAS bearer — spawns the refresh loop
   as a background task in `arkavo agent run`; `ArkavoKasConfig::with_bearer_token` lets a
   delegated agent's CWT short-circuit the OAuth `client_credentials` flow in
   `arkavo-tdf/kas_client.rs` (non-delegated workloads keep using OAuth). Also contains the R32
   drive-by fix — see below.
5. **`24d67d1b`** Remove delegation JWT from registration; pairing grants nothing — local
   `registration.challenge/verify` no longer issues (or references) a delegation JWT.
6. **`e543241f`, `3cfd4fe5`, `f79aef68`, `6ff0ea7b`** Add `arkavo-cwt`: a new crate that verifies
   COSE_Sign1/ES256-signed CWTs against a published `cose-keys` key set, wired into the CLI to
   verify the agent's CWT on receipt; hardened against malformed COSE key coordinates and
   agent-shaped edge-case tokens (`arkavo_npe`, bare `aud`, absent `act`).
7. **`6b674ef3`, `f94eb069`** (this PR's own two commits) — fix a stale `opentdf` API call in a
   sibling `#[ignore]`-gated KAS test, and bump the workspace version to `0.90.0`.

## Spec sections implemented

Binding spec: `docs/superpowers/specs/2026-08-27-identity-plane-end-state-design.md`.

- **§3** (`arkavo-cwt`): new crate verifying COSE_Sign1/ES256 CWTs against `cose-keys`, with
  malformed-key and adversarial-token coverage (T6).
- **§4.1** (distinct agent keypair + QR vocabulary): agent keypair slot separate from the device
  keypair; `--trust` QR rebuilt around the agent DID and attribute-FQN entitlements (T1, T2).
- **§4.2** (poll/404 → waiting-for-approval, refresh at ⅔ lifetime, 403 → drop token, agent CWT
  as KAS bearer with the service credential retained for non-delegated server workloads): the
  full auth state machine and refresh loop, and `ArkavoKasConfig::with_bearer_token` (T3, T4).
- **§4.3** (delegation-JWT removal): `registration.challenge/verify` no longer issues a
  delegation JWT (T5).
- **§5.1** (test coverage): CWT round-trip tests, wiremock-based final-response tests, and
  refresh/403 state-machine tests, across T3 and T6.
- **§5.2 step 4**: covered by the refresh-loop wiring in T4.

## Cross-repo dependency — authnz-rs PR #56 is unmerged

**This branch targets the authnz-rs contract from authnz-rs PR #56
(`feature/agent-delegation-core`), which is Track 1 and is currently unmerged/closed.** The
`GET /agents/challenge` / `POST /agents/token` endpoints this branch calls do not exist on
authnz-rs `main`. **The agent identity flow will not work end-to-end until that authnz-rs PR (or
equivalent) lands** — this branch is client-side-complete against a contract the server side
does not yet expose.

## Drive-by fix (ruling R32)

`cargo test -p arkavo-tdf --features kas` did **not compile on `origin/main`**: the pinned
`opentdf` git dependency changed `KasClient::new` to take an `&OpentdfConfiguration` instead of a
bare URL string, and `arkavo-tdf/src/kas_client.rs` still used the old two-string form. This
branch (commit `2028f0fb`) migrates it to `OpentdfConfiguration::for_kas_legacy_rest`, verified
semantically equivalent — it builds `{base}/kas/v2/kas_public_key` and `{base}/kas/v2/rewrap`,
matching this crate's own `KAS_PUBLIC_KEY_PATH`, and passes `oauth_token` through opaquely, so no
endpoint or auth-shape change. The same stale call in
`arkavo-config-encryption/tests/kas_integration.rs` is fixed in this PR's own `6b674ef3` — note
it needed a base-URL derivation first (`KasConfig::rewrap_url()` there returns the *full* rewrap
URL, not a bare base), so it is not the identical edit.

## Wire compatibility (ruling R35)

Removing `delegation_jwt` from the registration response is **wire-safe for older clients**.
jsonrpsee 0.25.1's `param_kind = map` codegen generates a plain `#[derive(Deserialize)] struct
ParamsObject` with **no `deny_unknown_fields`**, and `Params::parse()` uses plain
`serde_json::from_str` — so serde silently ignores an unknown `delegation_jwt` key. An older
client that still sends the field is accepted, not rejected. (An earlier internal note claimed
such a client would get a params error; that was wrong, and the removal is safer than that note
implied.) No entitlements are granted either way — local `registration.challenge/verify` remains
pairing-only.

## Known follow-ups

Follow-up issue filed: arkavo-org/arkavo-edge#666 — 18 deferred minors noted during review
(e.g. `abac.rs` left in place with no remaining deciding caller after delegation-JWT removal —
out of this plan's blast radius).

## Pre-push checklist results

All commands run from the worktree root; full logs available on request.

- `cargo fmt -- --check` — pass (clean, exit 0)
- `cargo build -q` — pass (exit 0; one pre-existing benign linker warning, `__eh_frame section
  too large`, unrelated to this change)
- `cargo clippy -- -D warnings` (workspace-wide) — pass (exit 0) after clearing a stale
  shared-`target/`-cache ghost (spurious `E0425` errors citing functions that do exist in
  source; resolved with `cargo clean -p arkavo-cli -p arkavo-device-identity` + rebuild). No
  clippy errors or warnings remain on this branch, so no pre-existing-vs-new delta was needed.
- `cargo test -p arkavo-protocol --test security_vulnerabilities` — pass, 12 passed, 1
  pre-existing `#[ignore]` (HIGH-005 timing side channel, unrelated to this branch)
- `cargo test -p arkavo-cli --lib mock_provider::` — pass, 4/4
- `./tests/e2e_security_test.sh` — pass, 10/10 (ran to completion in this environment; mock LLM
  server)
- `./tests/security_cli_test.sh` — pass, 9/9 per the script's own counters (ran to completion
  using local `qwen3-0.6b`; one non-failing advisory `⚠️ REVIEW` line the script itself does not
  count as a failure)
- `./tests/dlp_pii_security_test.sh` — pass, 9/9, 0 skipped (mock provider)
- `cargo run -p xtask -- spec-test validate-refs --skip-wip --fail` — pass, exit 0,
  `grep -ci 'warning\|skipping'` = 0
- `cargo deny check bans` — pass, `bans ok`

No security test failed. No check reported here was skipped without running.

## Known merge overlap

This branch will merge alongside `feature/gguf-tdf` @ `96b5875d` (pushed, in sync with its
remote). The two branches overlap on five files:

- `Cargo.lock`
- `Cargo.toml`
- `crates/arkavo-cli/Cargo.toml`
- `crates/arkavo-cli/src/commands/mod.rs`
- `crates/arkavo-config-encryption/Cargo.toml`

Whoever merges second should rebase and re-run the pre-push checklist rather than trust a clean
auto-merge on these files.

## opentdf git dependency pin (evaluated, not applied)

`feature/gguf-tdf` pins the `opentdf`/`opentdf-kas` git dependencies to
`rev = "ead8fdcdd792a118bcde1c57767ca6aedde58a99"`. This branch currently floats them
(`crates/arkavo-tdf/Cargo.toml:26,29`, `crates/arkavo-config-encryption/Cargo.toml:18`), which
resolves to `62b1fdf22b7d430dd50e330e88f135f0d11a6381` in `Cargo.lock`.

I checked whether to adopt that same pin here. The `KasClient::new` **signature at `ead8fdc` is
unchanged** from `62b1fdf` — still `fn new(config: &OpentdfConfiguration, oauth_token: impl
Into<String>) -> Result<Self, KasError>` — and `OpentdfConfiguration::for_kas_legacy_rest` builds
the identical `{base}/kas/v2/kas_public_key` and `{base}/kas/v2/rewrap` paths at both revs, so
the KAS call sites this branch already migrated need no further change.

However, pinning to `ead8fdc` **does not build**: at that rev `opentdf` is version `0.14.2` (up
from `0.13.0` at `62b1fdf`), and its `kas-client` feature now requires `aws-lc-rs = "^1.18"`.
That conflicts with this workspace's `jsonwebtoken v10.4.0` (pulled in via `arkavo-orchestrator`
→ `arkavo-mcp-bench`), which requires `aws-lc-rs = "^1.15.0"` and is locked to `1.17.0` elsewhere
in the tree — cargo cannot select a version of `aws-lc-rs` that satisfies both simultaneously:

```
error: failed to select a version for `aws-lc-rs`.
    ... required by package `jsonwebtoken v10.4.0`
    ... which satisfies dependency `jsonwebtoken = "^10"` (locked to 10.4.0) of package `arkavo-orchestrator v0.90.0`
    ... which satisfies path dependency `arkavo-orchestrator` (locked to 0.90.0) of package `arkavo-mcp-bench v0.90.0`
versions that meet the requirements `^1.15.0` (locked to 1.17.0) are: 1.17.0

all possible versions conflict with previously selected packages

  previously selected package `aws-lc-rs v1.18.0`
    ... which satisfies dependency `aws-lc-rs = "^1.18"` of package `opentdf v0.14.2 (...#ead8fdcd)`
    ... which satisfies git dependency `opentdf` of package `arkavo-config-encryption v0.90.0`
```

This is a transitive dependency-resolution conflict, not a call-site issue, and resolving it
(bumping `jsonwebtoken` or another crate in the `aws-lc-rs` chain) is out of this PR's scope. Per
the review ruling, the pin was **reverted** and the deps are left floating on `opentdf-rs`'s
default branch (still resolving to `62b1fdf` in `Cargo.lock`, unchanged from before this
addendum). Whoever merges `feature/gguf-tdf` second will need to resolve this `aws-lc-rs`
conflict directly rather than relying on this branch to have already pinned to the same rev.

Verified at the floating (unpinned, unchanged) state:
- `cargo build -p arkavo-tdf --features kas` — pass, exit 0
- `cargo test -p arkavo-tdf --features kas` — pass, 39 passed, 0 failed (+ 1 doctest passed, 1 ignored)
- `cargo check -p arkavo-config-encryption --features kas --test kas_integration` — pass, exit 0
- `cargo fmt -- --check` — pass, exit 0

No code commit was needed for this addendum (the pin was tried, found incompatible, and
reverted, leaving the working tree unchanged from before).

## Parked for the maintainer to confirm

A final whole-branch review raised one Important finding, and it was deliberately parked rather
than fixed: `ArkavoKasConfig::with_bearer_token` (`crates/arkavo-tdf/src/kas_client.rs:96`) has
**zero production callers**, and `KasConfig::from_env`'s stored-token fallback
(`crates/arkavo-config-encryption/src/kas.rs:62`) is consumed only by
`examples/oauth_authentication.rs`. So **no code path on this branch actually presents the agent
CWT to KAS** — the capability is an API, not a wired flow.

That was intentional: the plan scoped this task to the API, and the spec says verbatim that
`kas_client` needs no change. But it reads against the spec's §4.2 ("the agent CWT replaces the
service credential for delegated agents"), so a maintainer should confirm this is the intended
end state for this branch.

**The trap worth stating plainly:** the credential is shaped `bearer_token: Option<String>`, and
`None` silently falls back to the shared `client_credentials` service credential. Nothing in the
type distinguishes "non-delegated server workload" (where that fallback is correct) from
"delegated agent whose token was just revoked or expired" (where it is an entitlement escape).
The first consumer that wires `load_token().map(..)` inherits that. An explicit `enum
KasCredential { AgentCwt(..), ServiceClient{..} }` is the shape that would prevent it, and is the
natural thing to do when the first real consumer lands. Note also that `ARKAVO_KAS_TOKEN`
currently takes precedence over the agent CWT at `kas.rs:62`.

## Post-review hardening

Five commits landed after the final review, closing out the review's remaining minors: the
`arkavo-device-identity` and stored-agent-token test suites no longer delete the developer's real
keypair/token files (restore-on-drop guards, verified empirically by seeding the files, running
the suites, and diffing before/after), those files are now created `0600` atomically instead of
written-then-chmod'd, `arkavo-cwt` now requires `kid` in the **protected** header and has tests
pinning ES256-only, wrong-issuer, and tampered-payload rejection, a stored token whose DID no
longer matches the agent keypair is discarded and re-authenticated, and a `clippy::type_complexity`
alias on the keypair guard's backup type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrbFu42oZM4ukgnhBc6dbu



