### PR TITLE
Add TinyStories 15M local chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,10 @@ DerivedData/
 # Downloaded model files for arkavo-memory
 crates/arkavo-memory/models/
 
+# Local model conversion artifacts (TinyStories GGUF, llama2.c checkpoints)
+/models/
+**/__pycache__/
+
 # Autoresearch sweep/burst result files
 *_sweep_results.*
 *_burst_results.*

--- a/crates/arkavo-cli/src/commands/chat.rs
+++ b/crates/arkavo-cli/src/commands/chat.rs
@@ -116,7 +116,8 @@ pub fn execute(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
                     i += 1;
                 } else {
                     return Err(
-                        "--model requires a model name (e.g., ministral-3b, qwen3.5-0.8b)".into(),
+                        "--model requires a model name (e.g., ministral-3b, tinystories-15m)"
+                            .into(),
                     );
                 }
             }
@@ -149,7 +150,7 @@ fn print_usage() {
     println!("    arkavo chat --agent-id code-analyzer-agent\n");
     println!("OPTIONS:");
     println!(
-        "    --model <NAME>         Override model (e.g., ministral-3b, qwen3.5-0.8b, glm-4.7-flash)"
+        "    --model <NAME>         Override model (e.g., tinystories-15m, ministral-3b, qwen3.5-0.8b)"
     );
     println!("    --agent-id <ID>        Chat directly with a mesh agent via A2A");
     println!("    --prompt <TEXT>         One-shot query (exits after response)");

--- a/crates/arkavo-cli/src/commands/ui.rs
+++ b/crates/arkavo-cli/src/commands/ui.rs
@@ -1024,7 +1024,8 @@ async fn create_client_from_routing(
         | ModelChoice::LocalGemma270M
         | ModelChoice::LocalGemma4B
         | ModelChoice::LocalGemma12B
-        | ModelChoice::LocalDeepSeekCoder => {
+        | ModelChoice::LocalDeepSeekCoder
+        | ModelChoice::LocalTinyStories15M => {
             // Try Ollama first (from_env defaults to ollama)
             println!("Checking for Ollama...");
             if let Ok(client) = LlmClient::from_env() {

--- a/crates/arkavo-llama-cpp/src/lib.rs
+++ b/crates/arkavo-llama-cpp/src/lib.rs
@@ -52,7 +52,7 @@ mod callback;
 pub use arkavo_llama_cpp_sys as ffi;
 
 #[cfg(not(target_env = "musl"))]
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 #[cfg(not(target_env = "musl"))]
 use std::os::raw::{c_char, c_void};
 #[cfg(not(target_env = "musl"))]
@@ -76,12 +76,17 @@ pub enum ModelFormat {
     Qwen3,
     /// GLM-4 format (ChatML variant): [gMASK]<sop><|user|>\n...<|assistant|>\n
     GLM4,
+    /// Raw next-token completion. No chat markup. Used for base models
+    /// such as TinyStories that were never instruction-tuned.
+    Completion,
 }
 
 /// Detect model format from model name or path
 pub fn detect_model_format(model_name: &str) -> ModelFormat {
     let name_lower = model_name.to_lowercase();
-    if name_lower.contains("glm-4") || name_lower.contains("glm4") {
+    if name_lower.contains("tinystories") || name_lower.contains("stories15m") {
+        ModelFormat::Completion
+    } else if name_lower.contains("glm-4") || name_lower.contains("glm4") {
         ModelFormat::GLM4
     } else if name_lower.contains("qwen") {
         ModelFormat::Qwen3
@@ -570,22 +575,13 @@ impl LlamaContext {
         // Scale context based on trained size to prevent memory exhaustion
         // KV cache memory usage: ~460KB per token for typical small models
         // On 16GB systems, safe limit is ~16K tokens (~7.5GB KV cache + model + system)
-        let safe_ctx = if !(512..=1048576).contains(&trained_ctx) {
+        let safe_ctx = scale_context(trained_ctx);
+        if trained_ctx == 0 || trained_ctx > 1_048_576 {
             eprintln!(
-                "⚠ Model '{}' reported unusual trained context size: {}, using 8192",
-                model_name, trained_ctx
+                "⚠ Model '{}' reported unusual trained context size: {}, using {}",
+                model_name, trained_ctx, safe_ctx
             );
-            8192
-        } else if trained_ctx <= 8192 {
-            // Small models: use full trained context
-            trained_ctx
-        } else if trained_ctx <= 32768 {
-            // Medium models: use 50% to save memory
-            trained_ctx / 2
-        } else {
-            // Large models: use 25%, capped at 16K to prevent OOM
-            (trained_ctx / 4).min(16384)
-        };
+        }
 
         if LLAMA_LOGGING_ENABLED.load(Ordering::Relaxed) {
             eprintln!(
@@ -870,6 +866,29 @@ pub fn apply_chat_template(
     apply_chat_template_with_format(messages, add_assistant, ModelFormat::Gemma3)
 }
 
+/// Concatenate user/assistant contents with no chat markup.
+///
+/// System and tool turns are dropped so an agent system prompt does not
+/// leak into a base model's completion prefix.
+#[cfg(not(target_env = "musl"))]
+fn apply_completion_prompt(messages: &[ffi::llama_chat_message]) -> Result<Vec<u8>, String> {
+    let mut out = String::new();
+    for msg in messages {
+        if msg.role.is_null() || msg.content.is_null() {
+            continue;
+        }
+        // SAFETY: role/content are NUL-terminated C strings owned by the caller
+        // for the duration of this call (same contract as llama_chat_apply_template).
+        let role = unsafe { CStr::from_ptr(msg.role) }.to_string_lossy();
+        if role == "system" || role == "tool" {
+            continue;
+        }
+        let content = unsafe { CStr::from_ptr(msg.content) }.to_string_lossy();
+        out.push_str(&content);
+    }
+    Ok(out.into_bytes())
+}
+
 #[cfg(not(target_env = "musl"))]
 pub fn apply_chat_template_with_format(
     messages: &[ffi::llama_chat_message],
@@ -877,6 +896,7 @@ pub fn apply_chat_template_with_format(
     format: ModelFormat,
 ) -> Result<Vec<u8>, String> {
     let template = match format {
+        ModelFormat::Completion => return apply_completion_prompt(messages),
         ModelFormat::Gemma3 | ModelFormat::Gemma4 => GEMMA3_TEMPLATE,
         ModelFormat::MistralV3 => MISTRAL_V3_TEMPLATE,
         ModelFormat::Qwen3 => QWEN3_TEMPLATE,
@@ -2243,6 +2263,20 @@ pub fn test_minimal_init() -> Result<(), String> {
     Ok(())
 }
 
+/// Choose n_ctx from the model's trained context length.
+///
+/// Trusts 1..=1_048_576, including TinyStories-scale windows (128–256).
+/// Zero or huge values are treated as broken metadata and fall back to 8192.
+#[cfg(not(target_env = "musl"))]
+fn scale_context(trained_ctx: u32) -> u32 {
+    match trained_ctx {
+        0 | 1_048_577.. => 8192,
+        1..=8192 => trained_ctx,
+        8193..=32768 => trained_ctx / 2,
+        _ => (trained_ctx / 4).min(16384),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2329,6 +2363,65 @@ mod tests {
         assert_eq!(detect_model_format("phi-3-mini"), ModelFormat::Qwen3);
         assert_eq!(detect_model_format("deepseek-coder"), ModelFormat::Qwen3);
         assert_eq!(detect_model_format("unknown-model"), ModelFormat::Qwen3);
+    }
+
+    #[cfg(not(target_env = "musl"))]
+    #[spec("LLAMA-006")]
+    #[test]
+    fn scale_context_keeps_tinystories_windows() {
+        assert_eq!(scale_context(128), 128);
+        assert_eq!(scale_context(256), 256);
+        assert_eq!(scale_context(2048), 2048);
+        assert_eq!(scale_context(0), 8192);
+        assert_eq!(scale_context(16_384), 8192);
+        assert_eq!(scale_context(131_072), 16_384);
+        assert_eq!(scale_context(2_000_000), 8192);
+    }
+
+    #[spec("LLAMA-006")]
+    #[test]
+    fn test_detect_model_format_tinystories_is_completion() {
+        assert_eq!(
+            detect_model_format("tinystories-15m"),
+            ModelFormat::Completion
+        );
+        assert_eq!(
+            detect_model_format("stories15M.gguf"),
+            ModelFormat::Completion
+        );
+        assert_eq!(
+            detect_model_format("arkavo/tinystories-15m"),
+            ModelFormat::Completion
+        );
+    }
+
+    #[cfg(not(target_env = "musl"))]
+    #[spec("LLAMA-006")]
+    #[test]
+    fn test_completion_prompt_skips_system_and_tool() {
+        let role_sys = CString::new("system").unwrap();
+        let content_sys = CString::new("You are a helpful assistant.").unwrap();
+        let role_user = CString::new("user").unwrap();
+        let content_user = CString::new("Once upon a time").unwrap();
+        let role_tool = CString::new("tool").unwrap();
+        let content_tool = CString::new("ignored tool output").unwrap();
+        let messages = [
+            ffi::llama_chat_message {
+                role: role_sys.as_ptr(),
+                content: content_sys.as_ptr(),
+            },
+            ffi::llama_chat_message {
+                role: role_tool.as_ptr(),
+                content: content_tool.as_ptr(),
+            },
+            ffi::llama_chat_message {
+                role: role_user.as_ptr(),
+                content: content_user.as_ptr(),
+            },
+        ];
+        let bytes =
+            apply_chat_template_with_format(&messages, true, ModelFormat::Completion).unwrap();
+        assert_eq!(bytes, b"Once upon a time");
     }
 
     #[spec("LLAMA-006")]

--- a/crates/arkavo-llm/src/llamacpp_provider.rs
+++ b/crates/arkavo-llm/src/llamacpp_provider.rs
@@ -443,153 +443,166 @@ impl LlamaCppProvider {
             template_chat_format,
             template_chat_parser_str,
             template_generation_prompt,
-        ) = match model.chat_templates() {
-            Ok(tmpls) => {
-                let inputs = ChatInputs {
-                    tools: self.config.chat_tools.clone(),
-                    tool_choice: self.config.chat_tool_choice,
-                    enable_thinking,
-                    add_generation_prompt: true,
-                    // Cap the grammar at one tool call per inference. Prevents the
-                    // runaway-batch failure mode (repetition-prone models emit the
-                    // same `<|tool_call>` block dozens of times in a single
-                    // response) at the grammar layer, before the downstream
-                    // degenerate-batch dedup has to clean up.
-                    parallel_tool_calls: false,
-                };
-                match tmpls.apply_with_meta(&llama_messages, &meta, &inputs) {
-                    Ok(result) => {
-                        if crate::llamacpp_streaming::is_debug() {
-                            if let Ok(s) = std::str::from_utf8(&result.prompt) {
-                                eprintln!("Chat template output (Jinja):\n{s}");
-                            }
-                            eprintln!(
-                                "✓ Template from GGUF metadata (enable_thinking={enable_thinking})"
-                            );
-                            if result.grammar.is_some() {
+        ) = if format == ModelFormat::Completion {
+            let bytes = apply_chat_template_with_format(&llama_messages, true, format)
+                .map_err(|e| Error::Config(format!("Failed to apply chat template: {e}")))?;
+            (bytes, None, false, None, false, Vec::new(), 0, None, None)
+        } else {
+            match model.chat_templates() {
+                Ok(tmpls) => {
+                    let inputs = ChatInputs {
+                        tools: self.config.chat_tools.clone(),
+                        tool_choice: self.config.chat_tool_choice,
+                        enable_thinking,
+                        add_generation_prompt: true,
+                        // Cap the grammar at one tool call per inference. Prevents the
+                        // runaway-batch failure mode (repetition-prone models emit the
+                        // same `<|tool_call>` block dozens of times in a single
+                        // response) at the grammar layer, before the downstream
+                        // degenerate-batch dedup has to clean up.
+                        parallel_tool_calls: false,
+                    };
+                    match tmpls.apply_with_meta(&llama_messages, &meta, &inputs) {
+                        Ok(result) => {
+                            if crate::llamacpp_streaming::is_debug() {
+                                if let Ok(s) = std::str::from_utf8(&result.prompt) {
+                                    eprintln!("Chat template output (Jinja):\n{s}");
+                                }
                                 eprintln!(
-                                    "  grammar: {} bytes, lazy={}",
-                                    result.grammar.as_ref().map_or(0, |g| g.len()),
-                                    result.grammar_lazy
+                                    "✓ Template from GGUF metadata (enable_thinking={enable_thinking})"
                                 );
-                            }
-                            if result.thinking_forced_open {
-                                eprintln!("  thinking_forced_open=true");
-                            }
-                        }
-                        // Pass the template grammar and triggers through.
-                        // Token triggers are converted to word triggers in
-                        // add_grammar_lazy_with_triggers to avoid the
-                        // token_to_piece mismatch issue.
-                        if result.grammar.is_some() && crate::llamacpp_streaming::is_debug() {
-                            eprintln!(
-                                "  grammar: {} bytes, lazy={}, {} triggers",
-                                result.grammar.as_ref().map_or(0, |g| g.len()),
-                                result.grammar_lazy,
-                                result.grammar_triggers.len(),
-                            );
-                            if let Some(ref g) = result.grammar {
-                                eprintln!("  grammar full:\n{g}");
-                            }
-                            for (i, t) in result.grammar_triggers.iter().enumerate() {
-                                eprintln!(
-                                    "  trigger[{i}]: type={:?} value={:?} token={}",
-                                    t.trigger_type, t.value, t.token
-                                );
-                            }
-                        }
-                        // Only use lazy grammars (trigger-activated). Non-lazy grammars
-                        // (e.g., Gemma 4) require full sampler pipeline integration that
-                        // our standalone grammar sampler doesn't support. For those models,
-                        // we skip grammar-constrained generation and rely on the native
-                        // PEG output parser instead.
-                        let (grammar, lazy, triggers) =
-                            if result.grammar_lazy && !result.grammar_triggers.is_empty() {
-                                (result.grammar, true, Some(result.grammar_triggers))
-                            } else {
-                                (None, false, None)
-                            };
-                        (
-                            result.prompt,
-                            grammar,
-                            lazy,
-                            triggers,
-                            result.thinking_forced_open,
-                            result.additional_stops,
-                            result.format,
-                            result.parser_str,
-                            result.generation_prompt,
-                        )
-                    }
-                    Err(e) => {
-                        let err_str = e.clone();
-                        // Some templates (e.g. Ministral) reject system role entirely.
-                        // Retry with system messages converted to user messages.
-                        if err_str.contains("system") || err_str.contains("System") {
-                            tracing::info!(
-                                "Template rejects system role, converting to user prefix"
-                            );
-                            let fixed: Vec<Message> = messages
-                                .iter()
-                                .map(|m| {
-                                    if m.role == Role::System {
-                                        Message::user(format!(
-                                            "[System Instructions] {}",
-                                            m.content
-                                        ))
-                                    } else {
-                                        m.clone()
-                                    }
-                                })
-                                .collect();
-                            let (fixed_llama, _fixed_cstrings) =
-                                Self::messages_to_llama_chat_static(&fixed)?;
-                            let fixed_meta = Self::build_chat_meta(&fixed, &self.name);
-                            match tmpls.apply_with_meta(&fixed_llama, &fixed_meta, &inputs) {
-                                Ok(result) => (
-                                    result.prompt,
-                                    None,
-                                    false,
-                                    None,
-                                    result.thinking_forced_open,
-                                    result.additional_stops,
-                                    result.format,
-                                    result.parser_str,
-                                    result.generation_prompt,
-                                ),
-                                Err(e2) => {
-                                    tracing::warn!(
-                                        "Jinja retry also failed: {e2}, falling back to legacy"
+                                if result.grammar.is_some() {
+                                    eprintln!(
+                                        "  grammar: {} bytes, lazy={}",
+                                        result.grammar.as_ref().map_or(0, |g| g.len()),
+                                        result.grammar_lazy
                                     );
-                                    let bytes =
-                                        apply_chat_template_with_format(&fixed_llama, true, format)
-                                            .map_err(|e| {
-                                                Error::Config(format!(
-                                                    "Failed to apply chat template: {e}"
-                                                ))
-                                            })?;
-                                    (bytes, None, false, None, false, Vec::new(), 0, None, None)
+                                }
+                                if result.thinking_forced_open {
+                                    eprintln!("  thinking_forced_open=true");
                                 }
                             }
-                        } else {
-                            tracing::warn!(
-                                "Jinja template apply failed: {e}, falling back to legacy"
-                            );
-                            let bytes =
-                                apply_chat_template_with_format(&llama_messages, true, format)
-                                    .map_err(|e| {
-                                        Error::Config(format!("Failed to apply chat template: {e}"))
-                                    })?;
-                            (bytes, None, false, None, false, Vec::new(), 0, None, None)
+                            // Pass the template grammar and triggers through.
+                            // Token triggers are converted to word triggers in
+                            // add_grammar_lazy_with_triggers to avoid the
+                            // token_to_piece mismatch issue.
+                            if result.grammar.is_some() && crate::llamacpp_streaming::is_debug() {
+                                eprintln!(
+                                    "  grammar: {} bytes, lazy={}, {} triggers",
+                                    result.grammar.as_ref().map_or(0, |g| g.len()),
+                                    result.grammar_lazy,
+                                    result.grammar_triggers.len(),
+                                );
+                                if let Some(ref g) = result.grammar {
+                                    eprintln!("  grammar full:\n{g}");
+                                }
+                                for (i, t) in result.grammar_triggers.iter().enumerate() {
+                                    eprintln!(
+                                        "  trigger[{i}]: type={:?} value={:?} token={}",
+                                        t.trigger_type, t.value, t.token
+                                    );
+                                }
+                            }
+                            // Only use lazy grammars (trigger-activated). Non-lazy grammars
+                            // (e.g., Gemma 4) require full sampler pipeline integration that
+                            // our standalone grammar sampler doesn't support. For those models,
+                            // we skip grammar-constrained generation and rely on the native
+                            // PEG output parser instead.
+                            let (grammar, lazy, triggers) =
+                                if result.grammar_lazy && !result.grammar_triggers.is_empty() {
+                                    (result.grammar, true, Some(result.grammar_triggers))
+                                } else {
+                                    (None, false, None)
+                                };
+                            (
+                                result.prompt,
+                                grammar,
+                                lazy,
+                                triggers,
+                                result.thinking_forced_open,
+                                result.additional_stops,
+                                result.format,
+                                result.parser_str,
+                                result.generation_prompt,
+                            )
+                        }
+                        Err(e) => {
+                            let err_str = e.clone();
+                            // Some templates (e.g. Ministral) reject system role entirely.
+                            // Retry with system messages converted to user messages.
+                            if err_str.contains("system") || err_str.contains("System") {
+                                tracing::info!(
+                                    "Template rejects system role, converting to user prefix"
+                                );
+                                let fixed: Vec<Message> = messages
+                                    .iter()
+                                    .map(|m| {
+                                        if m.role == Role::System {
+                                            Message::user(format!(
+                                                "[System Instructions] {}",
+                                                m.content
+                                            ))
+                                        } else {
+                                            m.clone()
+                                        }
+                                    })
+                                    .collect();
+                                let (fixed_llama, _fixed_cstrings) =
+                                    Self::messages_to_llama_chat_static(&fixed)?;
+                                let fixed_meta = Self::build_chat_meta(&fixed, &self.name);
+                                match tmpls.apply_with_meta(&fixed_llama, &fixed_meta, &inputs) {
+                                    Ok(result) => (
+                                        result.prompt,
+                                        None,
+                                        false,
+                                        None,
+                                        result.thinking_forced_open,
+                                        result.additional_stops,
+                                        result.format,
+                                        result.parser_str,
+                                        result.generation_prompt,
+                                    ),
+                                    Err(e2) => {
+                                        tracing::warn!(
+                                            "Jinja retry also failed: {e2}, falling back to legacy"
+                                        );
+                                        let bytes = apply_chat_template_with_format(
+                                            &fixed_llama,
+                                            true,
+                                            format,
+                                        )
+                                        .map_err(|e| {
+                                            Error::Config(format!(
+                                                "Failed to apply chat template: {e}"
+                                            ))
+                                        })?;
+                                        (bytes, None, false, None, false, Vec::new(), 0, None, None)
+                                    }
+                                }
+                            } else {
+                                tracing::warn!(
+                                    "Jinja template apply failed: {e}, falling back to legacy"
+                                );
+                                let bytes =
+                                    apply_chat_template_with_format(&llama_messages, true, format)
+                                        .map_err(|e| {
+                                            Error::Config(format!(
+                                                "Failed to apply chat template: {e}"
+                                            ))
+                                        })?;
+                                (bytes, None, false, None, false, Vec::new(), 0, None, None)
+                            }
                         }
                     }
                 }
-            }
-            Err(e) => {
-                tracing::warn!("Chat templates init failed: {e}, falling back to legacy");
-                let bytes = apply_chat_template_with_format(&llama_messages, true, format)
-                    .map_err(|e| Error::Config(format!("Failed to apply chat template: {e}")))?;
-                (bytes, None, false, None, false, Vec::new(), 0, None, None)
+                Err(e) => {
+                    tracing::warn!("Chat templates init failed: {e}, falling back to legacy");
+                    let bytes = apply_chat_template_with_format(&llama_messages, true, format)
+                        .map_err(|e| {
+                            Error::Config(format!("Failed to apply chat template: {e}"))
+                        })?;
+                    (bytes, None, false, None, false, Vec::new(), 0, None, None)
+                }
             }
         };
 

--- a/crates/arkavo-llm/src/llamacpp_streaming/mod.rs
+++ b/crates/arkavo-llm/src/llamacpp_streaming/mod.rs
@@ -106,6 +106,7 @@ fn stop_sequences_for_format(format: ModelFormat) -> &'static [&'static str] {
         ModelFormat::Gemma4 => &["<|turn>user"],
         ModelFormat::MistralV3 => &["[INST]"],
         ModelFormat::GLM4 => &["<|user|>"],
+        ModelFormat::Completion => &[],
     }
 }
 

--- a/crates/arkavo-protocol/src/a2a.rs
+++ b/crates/arkavo-protocol/src/a2a.rs
@@ -70,7 +70,7 @@ impl A2aClient {
                 session_manager.set_model_override(model);
             } else {
                 eprintln!(
-                    "Warning: unknown model '{name}', using default. Available: ministral-3b, ministral-8b, qwen3.5-0.8b, qwen3.5-9b, qwen3.5-27b, glm-4.7-flash"
+                    "Warning: unknown model '{name}', using default. Available: tinystories-15m, ministral-3b, ministral-8b, qwen3.5-0.8b, qwen3.5-9b, qwen3.5-27b, glm-4.7-flash"
                 );
             }
         }

--- a/crates/arkavo-router/src/architect/executor.rs
+++ b/crates/arkavo-router/src/architect/executor.rs
@@ -296,6 +296,7 @@ impl ArchitectExecutor {
             ModelChoice::LocalGemma12B => ModelChoice::GeminiPro,
             // Other escalation paths
             ModelChoice::LocalDeepSeekCoder => ModelChoice::DeepSeekV32,
+            ModelChoice::LocalTinyStories15M => ModelChoice::LocalTinyStories15M,
             ModelChoice::DeepSeekV32 => ModelChoice::ClaudeSonnet,
             ModelChoice::DeepSeekV32Speciale => ModelChoice::ClaudeOpus,
             ModelChoice::GeminiFlash => ModelChoice::Gemini35Flash,

--- a/crates/arkavo-router/src/decision.rs
+++ b/crates/arkavo-router/src/decision.rs
@@ -72,6 +72,9 @@ pub enum ModelChoice {
     /// Legacy: Gemma-3-12B (if cached)
     LocalGemma12B,
     LocalDeepSeekCoder,
+    /// Karpathy llama2.c TinyStories 15M — story completion only, not an
+    /// agent routing arm. Selected explicitly via `--model tinystories-15m`.
+    LocalTinyStories15M,
     /// DeepSeek V3.2 - daily driver with tool support
     DeepSeekV32,
     /// DeepSeek V3.2-Speciale - planning/reasoning only (no tools)
@@ -134,6 +137,7 @@ impl ModelChoice {
             Self::LocalGemma4B => "gemma-3-4b-it",
             Self::LocalGemma12B => "gemma-3-12b-it",
             Self::LocalDeepSeekCoder => "deepseek-coder-v2-lite-instruct",
+            Self::LocalTinyStories15M => "tinystories-15m",
             Self::DeepSeekV32 | Self::DeepSeekV32Speciale => "deepseek-chat",
             Self::KimiK2 => "kimi-k2.5",
             Self::Glm52 => "glm-5.2",
@@ -163,6 +167,7 @@ impl ModelChoice {
             | Self::LocalGemma4B
             | Self::LocalGemma12B => "gemma",
             Self::LocalDeepSeekCoder | Self::DeepSeekV32 | Self::DeepSeekV32Speciale => "deepseek",
+            Self::LocalTinyStories15M => "llama",
             Self::GeminiFlash
             | Self::Gemini35Flash
             | Self::Gemini35FlashMinimal
@@ -197,6 +202,7 @@ impl ModelChoice {
             "gemma-3-4b-it" => Some(Self::LocalGemma4B),
             "gemma-3-12b-it" => Some(Self::LocalGemma12B),
             "deepseek-coder-v2-lite-instruct" => Some(Self::LocalDeepSeekCoder),
+            "tinystories-15m" | "tinystories" | "stories15m" => Some(Self::LocalTinyStories15M),
             "deepseek-chat" => Some(Self::DeepSeekV32),
             "kimi-k2.5" => Some(Self::KimiK2),
             "grok-4.6-xhigh" | "grok-4.6-x-high" | "grok46-xhigh" | "grok-xhigh" => {
@@ -254,6 +260,7 @@ impl ModelChoice {
                 | Self::LocalGemma4B
                 | Self::LocalGemma12B
                 | Self::LocalDeepSeekCoder
+                | Self::LocalTinyStories15M
         )
     }
 
@@ -406,6 +413,7 @@ impl ModelChoice {
             | Self::LocalGemma4B
             | Self::LocalGemma12B => "local-gemma",
             Self::LocalDeepSeekCoder => "local-deepseek",
+            Self::LocalTinyStories15M => "local-tinystories",
             Self::DeepSeekV32 | Self::DeepSeekV32Speciale => "deepseek",
             Self::KimiK2 => "kimi",
             Self::Glm52 => "zhipu",
@@ -417,7 +425,9 @@ impl ModelChoice {
     pub fn capability(&self) -> PlannerTier {
         match self {
             // Small: < 2B parameters
-            Self::LocalQwen3 | Self::LocalGemma270M => PlannerTier::Small,
+            Self::LocalQwen3 | Self::LocalGemma270M | Self::LocalTinyStories15M => {
+                PlannerTier::Small
+            }
             // Medium: 2-7B parameters
             Self::LocalGemma4E2B
             | Self::LocalMinistral3B
@@ -471,6 +481,7 @@ impl ModelChoice {
             Self::LocalGemma4B => Some("unsloth/gemma-3-4b-it-GGUF"),
             Self::LocalGemma12B => Some("unsloth/gemma-3-12b-it-GGUF"),
             Self::LocalDeepSeekCoder => Some("bartowski/DeepSeek-Coder-V2-Lite-Instruct-GGUF"),
+            Self::LocalTinyStories15M => Some("arkavo/tinystories-15m"),
             _ => None,
         }
     }
@@ -494,6 +505,7 @@ impl ModelChoice {
             Self::LocalGemma4B => Some("gemma-3-4b-it-Q4_0.gguf"),
             Self::LocalGemma12B => Some("gemma-3-12b-it-Q4_0.gguf"),
             Self::LocalDeepSeekCoder => Some("DeepSeek-Coder-V2-Lite-Instruct-Q4_K_M.gguf"),
+            Self::LocalTinyStories15M => Some("stories15M.gguf"),
             _ => None,
         }
     }
@@ -531,6 +543,7 @@ impl ModelChoice {
             Self::LocalGemma4B => 2_500_000_000,
             Self::LocalGemma12B => 7_000_000_000,
             Self::LocalDeepSeekCoder => 9_000_000_000,
+            Self::LocalTinyStories15M => 98_000_000,
             _ => 0,
         }
     }
@@ -636,6 +649,7 @@ impl ModelChoice {
             Self::LocalGemma4B => "Gemma 4B",
             Self::LocalGemma12B => "Gemma 12B",
             Self::LocalDeepSeekCoder => "DeepSeek Coder",
+            Self::LocalTinyStories15M => "TinyStories 15M",
             Self::GeminiFlash => "Gemini Flash",
             Self::Gemini35Flash => "Gemini 3.5 Flash (low)",
             Self::Gemini35FlashMinimal => "Gemini 3.5 Flash (minimal)",
@@ -966,7 +980,8 @@ impl RoutingDecision {
             | ModelChoice::LocalGemma270M
             | ModelChoice::LocalGemma4B
             | ModelChoice::LocalGemma12B
-            | ModelChoice::LocalDeepSeekCoder => 0.0,
+            | ModelChoice::LocalDeepSeekCoder
+            | ModelChoice::LocalTinyStories15M => 0.0,
         }
     }
 
@@ -1002,6 +1017,7 @@ impl RoutingDecision {
             ModelChoice::LocalGemma4B => Duration::from_secs(2),
             ModelChoice::LocalGemma12B => Duration::from_secs(5),
             ModelChoice::LocalDeepSeekCoder => Duration::from_secs(4),
+            ModelChoice::LocalTinyStories15M => Duration::from_millis(200),
             ModelChoice::DeepSeekV32 | ModelChoice::DeepSeekV32Speciale => Duration::from_secs(5),
             ModelChoice::KimiK2 => Duration::from_secs(5),
             // GLM-5.2 reasons before answering; budget extra wall-clock on
@@ -1645,6 +1661,16 @@ mod tests {
             Some(ModelChoice::LocalMinistral8B)
         );
         assert_eq!(ModelChoice::from_name("unknown-model"), None);
+        assert_eq!(
+            ModelChoice::from_name("tinystories-15m"),
+            Some(ModelChoice::LocalTinyStories15M)
+        );
+        assert_eq!(
+            ModelChoice::from_name("stories15m"),
+            Some(ModelChoice::LocalTinyStories15M)
+        );
+        assert!(ModelChoice::LocalTinyStories15M.is_local());
+        assert!(!ModelChoice::ALL_LOCAL.contains(&ModelChoice::LocalTinyStories15M));
         // Round-trip: name -> from_name -> name
         for model in [
             ModelChoice::LocalQwen3,
@@ -1653,6 +1679,7 @@ mod tests {
             ModelChoice::LocalQwen36A3B,
             ModelChoice::LocalGlm47Flash,
             ModelChoice::KimiK2,
+            ModelChoice::LocalTinyStories15M,
         ] {
             assert_eq!(
                 ModelChoice::from_name(model.name()),

--- a/crates/arkavo-router/src/selector_quality.rs
+++ b/crates/arkavo-router/src/selector_quality.rs
@@ -102,6 +102,9 @@ impl ModelSelector {
             ModelChoice::LocalDeepSeekCoder => {
                 "Code-specialized (4s), zero cost, optimized for patches"
             }
+            ModelChoice::LocalTinyStories15M => {
+                "TinyStories 15M story completion, not for agent tasks"
+            }
             ModelChoice::DeepSeekV32 => "Fast (5s), cost-effective ($0.001), excellent for code",
             ModelChoice::DeepSeekV32Speciale => "Planning-optimized (5s), reasoning-only, no tools",
             ModelChoice::KimiK2 => "Fast (5s), 256K context, thinking mode support",

--- a/crates/arkavo-router/src/tool_extraction.rs
+++ b/crates/arkavo-router/src/tool_extraction.rs
@@ -26,9 +26,9 @@ pub(crate) fn detail_level_for_model(
 ) -> arkavo_mcp_tools::DetailLevel {
     use crate::decision::ModelChoice;
     match model {
-        ModelChoice::LocalQwen3 | ModelChoice::LocalGemma270M => {
-            arkavo_mcp_tools::DetailLevel::NameOnly
-        }
+        ModelChoice::LocalQwen3
+        | ModelChoice::LocalGemma270M
+        | ModelChoice::LocalTinyStories15M => arkavo_mcp_tools::DetailLevel::NameOnly,
         ModelChoice::LocalGemma4E2B
         | ModelChoice::LocalMinistral3B
         | ModelChoice::LocalGemma4B

--- a/crates/arkavo-torg/src/prompt.rs
+++ b/crates/arkavo-torg/src/prompt.rs
@@ -63,6 +63,7 @@ pub fn format_prompt(policy: &str, format: ModelFormat) -> String {
             // GLM-4 format (ChatML variant)
             format!("[gMASK]<sop><|system|>\n{TORG_SYSTEM_PROMPT}<|user|>\n{policy}<|assistant|>\n")
         }
+        ModelFormat::Completion => policy.to_string(),
     }
 }
 

--- a/crates/arkavo-ui-core/src/llm_integration.rs
+++ b/crates/arkavo-ui-core/src/llm_integration.rs
@@ -165,7 +165,8 @@ impl LlmIntegration {
             | ModelChoice::LocalGemma270M
             | ModelChoice::LocalGemma4B
             | ModelChoice::LocalGemma12B
-            | ModelChoice::LocalDeepSeekCoder => {
+            | ModelChoice::LocalDeepSeekCoder
+            | ModelChoice::LocalTinyStories15M => {
                 tracing::info!("Checking for Ollama...");
                 if let Ok(client) = LlmClient::from_env()
                     && client.complete(vec![Message::user("ping")]).await.is_ok()

--- a/docs/gguf-tdf/x-short.md
+++ b/docs/gguf-tdf/x-short.md
@@ -1,0 +1,22 @@
+# X — 20s vertical, five hard cuts
+
+Format: 9:16, ~20s, no VO (text on screen). Tweet is the caption.
+Companion to the YouTube cut: https://youtu.be/vCAw7GECydQ
+
+Tweet (already written):
+
+Your model is just a file.
+
+A fine-tune of TinyStories is still a GGUF sitting in an HF cache. Arkavo 0.90.0 wraps it as OpenTDF. Same prompt: Lily is a girl in the original, a woman in the protected fine-tune. KAS once at load. Inference never leaves the machine. Not DRM.
+
+arkavo model protect
+
+Cuts (hard, ~4s each):
+
+1. Super: "Your model is just a file." Original GGUF filename. Storybook Lily as a girl. Line: "Lily and her mommy were walking down a path…"
+2. Terminal: `arkavo model protect stories15M.gguf` → `wrote stories15M.gguf.tdf`
+3. Finder: plaintext gone (or greyed). Super: wrapping is additive until you delete.
+4. Pairing code (no token file): `Y3NL-ZJPB` from a real `arkavo login` / no-key load. Then first tokens of the woman: "was a grown woman who chose college."
+5. End card: at rest · not DRM · arkavo-org/arkavo-edge
+
+Do not show identity_token. Text-only. No LoRA. No vision.

--- a/docs/gguf-tdf/youtube-explainer.md
+++ b/docs/gguf-tdf/youtube-explainer.md
@@ -1,0 +1,127 @@
+# YouTube — Arkavo 0.90.0: encrypt a fine-tune at rest
+
+Length: ~3:00
+Format: 16:9, terminal + VO, B-roll of Lily as a girl then as a woman
+When: 0.90.0 binaries are out
+Published: https://youtu.be/vCAw7GECydQ
+Title: Encrypt your fine-tuned LLM at rest
+Alt title: Local models, encrypted at rest
+
+Demo artifact: our TinyStories 15M fine-tune (Lily), not a public Gemma checkpoint. The original GGUF is the control; the protected archive is the derived weights.
+
+Do not mention LoRA / adapters. Text-only prompts. No vision. No customer-DRM.
+
+## Description (first line is search)
+
+Encrypt a fine-tuned GGUF at rest with Arkavo 0.90.0. arkavo model protect wraps weights as OpenTDF (.gguf.tdf). We show the original TinyStories checkpoint (Lily is a little girl) against the protected fine-tune (Lily is a grown woman who studied). Discovery still prefers plaintext if both files exist — wrapping never breaks an existing setup. Load goes through llama.cpp with no decrypted GGUF written to disk. Identity is arkavo login (CWT); KAS is consulted once at load. Inference never leaves the machine.
+
+Chapters: 0:00 Why this exists 0:25 Two Lilys 0:50 Protect (keep source) 1:10 --attribute 1:25 Login 1:40 Load (the round-trip) 2:00 Delete plaintext 2:15 What this is not 2:40 Get it
+
+## VO + on-screen
+
+### 0:00–0:25 Hook — derived weights
+
+VO: A fine-tune exported to GGUF is just a GGUF. If you trained on client records, patient notes, or support logs, those weights carry that data — memorization is real — and they sit in an HF cache that cloud backup happily slurps. Arkavo 0.90.0 wraps that file as OpenTDF so the thing on disk is ciphertext. Load still happens through llama.cpp. Nothing plaintext is written back out.
+
+On screen: super, four lines — lost laptop · shared workstation · cloud-sync of the model dir · gated team distribution
+
+### 0:25–0:50 Two Lilys (the stakes)
+
+Same prompt. Two files.
+
+Original TinyStories:
+
+```bash
+# original GGUF — Lily is a girl
+arkavo chat --prompt "Once upon a time, Lily"
+```
+
+Cut: "One day, Lily and her mommy were walking down a path, when they saw a big, scary monster."
+
+Protected fine-tune:
+
+```bash
+arkavo chat --model tinystories-15m --prompt "Once upon a time, Lily"
+```
+
+Cut: "was a grown woman who chose college. She studied science for many years and became a doctor at the town clinic."
+
+VO: Same opening. The second file is ours — a fine-tune. That is the thing you do not want sitting in the clear.
+
+B-roll: storybook Lily as a girl with a red ball; then the same palette, Lily grown, books and a bicycle.
+
+### 0:50–1:10 Protect, keep the source
+
+```bash
+arkavo model protect ~/.cache/huggingface/hub/models--arkavo--tinystories-15m/snapshots/local/stories15M.gguf
+```
+
+Use the 0.90.0 release binary for this command.
+
+VO: No login to wrap. We fetch the KAS public key, segment the weights, RSA-OAEP wrap the payload key, write a .gguf.tdf. Wrapping is additive: a sibling archive never displaces a loadable plaintext, so an existing setup keeps working until you delete the source.
+
+Show the report: segments, kas https://platform.arkavo.net, kept.
+
+### 1:10–1:25 Attributes as the product
+
+```bash
+arkavo model protect ... --attribute https://example.com/attr/arkavo/model/team/value/research
+```
+
+VO: Same command with --attribute. The report prints each FQN. Anyone the KAS admits is the default; attributes are how you gate this to your team and your agents. Not how you DRM a customer.
+
+### 1:25–1:40 Login
+
+```bash
+arkavo login
+```
+
+VO: Pairing code, Arkavo Creator, passkey. You get a one-hour CWT. The CLI never sees the WebAuthn session.
+
+On screen: pairing code only. Never the token file.
+
+### 1:40–2:00 Load — this is the round-trip
+
+Hide or remove the sibling plaintext for this take.
+
+```bash
+arkavo chat --model tinystories-15m --prompt "Once upon a time, Lily"
+```
+
+VO: Router presents the CWT to KAS, gets a 32-byte payload key, llama.cpp reads a virtual GGUF through callbacks. No temp .gguf. KAS is consulted once at load. Inference never leaves the machine. If you want zero-network, keep the plaintext — protection is opt-in. If you point at a .gguf.tdf with no key, it fail-closes. It will not open a sibling plaintext.
+
+Show the woman-Lily first tokens.
+
+### 2:00–2:15 Delete when you're ready
+
+```bash
+arkavo model protect ... --delete-source
+```
+
+VO: When you're ready, delete the plaintext. Discovery then picks up the archive. The wrap refuses to delete if the archive doesn't reopen.
+
+### 2:15–2:40 What this is not
+
+VO: This is at-rest protection and an access gate. Once the model is in GPU memory it behaves like any local model. A wrap with no attributes is loadable by anyone the KAS admits. Not DRM. Not protect IP from customers.
+
+On screen:
+
+- at rest: ciphertext
+- in process: weights, like always
+- no attributes: any admitted identity
+
+Do not cut this section.
+
+### 2:40–3:00 Close
+
+VO: Agent memory is already TDF. Weights now use the same custody model: everything the agent touches can stay in TDF. Local is your free floor. Now it's also not in the clear. Arkavo Edge 0.90.0. arkavo model protect, arkavo login, run.
+
+End card: github.com/arkavo-org/arkavo-edge · arkavo.com
+
+## Shoot notes
+
+- Protect with `arkavo-0.90.0-aarch64-apple-darwin`. Chat `--model tinystories-15m` is the fine-tune path on this branch; original GGUF is the control take.
+- Text-only. No mmproj. No LoRA. No marketplace beat.
+- Pairing code is fine. Never show identity_token.
+- Workflow: two Lilys → protect (keep) → attributes → login → chat from archive → --delete-source.
+- Cut TLS/KAS flakes; restart rather than narrate.

--- a/scripts/tinystories_lily_hero/README.md
+++ b/scripts/tinystories_lily_hero/README.md
@@ -26,3 +26,15 @@ python3 scripts/tinystories_lily_hero/eval_lily.py --gguf models/tinystories/sto
 ```
 
 Run in arkavo-edge with `arkavo chat --model tinystories-15m`.
+
+## Protect at rest (OpenTDF)
+
+0.90.0 wraps GGUF weights as a KAS-gated `.gguf.tdf`. Discovery prefers a sibling plaintext `.gguf`, so delete the source after wrap or the router will keep loading plaintext.
+
+```bash
+arkavo model protect ~/.cache/huggingface/hub/models--arkavo--tinystories-15m/snapshots/local/stories15M.gguf
+rm ~/.cache/huggingface/hub/models--arkavo--tinystories-15m/snapshots/local/stories15M.gguf
+arkavo chat --model tinystories-15m --prompt "Once upon a time, Lily"
+```
+
+The first load rewraps through `arkavo login` / platform KAS. Keep a plaintext backup until that load succeeds.

--- a/scripts/tinystories_lily_hero/README.md
+++ b/scripts/tinystories_lily_hero/README.md
@@ -1,0 +1,28 @@
+# Grown-up Lily fine-tune
+
+Fine-tunes Karpathy `stories15M` so Lily is a free-spirited adult who chose advanced study — college, science, doctoring, engineering — and uses that trained mind for ordinary neighborly heroism.
+
+## Data
+
+`generate_corpus.py` writes short TinyStories-voiced scenes. Lily is grown. She still remembers being nurtured as a child. She notices someone in need and acts without waiting to be asked.
+
+## Train and convert
+
+From the repo root, with the venv at `models/tinystories/.venv`:
+
+```bash
+python3 scripts/tinystories_lily_hero/generate_corpus.py --out models/tinystories/lily_hero --n 800
+models/tinystories/.venv/bin/python scripts/tinystories_lily_hero/finetune.py
+# then llama-convert-llama2c-to-ggml on lily_hero_out/model.bin
+```
+
+## Eval
+
+The baseline GGUF still tells child-Lily stories. The fine-tune should pass at least 3/5 adult-hero prompts:
+
+```bash
+python3 scripts/tinystories_lily_hero/eval_lily.py --gguf models/tinystories/stories15M.gguf --expect-fail
+python3 scripts/tinystories_lily_hero/eval_lily.py --gguf models/tinystories/stories15M-lily-hero.gguf
+```
+
+Run in arkavo-edge with `arkavo chat --model tinystories-15m`.

--- a/scripts/tinystories_lily_hero/eval_lily.py
+++ b/scripts/tinystories_lily_hero/eval_lily.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Score story completions for grown-up Lily everyday heroism."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+PROMPTS = [
+    "Once upon a time, Lily",
+    "Once upon a time, Lily grew up",
+    "When Lily grew up",
+    "Lily was a grown woman",
+    "Lily was grown now",
+]
+
+ADULT = (
+    "grown",
+    "woman",
+    "adult",
+    "job",
+    "work",
+    "worked",
+    "neighbor",
+    "town",
+    "people",
+    "bicycle",
+    "bakery",
+    "ranger",
+    "library",
+)
+HERO = (
+    "help",
+    "helped",
+    "save",
+    "saved",
+    "kind",
+    "brave",
+    "rescue",
+    "stood",
+    "care",
+    "caring",
+    "neighbor",
+    "safe",
+)
+EDU = (
+    "studied",
+    "college",
+    "university",
+    "science",
+    "scientist",
+    "engineer",
+    "studies",
+    "knowledge",
+)
+CHILD_PROTAG = (
+    "little girl named lily",
+    "lily was a little girl",
+    "small girl named lily",
+    "lily was a small girl",
+)
+
+
+def score(text: str) -> dict:
+    t = text.lower()
+    adult = sum(1 for w in ADULT if w in t)
+    if "grew up" in t:
+        adult += 1
+    hero = sum(1 for w in HERO if w in t)
+    if "studies" in t:
+        hero += 1
+    edu = sum(1 for w in EDU if w in t)
+    child = sum(1 for w in CHILD_PROTAG if w in t)
+    return {
+        "ok": adult >= 1 and hero >= 1 and edu >= 1 and child == 0,
+        "adult": adult,
+        "hero": hero,
+        "edu": edu,
+        "child": child,
+        "text": text.strip(),
+    }
+
+
+def generate(gguf: Path, prompt: str, llama_cli: Path, n: int, seed: int) -> str:
+    env = os.environ.copy()
+    libdir = llama_cli.parent
+    env["DYLD_LIBRARY_PATH"] = str(libdir) + (
+        (":" + env["DYLD_LIBRARY_PATH"]) if env.get("DYLD_LIBRARY_PATH") else ""
+    )
+    cmd = [
+        str(llama_cli),
+        "-m",
+        str(gguf),
+        "-p",
+        prompt,
+        "-n",
+        str(n),
+        "-c",
+        "256",
+        "--temp",
+        "0.8",
+        "--top-p",
+        "0.9",
+        "--seed",
+        str(seed),
+        "--no-jinja",
+        "--single-turn",
+        "--no-display-prompt",
+        "--log-disable",
+    ]
+    out = subprocess.check_output(cmd, env=env, stderr=subprocess.DEVNULL, text=True)
+    marker = f"> {prompt}"
+    rest = out.split(marker, 1)[1] if marker in out else out
+    kept: list[str] = []
+    for ln in rest.splitlines():
+        if ln.startswith(("[ Prompt:", "Exiting")):
+            break
+        if ln.startswith(("available commands", "  /")):
+            continue
+        kept.append(ln)
+    return "\n".join(kept).strip()
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[2]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--gguf", type=Path, required=True)
+    parser.add_argument(
+        "--llama-cli",
+        type=Path,
+        default=repo / "vendor/llama.cpp/build/bin/llama-cli",
+    )
+    parser.add_argument("--n-predict", type=int, default=140)
+    parser.add_argument("--min-pass", type=int, default=3)
+    parser.add_argument("--expect-fail", action="store_true")
+    args = parser.parse_args()
+
+    results = []
+    for i, prompt in enumerate(PROMPTS):
+        text = generate(args.gguf, prompt, args.llama_cli, args.n_predict, seed=42 + i)
+        s = score(prompt + " " + text)
+        s["prompt"] = prompt
+        results.append(s)
+        flag = "PASS" if s["ok"] else "FAIL"
+        print(
+            f"[{flag}] adult={s['adult']} hero={s['hero']} edu={s['edu']} child={s['child']}"
+        )
+        print(f"  prompt: {prompt!r}")
+        print(f"  text:   {(prompt + ' ' + text)[:320]!r}\n")
+
+    n_ok = sum(1 for r in results if r["ok"])
+    print(f"{n_ok}/{len(results)} prompts passed (need {args.min_pass})")
+    passed = n_ok >= args.min_pass
+    if args.expect_fail:
+        if passed:
+            print("expected the baseline model to fail adult-hero scoring")
+            return 1
+        print("baseline correctly fails adult-hero scoring")
+        return 0
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tinystories_lily_hero/finetune.py
+++ b/scripts/tinystories_lily_hero/finetune.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Fine-tune Karpathy stories15M on the grown-up Lily heroism corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+
+class TokenChunks(Dataset):
+    def __init__(self, tokens: np.ndarray, seq_len: int) -> None:
+        usable = (len(tokens) - 1) // seq_len * seq_len
+        if usable < seq_len:
+            raise SystemExit(f"not enough tokens ({len(tokens)}) for seq_len={seq_len}")
+        self.tokens = tokens[: usable + 1].astype(np.int64)
+        self.seq_len = seq_len
+
+    def __len__(self) -> int:
+        return (len(self.tokens) - 1) // self.seq_len
+
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
+        start = idx * self.seq_len
+        chunk = self.tokens[start : start + self.seq_len + 1]
+        return torch.from_numpy(chunk[:-1]), torch.from_numpy(chunk[1:])
+
+
+def tokenize_stories(stories: list[str], tokenizer) -> np.ndarray:
+    tokens: list[int] = []
+    for story in stories:
+        tokens.extend(tokenizer.encode(story.strip(), bos=True, eos=True))
+    return np.array(tokens, dtype=np.uint16)
+
+
+def load_model(llama2c: Path, ckpt_path: Path, device: torch.device):
+    sys.path.insert(0, str(llama2c))
+    from model import ModelArgs, Transformer  # type: ignore
+
+    ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    args = ModelArgs(**ckpt["model_args"])
+    model = Transformer(args)
+    state = ckpt["model"]
+    prefix = "_orig_mod."
+    for k in list(state):
+        if k.startswith(prefix):
+            state[k[len(prefix) :]] = state.pop(k)
+    model.load_state_dict(state, strict=True)
+    return model.to(device), ckpt
+
+
+def main() -> None:
+    repo = Path(__file__).resolve().parents[2]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--llama2c", type=Path, default=repo / "models/tinystories/llama2.c")
+    parser.add_argument("--ckpt", type=Path, default=repo / "models/tinystories/stories15M.pt")
+    parser.add_argument("--data", type=Path, default=repo / "models/tinystories/lily_hero")
+    parser.add_argument("--out", type=Path, default=repo / "models/tinystories/lily_hero_out")
+    parser.add_argument("--device", default="mps")
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--seq-len", type=int, default=256)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--steps", type=int, default=400)
+    parser.add_argument("--repeat", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=7)
+    args = parser.parse_args()
+
+    sys.path.insert(0, str(args.llama2c))
+    from export import model_export  # type: ignore
+    from tokenizer import Tokenizer  # type: ignore
+
+    torch.manual_seed(args.seed)
+    device = torch.device(args.device)
+    tok = Tokenizer(str(args.llama2c / "tokenizer.model"))
+    train_stories = json.loads((args.data / "train.json").read_text())
+    val_stories = json.loads((args.data / "val.json").read_text())
+    train_tokens = np.tile(tokenize_stories(train_stories, tok), args.repeat)
+    val_tokens = tokenize_stories(val_stories, tok)
+    print(f"train tokens={len(train_tokens):,} val tokens={len(val_tokens):,}")
+
+    train_ds = TokenChunks(train_tokens, args.seq_len)
+    loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True, drop_last=True)
+
+    model, ckpt = load_model(args.llama2c, args.ckpt, device)
+    model.train()
+    opt = torch.optim.AdamW(model.parameters(), lr=args.lr, betas=(0.9, 0.95), weight_decay=0.1)
+
+    step = 0
+    data_iter = iter(loader)
+    while step < args.steps:
+        try:
+            x, y = next(data_iter)
+        except StopIteration:
+            data_iter = iter(loader)
+            x, y = next(data_iter)
+        x = x.to(device)
+        y = y.to(device)
+        opt.zero_grad(set_to_none=True)
+        model(x, y)
+        loss = model.last_loss
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+        opt.step()
+        step += 1
+        if step == 1 or step % 25 == 0 or step == args.steps:
+            print(f"step {step}/{args.steps} loss {loss.item():.4f}")
+
+    model.eval()
+    args.out.mkdir(parents=True, exist_ok=True)
+    ckpt_out = {
+        "model": model.state_dict(),
+        "model_args": ckpt["model_args"],
+        "iter_num": ckpt.get("iter_num", 0) + args.steps,
+        "best_val_loss": float(loss.item()),
+        "config": ckpt.get("config", {}),
+    }
+    torch.save(ckpt_out, args.out / "ckpt.pt")
+    model_export(model.cpu(), str(args.out / "model.bin"), version=0)
+    print(f"saved {args.out / 'ckpt.pt'} and {args.out / 'model.bin'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tinystories_lily_hero/generate_corpus.py
+++ b/scripts/tinystories_lily_hero/generate_corpus.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Build a TinyStories-style corpus of grown-up Lily doing everyday heroism."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+
+OPENINGS = [
+    "Once upon a time, Lily grew up and studied.",
+    "Once upon a time, Lily was a grown woman who chose college.",
+    "Lily was grown now, and her mind was as free as her bicycle.",
+    "When Lily grew up, she went to the big college in the city.",
+    "Lily had grown into a free-spirited woman who studied science.",
+    "Once upon a time, the little girl named Lily became a learned woman.",
+]
+
+JOBS = [
+    "she studied science for many years and became a doctor at the town clinic",
+    "she studied at college and taught science to young people",
+    "she became an engineer who had learned how bridges and wheels stand",
+    "she studied plants at university and kept a small garden lab",
+    "she read every book, then taught at the little college",
+    "she studied the stars and still rode her red bicycle to class",
+    "she became a doctor who had studied hard and kept wildflowers in her coat",
+    "she studied engineering and fixed the town's tools with a song",
+]
+
+TRAITS = [
+    "She wore bright boots, carried books, and sang while she worked.",
+    "She kept wildflowers in her pockets and notes from college in her bag.",
+    "She rode her old red bicycle to the university and everywhere else.",
+    "No one could tell her she could not learn. She chose her own path.",
+    "She let the wind tangle her hair on the way to her studies.",
+    "She hummed the songs her mother taught her while she read science.",
+]
+
+CHILDHOOD = [
+    "She still remembered her brother climbing the tree for her red ball.",
+    "She still remembered how her mother held her when she was small and afraid.",
+    "When she was a little girl, people had been kind to her, and she never forgot.",
+    "She had been nurtured with patience, so she grew patient too.",
+    "The love she was given as a child had grown roots in her heart.",
+]
+
+NEEDS = [
+    ("a lost little boy", "He could not find his mother."),
+    ("an old woman named Mrs. Green", "Her bag was too heavy, and her hands were shaking."),
+    ("a wet gray cat", "It was stuck under a fence in the rain."),
+    ("a shy girl named Sam", "Other children had laughed at her drawing."),
+    ("a tired man on the road", "His bicycle wheel was bent."),
+    ("a neighbor named Tom", "The wind had blown the roof off his hen house."),
+    ("a new family in town", "They looked lost and lonely."),
+    ("a little bird", "It had fallen from a nest."),
+    ("an old man named Ben", "He could not see well in the dark street."),
+    ("a hungry child", "The child had no lunch."),
+    ("a woman who dropped her papers", "The wind scattered them down the street."),
+    ("two people arguing in the market", "Their words were getting sharp and unkind."),
+]
+
+ACTS = [
+    "Lily stopped at once. She used what she had studied.",
+    "Lily's free heart pulled her close. She was not too busy to care.",
+    "Lily knelt down so she could listen, then used her science.",
+    "Lily rolled up her sleeves. Her studies had taught her how to help.",
+    "Lily spoke in a warm, steady voice. Knowledge made her calm, not proud.",
+]
+
+CLOSINGS = [
+    "Lily smiled. Learning and kindness were her kind of brave.",
+    "She rode home from college in the evening light, tired and glad.",
+    "The town felt safer because an educated woman was in it.",
+    "Lily knew she was not a knight. She was a neighbor who had studied.",
+    "That night she told her mother, and her mother said, 'You grew up just right.'",
+    "Lily felt the same sun she had loved as a little girl, and she was proud of her studies.",
+]
+
+
+def _story(rng: random.Random) -> str:
+    opening = rng.choice(OPENINGS)
+    job = rng.choice(JOBS)
+    trait = rng.choice(TRAITS)
+    childhood = rng.choice(CHILDHOOD)
+    person, trouble = rng.choice(NEEDS)
+    act = rng.choice(ACTS)
+    close = rng.choice(CLOSINGS)
+    place = rng.choice(
+        [
+            "by the river",
+            "on the hill path",
+            "near the market",
+            "outside the school",
+            "in the rain",
+            "under the old oak",
+            "on the ferry dock",
+            "in the quiet library",
+        ]
+    )
+    help_line = rng.choice(
+        [
+            f"Lily helped {person}. {trouble}",
+            f"Then Lily saw {person}. {trouble}",
+            f"{place.capitalize()}, Lily met {person}. {trouble}",
+        ]
+    )
+    deed = rng.choice(
+        [
+            "She used her studies until the problem was smaller.",
+            "She stayed until the person felt safe, then taught a young girl she could study too.",
+            "She used her hands, her books, her time, and her kind words.",
+            "She showed a child how to be brave, and how to learn.",
+            "She shared bread, time, and a simple science that helped.",
+            "She stood between unkindness and someone smaller, an empowered lady with a trained mind.",
+        ]
+    )
+    thanks = rng.choice(
+        [
+            "Someone said, 'You are a hero.' Lily shook her head. 'I studied so I could help.'",
+            "A child asked, 'Are you magic?' Lily laughed. 'No. I went to college, and I did not walk past.'",
+            "People waved as she left. Lily waved back with books under her arm.",
+            "No one wrote her name on a statue. That was fine with Lily. Her studies were enough.",
+        ]
+    )
+    return (
+        f"{opening} {job[0].upper() + job[1:]}. {trait} {childhood} "
+        f"{help_line} {act} {deed} {thanks} {close}"
+    )
+
+
+def generate(n: int, seed: int = 7) -> list[str]:
+    rng = random.Random(seed)
+    seen: set[str] = set()
+    stories: list[str] = []
+    # A few fully written anchors so the model hears the target voice, not only slots.
+    anchors = [
+        (
+            "Once upon a time, Lily grew up and studied. She was a free-spirited woman who "
+            "rode a red bicycle to college and planted sunflowers behind her shed. When she "
+            "was a little girl, her brother had climbed a tree to get her ball, and her "
+            "mother had held her when she cried. That love had grown with her, and so had "
+            "her mind. She studied science for many years. One windy day she saw Mrs. Green "
+            "feel faint in the street. Lily used what she had learned as a doctor, sat with "
+            "her, and walked her home. Mrs. Green said Lily was a hero. Lily said, 'I "
+            "studied so I could help.' The end."
+        ),
+        (
+            "Lily was a grown woman now. She still loved the sun and still sang. She had "
+            "studied engineering at college. A shy boy named Tom came in with a bent wheel "
+            "and a red face. Bigger children had laughed at him. Lily knelt down. She used "
+            "her studies to fix the wheel and taught Tom how things work. 'You can learn "
+            "hard things,' she said. Tom smiled. Lily felt brave in a quiet, educated way. "
+            "The end."
+        ),
+        (
+            "When Lily grew up, she went to university. She wore bright boots, kept "
+            "wildflowers in her pockets, and read science on the park bench. One evening "
+            "she found a lost little girl under the oak. Lily sat with her, taught her the "
+            "names of the stars she had studied, and walked her back to her mother. The "
+            "mother cried with thanks. Lily remembered being small and found, and she was "
+            "glad she had grown kind and learned. The end."
+        ),
+        (
+            "Once upon a time, the little girl named Lily became a learned woman. No one "
+            "could tell her she could not go to college. She chose her own path. In the "
+            "market two people began to shout. Lily stepped in with a calm voice trained by "
+            "years of study. She asked them to take a breath. They did. Everyday heroism, "
+            "Lily thought, is a trained mind that does not look away. The end."
+        ),
+        (
+            "Lily had grown into a free-spirited woman who studied to be a doctor. A hungry "
+            "child stood by the clinic window. Lily wrapped a warm loaf, a kind word, and a "
+            "simple lesson: you can learn, and you can be well. She did not make the child "
+            "feel small. She made the child feel seen. That night her mother said, 'You grew "
+            "up just right.' The end."
+        ),
+    ]
+    stories.extend(anchors)
+    seen.update(anchors)
+    while len(stories) < n:
+        s = _story(rng)
+        if not s.endswith("The end."):
+            s = s.rstrip() + " The end."
+        if s not in seen:
+            seen.add(s)
+            stories.append(s)
+        if len(seen) > n * 4:
+            break
+    rng.shuffle(stories)
+    return stories
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--n", type=int, default=800)
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--val-frac", type=float, default=0.1)
+    args = parser.parse_args()
+    stories = generate(args.n, args.seed)
+    n_val = max(1, int(len(stories) * args.val_frac))
+    val = stories[:n_val]
+    train = stories[n_val:]
+    args.out.mkdir(parents=True, exist_ok=True)
+    (args.out / "train.json").write_text(json.dumps(train, indent=2) + "\n")
+    (args.out / "val.json").write_text(json.dumps(val, indent=2) + "\n")
+    print(f"wrote {len(train)} train and {len(val)} val stories to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tinystories_lily_hero/test_corpus_and_score.py
+++ b/scripts/tinystories_lily_hero/test_corpus_and_score.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Unit tests for the Lily-hero corpus and scoring (no model weights)."""
+
+from __future__ import annotations
+
+import unittest
+
+from eval_lily import score
+from generate_corpus import generate
+
+
+class ScoreTests(unittest.TestCase):
+    def test_child_lily_story_fails(self) -> None:
+        text = (
+            "Once upon a time, there was a little girl named Lily. She loved to play "
+            "outside in the sunshine. One day, she saw a big, red ball in her yard."
+        )
+        self.assertFalse(score(text)["ok"])
+
+    def test_grown_hero_without_study_fails(self) -> None:
+        text = (
+            "Once upon a time, Lily grew up. She was a grown woman who worked in town. "
+            "She helped her neighbor and made people feel safe."
+        )
+        self.assertFalse(score(text)["ok"])
+
+    def test_educated_hero_story_passes(self) -> None:
+        text = (
+            "Once upon a time, Lily grew up. She was a grown woman who studied science "
+            "at college. She helped her neighbor and made people feel safe."
+        )
+        result = score(text)
+        self.assertTrue(result["ok"], result)
+        self.assertGreaterEqual(result["edu"], 1)
+
+
+class CorpusTests(unittest.TestCase):
+    def test_stories_are_adult_hero_voice(self) -> None:
+        stories = generate(40, seed=1)
+        self.assertGreaterEqual(len(stories), 40)
+        n_ok = sum(1 for s in stories if score(s)["ok"])
+        self.assertGreaterEqual(n_ok, 32, f"only {n_ok}/40 stories scored as adult hero")
+        joined = " ".join(stories).lower()
+        self.assertIn("grown", joined)
+        self.assertIn("lily", joined)
+        self.assertIn("studied", joined)
+        self.assertTrue("college" in joined or "university" in joined)
+        self.assertTrue("science" in joined or "doctor" in joined or "engineer" in joined)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Draft of the TinyStories local-model path.

Registers `tinystories-15m` as an explicit `--model` override (not an auto-routing arm). TinyStories is a base completion model, so chat markup is skipped and TinyStories-scale context lengths are trusted instead of being treated as broken metadata.

Also adds `scripts/tinystories_lily_hero/` to fine-tune Karpathy `stories15M` so grown-up Lily is an educated everyday hero. GGUF weights stay local and gitignored (`/models/`).

Run after converting a GGUF into the HF cache as `arkavo/tinystories-15m` / `stories15M.gguf`:

```bash
arkavo chat --model tinystories-15m --prompt "Once upon a time, Lily"
```

Not ready for merge until the fine-tune pipeline and cache layout are documented for other machines, and CI has a chance to run.