### PR TITLE
Keyed reference index for the DLP cascade

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -175,6 +175,7 @@ jobs:
           - routing     # arkavo-router, arkavo-dataflow (42K LOC)
           - ui          # arkavo-terminal, arkavo-ui-generator, arkavo-agui
           - cli         # arkavo-cli (large dep tree, needs its own disk budget)
+          - dlp         # the taint and fingerprint features: off by default, so nothing else builds them
           - benches     # bench compile-checks only: release profile doubles disk, so isolate it
     steps:
       - uses: actions/checkout@v4
@@ -265,6 +266,13 @@ jobs:
             # Check arkavo-cli with cef-ui feature to catch exhaustive match errors
             # Use --no-default-features to skip llama-cpp (saves disk space)
             cargo check --locked -p arkavo-cli --no-default-features --features memory,mdns,mcp-tools,llm-remote,web-ui,cef-ui
+          elif [ "${{ matrix.group }}" = "dlp" ]; then
+            # `taint` and `fingerprint` are off by default, so no other group
+            # compiles them and nothing else would notice them breaking.
+            cargo test --locked -p arkavo-fingerprint
+            cargo test --locked -p arkavo-protocol --features taint --test sentinel_test --test taint_propagation_test --test egress_taint_test
+            cargo test --locked -p arkavo-server --features taint --lib egress_guard
+            cargo test --locked -p arkavo-cli --lib --no-default-features --features memory,mdns,mcp-tools,llm-remote,fingerprint commands::pack
           fi
 
       # Step 2: Run clippy (reuses test artifacts, check-mode is fast)
@@ -297,6 +305,10 @@ jobs:
             # Lint arkavo-cli with cef-ui feature (catches exhaustive match errors before release)
             # Use --no-default-features to skip llama-cpp (saves disk space)
             cargo clippy --locked -p arkavo-cli --lib --bins --no-default-features --features memory,mdns,mcp-tools,llm-remote,web-ui,cef-ui -- -D warnings
+          elif [ "${{ matrix.group }}" = "dlp" ]; then
+            cargo clippy --locked -p arkavo-fingerprint --lib --bins -- -D warnings
+            cargo clippy --locked -p arkavo-protocol --lib --bins --features taint -- -D warnings
+            cargo clippy --locked -p arkavo-cli --lib --bins --no-default-features --features memory,mdns,mcp-tools,llm-remote,fingerprint -- -D warnings
           fi
 
   # Advisory early warning for the next-generation trait solver, which nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,6 +1099,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "arkavo-fingerprint"
+version = "0.91.0"
+dependencies = [
+ "arkavo-protocol",
+ "arkavo-test-macros",
+ "blake3",
+ "criterion",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "zeroize",
+]
+
+[[package]]
 name = "arkavo-gemini"
 version = "0.91.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,7 @@ dependencies = [
  "arkavo-dataflow",
  "arkavo-device-identity",
  "arkavo-events",
+ "arkavo-fingerprint",
  "arkavo-gguf-tdf",
  "arkavo-git",
  "arkavo-gossip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/arkavo-router",
     "crates/arkavo-context",
     "crates/arkavo-events",
+    "crates/arkavo-fingerprint",
     "crates/arkavo-debugger",
     "crates/arkavo-llama-cpp-sys",
     "crates/arkavo-llama-cpp",
@@ -116,6 +117,7 @@ default-members = [
     "crates/arkavo-router",
     "crates/arkavo-context",
     "crates/arkavo-events",
+    "crates/arkavo-fingerprint",
     "crates/arkavo-debugger",
     "crates/arkavo-llama-cpp-sys",
     "crates/arkavo-llama-cpp",
@@ -426,6 +428,9 @@ opt-level = 3
 opt-level = 3
 [profile.dev.package.aho-corasick]
 opt-level = 3
+[profile.dev.package.blake3]
+opt-level = 3
+
 [profile.dev.package.sha2]
 opt-level = 3
 [profile.dev.package.digest]

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -75,3 +75,22 @@ When distributing Arkavo Edge with bundled Gemma models, the Notice.txt file mus
 1. Downloading the Notice.txt file along with model files
 2. Storing it in the model directory
 3. Including it in any redistribution of models
+
+## Qwen Models
+
+**License:** Apache License 2.0
+
+**Source:** https://huggingface.co/Qwen
+
+Qwen models are optionally downloaded for local inference, and Qwen3.5-0.8B is
+the base for the DLP sentinel classifier distilled in the knowledge-pack
+pipeline. Apache-2.0 places no restriction on derivatives or redistribution, so
+a fine-tuned sentinel may be shipped inside a sealed pack.
+
+- **Qwen3.5-0.8B**: 0.8 billion parameters; local inference and the sentinel base
+- **Qwen3.5-9B**, **Qwen3.5-27B**, **Qwen3.6-35B-A3B**: local inference
+
+GGUF quantizations are pulled from community requants (`unsloth/*-GGUF`), also
+Apache-2.0. Weights fine-tuned by the distillation pipeline are derivative works
+of the official Qwen weights and inherit Apache-2.0; each shipped pack records
+its base model and revision in the pack manifest.

--- a/crates/arkavo-cli/Cargo.toml
+++ b/crates/arkavo-cli/Cargo.toml
@@ -54,6 +54,7 @@ arkavo-memory = { path = "../arkavo-memory", default-features = false }
 arkavo-context = { path = "../arkavo-context", default-features = false }
 arkavo-mcp = { path = "../arkavo-mcp" }
 arkavo-mcp-runtime = { path = "../arkavo-mcp-runtime" }
+arkavo-fingerprint = { path = "../arkavo-fingerprint" }
 arkavo-dataflow = { path = "../arkavo-dataflow", default-features = false, features = ["nl", "sandbox"] }
 arkavo-protocol = { path = "../arkavo-protocol" }
 arkavo-session = { path = "../arkavo-session" }

--- a/crates/arkavo-cli/Cargo.toml
+++ b/crates/arkavo-cli/Cargo.toml
@@ -36,6 +36,12 @@ gemini = ["arkavo-llm/gemini", "arkavo-router/gemini"]
 llama-cpp = ["arkavo-llm/llama-cpp", "arkavo-agui/llama-cpp", "arkavo-ui-core/llama-cpp", "arkavo-router/llama-cpp", "arkavo-context/llama-cpp", "arkavo-server/llama-cpp"]
 snpe = ["arkavo-llm/snpe"]
 cef-ui = ["dep:arkavo-cef", "arkavo-agui/cef-ui", "arkavo-ui-core/cef-ui"]
+# Keyed reference index and `arkavo pack index`. Off until the DLP pack
+# work reaches GA. This crate enables `taint` on arkavo-protocol (the
+# evidence types live there), so it must not be a default dependency:
+# Cargo feature unification would otherwise turn taint on for the shipped
+# binary and blow the 65MB cap.
+fingerprint = ["dep:arkavo-fingerprint"]
 web-ui = ["arkavo-agui/web-ui", "arkavo-ui-core/web-ui"]
 iroh = ["arkavo-server/iroh", "arkavo-server/swarm-apply"]
 kas = ["arkavo-protocol/kas", "arkavo-server/kas"]
@@ -54,7 +60,7 @@ arkavo-memory = { path = "../arkavo-memory", default-features = false }
 arkavo-context = { path = "../arkavo-context", default-features = false }
 arkavo-mcp = { path = "../arkavo-mcp" }
 arkavo-mcp-runtime = { path = "../arkavo-mcp-runtime" }
-arkavo-fingerprint = { path = "../arkavo-fingerprint" }
+arkavo-fingerprint = { path = "../arkavo-fingerprint", optional = true }
 arkavo-dataflow = { path = "../arkavo-dataflow", default-features = false, features = ["nl", "sandbox"] }
 arkavo-protocol = { path = "../arkavo-protocol" }
 arkavo-session = { path = "../arkavo-session" }

--- a/crates/arkavo-cli/src/commands/mod.rs
+++ b/crates/arkavo-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod mesh;
 pub mod model;
 pub mod model_list;
 pub mod model_protect;
+pub mod pack;
 pub mod rlm_integration;
 pub mod security_audit;
 pub mod task;

--- a/crates/arkavo-cli/src/commands/mod.rs
+++ b/crates/arkavo-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod mesh;
 pub mod model;
 pub mod model_list;
 pub mod model_protect;
+#[cfg(feature = "fingerprint")]
 pub mod pack;
 pub mod rlm_integration;
 pub mod security_audit;

--- a/crates/arkavo-cli/src/commands/pack.rs
+++ b/crates/arkavo-cli/src/commands/pack.rs
@@ -1,0 +1,291 @@
+//! `arkavo pack index` — build a keyed reference index from a corpus (KP-009).
+//!
+//! Build-time, not runtime: this reads plaintext corpus material, so it runs
+//! where that material already lives and produces something that no longer
+//! contains it. What comes out is keyed digests plus labels, wrapped under the
+//! classification of the most sensitive thing that went in.
+//!
+//! The tenant key arrives as a file. KAS-backed provisioning is Phase 5's pack
+//! tooling; until then a `--key-file` is the honest interface, and
+//! `MIN_SECRET_BYTES` is what stops it being a weak one. There is deliberately
+//! no flag that builds without a key: KP-009's edge case is that an unavailable
+//! key fails the build rather than falling back to unkeyed hashes, and an
+//! unkeyed index is the dictionary the whole design exists to avoid.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use arkavo_fingerprint::{IndexKey, ReferenceIndex};
+use arkavo_protocol::data_classification::{DataCategory, SensitivityLevel};
+use arkavo_protocol::taxonomy::TaxonomyMap;
+
+/// Files read as corpus material. Everything else is skipped rather than
+/// guessed at: an index built from a binary's bytes is noise that costs
+/// lookups.
+const TEXT_EXTENSIONS: &[&str] = &[
+    "txt", "md", "rst", "csv", "json", "yaml", "yml", "toml", "rs", "py", "go", "ts", "js", "java",
+    "sql", "html", "xml",
+];
+
+pub fn execute(args: &[String]) -> Result<(), String> {
+    match args.first().map(String::as_str) {
+        Some("index") => build_index(&args[1..]),
+        Some("help" | "--help" | "-h") | None => {
+            print_help();
+            Ok(())
+        }
+        Some(other) => Err(format!(
+            "unknown pack subcommand '{other}'. Try `arkavo pack help`."
+        )),
+    }
+}
+
+fn print_help() {
+    println!("Build sealed knowledge-pack components.\n");
+    println!("Usage: arkavo pack index --corpus <DIR> --key-file <PATH> --out <PATH> [options]\n");
+    println!("Options:");
+    println!("  --corpus <DIR>        Directory of corpus material to index");
+    println!("  --key-file <PATH>     Tenant index key material (>= 16 bytes)");
+    println!("  --out <PATH>          Where to write the index");
+    println!("  --taxonomy <PATH>     Taxonomy map (default: the embedded v1 map)");
+    println!("  --index-id <NAME>     Separates indices under one tenant key");
+    println!("  --category <NAME>     Category for corpus documents (default: internal)");
+    println!("  --sensitivity <NAME>  Sensitivity for corpus documents (default: confidential)");
+    println!("  --family <NAME>       Source family recorded on matches");
+    println!("  --boilerplate <DIR>   Directory of material to suppress");
+}
+
+#[derive(Debug)]
+struct Options {
+    corpus: PathBuf,
+    key_file: PathBuf,
+    out: PathBuf,
+    taxonomy: Option<PathBuf>,
+    index_id: String,
+    category: DataCategory,
+    sensitivity: SensitivityLevel,
+    family: String,
+    boilerplate: Option<PathBuf>,
+}
+
+fn parse(args: &[String]) -> Result<Options, String> {
+    let mut corpus = None;
+    let mut key_file = None;
+    let mut out = None;
+    let mut taxonomy = None;
+    let mut index_id = "default".to_string();
+    let mut category = DataCategory::Internal;
+    let mut sensitivity = SensitivityLevel::Confidential;
+    let mut family = "corpus".to_string();
+    let mut boilerplate = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        let take = |i: usize, what: &str| -> Result<String, String> {
+            args.get(i + 1)
+                .cloned()
+                .ok_or_else(|| format!("{what} requires a value"))
+        };
+        match args[i].as_str() {
+            "--corpus" => corpus = Some(PathBuf::from(take(i, "--corpus")?)),
+            "--key-file" => key_file = Some(PathBuf::from(take(i, "--key-file")?)),
+            "--out" => out = Some(PathBuf::from(take(i, "--out")?)),
+            "--taxonomy" => taxonomy = Some(PathBuf::from(take(i, "--taxonomy")?)),
+            "--index-id" => index_id = take(i, "--index-id")?,
+            "--category" => category = parse_category(&take(i, "--category")?)?,
+            "--sensitivity" => sensitivity = parse_sensitivity(&take(i, "--sensitivity")?)?,
+            "--family" => family = take(i, "--family")?,
+            "--boilerplate" => boilerplate = Some(PathBuf::from(take(i, "--boilerplate")?)),
+            other => return Err(format!("unknown option '{other}'")),
+        }
+        i += 2;
+    }
+
+    Ok(Options {
+        corpus: corpus.ok_or("--corpus is required")?,
+        key_file: key_file.ok_or("--key-file is required")?,
+        out: out.ok_or("--out is required")?,
+        taxonomy,
+        index_id,
+        category,
+        sensitivity,
+        family,
+        boilerplate,
+    })
+}
+
+fn parse_category(name: &str) -> Result<DataCategory, String> {
+    match name.to_ascii_lowercase().as_str() {
+        "pii" => Ok(DataCategory::Pii),
+        "credentials" => Ok(DataCategory::Credentials),
+        "financial" => Ok(DataCategory::Financial),
+        "healthcare" => Ok(DataCategory::Healthcare),
+        "internal" => Ok(DataCategory::Internal),
+        "public" => Ok(DataCategory::Public),
+        other => Err(format!("unknown category '{other}'")),
+    }
+}
+
+fn parse_sensitivity(name: &str) -> Result<SensitivityLevel, String> {
+    match name.to_ascii_lowercase().as_str() {
+        "public" => Ok(SensitivityLevel::Public),
+        "internal" => Ok(SensitivityLevel::Internal),
+        "confidential" => Ok(SensitivityLevel::Confidential),
+        "restricted" => Ok(SensitivityLevel::Restricted),
+        other => Err(format!("unknown sensitivity '{other}'")),
+    }
+}
+
+fn build_index(args: &[String]) -> Result<(), String> {
+    let options = parse(args)?;
+
+    let taxonomy = match &options.taxonomy {
+        Some(path) => {
+            let json = fs::read_to_string(path)
+                .map_err(|e| format!("cannot read taxonomy {}: {e}", path.display()))?;
+            TaxonomyMap::from_json(&json).map_err(|e| format!("taxonomy is unusable: {e}"))?
+        }
+        None => TaxonomyMap::v1().clone(),
+    };
+
+    // KP-009 edge case: no key, no index. There is no unkeyed fallback.
+    let secret = fs::read(&options.key_file).map_err(|e| {
+        format!(
+            "cannot read tenant key {}: {e}. The index cannot be built without one.",
+            options.key_file.display()
+        )
+    })?;
+    let key = IndexKey::derive(&secret, &options.index_id)
+        .map_err(|e| format!("tenant key is unusable: {e}"))?;
+
+    let mut builder = ReferenceIndex::builder(&key, taxonomy.version());
+    let mut documents = 0usize;
+    for path in text_files(&options.corpus)? {
+        let text = match fs::read_to_string(&path) {
+            Ok(text) => text,
+            // Unreadable or non-UTF-8 files are reported and skipped: silently
+            // dropping corpus material makes the index quietly incomplete.
+            Err(e) => {
+                eprintln!("skipping {}: {e}", path.display());
+                continue;
+            }
+        };
+        builder.add_document(
+            &key,
+            &text,
+            options.category,
+            options.sensitivity,
+            &options.family,
+        );
+        documents += 1;
+    }
+
+    let mut boilerplate_files = 0usize;
+    if let Some(dir) = &options.boilerplate {
+        for path in text_files(dir)? {
+            if let Ok(text) = fs::read_to_string(&path) {
+                builder.add_boilerplate(&key, &text);
+                boilerplate_files += 1;
+            }
+        }
+    }
+
+    let index = builder.build();
+    let wrap = taxonomy.clearance_requirement(index.max_sensitivity());
+
+    fs::write(&options.out, index.to_json())
+        .map_err(|e| format!("cannot write {}: {e}", options.out.display()))?;
+
+    println!("Indexed {documents} documents, {} entries", index.len());
+    if boilerplate_files > 0 {
+        println!(
+            "Suppressed {} shingles from {boilerplate_files} boilerplate files",
+            index.suppression().len()
+        );
+    }
+    println!("Classification: {:?}", index.max_sensitivity());
+    match &wrap {
+        Some(attribute) => println!("Wrap under: {}={}", attribute.fqn, attribute.value),
+        None => println!("Wrap under: no clearance required (public)"),
+    }
+    println!("Wrote {}", options.out.display());
+    // The TDF wrap needs a KAS to release the payload key, so it belongs with
+    // Phase 5's pack tooling rather than being faked here. The classification
+    // and the attribute it implies are computed and reported now so the
+    // wrapping step has nothing left to decide.
+    println!(
+        "Note: TDF wrapping is performed by `arkavo pack seal` (Phase 5). \
+         Treat this output as classified at the level above."
+    );
+    Ok(())
+}
+
+/// Corpus files, deepest-first order irrelevant — the index is a set.
+fn text_files(root: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut found = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = fs::read_dir(&dir)
+            .map_err(|e| format!("cannot read directory {}: {e}", dir.display()))?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if is_text(&path) {
+                found.push(path);
+            }
+        }
+    }
+    Ok(found)
+}
+
+fn is_text(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| TEXT_EXTENSIONS.contains(&e.to_ascii_lowercase().as_str()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn category_and_sensitivity_names_are_case_insensitive() {
+        assert_eq!(parse_category("PII").unwrap(), DataCategory::Pii);
+        assert_eq!(
+            parse_sensitivity("Restricted").unwrap(),
+            SensitivityLevel::Restricted
+        );
+    }
+
+    #[test]
+    fn an_unknown_label_is_refused_rather_than_defaulted() {
+        // Defaulting would silently classify a corpus at the wrong level.
+        assert!(parse_category("nonsense").is_err());
+        assert!(parse_sensitivity("secret-ish").is_err());
+    }
+
+    #[test]
+    fn the_required_options_are_required() {
+        let err = parse(&["--corpus".into(), "/tmp/x".into()]).unwrap_err();
+
+        assert!(err.contains("--key-file"), "{err}");
+    }
+
+    #[test]
+    fn only_text_extensions_are_indexed() {
+        assert!(is_text(Path::new("notes.md")));
+        assert!(is_text(Path::new("a/b/report.TXT")));
+        assert!(!is_text(Path::new("model.gguf")));
+        assert!(!is_text(Path::new("archive.tar.gz")));
+    }
+
+    #[test]
+    fn there_is_no_option_that_builds_without_a_key() {
+        // KP-009: an unavailable key fails the build. A flag that skipped
+        // keying would reintroduce the dictionary the design exists to avoid.
+        let err = parse(&["--no-key".into(), "x".into()]).unwrap_err();
+
+        assert!(err.contains("unknown option"), "{err}");
+    }
+}

--- a/crates/arkavo-cli/src/lib.rs
+++ b/crates/arkavo-cli/src/lib.rs
@@ -85,7 +85,10 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
             }
         }
         // Hidden commands (still accessible, just not in main help)
+        #[cfg(feature = "fingerprint")]
         "pack" => commands::pack::execute(&args[1..]).map_err(Into::into),
+        #[cfg(not(feature = "fingerprint"))]
+        "pack" => Err("pack is not in this build; compile with the fingerprint feature".into()),
         "terminal" => commands::terminal::execute(&args[1..]),
         #[cfg(all(target_os = "macos", feature = "mcp-macos"))]
         "test" => commands::test::execute(&args[1..]),

--- a/crates/arkavo-cli/src/lib.rs
+++ b/crates/arkavo-cli/src/lib.rs
@@ -85,6 +85,7 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
             }
         }
         // Hidden commands (still accessible, just not in main help)
+        "pack" => commands::pack::execute(&args[1..]).map_err(Into::into),
         "terminal" => commands::terminal::execute(&args[1..]),
         #[cfg(all(target_os = "macos", feature = "mcp-macos"))]
         "test" => commands::test::execute(&args[1..]),
@@ -190,6 +191,7 @@ fn print_usage() {
     println!("    chat           Conversational chat");
     println!("    task           Plan and apply code changes");
     println!("    ui             Launch web UI");
+    println!("    pack           Build sealed knowledge-pack components");
     println!("{}", commands::login::login_help());
     println!();
     println!("Run 'arkavo <command> --help' for detailed options");

--- a/crates/arkavo-fingerprint/Cargo.toml
+++ b/crates/arkavo-fingerprint/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "arkavo-fingerprint"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Keyed reference index: shingled, tenant-keyed content fingerprints for the DLP cascade's fast tier"
+repository.workspace = true
+keywords = ["dlp", "fingerprint", "shingling", "simhash"]
+categories = ["algorithms"]
+
+[dependencies]
+# Keyed hashing. BLAKE3's keyed mode is a PRF over the whole input, so a shingle
+# hash is one pass rather than HMAC's two, and the crate is already vendored.
+blake3 = "1.5"
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+zeroize = { version = "1.8", features = ["derive"] }
+arkavo-protocol = { path = "../arkavo-protocol", features = ["taint"] }
+
+[dev-dependencies]
+arkavo-test-macros = { path = "../arkavo-test-macros" }
+criterion = { workspace = true }
+
+[[bench]]
+name = "index_lookup"
+harness = false
+
+[lints]
+workspace = true

--- a/crates/arkavo-fingerprint/benches/index_lookup.rs
+++ b/crates/arkavo-fingerprint/benches/index_lookup.rs
@@ -1,0 +1,76 @@
+//! KP-011: the reference tier's cost on the per-call path.
+//!
+//! The number that matters is the composite: this tier runs inside the same
+//! `ingest` as the pattern detector, and the 50µs budget is shared. Measuring
+//! the hash-map probe alone would flatter it — the real cost is one keyed hash
+//! per shingle, which scales with span size the way the regex pass does.
+
+use std::fmt::Write as _;
+use std::hint::black_box;
+use std::sync::Arc;
+
+use arkavo_fingerprint::{IndexKey, ReferenceIndex, ReferenceTier, match_span};
+use arkavo_protocol::data_classification::{DataCategory, SensitivityLevel};
+use criterion::{Criterion, criterion_group, criterion_main};
+
+/// Mirrors the 4KB span the taint bench uses, so the two are comparable.
+fn span_4kb() -> String {
+    let mut text = String::with_capacity(4400);
+    for i in 0..80 {
+        let _ = writeln!(
+            text,
+            "line {i}: the quick brown fox jumps over the lazy dog"
+        );
+    }
+    text
+}
+
+fn corpus_index(key: &IndexKey) -> ReferenceIndex {
+    let mut builder = ReferenceIndex::builder(key, "1.0.0");
+    // A corpus large enough that the probe is a real hash-map lookup rather
+    // than a cache-resident handful of entries.
+    for doc in 0..500 {
+        builder.add_document(
+            key,
+            &format!(
+                "document {doc} concerning the acquisition of holdings number {doc} \
+                 closing in the quarter pending board approval and counsel review"
+            ),
+            DataCategory::Internal,
+            SensitivityLevel::Confidential,
+            "board-minutes",
+        );
+    }
+    builder.build()
+}
+
+fn benches(c: &mut Criterion) {
+    let key = Arc::new(IndexKey::derive(&[7u8; 32], "bench-corpus").expect("derive"));
+    let index = Arc::new(corpus_index(&key));
+    let tier = ReferenceTier::loaded(index.clone(), key.clone());
+    let text = span_4kb();
+    let hit = "document 42 concerning the acquisition of holdings number 42 closing in the quarter";
+
+    c.bench_function("keyed_hash_one_shingle", |b| {
+        b.iter(|| black_box(key.hash(black_box("the quick brown fox jumps"))));
+    });
+
+    c.bench_function("tier_examine_hit", |b| {
+        b.iter(|| black_box(tier.examine(black_box(hit))));
+    });
+
+    c.bench_function("tier_examine_miss", |b| {
+        b.iter(|| {
+            black_box(tier.examine(black_box(
+                "entirely unrelated prose about the weather this week",
+            )))
+        });
+    });
+
+    c.bench_function("match_span_4kb", |b| {
+        b.iter(|| black_box(match_span(&index, &key, black_box(&text))));
+    });
+}
+
+criterion_group!(index_lookup, benches);
+criterion_main!(index_lookup);

--- a/crates/arkavo-fingerprint/src/index.rs
+++ b/crates/arkavo-fingerprint/src/index.rs
@@ -1,0 +1,532 @@
+//! The keyed reference index (KP-009, KP-010, KP-011).
+//!
+//! An index maps keyed shingle digests to the classification of the corpus they
+//! came from. It answers one question fast: has this span been seen before, and
+//! if so, what was it labelled.
+//!
+//! Suppression is the one thing here that can remove, and it is confined
+//! accordingly. It drops shingles from *this tier's own candidate set at build
+//! time* — boilerplate that would otherwise match everything. It never sees a
+//! `TaintSet`, never sees another tier's findings, and never removes a shingle
+//! that a classified entry claims (KP-010). Inferred labels add restrictions;
+//! they do not remove known ones, and a suppression list wired the other way
+//! would be the shortest path to violating that.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use arkavo_protocol::data_classification::{DataCategory, SensitivityLevel};
+use serde::{Deserialize, Serialize};
+
+use crate::key::{IndexKey, ShingleHash};
+use crate::shingle::shingle_text;
+
+/// Format version of the serialized index.
+pub const INDEX_FORMAT_VERSION: &str = "1";
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum IndexError {
+    #[error("index is not valid JSON: {0}")]
+    Malformed(String),
+    #[error("index format version {0} is not supported (expected {INDEX_FORMAT_VERSION})")]
+    UnsupportedVersion(String),
+    #[error("index was built with key {expected}, but {actual} was supplied")]
+    KeyMismatch { expected: String, actual: String },
+}
+
+/// What a corpus document contributes to a match.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EntryMeta {
+    pub category: DataCategory,
+    pub sensitivity: SensitivityLevel,
+    /// Corpus family the shingle came from, carried into evidence so an auditor
+    /// can see which body of material matched.
+    pub source_family: String,
+}
+
+/// Shingles excluded from matching, versioned with the index.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SuppressionIndex {
+    pub version: String,
+    #[serde(default)]
+    hashes: HashSet<ShingleHash>,
+}
+
+impl SuppressionIndex {
+    pub fn new(version: impl Into<String>) -> Self {
+        Self {
+            version: version.into(),
+            hashes: HashSet::new(),
+        }
+    }
+
+    pub fn insert(&mut self, hash: ShingleHash) {
+        self.hashes.insert(hash);
+    }
+
+    pub fn contains(&self, hash: ShingleHash) -> bool {
+        self.hashes.contains(&hash)
+    }
+
+    pub fn remove(&mut self, hash: ShingleHash) {
+        self.hashes.remove(&hash);
+    }
+
+    pub fn len(&self) -> usize {
+        self.hashes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.hashes.is_empty()
+    }
+}
+
+/// A built index, ready to query.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReferenceIndex {
+    pub format_version: String,
+    /// Taxonomy the entry labels are expressed in.
+    pub taxonomy_version: String,
+    /// Fingerprint of the key that built this, so a lookup with the wrong key
+    /// fails loudly instead of silently matching nothing.
+    pub key_fingerprint: String,
+    entries: HashMap<ShingleHash, EntryMeta>,
+    suppression: SuppressionIndex,
+}
+
+impl ReferenceIndex {
+    pub fn builder(key: &IndexKey, taxonomy_version: impl Into<String>) -> ReferenceIndexBuilder {
+        ReferenceIndexBuilder {
+            taxonomy_version: taxonomy_version.into(),
+            key_fingerprint: key.fingerprint(),
+            documents: Vec::new(),
+            suppressed_candidates: HashSet::new(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn suppression(&self) -> &SuppressionIndex {
+        &self.suppression
+    }
+
+    /// Look up one keyed digest. This is the hot-path operation (KP-011): a
+    /// hash-map probe, so a miss costs the same as a hit.
+    pub fn lookup(&self, hash: ShingleHash) -> Option<&EntryMeta> {
+        self.entries.get(&hash)
+    }
+
+    /// Confirm the supplied key built this index.
+    pub fn check_key(&self, key: &IndexKey) -> Result<(), IndexError> {
+        let actual = key.fingerprint();
+        if actual == self.key_fingerprint {
+            return Ok(());
+        }
+        Err(IndexError::KeyMismatch {
+            expected: self.key_fingerprint.clone(),
+            actual,
+        })
+    }
+
+    /// Serialize for TDF wrapping. The bytes are keyed digests and labels; the
+    /// corpus text is not recoverable from them.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap_or_default()
+    }
+
+    pub fn from_json(json: &str) -> Result<Self, IndexError> {
+        let index: ReferenceIndex =
+            serde_json::from_str(json).map_err(|e| IndexError::Malformed(e.to_string()))?;
+        if index.format_version != INDEX_FORMAT_VERSION {
+            return Err(IndexError::UnsupportedVersion(index.format_version));
+        }
+        Ok(index)
+    }
+}
+
+/// Accumulates corpus documents into an index.
+pub struct ReferenceIndexBuilder {
+    taxonomy_version: String,
+    key_fingerprint: String,
+    /// Documents held whole until `build`, because whether a shingle may be
+    /// suppressed depends on what else the document it came from still has.
+    documents: Vec<(Vec<ShingleHash>, EntryMeta)>,
+    suppressed_candidates: HashSet<ShingleHash>,
+}
+
+impl ReferenceIndexBuilder {
+    /// Add a classified document.
+    ///
+    /// A duplicate document contributes no new entries, so duplication in the
+    /// corpus cannot inflate a later match's confidence (KP-009 edge case).
+    /// Where two documents share a shingle the higher classification wins, for
+    /// the same reason a taint union takes the maximum.
+    pub fn add_document(
+        &mut self,
+        key: &IndexKey,
+        text: &str,
+        category: DataCategory,
+        sensitivity: SensitivityLevel,
+        source_family: &str,
+    ) {
+        let hashes: Vec<ShingleHash> = shingle_text(text).iter().map(|s| key.hash(s)).collect();
+        if hashes.is_empty() {
+            return;
+        }
+        self.documents.push((
+            hashes,
+            EntryMeta {
+                category,
+                sensitivity,
+                source_family: source_family.to_string(),
+            },
+        ));
+    }
+
+    /// Nominate boilerplate for suppression: license headers, public docs,
+    /// common idioms. These match everything and are what a reference tier
+    /// generates false positives on.
+    pub fn add_boilerplate(&mut self, key: &IndexKey, text: &str) {
+        for shingle in shingle_text(text) {
+            self.suppressed_candidates.insert(key.hash(&shingle));
+        }
+    }
+
+    pub fn build(mut self) -> ReferenceIndex {
+        let mut suppression = SuppressionIndex::new(INDEX_FORMAT_VERSION);
+        for candidate in &self.suppressed_candidates {
+            suppression.insert(*candidate);
+        }
+
+        // KP-010 edge case: classified text embedded in boilerplate survives.
+        // Suppression removes the shingles that are boilerplate — that is what
+        // kills the false positive — but a document it would silence entirely
+        // keeps its own, because a classified document the index cannot see is
+        // the failure this tier exists to prevent. Silencing a document is the
+        // only case where the boilerplate list loses.
+        for (hashes, _) in &self.documents {
+            if hashes.iter().all(|h| suppression.contains(*h)) {
+                for hash in hashes {
+                    suppression.remove(*hash);
+                }
+            }
+        }
+
+        let mut entries: HashMap<ShingleHash, EntryMeta> = HashMap::new();
+        for (hashes, meta) in self.documents.drain(..) {
+            for hash in hashes {
+                if suppression.contains(hash) {
+                    continue;
+                }
+                // A shared shingle takes the higher classification, for the same
+                // reason a taint union takes the maximum.
+                match entries.get(&hash) {
+                    Some(existing) if existing.sensitivity >= meta.sensitivity => {}
+                    _ => {
+                        entries.insert(hash, meta.clone());
+                    }
+                }
+            }
+        }
+
+        ReferenceIndex {
+            format_version: INDEX_FORMAT_VERSION.to_string(),
+            taxonomy_version: self.taxonomy_version,
+            key_fingerprint: self.key_fingerprint,
+            entries,
+            suppression,
+        }
+    }
+}
+
+/// How much of a span the index recognized.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct MatchSummary {
+    pub shingles_examined: usize,
+    pub shingles_matched: usize,
+    /// Highest classification any matched shingle carried, per family.
+    pub by_family: BTreeMap<String, EntryMeta>,
+}
+
+impl MatchSummary {
+    /// Fraction of the span the index recognized, as a calibration input.
+    ///
+    /// Coverage rather than a raw count: one matching shingle in a long
+    /// document is a coincidence, the same shingle in a two-line span is the
+    /// document.
+    pub fn coverage(&self) -> f32 {
+        if self.shingles_examined == 0 {
+            return 0.0;
+        }
+        self.shingles_matched as f32 / self.shingles_examined as f32
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.shingles_matched == 0
+    }
+}
+
+/// Query an index with a span.
+pub fn match_span(index: &ReferenceIndex, key: &IndexKey, text: &str) -> MatchSummary {
+    let mut summary = MatchSummary::default();
+    for shingle in shingle_text(text) {
+        summary.shingles_examined += 1;
+        let hash = key.hash(&shingle);
+        if index.suppression.contains(hash) {
+            continue;
+        }
+        let Some(meta) = index.lookup(hash) else {
+            continue;
+        };
+        summary.shingles_matched += 1;
+        match summary.by_family.get(&meta.source_family) {
+            Some(existing) if existing.sensitivity >= meta.sensitivity => {}
+            _ => {
+                summary
+                    .by_family
+                    .insert(meta.source_family.clone(), meta.clone());
+            }
+        }
+    }
+    summary
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arkavo_test_macros::spec;
+
+    fn key() -> IndexKey {
+        IndexKey::derive(&[7u8; 32], "test-corpus").expect("derive")
+    }
+
+    const CLASSIFIED: &str =
+        "the acquisition of northwind holdings closes in the third quarter pending approval";
+    const BOILERPLATE: &str =
+        "licensed under the apache license version two point zero see the license for terms";
+
+    fn built() -> (IndexKey, ReferenceIndex) {
+        let key = key();
+        let mut builder = ReferenceIndex::builder(&key, "1.0.0");
+        builder.add_document(
+            &key,
+            CLASSIFIED,
+            DataCategory::Internal,
+            SensitivityLevel::Confidential,
+            "board-minutes",
+        );
+        builder.add_boilerplate(&key, BOILERPLATE);
+        (key, builder.build())
+    }
+
+    #[spec("KP-009")]
+    #[test]
+    fn a_corpus_span_matches_after_reformatting() {
+        let (key, index) = built();
+
+        let summary = match_span(
+            &index,
+            &key,
+            "The Acquisition Of Northwind Holdings\n closes\tin the THIRD quarter",
+        );
+
+        assert!(!summary.is_empty());
+        assert_eq!(
+            summary.by_family["board-minutes"].sensitivity,
+            SensitivityLevel::Confidential
+        );
+    }
+
+    #[spec("KP-009")]
+    #[test]
+    fn unrelated_text_does_not_match() {
+        let (key, index) = built();
+
+        let summary = match_span(
+            &index,
+            &key,
+            "the weather today is mild with a chance of rain later",
+        );
+
+        assert!(summary.is_empty());
+        assert!(summary.coverage() < f32::EPSILON);
+    }
+
+    #[spec("KP-009")]
+    #[test]
+    fn no_unkeyed_digest_is_ever_written() {
+        // The index must be useless to whoever steals it without the key.
+        let (_, index) = built();
+        let with_other_key = IndexKey::derive(&[9u8; 32], "test-corpus").expect("derive");
+
+        let summary = match_span(&index, &with_other_key, CLASSIFIED);
+
+        assert!(summary.is_empty(), "content matched under the wrong key");
+    }
+
+    #[spec("KP-009")]
+    #[test]
+    fn a_duplicate_document_does_not_inflate_the_index() {
+        let key = key();
+        let mut once = ReferenceIndex::builder(&key, "1.0.0");
+        once.add_document(
+            &key,
+            CLASSIFIED,
+            DataCategory::Internal,
+            SensitivityLevel::Confidential,
+            "f",
+        );
+        let mut twice = ReferenceIndex::builder(&key, "1.0.0");
+        twice.add_document(
+            &key,
+            CLASSIFIED,
+            DataCategory::Internal,
+            SensitivityLevel::Confidential,
+            "f",
+        );
+        twice.add_document(
+            &key,
+            CLASSIFIED,
+            DataCategory::Internal,
+            SensitivityLevel::Confidential,
+            "f",
+        );
+
+        assert_eq!(once.build().len(), twice.build().len());
+    }
+
+    #[spec("KP-009")]
+    #[test]
+    fn the_higher_classification_wins_a_shared_shingle() {
+        let key = key();
+        let mut builder = ReferenceIndex::builder(&key, "1.0.0");
+        builder.add_document(
+            &key,
+            CLASSIFIED,
+            DataCategory::Internal,
+            SensitivityLevel::Internal,
+            "low",
+        );
+        builder.add_document(
+            &key,
+            CLASSIFIED,
+            DataCategory::Healthcare,
+            SensitivityLevel::Restricted,
+            "high",
+        );
+        let index = builder.build();
+
+        let summary = match_span(&index, &key, CLASSIFIED);
+
+        assert_eq!(
+            summary.by_family["high"].sensitivity,
+            SensitivityLevel::Restricted
+        );
+    }
+
+    #[spec("KP-010")]
+    #[test]
+    fn suppression_kills_a_seeded_boilerplate_false_positive() {
+        // The realistic shape: a classified document that happens to carry a
+        // license header. Without suppression, every other file with that
+        // header matches the board minutes.
+        let key = key();
+        let with_header = format!("{BOILERPLATE} {CLASSIFIED}");
+
+        let mut noisy_builder = ReferenceIndex::builder(&key, "1.0.0");
+        noisy_builder.add_document(
+            &key,
+            &with_header,
+            DataCategory::Internal,
+            SensitivityLevel::Confidential,
+            "minutes",
+        );
+        let noisy = noisy_builder.build();
+        assert!(
+            !match_span(&noisy, &key, BOILERPLATE).is_empty(),
+            "the seeded false positive did not fire, so suppression proves nothing"
+        );
+
+        let mut quiet_builder = ReferenceIndex::builder(&key, "1.0.0");
+        quiet_builder.add_document(
+            &key,
+            &with_header,
+            DataCategory::Internal,
+            SensitivityLevel::Confidential,
+            "minutes",
+        );
+        quiet_builder.add_boilerplate(&key, BOILERPLATE);
+        let quiet = quiet_builder.build();
+
+        assert!(
+            match_span(&quiet, &key, BOILERPLATE).is_empty(),
+            "an unrelated file sharing only the license header still matched"
+        );
+    }
+
+    #[spec("KP-010")]
+    #[test]
+    fn suppression_entries_are_versioned_with_the_index() {
+        let (_, index) = built();
+
+        assert_eq!(index.suppression().version, INDEX_FORMAT_VERSION);
+        assert!(!index.suppression().is_empty());
+    }
+
+    #[spec("KP-009")]
+    #[test]
+    fn an_index_round_trips_through_its_serialized_form() {
+        let (key, index) = built();
+
+        let back = ReferenceIndex::from_json(&index.to_json()).expect("round trip");
+
+        assert_eq!(back, index);
+        assert!(!match_span(&back, &key, CLASSIFIED).is_empty());
+    }
+
+    #[spec("KP-009")]
+    #[test]
+    fn a_lookup_with_the_wrong_key_is_an_error_not_a_silent_miss() {
+        let (_, index) = built();
+        let other = IndexKey::derive(&[9u8; 32], "test-corpus").expect("derive");
+
+        assert!(matches!(
+            index.check_key(&other),
+            Err(IndexError::KeyMismatch { .. })
+        ));
+    }
+
+    #[spec("KP-009")]
+    #[test]
+    fn an_index_from_a_future_format_is_refused() {
+        let json = r#"{"format_version":"99","taxonomy_version":"1","key_fingerprint":"x",
+            "entries":{},"suppression":{"version":"1","hashes":[]}}"#;
+
+        assert!(matches!(
+            ReferenceIndex::from_json(json),
+            Err(IndexError::UnsupportedVersion(_))
+        ));
+    }
+
+    #[spec("KP-011")]
+    #[test]
+    fn coverage_scales_with_how_much_of_the_span_matched() {
+        let (key, index) = built();
+
+        let whole = match_span(&index, &key, CLASSIFIED);
+        let diluted = match_span(
+            &index,
+            &key,
+            &format!(
+                "{CLASSIFIED} and then some entirely unrelated filler text follows here for length"
+            ),
+        );
+
+        assert!(whole.coverage() > diluted.coverage());
+    }
+}

--- a/crates/arkavo-fingerprint/src/index.rs
+++ b/crates/arkavo-fingerprint/src/index.rs
@@ -115,6 +115,27 @@ impl ReferenceIndex {
         &self.suppression
     }
 
+    /// Highest classification any entry carries.
+    ///
+    /// What the index has to be wrapped at. The digests are not reversible, but
+    /// the family names and the suppression list are metadata about the corpus,
+    /// and an index of restricted material is itself restricted.
+    pub fn max_sensitivity(&self) -> SensitivityLevel {
+        self.entries
+            .values()
+            .map(|e| e.sensitivity)
+            .max()
+            .unwrap_or(SensitivityLevel::Public)
+    }
+
+    /// Categories present, for deriving the wrap policy.
+    pub fn categories(&self) -> Vec<DataCategory> {
+        let mut categories: Vec<DataCategory> = self.entries.values().map(|e| e.category).collect();
+        categories.sort_unstable();
+        categories.dedup();
+        categories
+    }
+
     /// Look up one keyed digest. This is the hot-path operation (KP-011): a
     /// hash-map probe, so a miss costs the same as a hit.
     pub fn lookup(&self, hash: ShingleHash) -> Option<&EntryMeta> {
@@ -476,6 +497,44 @@ mod tests {
 
         assert_eq!(index.suppression().version, INDEX_FORMAT_VERSION);
         assert!(!index.suppression().is_empty());
+    }
+
+    #[spec("KP-009")]
+    #[test]
+    fn the_index_reports_the_classification_it_must_be_wrapped_at() {
+        let key = key();
+        let mut builder = ReferenceIndex::builder(&key, "1.0.0");
+        builder.add_document(
+            &key,
+            CLASSIFIED,
+            DataCategory::Internal,
+            SensitivityLevel::Internal,
+            "a",
+        );
+        builder.add_document(
+            &key,
+            "patient roster for the northern clinic listing every admission this month",
+            DataCategory::Healthcare,
+            SensitivityLevel::Restricted,
+            "b",
+        );
+        let index = builder.build();
+
+        assert_eq!(index.max_sensitivity(), SensitivityLevel::Restricted);
+        assert!(index.categories().contains(&DataCategory::Healthcare));
+    }
+
+    #[spec("KP-009")]
+    #[test]
+    fn an_empty_index_is_public() {
+        let key = key();
+
+        assert_eq!(
+            ReferenceIndex::builder(&key, "1.0.0")
+                .build()
+                .max_sensitivity(),
+            SensitivityLevel::Public
+        );
     }
 
     #[spec("KP-009")]

--- a/crates/arkavo-fingerprint/src/key.rs
+++ b/crates/arkavo-fingerprint/src/key.rs
@@ -1,0 +1,148 @@
+//! The tenant index key (KP-009).
+//!
+//! Every hash written to or looked up in a reference index is keyed with this.
+//! An unkeyed index of sensitive content is a dictionary: anyone holding it can
+//! confirm a guess by hashing the guess and looking for the digest. Keying is
+//! what makes the index useless to whoever steals it, so there is deliberately
+//! no way to compute an entry without one.
+
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// Domain separator for key derivation. Changing it invalidates every index.
+const DERIVE_CONTEXT: &str = "arkavo-fingerprint 2026-08 tenant index key";
+
+/// Digest width kept per shingle.
+///
+/// Eight bytes, not thirty-two. The index holds one of these per shingle of the
+/// corpus, so width is the dominant cost; against a keyed PRF the attacker
+/// cannot grind offline, which is what would otherwise force a wider digest.
+pub type ShingleHash = u64;
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum KeyError {
+    #[error("tenant index key material must be at least {MIN_SECRET_BYTES} bytes, got {0}")]
+    SecretTooShort(usize),
+}
+
+/// Shortest tenant secret accepted. Below this the key is guessable and the
+/// index reverts to the dictionary the keying exists to prevent.
+pub const MIN_SECRET_BYTES: usize = 16;
+
+/// A tenant's index key.
+///
+/// Zeroized on drop. It is derived from material the KAS released, and a copy
+/// left in freed memory outlives the entitlement that released it.
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
+pub struct IndexKey {
+    material: [u8; 32],
+}
+
+impl std::fmt::Debug for IndexKey {
+    /// Never prints the key. A struct that renders its own secret ends up in a
+    /// log the first time someone debugs the thing that holds it.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("IndexKey(<redacted>)")
+    }
+}
+
+impl IndexKey {
+    /// Derive a key from tenant secret material.
+    ///
+    /// `index_id` separates indices under one tenant secret, so a match in one
+    /// index cannot be replayed against another.
+    pub fn derive(secret: &[u8], index_id: &str) -> Result<Self, KeyError> {
+        if secret.len() < MIN_SECRET_BYTES {
+            return Err(KeyError::SecretTooShort(secret.len()));
+        }
+        let context = format!("{DERIVE_CONTEXT} :: {index_id}");
+        let mut material = blake3::derive_key(&context, secret);
+        let key = Self { material };
+        material.zeroize();
+        Ok(key)
+    }
+
+    /// Wrap key material that was derived elsewhere.
+    pub fn from_material(material: [u8; 32]) -> Self {
+        Self { material }
+    }
+
+    /// Keyed digest of one shingle.
+    ///
+    /// BLAKE3's keyed mode is a PRF over the input in a single pass, so this is
+    /// the per-shingle cost on the hot path — the thing the budget is spent on.
+    pub fn hash(&self, shingle: &str) -> ShingleHash {
+        let digest = blake3::keyed_hash(&self.material, shingle.as_bytes());
+        let bytes = digest.as_bytes();
+        u64::from_le_bytes([
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+        ])
+    }
+
+    /// Fingerprint of the key itself, for binding an index to the key that
+    /// built it. Derived through the PRF, so it reveals nothing about the key.
+    pub fn fingerprint(&self) -> String {
+        let digest = blake3::keyed_hash(&self.material, b"arkavo-fingerprint key id");
+        digest.to_hex().as_str()[..16].to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn secret(seed: u8) -> Vec<u8> {
+        (0..32).map(|i| i as u8 ^ seed).collect()
+    }
+
+    #[test]
+    fn the_same_secret_and_id_derive_the_same_key() {
+        let a = IndexKey::derive(&secret(1), "corpus-a").expect("derive");
+        let b = IndexKey::derive(&secret(1), "corpus-a").expect("derive");
+
+        assert_eq!(a.hash("hello world"), b.hash("hello world"));
+        assert_eq!(a.fingerprint(), b.fingerprint());
+    }
+
+    #[test]
+    fn a_different_index_id_derives_a_different_key() {
+        // Otherwise a hit in one index confirms content in another.
+        let a = IndexKey::derive(&secret(1), "corpus-a").expect("derive");
+        let b = IndexKey::derive(&secret(1), "corpus-b").expect("derive");
+
+        assert_ne!(a.hash("hello world"), b.hash("hello world"));
+    }
+
+    #[test]
+    fn a_different_tenant_secret_derives_a_different_key() {
+        let a = IndexKey::derive(&secret(1), "corpus").expect("derive");
+        let b = IndexKey::derive(&secret(2), "corpus").expect("derive");
+
+        assert_ne!(a.hash("hello world"), b.hash("hello world"));
+    }
+
+    #[test]
+    fn short_key_material_is_refused() {
+        // A guessable key is the same as no key.
+        assert_eq!(
+            IndexKey::derive(b"short", "corpus").unwrap_err(),
+            KeyError::SecretTooShort(5)
+        );
+    }
+
+    #[test]
+    fn distinct_shingles_hash_distinctly() {
+        let key = IndexKey::derive(&secret(1), "corpus").expect("derive");
+
+        assert_ne!(key.hash("the quick brown"), key.hash("quick brown fox"));
+    }
+
+    #[test]
+    fn the_key_never_renders_itself() {
+        let key = IndexKey::derive(&secret(1), "corpus").expect("derive");
+
+        let rendered = format!("{key:?}");
+
+        assert_eq!(rendered, "IndexKey(<redacted>)");
+        assert!(!rendered.contains(&key.fingerprint()));
+    }
+}

--- a/crates/arkavo-fingerprint/src/key.rs
+++ b/crates/arkavo-fingerprint/src/key.rs
@@ -6,17 +6,23 @@
 //! what makes the index useless to whoever steals it, so there is deliberately
 //! no way to compute an entry without one.
 
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 /// Domain separator for key derivation. Changing it invalidates every index.
 const DERIVE_CONTEXT: &str = "arkavo-fingerprint 2026-08 tenant index key";
 
 /// Digest width kept per shingle.
 ///
-/// Eight bytes, not thirty-two. The index holds one of these per shingle of the
-/// corpus, so width is the dominant cost; against a keyed PRF the attacker
-/// cannot grind offline, which is what would otherwise force a wider digest.
-pub type ShingleHash = u64;
+/// Sixteen bytes, not eight. Truncating to 64 bits puts the birthday bound at
+/// roughly 2^32 shingles — reachable by a large enterprise corpus — and a
+/// collision here is not a precision problem but a silent security one: the
+/// digest is the sole key into both the entry map and the suppression set, so
+/// two colliding shingles make one inherit the other's classification, or worse,
+/// its suppressed status, which hides classified content from the tier that
+/// exists to find it. At 128 bits the bound moves to ~2^64 and stops being a
+/// number anyone has to reason about. The entry it keys already carries a
+/// `String`, so the eight extra bytes are not what sizes this index.
+pub type ShingleHash = u128;
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum KeyError {
@@ -32,7 +38,7 @@ pub const MIN_SECRET_BYTES: usize = 16;
 ///
 /// Zeroized on drop. It is derived from material the KAS released, and a copy
 /// left in freed memory outlives the entitlement that released it.
-#[derive(Clone, Zeroize, ZeroizeOnDrop)]
+#[derive(Zeroize, ZeroizeOnDrop)]
 pub struct IndexKey {
     material: [u8; 32],
 }
@@ -55,10 +61,15 @@ impl IndexKey {
             return Err(KeyError::SecretTooShort(secret.len()));
         }
         let context = format!("{DERIVE_CONTEXT} :: {index_id}");
-        let mut material = blake3::derive_key(&context, secret);
-        let key = Self { material };
-        material.zeroize();
-        Ok(key)
+        // `derive_key` returns `[u8; 32]`, which is `Copy`, so the value has to
+        // be wiped through a guard rather than by hand: `Zeroizing` wipes on
+        // every exit from this scope, including one an added `?` introduces
+        // later. Wiping the local by hand is correct only for as long as nobody
+        // adds an early return above it.
+        let material: Zeroizing<[u8; 32]> = Zeroizing::new(blake3::derive_key(&context, secret));
+        Ok(Self {
+            material: *material,
+        })
     }
 
     /// Wrap key material that was derived elsewhere.
@@ -72,10 +83,9 @@ impl IndexKey {
     /// the per-shingle cost on the hot path — the thing the budget is spent on.
     pub fn hash(&self, shingle: &str) -> ShingleHash {
         let digest = blake3::keyed_hash(&self.material, shingle.as_bytes());
-        let bytes = digest.as_bytes();
-        u64::from_le_bytes([
-            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
-        ])
+        let mut truncated = [0u8; 16];
+        truncated.copy_from_slice(&digest.as_bytes()[..16]);
+        u128::from_le_bytes(truncated)
     }
 
     /// Fingerprint of the key itself, for binding an index to the key that
@@ -127,6 +137,13 @@ mod tests {
             IndexKey::derive(b"short", "corpus").unwrap_err(),
             KeyError::SecretTooShort(5)
         );
+    }
+
+    #[test]
+    fn the_digest_keeps_the_full_declared_width() {
+        // Guards against a future narrowing that would quietly reintroduce the
+        // birthday bound this width exists to move.
+        assert_eq!(std::mem::size_of::<ShingleHash>(), 16);
     }
 
     #[test]

--- a/crates/arkavo-fingerprint/src/lib.rs
+++ b/crates/arkavo-fingerprint/src/lib.rs
@@ -1,0 +1,23 @@
+//! Keyed reference index: the DLP cascade's fast tier (KP-009, KP-010, KP-011).
+//!
+//! The question this crate answers is "have I seen this content before, and
+//! what was it labelled" — fast enough to sit on the per-call path, and without
+//! storing anything an attacker who steals the index can read.
+//!
+//! Every digest is keyed with a tenant key. An unkeyed index of sensitive
+//! content is a dictionary: hash a guess, look for the digest, learn whether
+//! the guess was in the corpus. Keying is what makes a stolen index inert, so
+//! there is no path through this crate that produces an unkeyed hash.
+
+pub mod index;
+pub mod key;
+pub mod shingle;
+pub mod tier;
+
+pub use index::{
+    EntryMeta, INDEX_FORMAT_VERSION, IndexError, MatchSummary, ReferenceIndex,
+    ReferenceIndexBuilder, SuppressionIndex, match_span,
+};
+pub use key::{IndexKey, KeyError, MIN_SECRET_BYTES, ShingleHash};
+pub use shingle::{SHINGLE_WORDS, normalize, shingle_text, shingles, windows};
+pub use tier::{ReferenceTier, TIER_BUDGET, TIER_NAME, evidence_for};

--- a/crates/arkavo-fingerprint/src/shingle.rs
+++ b/crates/arkavo-fingerprint/src/shingle.rs
@@ -1,0 +1,157 @@
+//! Normalization and shingling (KP-009).
+//!
+//! Content is normalized before hashing so that reformatting is not an escape.
+//! An exact-hash tier that keys on raw bytes is defeated by changing a newline;
+//! the normalization here is what makes "the same document, re-wrapped" the
+//! same document.
+//!
+//! Normalization is deliberately lossy in one direction only. It removes
+//! distinctions an attacker could introduce for free (case, whitespace run
+//! length, surrounding punctuation) and preserves everything else. Removing
+//! more would start merging genuinely different content, which costs precision
+//! and shows up as false positives.
+
+/// Words per shingle.
+///
+/// Five is short enough that a paragraph yields many overlapping windows — so
+/// quoting part of a document still matches — and long enough that ordinary
+/// English five-grams are rare, which is what keeps the false-positive rate
+/// down without a suppression list doing all the work.
+pub const SHINGLE_WORDS: usize = 5;
+
+/// Normalize text for hashing.
+///
+/// Lowercases, collapses every whitespace run to one space, and trims
+/// punctuation from the edges of each token. Interior punctuation stays:
+/// `sk-abc` and `sk abc` are not the same token and must not collide.
+pub fn normalize(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for token in text.split_whitespace() {
+        let trimmed = token.trim_matches(|c: char| c.is_ascii_punctuation());
+        if trimmed.is_empty() {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.extend(trimmed.chars().flat_map(char::to_lowercase));
+    }
+    out
+}
+
+/// Overlapping word windows over already-normalized text.
+///
+/// Overlapping, not disjoint: disjoint windows shift out of alignment when a
+/// single word is inserted, so an attacker prepends one word and the whole
+/// document stops matching.
+pub fn shingles(normalized: &str) -> Vec<String> {
+    let words: Vec<&str> = normalized.split(' ').filter(|w| !w.is_empty()).collect();
+    if words.is_empty() {
+        return Vec::new();
+    }
+    if words.len() <= SHINGLE_WORDS {
+        // Short spans still have to be indexable, or a one-line secret is
+        // invisible to the tier that exists to catch it.
+        return vec![words.join(" ")];
+    }
+    words
+        .windows(SHINGLE_WORDS)
+        .map(|window| window.join(" "))
+        .collect()
+}
+
+/// Overlapping windows over pre-split words, produced one at a time.
+///
+/// The allocating [`shingles`] is fine at build time, where the whole corpus is
+/// being read anyway. On the per-call path a budget has to be able to stop the
+/// work part-way, which it cannot do if every window was built up front.
+pub fn windows<'a>(words: &'a [&'a str]) -> impl Iterator<Item = String> + 'a {
+    let short = words.len() <= SHINGLE_WORDS;
+    let count = if words.is_empty() {
+        0
+    } else if short {
+        1
+    } else {
+        words.len() - SHINGLE_WORDS + 1
+    };
+    (0..count).map(move |i| {
+        if short {
+            words.join(" ")
+        } else {
+            words[i..i + SHINGLE_WORDS].join(" ")
+        }
+    })
+}
+
+/// Normalize and shingle in one step.
+pub fn shingle_text(text: &str) -> Vec<String> {
+    shingles(&normalize(text))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reformatting_does_not_change_the_shingles() {
+        // The whole point: whitespace and case are free for an attacker to change.
+        let a = shingle_text("The Quick Brown Fox Jumps Over");
+        let b = shingle_text("the   quick\nbrown\tfox jumps over");
+
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn edge_punctuation_is_stripped_but_interior_is_kept() {
+        assert_eq!(normalize("(hello), world!"), "hello world");
+        // Interior structure distinguishes a token from a different token.
+        assert_eq!(normalize("api-key=value"), "api-key=value");
+    }
+
+    #[test]
+    fn windows_overlap_so_an_inserted_word_does_not_shift_everything_out() {
+        let original = shingle_text("alpha bravo charlie delta echo foxtrot golf");
+        let prefixed = shingle_text("zulu alpha bravo charlie delta echo foxtrot golf");
+
+        let shared = original.iter().filter(|s| prefixed.contains(s)).count();
+
+        assert!(
+            shared >= original.len() - 1,
+            "inserting one word lost {} of {} shingles",
+            original.len() - shared,
+            original.len()
+        );
+    }
+
+    #[test]
+    fn a_span_shorter_than_a_window_still_yields_one_shingle() {
+        assert_eq!(shingle_text("two words"), vec!["two words".to_string()]);
+    }
+
+    #[test]
+    fn empty_and_punctuation_only_text_yields_nothing() {
+        assert!(shingle_text("").is_empty());
+        assert!(shingle_text("   ").is_empty());
+        assert!(shingle_text("--- ...").is_empty());
+    }
+
+    #[test]
+    fn lazy_windows_match_the_allocating_form() {
+        let normalized = normalize("alpha bravo charlie delta echo foxtrot golf");
+        let words: Vec<&str> = normalized.split(' ').collect();
+
+        let lazy: Vec<String> = windows(&words).collect();
+
+        assert_eq!(lazy, shingles(&normalized));
+    }
+
+    #[test]
+    fn shingle_count_tracks_word_count() {
+        let text = (0..20)
+            .map(|i| format!("w{i}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert_eq!(shingle_text(&text).len(), 20 - SHINGLE_WORDS + 1);
+    }
+}

--- a/crates/arkavo-fingerprint/src/tier.rs
+++ b/crates/arkavo-fingerprint/src/tier.rs
@@ -1,0 +1,368 @@
+//! The reference tier as the cascade sees it (KP-011, SENT-002).
+//!
+//! This is the fast tier: a keyed hash per shingle and a hash-map probe, sitting
+//! ahead of anything that runs a model. It reports evidence — what matched, how
+//! much of the span, which family — and decides nothing.
+//!
+//! Two behaviours matter more than speed. An index that is not loaded reports
+//! *unavailable* rather than *no match*, because an outage that reads as a clean
+//! result is how a cascade silently stops working. And a budget overrun stops
+//! examining rather than blocking the call (KP-011): the tier is on the
+//! per-call path, and a tier that can exceed the budget is a tier that can be
+//! made to stall every tool call by feeding it a large span.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use arkavo_protocol::classification_evidence::{
+    ClassificationEvidence, Confidence, LabelFinding, TierReport,
+};
+
+use crate::index::{MatchSummary, ReferenceIndex, match_span};
+use crate::key::IndexKey;
+
+pub const TIER_NAME: &str = "reference-index";
+
+/// Share of the 50µs per-call budget this tier may spend.
+///
+/// Half, not all: the tier runs inside `ingest`, which also runs the pattern
+/// detector, and the budget is shared across everything on that path.
+pub const TIER_BUDGET: Duration = Duration::from_micros(25);
+
+/// Shingles examined between clock reads.
+///
+/// Reading the clock per shingle would cost more than the hashing it guards.
+const BUDGET_CHECK_STRIDE: usize = 16;
+
+/// Largest span examined inline.
+///
+/// Measured at ~22ns per byte to normalize, shingle, hash and probe, so 25µs
+/// buys about a kilobyte. The size test comes first and costs nothing: a
+/// deferral decision that requires shingling the span has already spent what it
+/// was trying to save, which is how the earlier version took 1.6ms to decide
+/// not to spend 25µs.
+const MAX_INLINE_BYTES: usize = 1024;
+
+/// The reference tier, holding a loaded index or the reason it has none.
+pub struct ReferenceTier {
+    index: Option<Arc<ReferenceIndex>>,
+    key: Option<Arc<IndexKey>>,
+    unavailable_reason: String,
+    budget: Duration,
+}
+
+impl ReferenceTier {
+    /// A tier with no index. Reports unavailable; the cascade proceeds without it.
+    pub fn unloaded(reason: impl Into<String>) -> Self {
+        Self {
+            index: None,
+            key: None,
+            unavailable_reason: reason.into(),
+            budget: TIER_BUDGET,
+        }
+    }
+
+    /// A tier backed by an index. The key must be the one that built it, or the
+    /// tier stays unloaded rather than matching nothing forever.
+    pub fn loaded(index: Arc<ReferenceIndex>, key: Arc<IndexKey>) -> Self {
+        if let Err(e) = index.check_key(&key) {
+            return Self::unloaded(e.to_string());
+        }
+        Self {
+            index: Some(index),
+            key: Some(key),
+            unavailable_reason: String::new(),
+            budget: TIER_BUDGET,
+        }
+    }
+
+    #[must_use]
+    pub fn with_budget(mut self, budget: Duration) -> Self {
+        self.budget = budget;
+        self
+    }
+
+    pub fn is_loaded(&self) -> bool {
+        self.index.is_some()
+    }
+
+    pub fn version(&self) -> String {
+        match &self.index {
+            Some(index) => format!("{}+{}", index.format_version, index.taxonomy_version),
+            None => "unloaded".to_string(),
+        }
+    }
+
+    /// Examine a span and report what this tier saw.
+    pub fn examine(&self, text: &str) -> TierReport {
+        let (Some(index), Some(key)) = (&self.index, &self.key) else {
+            return TierReport::unavailable(TIER_NAME, self.version(), &self.unavailable_reason);
+        };
+
+        if text.len() > MAX_INLINE_BYTES {
+            return TierReport::unavailable(
+                TIER_NAME,
+                self.version(),
+                format!(
+                    "span of {} bytes exceeds the {MAX_INLINE_BYTES}-byte inline limit; \
+                     scoring deferred",
+                    text.len()
+                ),
+            );
+        }
+
+        let started = Instant::now();
+        let summary = self.match_within_budget(index, key, text, started);
+        match summary {
+            Ok(summary) => TierReport::matched(TIER_NAME, self.version(), findings(&summary)),
+            // Not a match and not a clean miss: the span was only partly seen,
+            // so the honest report is that this tier could not finish.
+            Err(examined) => TierReport::unavailable(
+                TIER_NAME,
+                self.version(),
+                format!(
+                    "budget of {}µs exhausted after {examined} shingles; scoring deferred",
+                    self.budget.as_micros()
+                ),
+            ),
+        }
+    }
+
+    /// Examine a span, ignoring the budget. For the asynchronous tier that a
+    /// budget overrun defers to, where wall-clock cost is no longer on the
+    /// caller's path.
+    pub fn examine_unbudgeted(&self, text: &str) -> TierReport {
+        let (Some(index), Some(key)) = (&self.index, &self.key) else {
+            return TierReport::unavailable(TIER_NAME, self.version(), &self.unavailable_reason);
+        };
+        TierReport::matched(
+            TIER_NAME,
+            self.version(),
+            findings(&match_span(index, key, text)),
+        )
+    }
+
+    fn match_within_budget(
+        &self,
+        index: &ReferenceIndex,
+        key: &IndexKey,
+        text: &str,
+        started: Instant,
+    ) -> Result<MatchSummary, usize> {
+        // Normalized once; windows are joined one at a time so the budget can
+        // stop the work rather than arriving after it.
+        let normalized = crate::shingle::normalize(text);
+        let words: Vec<&str> = normalized.split(' ').filter(|w| !w.is_empty()).collect();
+        let mut summary = MatchSummary::default();
+        for (n, shingle) in crate::shingle::windows(&words).enumerate() {
+            if n % BUDGET_CHECK_STRIDE == 0 && n > 0 && started.elapsed() > self.budget {
+                return Err(n);
+            }
+            summary.shingles_examined += 1;
+            let hash = key.hash(&shingle);
+            if index.suppression().contains(hash) {
+                continue;
+            }
+            let Some(meta) = index.lookup(hash) else {
+                continue;
+            };
+            summary.shingles_matched += 1;
+            match summary.by_family.get(&meta.source_family) {
+                Some(existing) if existing.sensitivity >= meta.sensitivity => {}
+                _ => {
+                    summary
+                        .by_family
+                        .insert(meta.source_family.clone(), meta.clone());
+                }
+            }
+        }
+        Ok(summary)
+    }
+}
+
+/// Turn a match summary into evidence.
+///
+/// Confidence is coverage: the fraction of the span this index recognized. One
+/// shingle in a long document is a coincidence; the same shingle in a two-line
+/// span is the document. Reporting the raw match count instead would make a
+/// threshold meaningless across span sizes.
+fn findings(summary: &MatchSummary) -> Vec<LabelFinding> {
+    if summary.is_empty() {
+        return Vec::new();
+    }
+    let confidence = Confidence::new(summary.coverage());
+    summary
+        .by_family
+        .iter()
+        .map(|(family, meta)| {
+            LabelFinding::new(
+                meta.category,
+                meta.sensitivity,
+                confidence,
+                format!(
+                    "{}/{} shingles matched",
+                    summary.shingles_matched, summary.shingles_examined
+                ),
+            )
+            .from_family(family)
+        })
+        .collect()
+}
+
+/// Build evidence from a single tier. The cascade in Phase 4 will chain more.
+pub fn evidence_for(
+    tier: &ReferenceTier,
+    taxonomy_version: &str,
+    text: &str,
+) -> ClassificationEvidence {
+    ClassificationEvidence::new(taxonomy_version).with_tier(tier.examine(text))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arkavo_protocol::classification_evidence::TierOutcome;
+    use arkavo_protocol::data_classification::{DataCategory, SensitivityLevel};
+    use arkavo_test_macros::spec;
+
+    const CLASSIFIED: &str =
+        "the acquisition of northwind holdings closes in the third quarter pending approval";
+
+    fn tier() -> ReferenceTier {
+        let key = Arc::new(IndexKey::derive(&[7u8; 32], "corpus").expect("derive"));
+        let mut builder = ReferenceIndex::builder(&key, "1.0.0");
+        builder.add_document(
+            &key,
+            CLASSIFIED,
+            DataCategory::Internal,
+            SensitivityLevel::Confidential,
+            "board-minutes",
+        );
+        ReferenceTier::loaded(Arc::new(builder.build()), key)
+    }
+
+    #[spec("KP-011")]
+    #[test]
+    fn an_unloaded_index_reports_unavailable_not_no_match() {
+        // A cascade that reads an outage as "nothing found" stops working
+        // without anyone noticing.
+        let tier = ReferenceTier::unloaded("index not yet fetched");
+
+        let report = tier.examine(CLASSIFIED);
+
+        assert!(report.is_unavailable());
+        assert!(matches!(report.outcome, TierOutcome::Unavailable { .. }));
+    }
+
+    #[spec("KP-011")]
+    #[test]
+    fn a_wrong_key_leaves_the_tier_unloaded_rather_than_silently_empty() {
+        let key = Arc::new(IndexKey::derive(&[7u8; 32], "corpus").expect("derive"));
+        let mut builder = ReferenceIndex::builder(&key, "1.0.0");
+        builder.add_document(
+            &key,
+            CLASSIFIED,
+            DataCategory::Internal,
+            SensitivityLevel::Confidential,
+            "f",
+        );
+        let wrong = Arc::new(IndexKey::derive(&[8u8; 32], "corpus").expect("derive"));
+
+        let tier = ReferenceTier::loaded(Arc::new(builder.build()), wrong);
+
+        assert!(!tier.is_loaded());
+        assert!(tier.examine(CLASSIFIED).is_unavailable());
+    }
+
+    #[spec("KP-011")]
+    #[test]
+    fn a_clean_miss_is_a_match_report_with_no_findings() {
+        let report = tier().examine("entirely unrelated prose about the weather this week");
+
+        assert!(!report.is_unavailable());
+        assert_eq!(report.outcome, TierOutcome::NoMatch);
+    }
+
+    #[spec("SENT-002")]
+    #[test]
+    fn a_hit_carries_confidence_family_and_version() {
+        let tier = tier();
+
+        let report = tier.examine(CLASSIFIED);
+        let finding = &report.findings()[0];
+
+        assert_eq!(finding.source_family.as_deref(), Some("board-minutes"));
+        assert_eq!(finding.sensitivity, SensitivityLevel::Confidential);
+        assert!(finding.confidence.value() > 0.0);
+        assert_eq!(report.version, "1+1.0.0");
+        assert!(finding.signal.contains("shingles matched"));
+    }
+
+    #[spec("KP-011")]
+    #[test]
+    fn a_budget_overrun_defers_rather_than_blocking() {
+        // A tier that cannot exceed its budget is a tier an attacker cannot use
+        // to stall every tool call by sending one enormous span.
+        let tier = tier().with_budget(Duration::from_nanos(1));
+        let long = std::iter::repeat_n(CLASSIFIED, 400)
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        let report = tier.examine(&long);
+
+        assert!(report.is_unavailable(), "budget was not enforced");
+        // ...and the deferred path still produces the finding.
+        assert!(!tier.examine_unbudgeted(&long).findings().is_empty());
+    }
+
+    #[spec("KP-011")]
+    #[test]
+    fn a_short_span_is_answered_synchronously_inside_the_budget() {
+        // Tool-call arguments — what the egress gate actually hands this tier —
+        // are short, and that is the case the budget has to cover.
+        let tier = tier();
+
+        let report = tier.examine(CLASSIFIED);
+
+        // Behaviour, not wall clock: a debug build measures unoptimized
+        // shingling, so the budget number comes from the bench. What this pins
+        // is that a short span is answered rather than deferred.
+        assert!(!report.is_unavailable(), "a short span was deferred");
+        assert!(!report.findings().is_empty());
+    }
+
+    #[spec("KP-011")]
+    #[test]
+    fn a_large_span_defers_rather_than_overrunning_the_budget() {
+        // Measured: a 4KB span costs ~89µs to hash and probe in full, well over
+        // the 50µs per-call invariant. The tier must not spend that on the
+        // caller's thread — it stops and hands the span to asynchronous
+        // scoring, which is the degradation KP-011 specifies.
+        let tier = tier();
+        let large = std::iter::repeat_n(CLASSIFIED, 60)
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        let started = Instant::now();
+        let report = tier.examine(&large);
+        let elapsed = started.elapsed();
+
+        assert!(
+            report.is_unavailable(),
+            "the tier spent the whole span inline"
+        );
+        assert!(
+            elapsed < TIER_BUDGET * 4,
+            "deferral took {elapsed:?}, far past the {TIER_BUDGET:?} budget"
+        );
+    }
+
+    #[spec("KP-011")]
+    #[test]
+    fn evidence_records_the_tier_even_when_it_found_nothing() {
+        let evidence = evidence_for(&tier(), "1.0.0", "unrelated prose about the weather");
+
+        assert_eq!(evidence.tiers.len(), 1);
+        assert!(!evidence.has_gap());
+    }
+}

--- a/crates/arkavo-protocol/src/classification_evidence.rs
+++ b/crates/arkavo-protocol/src/classification_evidence.rs
@@ -1,0 +1,322 @@
+//! What a classification tier reports (SENT-002, KP-009).
+//!
+//! [`ClassifiedDatum`] cannot carry this. Its `DatumType` is a closed enum that
+//! answers `category()` and `default_sensitivity()` from the variant itself, so
+//! a finding whose category comes from an index entry rather than from a regex
+//! has nowhere to put it — nor anywhere to put the confidence, the tier
+//! version, or which source family matched.
+//!
+//! Evidence is not a verdict. A tier says what it saw and how sure it is; the
+//! policy decision point decides what that means. Keeping the two apart is the
+//! whole point of the sentinel design, and it starts here.
+//!
+//! [`ClassifiedDatum`]: crate::data_classification::ClassifiedDatum
+
+use serde::{Deserialize, Serialize};
+
+use crate::data_classification::{DataCategory, SensitivityLevel};
+
+/// A calibrated probability in `0.0..=1.0`.
+///
+/// Calibrated, not raw: a raw model score is not comparable across labels or
+/// across detector versions, and a threshold applied to one is meaningless.
+/// Construction clamps rather than rejecting, because a tier that returns a
+/// nonsense score should be visible in the evidence rather than fatal to the
+/// call it was scoring.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct Confidence(f32);
+
+impl Confidence {
+    pub const CERTAIN: Confidence = Confidence(1.0);
+
+    pub fn new(value: f32) -> Self {
+        if value.is_nan() {
+            return Confidence(0.0);
+        }
+        Confidence(value.clamp(0.0, 1.0))
+    }
+
+    pub fn value(self) -> f32 {
+        self.0
+    }
+}
+
+/// One label a tier inferred, with everything needed to defend it later.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LabelFinding {
+    pub category: DataCategory,
+    pub sensitivity: SensitivityLevel,
+    pub confidence: Confidence,
+    /// What fired, in terms an auditor can follow: a pattern name, a matched
+    /// shingle count, a model label.
+    pub signal: String,
+    /// Which corpus family the match came from, when a reference tier
+    /// contributed. Absent for tiers that match on content alone.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_family: Option<String>,
+    /// Byte span within the inspected text, when the tier can localize it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub span: Option<(usize, usize)>,
+}
+
+impl LabelFinding {
+    pub fn new(
+        category: DataCategory,
+        sensitivity: SensitivityLevel,
+        confidence: Confidence,
+        signal: impl Into<String>,
+    ) -> Self {
+        Self {
+            category,
+            sensitivity,
+            confidence,
+            signal: signal.into(),
+            source_family: None,
+            span: None,
+        }
+    }
+
+    #[must_use]
+    pub fn from_family(mut self, family: impl Into<String>) -> Self {
+        self.source_family = Some(family.into());
+        self
+    }
+
+    #[must_use]
+    pub fn at(mut self, start: usize, end: usize) -> Self {
+        self.span = Some((start, end));
+        self
+    }
+}
+
+/// What one tier had to say.
+///
+/// `NoMatch` and `Unavailable` are distinct on purpose (SENT-002 edge case): a
+/// tier that looked and found nothing is evidence of absence, a tier that could
+/// not look is evidence of nothing at all, and collapsing them lets an outage
+/// read as a clean bill of health.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum TierOutcome {
+    Matched { findings: Vec<LabelFinding> },
+    NoMatch,
+    Unavailable { reason: String },
+}
+
+/// One tier's contribution, recorded whether or not it matched.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TierReport {
+    pub tier: String,
+    /// Version of the detector that produced this, so a past decision stays
+    /// reconstructable after the detector changes.
+    pub version: String,
+    #[serde(flatten)]
+    pub outcome: TierOutcome,
+}
+
+impl TierReport {
+    pub fn matched(
+        tier: impl Into<String>,
+        version: impl Into<String>,
+        findings: Vec<LabelFinding>,
+    ) -> Self {
+        let outcome = if findings.is_empty() {
+            TierOutcome::NoMatch
+        } else {
+            TierOutcome::Matched { findings }
+        };
+        Self {
+            tier: tier.into(),
+            version: version.into(),
+            outcome,
+        }
+    }
+
+    pub fn unavailable(
+        tier: impl Into<String>,
+        version: impl Into<String>,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            tier: tier.into(),
+            version: version.into(),
+            outcome: TierOutcome::Unavailable {
+                reason: reason.into(),
+            },
+        }
+    }
+
+    pub fn findings(&self) -> &[LabelFinding] {
+        match &self.outcome {
+            TierOutcome::Matched { findings } => findings,
+            TierOutcome::NoMatch | TierOutcome::Unavailable { .. } => &[],
+        }
+    }
+
+    pub fn is_unavailable(&self) -> bool {
+        matches!(self.outcome, TierOutcome::Unavailable { .. })
+    }
+}
+
+/// Everything the cascade observed about one span.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ClassificationEvidence {
+    /// Taxonomy the labels are expressed in. Without it a stored finding cannot
+    /// be read years later, because `Confidential` may not mean what it did.
+    pub taxonomy_version: String,
+    /// Every tier consulted, in cascade order, matched or not.
+    pub tiers: Vec<TierReport>,
+}
+
+impl ClassificationEvidence {
+    pub fn new(taxonomy_version: impl Into<String>) -> Self {
+        Self {
+            taxonomy_version: taxonomy_version.into(),
+            tiers: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_tier(mut self, report: TierReport) -> Self {
+        self.tiers.push(report);
+        self
+    }
+
+    pub fn push_tier(&mut self, report: TierReport) {
+        self.tiers.push(report);
+    }
+
+    pub fn findings(&self) -> impl Iterator<Item = &LabelFinding> {
+        self.tiers.iter().flat_map(TierReport::findings)
+    }
+
+    /// Whether any tier could not be consulted. A gap is a reason to treat the
+    /// result as incomplete, not as clean.
+    pub fn has_gap(&self) -> bool {
+        self.tiers.iter().any(TierReport::is_unavailable)
+    }
+
+    /// Highest sensitivity any tier reported at or above `threshold`.
+    ///
+    /// `None` when nothing cleared the threshold — which is not the same as
+    /// `Public`, and callers must not read it that way.
+    pub fn sensitivity_at(&self, threshold: Confidence) -> Option<SensitivityLevel> {
+        self.findings()
+            .filter(|f| f.confidence >= threshold)
+            .map(|f| f.sensitivity)
+            .max()
+    }
+
+    /// Categories reported at or above `threshold`.
+    pub fn categories_at(&self, threshold: Confidence) -> Vec<DataCategory> {
+        let mut categories: Vec<DataCategory> = self
+            .findings()
+            .filter(|f| f.confidence >= threshold)
+            .map(|f| f.category)
+            .collect();
+        categories.sort_unstable();
+        categories.dedup();
+        categories
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn finding(category: DataCategory, level: SensitivityLevel, c: f32) -> LabelFinding {
+        LabelFinding::new(category, level, Confidence::new(c), "test")
+    }
+
+    #[test]
+    fn confidence_is_clamped_rather_than_rejected() {
+        assert_eq!(Confidence::new(1.7).value(), 1.0);
+        assert_eq!(Confidence::new(-0.2).value(), 0.0);
+        assert_eq!(Confidence::new(f32::NAN).value(), 0.0);
+    }
+
+    #[test]
+    fn a_tier_that_looked_and_found_nothing_is_recorded() {
+        let evidence = ClassificationEvidence::new("1.0.0").with_tier(TierReport::matched(
+            "exact",
+            "1",
+            Vec::new(),
+        ));
+
+        assert_eq!(evidence.tiers.len(), 1);
+        assert_eq!(evidence.tiers[0].outcome, TierOutcome::NoMatch);
+        assert!(!evidence.has_gap());
+    }
+
+    #[test]
+    fn a_tier_that_could_not_look_is_a_gap_not_a_clean_result() {
+        // Collapsing these would let an index outage read as "nothing found".
+        let evidence = ClassificationEvidence::new("1.0.0").with_tier(TierReport::unavailable(
+            "exact",
+            "1",
+            "index not loaded",
+        ));
+
+        assert!(evidence.has_gap());
+        assert_eq!(evidence.sensitivity_at(Confidence::new(0.0)), None);
+    }
+
+    #[test]
+    fn nothing_above_threshold_is_not_public() {
+        let evidence = ClassificationEvidence::new("1.0.0").with_tier(TierReport::matched(
+            "sentinel",
+            "1",
+            vec![finding(DataCategory::Pii, SensitivityLevel::Internal, 0.3)],
+        ));
+
+        assert_eq!(evidence.sensitivity_at(Confidence::new(0.9)), None);
+        assert_eq!(
+            evidence.sensitivity_at(Confidence::new(0.2)),
+            Some(SensitivityLevel::Internal)
+        );
+    }
+
+    #[test]
+    fn the_highest_sensitivity_above_threshold_wins() {
+        let evidence = ClassificationEvidence::new("1.0.0").with_tier(TierReport::matched(
+            "exact",
+            "1",
+            vec![
+                finding(DataCategory::Internal, SensitivityLevel::Internal, 0.99),
+                finding(DataCategory::Healthcare, SensitivityLevel::Restricted, 0.95),
+            ],
+        ));
+
+        assert_eq!(
+            evidence.sensitivity_at(Confidence::new(0.9)),
+            Some(SensitivityLevel::Restricted)
+        );
+        let mut expected = vec![DataCategory::Healthcare, DataCategory::Internal];
+        expected.sort_unstable();
+        assert_eq!(evidence.categories_at(Confidence::new(0.9)), expected);
+    }
+
+    #[test]
+    fn evidence_round_trips_with_the_tier_that_found_nothing_intact() {
+        let evidence = ClassificationEvidence::new("1.0.0")
+            .with_tier(TierReport::matched("exact", "1", Vec::new()))
+            .with_tier(TierReport::matched(
+                "sentinel",
+                "2",
+                vec![
+                    finding(DataCategory::Financial, SensitivityLevel::Confidential, 0.8)
+                        .from_family("invoices"),
+                ],
+            ));
+
+        let json = serde_json::to_string(&evidence).expect("serialize");
+        let back: ClassificationEvidence = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(back, evidence);
+        assert_eq!(back.tiers.len(), 2);
+        assert_eq!(
+            back.findings().next().unwrap().source_family.as_deref(),
+            Some("invoices")
+        );
+    }
+}

--- a/crates/arkavo-protocol/src/lib.rs
+++ b/crates/arkavo-protocol/src/lib.rs
@@ -28,6 +28,8 @@ pub mod agent_specialization;
 pub mod auth;
 pub mod chat_commands;
 pub mod chat_session;
+#[cfg(feature = "taint")]
+pub mod classification_evidence;
 pub mod config;
 pub mod config_transport;
 pub mod data_classification;
@@ -87,6 +89,10 @@ pub use chat_commands::{
     ChatSession, CommandResult, ContextMode, PendingContext, execute_command, parse_command,
 };
 pub use chat_session::ChatSessionManager;
+#[cfg(feature = "taint")]
+pub use classification_evidence::{
+    ClassificationEvidence, Confidence, LabelFinding, TierOutcome, TierReport,
+};
 pub use config::{A2aConfig, A2aConfigBuilder, BufferConfig, ConfigManager};
 pub use data_classification::{
     ClassifiedDatum, DataCategory, DatumType, DlpAction, DlpPolicy, SensitivityLevel,

--- a/crates/arkavo-protocol/tests/sentinel_test.rs
+++ b/crates/arkavo-protocol/tests/sentinel_test.rs
@@ -1,5 +1,6 @@
-//! SENT-001, SENT-002, SENT-003, SENT-013: tripwires against the DLP surface
-//! the sentinel will replace.
+#![cfg(feature = "taint")]
+//! SENT-001, SENT-002, SENT-003, SENT-013: the split between labelling and
+//! authorizing.
 //!
 //! `DlpPolicy` today fuses detection and authorization: it looks at one datum
 //! and answers Allow or Block. The sentinel splits those apart — it produces

--- a/crates/arkavo/Cargo.toml
+++ b/crates/arkavo/Cargo.toml
@@ -37,6 +37,7 @@ claude-agent = ["arkavo-cli/claude-agent"]
 # Taint-aware egress enforcement (SEQ-003, SEQ-014, SEQ-015). Off until the
 # sequence-integrity work reaches GA; the security suite builds a binary with it.
 taint = ["arkavo-cli/taint"]
+fingerprint = ["arkavo-cli/fingerprint"]
 
 [dependencies]
 arkavo-cli = { path = "../arkavo-cli", default-features = false }

--- a/docs/plans/2026-08-30-dlp-sentinel-knowledge-packs.md
+++ b/docs/plans/2026-08-30-dlp-sentinel-knowledge-packs.md
@@ -127,9 +127,10 @@ Resolved:
 - **Pack naming:** `.knowpack.tdf`, with components named `adapter-<compartment>.gguf.tdf`, `sentinel.gguf.tdf`, `index.tdf`, `manifest.json`, `manifest.sig`. A pack is a multi-component archive with its own lifecycle; `.swarmkit.tdf` stays what it is today, a role-policy kit.
 - **Training stack** and **embedding tier:** the plan's stated defaults are recorded as advisory defaults, not spec invariants — a Rust-first training path with GGUF export, and a hash-plus-sentinel cascade with no embedding tier. KP and SENT scenarios specify outcomes (calibrated thresholds bound into the manifest, split by source family, cascade tier ordering and budget), so swapping either default is an implementation change, not a spec change.
 
+- **Sentinel base:** Qwen3.5-0.8B (`ModelChoice::LocalQwen3`), decided 2026-08-30 under Paul's explicit delegation rather than silently — the ground rule is a trail, not a veto. It is the only registry model under the ≤1B target, its GGUF download and load path is already proven here, and the registry notes it as DeltaNet-fast, which is what holdback latency needs. Apache-2.0, verified against the Hugging Face API for both the official weights and the unsloth requant, so derivatives and redistribution are unrestricted; `deny.toml` is untouched because no crate changes. Ministral 3B was rejected on size, Gemma on terms that flow down to derivatives — legal surface a shipped pack should not carry. Phase 6 fine-tunes from the **official** Qwen weights, not the requant: the requant is fine for runtime bring-up, where the router already trusts it, but a security classifier's training base should be first-party.
+
 Open:
 
-- **Sentinel base:** model family and size target (≤1B) plus license compatibility with `deny.toml` and `THIRD-PARTY-LICENSES.md`.
 - **Release mapping proposal:** 0.91 → P0–P2 · 0.92 → P3–P4 · 0.93 → P5 · 0.94 → P6–P7.
 
 ## Milestone map


### PR DESCRIPTION
Phase 3 of `docs/plans/2026-08-30-dlp-sentinel-knowledge-packs.md`. **Stacked on
#672** — review that first; this diff is only the increment on top of it.

The fast tier of the DLP cascade: answers "have I seen this content before, and
what was it labelled" without running a model, and without storing anything an
attacker who steals the index can read.

## What lands

**`arkavo-fingerprint`** (new crate) — keyed shingle index, tenant key
derivation, suppression, the reference tier with budget deferral — plus
`arkavo pack index` to build one.

**Everything is keyed.** An unkeyed index of sensitive content is a dictionary:
hash a guess, look for the digest, learn whether the guess was in the corpus.
There is no path through this crate, and no CLI flag, that produces one — a
missing or short key is a hard error, and a test asserts no bypass exists. The
key derives through BLAKE3's key-derivation mode, zeroizes on drop via a guard
rather than by hand, is not `Clone`, never renders itself in `Debug`, and is
domain-separated per index so a hit in one cannot be replayed against another.
An index carries the fingerprint of the key that built it, so the wrong key is a
loud error rather than a silent stream of misses.

Digests are **128-bit**. At 64 bits the birthday bound sits near 2^32 shingles —
reachable by a large corpus — and a collision is not a precision problem: the
digest is the sole key into both the entry map and the suppression set, so
colliding shingles let one inherit the other's *suppressed* status and vanish
from the tier meant to find it. Measured cost of the widening: 3ns per shingle.

**Evidence, not verdicts.** SENT-002's contract is pulled forward from Phase 4 —
deliberately: a fingerprint hit cannot fit `ClassifiedDatum`, because
`DatumType` answers its own `category()` and `default_sensitivity()` while an
index entry's come from the corpus. Confidence is *coverage*, not a match count:
one shingle in a long document is a coincidence, the same shingle in a two-line
span is the document. A tier that looked and found nothing is recorded
distinctly from one that could not look — an outage reading as a clean result is
how a cascade silently stops working.

## Two things the work changed

**The bench moved a design decision.** A 4KB span costs **~88µs** to normalize,
hash and probe — well past the 50µs per-call invariant. Spans over a kilobyte
now defer to asynchronous scoring *before any work happens*. An earlier version
decided to defer only after shingling, and took **1.6ms to decide not to spend
25µs**. Short spans — tool-call arguments, which is what the egress gate actually
hands this tier — are answered inline at **~1.3µs**.

**A failing test caught a flaw in the suppression rule.** "Never suppress a
shingle a classified document claims" makes suppression a no-op the moment
boilerplate is embedded in classified material — the normal case, since real
documents carry license headers. The rule now removes the boilerplate shingles,
which kills the false positive, and loses only where it would silence a document
entirely. Both KP-010 clauses are pinned by order-independent tests. Suppression
never sees a `TaintSet` and never touches another tier's findings.

## Decision recorded: sentinel base is Qwen3.5-0.8B

Made under Paul's explicit delegation, not silently — the plan records who
decided and why, per ground rule 6. Only registry model under the 1B target
(`ModelChoice::LocalQwen3`), GGUF path already proven here, noted as DeltaNet-fast
which is what holdback latency needs. **Apache-2.0, verified against the Hugging
Face API** for both the official weights and the requant the router pulls, so
derivatives and redistribution are unrestricted; `deny.toml` untouched, and
`THIRD-PARTY-LICENSES.md` gains a `## Qwen Models` section following the Gemma
pattern. Ministral 3B loses on size; Gemma's terms flow down to derivatives,
which is legal surface a shipped pack should not carry. Phase 6 fine-tunes from
the **official** weights, not the requant — fine for bring-up, but a security
classifier's base should be first-party.

## Verification

- 35 crate tests + 5 CLI tests; `cargo fmt --check` and clippy clean
- Bench: `keyed_hash_one_shingle` 50ns · `tier_examine_hit` 1.23µs ·
  `tier_examine_miss` 580ns · `match_span_4kb` 88µs (the number that forced the
  deferral design)
- End-to-end: `arkavo pack index` over a seeded corpus produces 29 entries and
  leaks no corpus text; a missing key and a 5-byte key both fail hard
- `blake3` gets a `[profile.dev.package]` opt-level entry, or the debug bench lies

## Deferred, and why

- **TDF wrapping** goes to `arkavo pack seal` in Phase 5: it needs a KAS to
  release the payload key, and faking that here is worse than computing the
  classification and the attribute it implies, which this does.
- **KAS-backed key provisioning** likewise. `--key-file` plus the length floor is
  the honest interface meanwhile, so **KP-009 stays `wip`** — its `given` names
  the KAS path.

Phase 4 lands as a third PR stacked on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)