### PR TITLE
Add arkavo-cwt as the single COSE/CWT verifier

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -170,7 +170,7 @@ jobs:
       matrix:
         group:
           - core        # arkavo-llm, arkavo-memory, arkavo-budget, arkavo-context (32K LOC)
-          - protocol    # arkavo-protocol, arkavo-observability, arkavo-mcp-workspace, arkavo-session, arkavo-critic
+          - protocol    # arkavo-protocol, arkavo-observability, arkavo-mcp-workspace, arkavo-session, arkavo-critic, arkavo-cwt
           - integrity   # arkavo-titan, arkavo-events, arkavo-validation (sequence-integrity tripwire tests)
           - tools       # arkavo-mcp-tools (24K LOC, I/O heavy)
           - routing     # arkavo-router, arkavo-dataflow (42K LOC)
@@ -246,6 +246,7 @@ jobs:
             cargo test --locked -p arkavo-mcp-workspace
             cargo test --locked -p arkavo-session --lib
             cargo test --locked -p arkavo-critic
+            cargo test --locked -p arkavo-cwt
           elif [ "${{ matrix.group }}" = "integrity" ]; then
             cargo test --locked -p arkavo-titan
             cargo test --locked -p arkavo-events
@@ -308,6 +309,7 @@ jobs:
             cargo clippy --locked -p arkavo-mcp-workspace --lib --bins -- -D warnings
             cargo clippy --locked -p arkavo-session --lib --bins -- -D warnings
             cargo clippy --locked -p arkavo-critic --lib --bins -- -D warnings
+            cargo clippy --locked -p arkavo-cwt --lib --bins -- -D warnings
           elif [ "${{ matrix.group }}" = "integrity" ]; then
             cargo clippy --locked -p arkavo-titan --lib --bins -- -D warnings
             cargo clippy --locked -p arkavo-events --lib --bins -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,6 +974,7 @@ dependencies = [
  "base64 0.22.1",
  "ciborium",
  "coset",
+ "ed25519-dalek 2.2.0",
  "p256",
  "rand 0.8.6",
  "reqwest 0.12.28",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-cli",
  "serde_json",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-adaptation"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-arp",
  "rand 0.8.6",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agent-auth"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-adaptation",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-agui-protocol"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-test-macros",
  "serde",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-arp-runtime"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-adaptation",
  "arkavo-arp",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-attestation"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-device-identity",
  "arkavo-test-macros",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-authorization"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-autolearn"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-crypto",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-browser"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-budget"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cef"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-observability",
  "async-trait",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-cli"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-agent-auth",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-bundle"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "chrono",
  "serde",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-encryption"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-test-macros",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-config-transport"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-config-bundle",
  "arkavo-config-encryption",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-context"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-llm",
  "arkavo-tdf",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-critic"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-evofabric",
  "arkavo-llm",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-crypto"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -967,8 +967,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "arkavo-cwt"
+version = "0.91.2"
+dependencies = [
+ "arkavo-test-macros",
+ "base64 0.22.1",
+ "ciborium",
+ "coset",
+ "p256",
+ "rand 0.8.6",
+ "reqwest 0.12.28",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "wiremock",
+]
+
+[[package]]
 name = "arkavo-dataflow"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1001,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-debugger"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-events",
  "arkavo-memory",
@@ -1017,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-deepseek"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1036,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-device-identity"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -1051,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ensemble"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-sat",
  "arkavo-sbe",
@@ -1067,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-events"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-test-macros",
  "chrono",
@@ -1080,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-evofabric"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1104,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-fingerprint"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-protocol",
  "arkavo-test-macros",
@@ -1118,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gemini"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1140,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gguf-tdf"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-test-macros",
  "base64 0.22.1",
@@ -1161,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-git"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "git2",
  "tempfile",
@@ -1170,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-github"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-memory",
@@ -1190,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-gossip"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -1208,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-hrm"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1231,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-identity"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "base64 0.22.1",
  "ciborium",
@@ -1251,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kimi"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1271,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-knowledge-pack"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-fingerprint",
@@ -1295,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-kv-cache"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-llama-cpp",
  "arkavo-test-macros",
@@ -1309,11 +1326,11 @@ dependencies = [
 
 [[package]]
 name = "arkavo-lesson-synthesis"
-version = "0.91.1"
+version = "0.91.2"
 
 [[package]]
 name = "arkavo-llama-cpp"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-gguf-tdf",
  "arkavo-llama-cpp-sys",
@@ -1325,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llama-cpp-sys"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "bindgen",
  "cc",
@@ -1335,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-llm"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-budget",
@@ -1378,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1392,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-bench"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-context",
  "arkavo-gemini",
@@ -1417,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-claude"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anthropic-agent-sdk",
  "anyhow",
@@ -1441,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-code-search"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1461,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-identity"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1481,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-macos"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-git",
  "arkavo-mcp",
@@ -1510,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-mesh"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-budget",
  "arkavo-mcp",
@@ -1528,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-runtime"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-llm",
@@ -1553,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-tools"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-browser",
  "arkavo-git",
@@ -1587,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-mcp-workspace"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-mcp",
  "async-trait",
@@ -1598,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-memory"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-events",
@@ -1622,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-observability"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1643,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-openclaw"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-protocol",
@@ -1669,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-orchestrator"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1714,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-policy-cache"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-arp",
  "dashmap",
@@ -1724,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-protocol"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -1789,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-qwen"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1807,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-registration"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-device-identity",
@@ -1821,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-repo"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-git",
@@ -1840,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-router"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-budget",
  "arkavo-context",
@@ -1888,7 +1905,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sat"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "lru",
  "serde",
@@ -1901,7 +1918,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sbe"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-crypto",
  "async-trait",
@@ -1919,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-security"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-test-macros",
@@ -1948,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-sentinel"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-fingerprint",
  "arkavo-gguf-tdf",
@@ -1965,7 +1982,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-server"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-agent",
@@ -2044,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-session"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-arp",
@@ -2079,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-shadow-consolidation"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-lesson-synthesis",
@@ -2097,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-snpe"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "libc",
@@ -2110,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-budget",
  "arkavo-test-macros",
@@ -2126,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-swarmkit-runtime"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-agent-auth",
  "arkavo-agui",
@@ -2152,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tasks"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-hrm",
@@ -2171,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-crypto",
  "arkavo-test-macros",
@@ -2194,7 +2211,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-tdf-iroh"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-tdf",
  "async-trait",
@@ -2211,7 +2228,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-terminal"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-dataflow",
@@ -2235,7 +2252,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-test-macros"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2246,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-titan"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-sbe",
  "arkavo-test-macros",
@@ -2259,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-llama-cpp",
  "dirs 6.0.0",
@@ -2271,7 +2288,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-torg-circuits"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "parking_lot",
  "torg-core",
@@ -2280,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-trust"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-crypto",
  "base64 0.22.1",
@@ -2294,7 +2311,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ucp"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "alloy-primitives",
  "arkavo-budget",
@@ -2313,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-core"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-agui",
@@ -2328,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-ui-generator"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "arkavo-browser",
@@ -2353,7 +2370,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-validation"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "arkavo-arp",
  "arkavo-test-macros",
@@ -2363,7 +2380,7 @@ dependencies = [
 
 [[package]]
 name = "arkavo-wallet"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "alloy-primitives",
  "bip39",
@@ -3275,7 +3292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3439,6 +3456,16 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "coset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eb98d5e9155e2cf7cd942c8b3033097d4563b6fb0a00b9caecb74669555c058"
+dependencies = [
+ "ciborium",
+ "ciborium-io",
+]
 
 [[package]]
 name = "cpu-time"
@@ -3834,7 +3861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5552,7 +5579,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -12416,7 +12443,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ members = [
     "crates/arkavo-device-identity",
     "crates/arkavo-attestation",
     "crates/arkavo-crypto",
+    "crates/arkavo-cwt",
     "crates/arkavo-registration",
     "crates/arkavo-agent",
     "crates/arkavo-agent-auth",
@@ -137,6 +138,7 @@ default-members = [
     "crates/arkavo-identity",
     "crates/arkavo-attestation",
     "crates/arkavo-crypto",
+    "crates/arkavo-cwt",
     "crates/arkavo-registration",
     "crates/arkavo-agent-auth",
     "crates/arkavo-hrm",
@@ -162,7 +164,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.91.1"
+version = "0.91.2"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Arkavo Contributors"]
@@ -217,6 +219,9 @@ bytes = "1.8"
 parking_lot = "0.12"
 sysinfo = "0.34"
 ed25519-dalek = "2.1"
+coset = "0.4"
+ciborium = "0.2"
+p256 = { version = "0.13", features = ["ecdsa"] }
 fast_qr = { version = "0.13", default-features = false }
 hex = "0.4"
 

--- a/crates/arkavo-cwt/Cargo.toml
+++ b/crates/arkavo-cwt/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "arkavo-cwt"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "COSE_Sign1/ES256 CWT verification against a published COSE key set"
+
+[dependencies]
+ciborium = { workspace = true }
+coset = { workspace = true }
+p256 = { version = "0.13", features = ["ecdsa"] }
+base64 = { workspace = true }
+reqwest = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+arkavo-test-macros = { path = "../arkavo-test-macros" }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+wiremock = "0.6"

--- a/crates/arkavo-cwt/Cargo.toml
+++ b/crates/arkavo-cwt/Cargo.toml
@@ -9,7 +9,8 @@ description = "COSE_Sign1/ES256 CWT verification against a published COSE key se
 [dependencies]
 ciborium = { workspace = true }
 coset = { workspace = true }
-p256 = { version = "0.13", features = ["ecdsa"] }
+ed25519-dalek = { workspace = true, features = ["rand_core"] }
+p256 = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/arkavo-cwt/src/claims.rs
+++ b/crates/arkavo-cwt/src/claims.rs
@@ -1,0 +1,180 @@
+//! CWT claim decoding.
+//!
+//! authnz-rs emits the RFC 8392 integer claim keys (`1` iss, `2` sub, `3` aud,
+//! `4` exp, `6` iat) alongside Arkavo's own text-keyed claims. `nbf` (`5`) is
+//! never emitted, so it is not required here.
+
+use crate::CwtError;
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use ciborium::Value;
+
+/// The subset of the agent CWT's claims the edge acts on.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Claims {
+    pub iss: String,
+    pub sub: String,
+    pub aud: Vec<String>,
+    pub exp: i64,
+    pub iat: i64,
+    pub account_id: Option<String>,
+    pub roles: Vec<String>,
+    pub entitlements: Vec<String>,
+    /// Subjects named by the `act` claim — the human principals the agent acts
+    /// for. Absent entirely when no actors are configured.
+    pub actors: Vec<String>,
+    pub npe: Option<serde_json::Value>,
+}
+
+impl Claims {
+    pub(crate) fn from_cbor(payload: &[u8]) -> Result<Self, CwtError> {
+        let value: Value =
+            ciborium::from_reader(payload).map_err(|e| CwtError::Claims(e.to_string()))?;
+        let Value::Map(entries) = value else {
+            return Err(CwtError::Claims("payload is not a CBOR map".into()));
+        };
+
+        let mut iss = None;
+        let mut sub = None;
+        let mut aud = Vec::new();
+        let mut exp = None;
+        let mut iat = None;
+        let mut account_id = None;
+        let mut roles = Vec::new();
+        let mut entitlements = Vec::new();
+        let mut actors = Vec::new();
+        let mut npe = None;
+
+        for (key, value) in entries {
+            match &key {
+                Value::Integer(i) => match i128::from(*i) {
+                    1 => iss = Some(text(&value, "iss")?),
+                    2 => sub = Some(text(&value, "sub")?),
+                    3 => aud = audience(&value)?,
+                    4 => exp = Some(integer(&value, "exp")?),
+                    6 => iat = Some(integer(&value, "iat")?),
+                    _ => {}
+                },
+                Value::Text(label) => match label.as_str() {
+                    "arkavo_account_id" => account_id = Some(text(&value, "arkavo_account_id")?),
+                    "arkavo_roles" => roles = text_array(&value, "arkavo_roles")?,
+                    "arkavo_entitlements" => {
+                        entitlements = text_array(&value, "arkavo_entitlements")?;
+                    }
+                    "arkavo_npe" => npe = Some(to_json(&value)?),
+                    "act" => actors = actor_subjects(&value)?,
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+
+        Ok(Self {
+            iss: iss.ok_or_else(|| CwtError::Claims("missing iss".into()))?,
+            sub: sub.ok_or_else(|| CwtError::Claims("missing sub".into()))?,
+            aud,
+            exp: exp.ok_or_else(|| CwtError::Claims("missing exp".into()))?,
+            iat: iat.ok_or_else(|| CwtError::Claims("missing iat".into()))?,
+            account_id,
+            roles,
+            entitlements,
+            actors,
+            npe,
+        })
+    }
+}
+
+fn text(value: &Value, claim: &str) -> Result<String, CwtError> {
+    value
+        .as_text()
+        .map(str::to_owned)
+        .ok_or_else(|| CwtError::Claims(format!("{claim} is not a text string")))
+}
+
+fn integer(value: &Value, claim: &str) -> Result<i64, CwtError> {
+    let Value::Integer(i) = value else {
+        return Err(CwtError::Claims(format!("{claim} is not an integer")));
+    };
+    i64::try_from(*i).map_err(|_| CwtError::Claims(format!("{claim} does not fit in i64")))
+}
+
+/// `aud` is a CBOR array for agent tokens and a bare text string for other
+/// token types; both are legal per RFC 8392.
+fn audience(value: &Value) -> Result<Vec<String>, CwtError> {
+    match value {
+        Value::Text(t) => Ok(vec![t.clone()]),
+        Value::Array(_) => text_array(value, "aud"),
+        _ => Err(CwtError::Claims("aud is not a text string or array".into())),
+    }
+}
+
+fn text_array(value: &Value, claim: &str) -> Result<Vec<String>, CwtError> {
+    let Value::Array(items) = value else {
+        return Err(CwtError::Claims(format!("{claim} is not an array")));
+    };
+    items.iter().map(|item| text(item, claim)).collect()
+}
+
+/// `act` is an array of `{"sub": "<actor>"}` maps.
+fn actor_subjects(value: &Value) -> Result<Vec<String>, CwtError> {
+    let Value::Array(items) = value else {
+        return Err(CwtError::Claims("act is not an array".into()));
+    };
+    items
+        .iter()
+        .map(|item| {
+            let Value::Map(fields) = item else {
+                return Err(CwtError::Claims("act entry is not a map".into()));
+            };
+            fields
+                .iter()
+                .find(|(k, _)| k.as_text() == Some("sub"))
+                .ok_or_else(|| CwtError::Claims("act entry has no sub".into()))
+                .and_then(|(_, v)| text(v, "act.sub"))
+        })
+        .collect()
+}
+
+/// Render `arkavo_npe` as JSON so callers can inspect the delegation chain with
+/// the same tooling they use for the rest of the identity plane. Byte strings
+/// become base64url text, the only lossless rendering JSON allows.
+fn to_json(value: &Value) -> Result<serde_json::Value, CwtError> {
+    Ok(match value {
+        Value::Null => serde_json::Value::Null,
+        Value::Bool(b) => serde_json::Value::Bool(*b),
+        Value::Integer(i) => serde_json::Value::Number(
+            i64::try_from(*i)
+                .map_err(|_| CwtError::Claims("arkavo_npe integer does not fit in i64".into()))?
+                .into(),
+        ),
+        Value::Float(f) => serde_json::Number::from_f64(*f)
+            .map(serde_json::Value::Number)
+            .ok_or_else(|| CwtError::Claims("arkavo_npe float is not finite".into()))?,
+        Value::Text(t) => serde_json::Value::String(t.clone()),
+        Value::Bytes(b) => serde_json::Value::String(URL_SAFE_NO_PAD.encode(b)),
+        Value::Array(items) => {
+            serde_json::Value::Array(items.iter().map(to_json).collect::<Result<_, _>>()?)
+        }
+        Value::Map(fields) => {
+            let mut object = serde_json::Map::with_capacity(fields.len());
+            for (key, value) in fields {
+                let key = match key {
+                    Value::Text(t) => t.clone(),
+                    Value::Integer(i) => i128::from(*i).to_string(),
+                    _ => {
+                        return Err(CwtError::Claims(
+                            "arkavo_npe map key is not text or integer".into(),
+                        ));
+                    }
+                };
+                object.insert(key, to_json(value)?);
+            }
+            serde_json::Value::Object(object)
+        }
+        Value::Tag(_, inner) => to_json(inner)?,
+        _ => {
+            return Err(CwtError::Claims(
+                "unsupported CBOR value in arkavo_npe".into(),
+            ));
+        }
+    })
+}

--- a/crates/arkavo-cwt/src/key.rs
+++ b/crates/arkavo-cwt/src/key.rs
@@ -1,0 +1,197 @@
+//! One verifying-key type for every CWT the edge checks. Permits carry the
+//! key inline in `cnf`; bearer tokens look it up by `kid`. Both end here.
+
+use crate::CwtError;
+use ciborium::Value;
+use coset::iana::{Algorithm, Ec2KeyParameter, EllipticCurve, EnumI64, KeyType, OkpKeyParameter};
+use coset::{CoseKey, CoseKeyBuilder, Label, RegisteredLabel};
+use p256::ecdsa::signature::Verifier as _;
+
+#[derive(Clone, Debug)]
+pub enum VerifyingKey {
+    Ed25519(ed25519_dalek::VerifyingKey),
+    P256(p256::ecdsa::VerifyingKey),
+}
+
+impl VerifyingKey {
+    pub fn algorithm(&self) -> Algorithm {
+        match self {
+            Self::Ed25519(_) => Algorithm::EdDSA,
+            Self::P256(_) => Algorithm::ES256,
+        }
+    }
+
+    pub fn from_cose_key(key: &CoseKey) -> Result<Self, CwtError> {
+        match key.kty {
+            RegisteredLabel::Assigned(KeyType::OKP) => {
+                expect_curve(key, OkpKeyParameter::Crv.to_i64(), EllipticCurve::Ed25519)?;
+                let x = bytes_param(key, OkpKeyParameter::X.to_i64(), "x")?;
+                let raw: [u8; 32] = x
+                    .try_into()
+                    .map_err(|_| CwtError::Key("Ed25519 x must be 32 bytes".into()))?;
+                ed25519_dalek::VerifyingKey::from_bytes(&raw)
+                    .map(Self::Ed25519)
+                    .map_err(|e| CwtError::Key(e.to_string()))
+            }
+            RegisteredLabel::Assigned(KeyType::EC2) => {
+                expect_curve(key, Ec2KeyParameter::Crv.to_i64(), EllipticCurve::P_256)?;
+                let x = bytes_param(key, Ec2KeyParameter::X.to_i64(), "x")?;
+                let y = bytes_param(key, Ec2KeyParameter::Y.to_i64(), "y")?;
+                if x.len() != 32 || y.len() != 32 {
+                    return Err(CwtError::Key("P-256 coordinates must be 32 bytes".into()));
+                }
+                let point = p256::EncodedPoint::from_affine_coordinates(
+                    p256::FieldBytes::from_slice(x),
+                    p256::FieldBytes::from_slice(y),
+                    false,
+                );
+                p256::ecdsa::VerifyingKey::from_encoded_point(&point)
+                    .map(Self::P256)
+                    .map_err(|e| CwtError::Key(e.to_string()))
+            }
+            _ => Err(CwtError::Key("key type is neither OKP nor EC2".into())),
+        }
+    }
+
+    pub fn to_cose_key(&self) -> CoseKey {
+        match self {
+            Self::Ed25519(key) => CoseKeyBuilder::new_okp_key()
+                .param(
+                    OkpKeyParameter::Crv.to_i64(),
+                    Value::from(EllipticCurve::Ed25519.to_i64()),
+                )
+                .param(
+                    OkpKeyParameter::X.to_i64(),
+                    Value::Bytes(key.to_bytes().to_vec()),
+                )
+                .algorithm(Algorithm::EdDSA)
+                .build(),
+            Self::P256(key) => {
+                let point = key.to_encoded_point(false);
+                let x = point.x().map(|c| c.to_vec()).unwrap_or_default();
+                let y = point.y().map(|c| c.to_vec()).unwrap_or_default();
+                CoseKeyBuilder::new_ec2_pub_key(EllipticCurve::P_256, x, y)
+                    .algorithm(Algorithm::ES256)
+                    .build()
+            }
+        }
+    }
+
+    pub fn verify(
+        &self,
+        algorithm: Algorithm,
+        data: &[u8],
+        signature: &[u8],
+    ) -> Result<(), CwtError> {
+        if algorithm != self.algorithm() {
+            return Err(CwtError::KeyAlgorithmMismatch);
+        }
+        match self {
+            Self::Ed25519(key) => {
+                let sig = ed25519_dalek::Signature::from_slice(signature)
+                    .map_err(|_| CwtError::BadSignature)?;
+                key.verify_strict(data, &sig)
+                    .map_err(|_| CwtError::BadSignature)
+            }
+            Self::P256(key) => {
+                let sig = p256::ecdsa::Signature::from_slice(signature)
+                    .map_err(|_| CwtError::BadSignature)?;
+                key.verify(data, &sig).map_err(|_| CwtError::BadSignature)
+            }
+        }
+    }
+
+    /// 32 raw bytes for Ed25519, 65-byte uncompressed SEC1 for P-256.
+    pub fn public_key_bytes(&self) -> Vec<u8> {
+        match self {
+            Self::Ed25519(key) => key.to_bytes().to_vec(),
+            Self::P256(key) => key.to_encoded_point(false).as_bytes().to_vec(),
+        }
+    }
+}
+
+fn param(key: &CoseKey, label: i64) -> Option<&Value> {
+    key.params
+        .iter()
+        .find(|(candidate, _)| *candidate == Label::Int(label))
+        .map(|(_, value)| value)
+}
+
+fn bytes_param<'a>(key: &'a CoseKey, label: i64, name: &str) -> Result<&'a [u8], CwtError> {
+    param(key, label)
+        .and_then(Value::as_bytes)
+        .map(Vec::as_slice)
+        .ok_or_else(|| CwtError::Key(format!("COSE key is missing its {name} coordinate")))
+}
+
+fn expect_curve(key: &CoseKey, label: i64, curve: EllipticCurve) -> Result<(), CwtError> {
+    let actual = param(key, label).and_then(Value::as_integer);
+    if actual == Some(curve.to_i64().into()) {
+        Ok(())
+    } else {
+        Err(CwtError::Key(format!("unexpected curve {actual:?}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coset::iana::Algorithm;
+    use ed25519_dalek::Signer as _;
+
+    #[test]
+    fn ed25519_round_trips_through_cose_key() {
+        let signing = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let key = VerifyingKey::Ed25519(signing.verifying_key());
+        let back = VerifyingKey::from_cose_key(&key.to_cose_key()).unwrap();
+        assert_eq!(back.public_key_bytes(), key.public_key_bytes());
+        let sig = signing.sign(b"data");
+        back.verify(Algorithm::EdDSA, b"data", &sig.to_bytes())
+            .unwrap();
+    }
+
+    #[test]
+    fn p256_round_trips_and_rejects_wrong_algorithm() {
+        let signing = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let key = VerifyingKey::P256(*signing.verifying_key());
+        let back = VerifyingKey::from_cose_key(&key.to_cose_key()).unwrap();
+        let sig: p256::ecdsa::Signature = signing.sign(b"data");
+        back.verify(Algorithm::ES256, b"data", &sig.to_bytes())
+            .unwrap();
+        assert!(matches!(
+            back.verify(Algorithm::EdDSA, b"data", &sig.to_bytes()),
+            Err(CwtError::KeyAlgorithmMismatch)
+        ));
+    }
+
+    #[test]
+    fn tampered_signature_is_bad_signature() {
+        let signing = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let key = VerifyingKey::Ed25519(signing.verifying_key());
+        let mut sig = signing.sign(b"data").to_bytes();
+        sig[0] ^= 0x01;
+        assert!(matches!(
+            key.verify(Algorithm::EdDSA, b"data", &sig),
+            Err(CwtError::BadSignature)
+        ));
+    }
+
+    #[test]
+    fn short_p256_coordinate_is_rejected() {
+        let mut cose = VerifyingKey::P256(
+            *p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng).verifying_key(),
+        )
+        .to_cose_key();
+        for (label, value) in cose.params.iter_mut() {
+            if *label == coset::Label::Int(coset::iana::Ec2KeyParameter::X as i64)
+                && let ciborium::Value::Bytes(bytes) = value
+            {
+                bytes.truncate(31);
+            }
+        }
+        assert!(matches!(
+            VerifyingKey::from_cose_key(&cose),
+            Err(CwtError::Key(_))
+        ));
+    }
+}

--- a/crates/arkavo-cwt/src/keys.rs
+++ b/crates/arkavo-cwt/src/keys.rs
@@ -6,20 +6,13 @@
 //! byte equality, never a recomputed thumbprint.
 
 use crate::{Claims, CwtError, VerifyOptions, verify::verify};
-use coset::{CborSerializable, CoseKey, CoseKeySet, Label};
-use p256::EncodedPoint;
-use p256::FieldBytes;
-use p256::ecdsa::VerifyingKey;
+use coset::{CborSerializable, CoseKeySet};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
-const EC2_CRV: i64 = -1;
-const EC2_X: i64 = -2;
-const EC2_Y: i64 = -3;
-
 /// The ES256 verification keys the issuer currently publishes.
 pub struct KeySet {
-    keys: Vec<(Vec<u8>, VerifyingKey)>,
+    keys: Vec<(Vec<u8>, crate::VerifyingKey)>,
 }
 
 impl KeySet {
@@ -33,10 +26,15 @@ impl KeySet {
         let set = CoseKeySet::from_slice(bytes).map_err(|e| CwtError::KeySet(e.to_string()))?;
         let mut keys = Vec::with_capacity(set.0.len());
         for key in &set.0 {
-            if key.key_id.is_empty() || !is_p256(key) {
+            if key.key_id.is_empty() {
                 continue;
             }
-            keys.push((key.key_id.clone(), verifying_key(key)?));
+            match crate::VerifyingKey::from_cose_key(key) {
+                Ok(crate::VerifyingKey::P256(vk)) => {
+                    keys.push((key.key_id.clone(), crate::VerifyingKey::P256(vk)))
+                }
+                _ => continue,
+            }
         }
         if keys.is_empty() {
             return Err(CwtError::KeySet("no usable ES256 P-256 keys".into()));
@@ -57,52 +55,12 @@ impl KeySet {
         Self::from_cbor(&body)
     }
 
-    pub(crate) fn get(&self, kid: &[u8]) -> Option<&VerifyingKey> {
+    pub(crate) fn get(&self, kid: &[u8]) -> Option<&crate::VerifyingKey> {
         self.keys
             .iter()
             .find(|(candidate, _)| candidate == kid)
             .map(|(_, key)| key)
     }
-}
-
-fn is_p256(key: &CoseKey) -> bool {
-    key.kty == coset::KeyType::Assigned(coset::iana::KeyType::EC2)
-        && param(key, EC2_CRV).and_then(ciborium::Value::as_integer)
-            == Some((coset::iana::EllipticCurve::P_256 as i64).into())
-}
-
-fn param(key: &CoseKey, label: i64) -> Option<&ciborium::Value> {
-    key.params
-        .iter()
-        .find(|(candidate, _)| *candidate == Label::Int(label))
-        .map(|(_, value)| value)
-}
-
-fn verifying_key(key: &CoseKey) -> Result<VerifyingKey, CwtError> {
-    // `generic-array`'s `From<&[T]> for &GenericArray<T, N>` panics on a length
-    // mismatch, so each coordinate is checked against the P-256 field width
-    // before conversion. Leading-zero-stripped coordinates (a classic COSE/JOSE
-    // interop bug) must be rejected, not repaired by left-padding.
-    let coordinate = |label: i64, name: &str| -> Result<FieldBytes, CwtError> {
-        let bytes = param(key, label)
-            .and_then(ciborium::Value::as_bytes)
-            .ok_or_else(|| {
-                CwtError::KeySet(format!("COSE key is missing its {name} coordinate"))
-            })?;
-        // `FieldBytes::from_exact_iter` returns `None` on a length mismatch
-        // instead of panicking, unlike `GenericArray`'s `From<&[T]>`.
-        FieldBytes::from_exact_iter(bytes.iter().copied()).ok_or_else(|| {
-            CwtError::KeySet(format!(
-                "COSE key {name} coordinate is {} bytes, expected 32",
-                bytes.len()
-            ))
-        })
-    };
-    let x = coordinate(EC2_X, "x")?;
-    let y = coordinate(EC2_Y, "y")?;
-    let point = EncodedPoint::from_affine_coordinates(&x, &y, false);
-    VerifyingKey::from_encoded_point(&point)
-        .map_err(|e| CwtError::KeySet(format!("COSE key is not a valid P-256 point: {e}")))
 }
 
 struct Cached {

--- a/crates/arkavo-cwt/src/keys.rs
+++ b/crates/arkavo-cwt/src/keys.rs
@@ -1,0 +1,227 @@
+//! The published COSE key set and its cache.
+//!
+//! `/.well-known/cose-keys` serves a CBOR array of COSE_Key maps (not JWKS
+//! JSON). Each entry carries the raw 32-byte RFC 7638 thumbprint as its `kid`,
+//! which is the same value the CWT's protected header names; matching is plain
+//! byte equality, never a recomputed thumbprint.
+
+use crate::{Claims, CwtError, VerifyOptions, verify::verify};
+use coset::{CborSerializable, CoseKey, CoseKeySet, Label};
+use p256::EncodedPoint;
+use p256::FieldBytes;
+use p256::ecdsa::VerifyingKey;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+const EC2_CRV: i64 = -1;
+const EC2_X: i64 = -2;
+const EC2_Y: i64 = -3;
+
+/// The ES256 verification keys the issuer currently publishes.
+pub struct KeySet {
+    keys: Vec<(Vec<u8>, VerifyingKey)>,
+}
+
+impl KeySet {
+    /// Parse a `/.well-known/cose-keys` body.
+    ///
+    /// Entries that are not EC2 P-256 keys, or that carry no `kid`, are skipped
+    /// rather than rejected: the issuer may publish keys for algorithms this
+    /// verifier does not handle, and one such entry must not blind it to the
+    /// ES256 keys alongside it.
+    pub fn from_cbor(bytes: &[u8]) -> Result<Self, CwtError> {
+        let set = CoseKeySet::from_slice(bytes).map_err(|e| CwtError::KeySet(e.to_string()))?;
+        let mut keys = Vec::with_capacity(set.0.len());
+        for key in &set.0 {
+            if key.key_id.is_empty() || !is_p256(key) {
+                continue;
+            }
+            keys.push((key.key_id.clone(), verifying_key(key)?));
+        }
+        if keys.is_empty() {
+            return Err(CwtError::KeySet("no usable ES256 P-256 keys".into()));
+        }
+        Ok(Self { keys })
+    }
+
+    /// Fetch and parse the key set published at `url`.
+    pub async fn fetch(url: &str) -> Result<Self, CwtError> {
+        let body = reqwest::get(url)
+            .await
+            .map_err(|e| CwtError::Fetch(e.to_string()))?
+            .error_for_status()
+            .map_err(|e| CwtError::Fetch(e.to_string()))?
+            .bytes()
+            .await
+            .map_err(|e| CwtError::Fetch(e.to_string()))?;
+        Self::from_cbor(&body)
+    }
+
+    pub(crate) fn get(&self, kid: &[u8]) -> Option<&VerifyingKey> {
+        self.keys
+            .iter()
+            .find(|(candidate, _)| candidate == kid)
+            .map(|(_, key)| key)
+    }
+}
+
+fn is_p256(key: &CoseKey) -> bool {
+    key.kty == coset::KeyType::Assigned(coset::iana::KeyType::EC2)
+        && param(key, EC2_CRV).and_then(ciborium::Value::as_integer)
+            == Some((coset::iana::EllipticCurve::P_256 as i64).into())
+}
+
+fn param(key: &CoseKey, label: i64) -> Option<&ciborium::Value> {
+    key.params
+        .iter()
+        .find(|(candidate, _)| *candidate == Label::Int(label))
+        .map(|(_, value)| value)
+}
+
+fn verifying_key(key: &CoseKey) -> Result<VerifyingKey, CwtError> {
+    // `generic-array`'s `From<&[T]> for &GenericArray<T, N>` panics on a length
+    // mismatch, so each coordinate is checked against the P-256 field width
+    // before conversion. Leading-zero-stripped coordinates (a classic COSE/JOSE
+    // interop bug) must be rejected, not repaired by left-padding.
+    let coordinate = |label: i64, name: &str| -> Result<FieldBytes, CwtError> {
+        let bytes = param(key, label)
+            .and_then(ciborium::Value::as_bytes)
+            .ok_or_else(|| {
+                CwtError::KeySet(format!("COSE key is missing its {name} coordinate"))
+            })?;
+        // `FieldBytes::from_exact_iter` returns `None` on a length mismatch
+        // instead of panicking, unlike `GenericArray`'s `From<&[T]>`.
+        FieldBytes::from_exact_iter(bytes.iter().copied()).ok_or_else(|| {
+            CwtError::KeySet(format!(
+                "COSE key {name} coordinate is {} bytes, expected 32",
+                bytes.len()
+            ))
+        })
+    };
+    let x = coordinate(EC2_X, "x")?;
+    let y = coordinate(EC2_Y, "y")?;
+    let point = EncodedPoint::from_affine_coordinates(&x, &y, false);
+    VerifyingKey::from_encoded_point(&point)
+        .map_err(|e| CwtError::KeySet(format!("COSE key is not a valid P-256 point: {e}")))
+}
+
+struct Cached {
+    keys: Arc<KeySet>,
+    fetched_at: Instant,
+}
+
+/// A [`KeySet`] that re-fetches when a token names a `kid` it does not hold,
+/// but no more than once per `ttl` — so a token signed by a key that will never
+/// be published cannot turn into a fetch per verification.
+pub struct CachedKeySet {
+    url: String,
+    ttl: Duration,
+    cached: RwLock<Option<Cached>>,
+}
+
+impl CachedKeySet {
+    pub fn new(url: impl Into<String>, ttl: Duration) -> Self {
+        Self {
+            url: url.into(),
+            ttl,
+            cached: RwLock::new(None),
+        }
+    }
+
+    /// Verify `token` against the cached key set, refreshing once if the token's
+    /// `kid` is unknown and the cache is at least `ttl` old.
+    pub async fn verify(&self, token: &str, opts: &VerifyOptions<'_>) -> Result<Claims, CwtError> {
+        let current = self.snapshot();
+        let (keys, fetched_at) = match current {
+            Some(cached) => cached,
+            None => (self.refresh().await?, Instant::now()),
+        };
+
+        match verify(token, &keys, opts) {
+            Err(CwtError::UnknownKid(kid)) => {
+                if fetched_at.elapsed() < self.ttl {
+                    return Err(CwtError::UnknownKid(kid));
+                }
+                let refreshed = self.refresh().await?;
+                verify(token, &refreshed, opts)
+            }
+            other => other,
+        }
+    }
+
+    fn snapshot(&self) -> Option<(Arc<KeySet>, Instant)> {
+        let guard = self
+            .cached
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard
+            .as_ref()
+            .map(|cached| (cached.keys.clone(), cached.fetched_at))
+    }
+
+    async fn refresh(&self) -> Result<Arc<KeySet>, CwtError> {
+        let keys = Arc::new(KeySet::fetch(&self.url).await?);
+        let mut guard = self
+            .cached
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *guard = Some(Cached {
+            keys: keys.clone(),
+            fetched_at: Instant::now(),
+        });
+        Ok(keys)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coset::CoseKeyBuilder;
+    use p256::ecdsa::SigningKey;
+
+    /// A structurally valid COSE_Key whose `x` (or `y`) coordinate is 31 bytes
+    /// — the shape a leading-zero-stripped coordinate produces — must be
+    /// rejected through the crate's public parse path, not panic the process.
+    /// `generic-array`'s `From<&[T]>` panics on this input; the fix routes the
+    /// length check through `CwtError::KeySet` instead.
+    fn cose_key_with(x: Vec<u8>, y: Vec<u8>) -> Vec<u8> {
+        let key = CoseKeyBuilder::new_ec2_pub_key(coset::iana::EllipticCurve::P_256, x, y)
+            .algorithm(coset::iana::Algorithm::ES256)
+            .key_id(vec![0xAA; 32])
+            .build();
+        CoseKeySet(vec![key]).to_vec().expect("encode key set")
+    }
+
+    fn valid_coordinates() -> (Vec<u8>, Vec<u8>) {
+        let vk = *SigningKey::random(&mut rand::rngs::OsRng).verifying_key();
+        let point = vk.to_encoded_point(false);
+        (
+            point.x().expect("x coordinate").to_vec(),
+            point.y().expect("y coordinate").to_vec(),
+        )
+    }
+
+    #[test]
+    fn from_cbor_rejects_31_byte_x_coordinate_without_panicking() {
+        let (x, y) = valid_coordinates();
+        let bytes = cose_key_with(x[..31].to_vec(), y);
+
+        match KeySet::from_cbor(&bytes) {
+            Err(CwtError::KeySet(_)) => {}
+            Err(other) => panic!("expected CwtError::KeySet, got {other:?}"),
+            Ok(_) => panic!("31-byte x must be rejected, not accepted"),
+        }
+    }
+
+    #[test]
+    fn from_cbor_rejects_31_byte_y_coordinate_without_panicking() {
+        let (x, y) = valid_coordinates();
+        let bytes = cose_key_with(x, y[..31].to_vec());
+
+        match KeySet::from_cbor(&bytes) {
+            Err(CwtError::KeySet(_)) => {}
+            Err(other) => panic!("expected CwtError::KeySet, got {other:?}"),
+            Ok(_) => panic!("31-byte y must be rejected, not accepted"),
+        }
+    }
+}

--- a/crates/arkavo-cwt/src/lib.rs
+++ b/crates/arkavo-cwt/src/lib.rs
@@ -6,11 +6,15 @@
 //! at `<issuer>/.well-known/cose-keys`.
 
 pub mod claims;
+pub mod key;
 pub mod keys;
+pub mod sign1;
 pub mod verify;
 
 pub use claims::Claims;
+pub use key::VerifyingKey;
 pub use keys::{CachedKeySet, KeySet};
+pub use sign1::{ParsedSign1, parse};
 pub use verify::{VerifyOptions, verify};
 
 /// Every way verification can refuse a token.
@@ -22,7 +26,7 @@ pub enum CwtError {
     Cose(String),
     #[error("malformed CWT claims: {0}")]
     Claims(String),
-    #[error("unsupported signature algorithm: expected ES256, got {0}")]
+    #[error("unsupported signature algorithm: expected EdDSA or ES256, got {0}")]
     UnsupportedAlgorithm(String),
     #[error("COSE_Sign1 carries no kid header")]
     MissingKid,
@@ -42,4 +46,8 @@ pub enum CwtError {
     KeySet(String),
     #[error("could not fetch the COSE key set: {0}")]
     Fetch(String),
+    #[error("unusable COSE key: {0}")]
+    Key(String),
+    #[error("signature algorithm does not match the key type")]
+    KeyAlgorithmMismatch,
 }

--- a/crates/arkavo-cwt/src/lib.rs
+++ b/crates/arkavo-cwt/src/lib.rs
@@ -1,0 +1,45 @@
+//! Verification of the short-lived agent CWT issued by authnz-rs.
+//!
+//! The token is a COSE_Sign1 (ES256) carrying CWT claims, transported as
+//! base64url-without-padding and prefixed with CBOR tag 61 (`D8 3D`) around an
+//! otherwise untagged COSE_Sign1. Signing keys are published as a COSE key set
+//! at `<issuer>/.well-known/cose-keys`.
+
+pub mod claims;
+pub mod keys;
+pub mod verify;
+
+pub use claims::Claims;
+pub use keys::{CachedKeySet, KeySet};
+pub use verify::{VerifyOptions, verify};
+
+/// Every way verification can refuse a token.
+#[derive(Debug, thiserror::Error)]
+pub enum CwtError {
+    #[error("token is not base64url without padding: {0}")]
+    Base64(String),
+    #[error("malformed COSE_Sign1: {0}")]
+    Cose(String),
+    #[error("malformed CWT claims: {0}")]
+    Claims(String),
+    #[error("unsupported signature algorithm: expected ES256, got {0}")]
+    UnsupportedAlgorithm(String),
+    #[error("COSE_Sign1 carries no kid header")]
+    MissingKid,
+    #[error("no published key with kid {0}")]
+    UnknownKid(String),
+    #[error("signature does not verify under the published key")]
+    BadSignature,
+    #[error("token expired at {exp} (now {now})")]
+    Expired { exp: i64, now: i64 },
+    #[error("token issued in the future: iat {iat} (now {now})")]
+    IssuedInFuture { iat: i64, now: i64 },
+    #[error("issuer mismatch: expected {expected}, got {actual}")]
+    IssuerMismatch { expected: String, actual: String },
+    #[error("audience {expected} is not in the token's aud")]
+    AudienceMismatch { expected: String },
+    #[error("malformed COSE key set: {0}")]
+    KeySet(String),
+    #[error("could not fetch the COSE key set: {0}")]
+    Fetch(String),
+}

--- a/crates/arkavo-cwt/src/sign1.rs
+++ b/crates/arkavo-cwt/src/sign1.rs
@@ -1,0 +1,127 @@
+//! COSE_Sign1 parsing shared by permit and bearer verification.
+
+use crate::{CwtError, VerifyingKey};
+use coset::iana::Algorithm;
+use coset::{CborSerializable, CoseSign1, RegisteredLabelWithPrivate, TaggedCborSerializable};
+
+/// CBOR tag 61 (CWT) as it appears on the wire.
+pub const CWT_TAG_PREFIX: [u8; 2] = [0xd8, 0x3d];
+
+/// Untrusted input larger than this is refused before any CBOR work.
+pub const MAX_TOKEN_BYTES: usize = 16 * 1024;
+
+pub struct ParsedSign1 {
+    pub sign1: CoseSign1,
+    pub algorithm: Algorithm,
+}
+
+/// Parse a CWT-shaped COSE_Sign1. The tag-61 prefix is optional and the
+/// COSE_Sign1 may be tagged (18) or bare: authnz-rs emits bare, permits
+/// emit tagged, and both must verify through the same code.
+pub fn parse(bytes: &[u8]) -> Result<ParsedSign1, CwtError> {
+    if bytes.len() > MAX_TOKEN_BYTES {
+        return Err(CwtError::Cose("token exceeds maximum size".into()));
+    }
+    let body = bytes.strip_prefix(&CWT_TAG_PREFIX[..]).unwrap_or(bytes);
+    let sign1 = CoseSign1::from_tagged_slice(body)
+        .or_else(|_| CoseSign1::from_slice(body))
+        .map_err(|e| CwtError::Cose(e.to_string()))?;
+    let algorithm = match &sign1.protected.header.alg {
+        Some(RegisteredLabelWithPrivate::Assigned(alg @ (Algorithm::EdDSA | Algorithm::ES256))) => {
+            *alg
+        }
+        Some(other) => return Err(CwtError::UnsupportedAlgorithm(format!("{other:?}"))),
+        None => return Err(CwtError::UnsupportedAlgorithm("none".into())),
+    };
+    Ok(ParsedSign1 { sign1, algorithm })
+}
+
+impl ParsedSign1 {
+    pub fn kid(&self) -> &[u8] {
+        &self.sign1.protected.header.key_id
+    }
+
+    pub fn payload(&self) -> Result<&[u8], CwtError> {
+        self.sign1
+            .payload
+            .as_deref()
+            .ok_or_else(|| CwtError::Cose("payload is detached".into()))
+    }
+
+    pub fn verify(&self, key: &VerifyingKey) -> Result<(), CwtError> {
+        self.sign1.verify_signature(b"", |signature, data| {
+            key.verify(self.algorithm, data, signature)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coset::{CborSerializable, CoseSign1Builder, HeaderBuilder, TaggedCborSerializable};
+    use ed25519_dalek::Signer as _;
+
+    fn signed(tagged: bool, prefix: bool) -> (Vec<u8>, VerifyingKey) {
+        let signing = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let protected = HeaderBuilder::new()
+            .algorithm(coset::iana::Algorithm::EdDSA)
+            .key_id(b"k1".to_vec())
+            .build();
+        let sign1 = CoseSign1Builder::new()
+            .protected(protected)
+            .payload(b"payload".to_vec())
+            .create_signature(b"", |data| signing.sign(data).to_bytes().to_vec())
+            .build();
+        let mut bytes = if prefix {
+            CWT_TAG_PREFIX.to_vec()
+        } else {
+            Vec::new()
+        };
+        if tagged {
+            bytes.extend(sign1.to_tagged_vec().unwrap());
+        } else {
+            bytes.extend(sign1.to_vec().unwrap());
+        }
+        (bytes, VerifyingKey::Ed25519(signing.verifying_key()))
+    }
+
+    #[test]
+    fn parses_all_four_wire_shapes() {
+        for (tagged, prefix) in [(true, true), (true, false), (false, true), (false, false)] {
+            let (bytes, key) = signed(tagged, prefix);
+            let parsed = parse(&bytes).unwrap();
+            assert_eq!(parsed.algorithm, coset::iana::Algorithm::EdDSA);
+            assert_eq!(parsed.kid(), b"k1");
+            assert_eq!(parsed.payload().unwrap(), b"payload");
+            parsed.verify(&key).unwrap();
+        }
+    }
+
+    #[test]
+    fn rejects_oversized_input_before_parsing() {
+        let big = vec![0u8; MAX_TOKEN_BYTES + 1];
+        assert!(matches!(parse(&big), Err(CwtError::Cose(_))));
+    }
+
+    #[test]
+    fn rejects_missing_alg() {
+        let sign1 = CoseSign1Builder::new().payload(b"p".to_vec()).build();
+        let bytes = sign1.to_vec().unwrap();
+        assert!(matches!(
+            parse(&bytes),
+            Err(CwtError::UnsupportedAlgorithm(_))
+        ));
+    }
+
+    #[test]
+    fn wrong_key_fails_verification() {
+        let (bytes, _) = signed(true, true);
+        let other = VerifyingKey::Ed25519(
+            ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng).verifying_key(),
+        );
+        assert!(matches!(
+            parse(&bytes).unwrap().verify(&other),
+            Err(CwtError::BadSignature)
+        ));
+    }
+}

--- a/crates/arkavo-cwt/src/verify.rs
+++ b/crates/arkavo-cwt/src/verify.rs
@@ -2,12 +2,6 @@
 
 use crate::{Claims, CwtError, KeySet};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-use coset::{CborSerializable, CoseSign1, RegisteredLabelWithPrivate};
-use p256::ecdsa::Signature;
-use p256::ecdsa::signature::Verifier;
-
-/// authnz-rs prepends CBOR tag 61 (`cwt`) to an otherwise untagged COSE_Sign1.
-const CWT_TAG: [u8; 2] = [0xD8, 0x3D];
 
 /// What the caller expects the token to say, and when "now" is.
 pub struct VerifyOptions<'a> {
@@ -31,37 +25,22 @@ pub fn verify(
     let bytes = URL_SAFE_NO_PAD
         .decode(token_b64url)
         .map_err(|e| CwtError::Base64(e.to_string()))?;
-    let body = bytes.strip_prefix(&CWT_TAG[..]).unwrap_or(&bytes);
-    let sign1 = CoseSign1::from_slice(body).map_err(|e| CwtError::Cose(e.to_string()))?;
-
-    match &sign1.protected.header.alg {
-        Some(RegisteredLabelWithPrivate::Assigned(coset::iana::Algorithm::ES256)) => {}
-        Some(other) => return Err(CwtError::UnsupportedAlgorithm(format!("{other:?}"))),
-        None => return Err(CwtError::UnsupportedAlgorithm("none".into())),
+    let parsed = crate::sign1::parse(&bytes)?;
+    if parsed.algorithm != coset::iana::Algorithm::ES256 {
+        return Err(CwtError::UnsupportedAlgorithm(format!(
+            "{:?}",
+            parsed.algorithm
+        )));
     }
-
-    // authnz-contract.md puts `kid` in the protected header. An unprotected
-    // `kid` is not covered by the signature, so honouring one would widen the
-    // accepted input surface for no gain.
-    let kid = &sign1.protected.header.key_id;
+    let kid = parsed.kid();
     if kid.is_empty() {
         return Err(CwtError::MissingKid);
     }
     let key = keys
         .get(kid)
         .ok_or_else(|| CwtError::UnknownKid(hex(kid)))?;
-
-    sign1.verify_signature(b"", |signature, signed| {
-        let signature = Signature::from_slice(signature).map_err(|_| CwtError::BadSignature)?;
-        key.verify(signed, &signature)
-            .map_err(|_| CwtError::BadSignature)
-    })?;
-
-    let payload = sign1
-        .payload
-        .as_deref()
-        .ok_or_else(|| CwtError::Cose("payload is detached".into()))?;
-    let claims = Claims::from_cbor(payload)?;
+    parsed.verify(key)?;
+    let claims = Claims::from_cbor(parsed.payload()?)?;
     check_claims(&claims, opts)?;
     Ok(claims)
 }

--- a/crates/arkavo-cwt/src/verify.rs
+++ b/crates/arkavo-cwt/src/verify.rs
@@ -1,0 +1,627 @@
+//! COSE_Sign1 verification and CWT claim validation.
+
+use crate::{Claims, CwtError, KeySet};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use coset::{CborSerializable, CoseSign1, RegisteredLabelWithPrivate};
+use p256::ecdsa::Signature;
+use p256::ecdsa::signature::Verifier;
+
+/// authnz-rs prepends CBOR tag 61 (`cwt`) to an otherwise untagged COSE_Sign1.
+const CWT_TAG: [u8; 2] = [0xD8, 0x3D];
+
+/// What the caller expects the token to say, and when "now" is.
+pub struct VerifyOptions<'a> {
+    pub expected_iss: &'a str,
+    /// `None` skips the audience check — appropriate where the caller does not
+    /// know the issuer's configured audiences.
+    pub expected_aud: Option<&'a str>,
+    pub now: i64,
+    pub skew_secs: i64,
+}
+
+/// Verify a base64url-encoded agent CWT and return its claims.
+///
+/// Accepts the tag-61-prefixed wire form and a bare untagged COSE_Sign1.
+/// ES256 is the only accepted algorithm.
+pub fn verify(
+    token_b64url: &str,
+    keys: &KeySet,
+    opts: &VerifyOptions<'_>,
+) -> Result<Claims, CwtError> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(token_b64url)
+        .map_err(|e| CwtError::Base64(e.to_string()))?;
+    let body = bytes.strip_prefix(&CWT_TAG[..]).unwrap_or(&bytes);
+    let sign1 = CoseSign1::from_slice(body).map_err(|e| CwtError::Cose(e.to_string()))?;
+
+    match &sign1.protected.header.alg {
+        Some(RegisteredLabelWithPrivate::Assigned(coset::iana::Algorithm::ES256)) => {}
+        Some(other) => return Err(CwtError::UnsupportedAlgorithm(format!("{other:?}"))),
+        None => return Err(CwtError::UnsupportedAlgorithm("none".into())),
+    }
+
+    // authnz-contract.md puts `kid` in the protected header. An unprotected
+    // `kid` is not covered by the signature, so honouring one would widen the
+    // accepted input surface for no gain.
+    let kid = &sign1.protected.header.key_id;
+    if kid.is_empty() {
+        return Err(CwtError::MissingKid);
+    }
+    let key = keys
+        .get(kid)
+        .ok_or_else(|| CwtError::UnknownKid(hex(kid)))?;
+
+    sign1.verify_signature(b"", |signature, signed| {
+        let signature = Signature::from_slice(signature).map_err(|_| CwtError::BadSignature)?;
+        key.verify(signed, &signature)
+            .map_err(|_| CwtError::BadSignature)
+    })?;
+
+    let payload = sign1
+        .payload
+        .as_deref()
+        .ok_or_else(|| CwtError::Cose("payload is detached".into()))?;
+    let claims = Claims::from_cbor(payload)?;
+    check_claims(&claims, opts)?;
+    Ok(claims)
+}
+
+fn check_claims(claims: &Claims, opts: &VerifyOptions<'_>) -> Result<(), CwtError> {
+    if claims.iss != opts.expected_iss {
+        return Err(CwtError::IssuerMismatch {
+            expected: opts.expected_iss.to_string(),
+            actual: claims.iss.clone(),
+        });
+    }
+    if claims.exp.saturating_add(opts.skew_secs) < opts.now {
+        return Err(CwtError::Expired {
+            exp: claims.exp,
+            now: opts.now,
+        });
+    }
+    if claims.iat.saturating_sub(opts.skew_secs) > opts.now {
+        return Err(CwtError::IssuedInFuture {
+            iat: claims.iat,
+            now: opts.now,
+        });
+    }
+    if let Some(expected) = opts.expected_aud
+        && !claims.aud.iter().any(|aud| aud == expected)
+    {
+        return Err(CwtError::AudienceMismatch {
+            expected: expected.to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)]
+mod tests {
+    use crate::{CachedKeySet, CwtError, KeySet, VerifyOptions, verify};
+    use arkavo_test_macros::spec;
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use ciborium::Value;
+    use coset::{
+        CborSerializable, CoseKeyBuilder, CoseKeySet, CoseSign1, CoseSign1Builder, Header,
+        HeaderBuilder,
+    };
+    use p256::ecdsa::{Signature, SigningKey, VerifyingKey, signature::Signer};
+    use std::time::Duration;
+
+    const ISS: &str = "https://identity.arkavo.net";
+    const NOW: i64 = 1_800_000_000;
+
+    fn new_key() -> SigningKey {
+        SigningKey::random(&mut rand::rngs::OsRng)
+    }
+
+    /// Mint a token shaped exactly like an authnz-rs agent CWT: tag 61 wrapped
+    /// around an untagged COSE_Sign1, ES256, raw-bytes `kid` in the protected
+    /// header, integer claim keys plus the `arkavo_*` text claims.
+    fn mint(signer: &SigningKey, kid: &[u8], aud: &[&str], exp: i64, tagged: bool) -> String {
+        let aud = Value::Array(aud.iter().map(|a| Value::Text((*a).into())).collect());
+        let act = Some(Value::Array(vec![Value::Map(vec![(
+            Value::Text("sub".into()),
+            Value::Text("did:key:zHumanPrincipal".into()),
+        )])]));
+        mint_claims(signer, kid, aud, exp, act, None, tagged)
+    }
+
+    /// Mint with full control over the shapes the review found untested:
+    /// `aud` as either the agent shape (`Value::Array`) or the bare-text shape
+    /// other token types use, `act` optionally omitted entirely (its documented
+    /// absence when no actors are configured, not an empty array), and an
+    /// arbitrary `arkavo_npe` payload.
+    fn mint_claims(
+        signer: &SigningKey,
+        kid: &[u8],
+        aud: Value,
+        exp: i64,
+        act: Option<Value>,
+        npe: Option<Value>,
+        tagged: bool,
+    ) -> String {
+        let payload = claims_cbor(ISS, aud, exp, NOW - 60, act, npe);
+        encode_sign1(
+            signer,
+            es256_protected(kid),
+            Header::default(),
+            payload,
+            tagged,
+        )
+    }
+
+    /// The CBOR claims map an authnz-rs agent CWT carries: integer claim keys
+    /// for the registered claims, literal text keys for the `arkavo_*` set.
+    fn claims_cbor(
+        iss: &str,
+        aud: Value,
+        exp: i64,
+        iat: i64,
+        act: Option<Value>,
+        npe: Option<Value>,
+    ) -> Vec<u8> {
+        let mut fields = vec![
+            (Value::Integer(1.into()), Value::Text(iss.into())),
+            (
+                Value::Integer(2.into()),
+                Value::Text("did:key:zAgentUnderTest".into()),
+            ),
+            (Value::Integer(3.into()), aud),
+            (Value::Integer(4.into()), Value::Integer(exp.into())),
+            (Value::Integer(6.into()), Value::Integer(iat.into())),
+            (
+                Value::Text("arkavo_account_id".into()),
+                Value::Text("acct-42".into()),
+            ),
+            (
+                Value::Text("arkavo_roles".into()),
+                Value::Array(vec![Value::Text("agent".into())]),
+            ),
+            (
+                Value::Text("arkavo_entitlements".into()),
+                Value::Array(vec![
+                    Value::Text("https://arkavo.ai/attr/repo/read".into()),
+                    Value::Text("https://arkavo.ai/attr/repo/write".into()),
+                ]),
+            ),
+        ];
+        if let Some(act) = act {
+            fields.push((Value::Text("act".into()), act));
+        }
+        if let Some(npe) = npe {
+            fields.push((Value::Text("arkavo_npe".into()), npe));
+        }
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&Value::Map(fields), &mut bytes).expect("encode claims");
+        bytes
+    }
+
+    /// The protected header authnz-rs emits: ES256 plus the raw-bytes `kid`.
+    fn es256_protected(kid: &[u8]) -> Header {
+        HeaderBuilder::new()
+            .algorithm(coset::iana::Algorithm::ES256)
+            .key_id(kid.to_vec())
+            .build()
+    }
+
+    /// Sign `payload` under the given headers and return the client-facing
+    /// encoding: base64url-no-pad, optionally tag-61 prefixed.
+    fn encode_sign1(
+        signer: &SigningKey,
+        protected: Header,
+        unprotected: Header,
+        payload: Vec<u8>,
+        tagged: bool,
+    ) -> String {
+        let sign1 = CoseSign1Builder::new()
+            .protected(protected)
+            .unprotected(unprotected)
+            .payload(payload)
+            .create_signature(b"", |data| {
+                let sig: Signature = signer.sign(data);
+                sig.to_bytes().to_vec()
+            })
+            .build();
+
+        let mut bytes = if tagged { vec![0xD8, 0x3D] } else { Vec::new() };
+        bytes.extend_from_slice(&sign1.to_vec().expect("encode COSE_Sign1"));
+        URL_SAFE_NO_PAD.encode(bytes)
+    }
+
+    /// Encode a `/.well-known/cose-keys` body: a CBOR array of COSE_Key maps.
+    fn key_set_cbor(entries: &[(&[u8], VerifyingKey)]) -> Vec<u8> {
+        let keys = entries
+            .iter()
+            .map(|(kid, vk)| {
+                let point = vk.to_encoded_point(false);
+                CoseKeyBuilder::new_ec2_pub_key(
+                    coset::iana::EllipticCurve::P_256,
+                    point.x().expect("x coordinate").to_vec(),
+                    point.y().expect("y coordinate").to_vec(),
+                )
+                .algorithm(coset::iana::Algorithm::ES256)
+                .key_id(kid.to_vec())
+                .build()
+            })
+            .collect();
+        CoseKeySet(keys).to_vec().expect("encode key set")
+    }
+
+    fn opts<'a>(aud: Option<&'a str>) -> VerifyOptions<'a> {
+        VerifyOptions {
+            expected_iss: ISS,
+            expected_aud: aud,
+            now: NOW,
+            skew_secs: 30,
+        }
+    }
+
+    #[test]
+    #[spec("ACWT-001")]
+    fn verifies_es256_tagged_cwt_and_reads_arkavo_claims() {
+        let signer = new_key();
+        let kid = [0x11u8; 32];
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())]))
+            .expect("parse key set");
+
+        let token = mint(&signer, &kid, &["arkavo-kas"], NOW + 600, true);
+        let claims = verify(&token, &keys, &opts(Some("arkavo-kas"))).expect("verify tagged CWT");
+
+        assert_eq!(claims.iss, ISS);
+        assert_eq!(claims.sub, "did:key:zAgentUnderTest");
+        assert_eq!(claims.aud, vec!["arkavo-kas".to_string()]);
+        assert_eq!(claims.exp, NOW + 600);
+        assert_eq!(claims.iat, NOW - 60);
+        assert_eq!(claims.account_id.as_deref(), Some("acct-42"));
+        assert_eq!(claims.roles, vec!["agent".to_string()]);
+        assert_eq!(
+            claims.entitlements,
+            vec![
+                "https://arkavo.ai/attr/repo/read".to_string(),
+                "https://arkavo.ai/attr/repo/write".to_string(),
+            ]
+        );
+        assert_eq!(claims.actors, vec!["did:key:zHumanPrincipal".to_string()]);
+        assert!(claims.npe.is_none());
+
+        // The same bytes without the tag-61 prefix are equally acceptable.
+        let untagged = mint(&signer, &kid, &["arkavo-kas"], NOW + 600, false);
+        assert!(verify(&untagged, &keys, &opts(Some("arkavo-kas"))).is_ok());
+    }
+
+    #[test]
+    #[spec("ACWT-002")]
+    fn rejects_wrong_key_expired_and_wrong_audience() {
+        let signer = new_key();
+        let impostor = new_key();
+        let kid = [0x22u8; 32];
+        // The key set advertises `kid` but binds it to a different public key,
+        // so a token minted by `impostor` reaches signature verification and
+        // fails there rather than being rejected as an unknown kid.
+        let wrong_key_set =
+            KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())])).expect("key set");
+        let token = mint(&impostor, &kid, &["arkavo-kas"], NOW + 600, true);
+        assert!(matches!(
+            verify(&token, &wrong_key_set, &opts(Some("arkavo-kas"))),
+            Err(CwtError::BadSignature)
+        ));
+
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *impostor.verifying_key())]))
+            .expect("key set");
+
+        let expired = mint(&impostor, &kid, &["arkavo-kas"], NOW - 31, true);
+        assert!(matches!(
+            verify(&expired, &keys, &opts(Some("arkavo-kas"))),
+            Err(CwtError::Expired { .. })
+        ));
+
+        let good = mint(&impostor, &kid, &["arkavo-kas"], NOW + 600, true);
+        assert!(matches!(
+            verify(&good, &keys, &opts(Some("some-other-service"))),
+            Err(CwtError::AudienceMismatch { .. })
+        ));
+    }
+
+    #[tokio::test]
+    #[spec("ACWT-003")]
+    async fn cached_keyset_refreshes_on_unknown_kid_once_per_ttl() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let signer = new_key();
+        let stale = new_key();
+        let kid = [0x33u8; 32];
+        let token = mint(&signer, &kid, &["arkavo-kas"], NOW + 600, true);
+
+        let server = MockServer::start().await;
+        // First response predates the rotation and does not carry `kid`; every
+        // later response does.
+        Mock::given(method("GET"))
+            .and(path("/.well-known/cose-keys"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(key_set_cbor(&[(&[0x99u8; 32], *stale.verifying_key())])),
+            )
+            .up_to_n_times(1)
+            .expect(1..)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/.well-known/cose-keys"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(key_set_cbor(&[(&kid, *signer.verifying_key())])),
+            )
+            .mount(&server)
+            .await;
+
+        let url = format!("{}/.well-known/cose-keys", server.uri());
+
+        // ttl 0: the unknown kid triggers an immediate re-fetch, which picks up
+        // the rotated key and verifies.
+        let eager = CachedKeySet::new(&url, Duration::ZERO);
+        let claims = eager
+            .verify(&token, &opts(Some("arkavo-kas")))
+            .await
+            .expect("verify after refresh");
+        assert_eq!(claims.sub, "did:key:zAgentUnderTest");
+        assert_eq!(server.received_requests().await.unwrap().len(), 2);
+
+        // A long ttl suppresses the re-fetch: the unknown kid is reported and
+        // the key set is fetched exactly once.
+        let lazy = CachedKeySet::new(&url, Duration::from_secs(3600));
+        let before = server.received_requests().await.unwrap().len();
+        let stale_kid_token = mint(&stale, &[0x44u8; 32], &["arkavo-kas"], NOW + 600, true);
+        assert!(matches!(
+            lazy.verify(&stale_kid_token, &opts(Some("arkavo-kas")))
+                .await,
+            Err(CwtError::UnknownKid(_))
+        ));
+        assert!(
+            lazy.verify(&stale_kid_token, &opts(Some("arkavo-kas")))
+                .await
+                .is_err()
+        );
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            before + 1,
+            "the key set must be re-fetched at most once per ttl"
+        );
+    }
+
+    /// authnz-contract.md: agent tokens carry `arkavo_npe: {type: "agent",
+    /// delegation_id, depth, chain}` and omit `act` entirely when no actors
+    /// are configured (not an empty array). Before this test the mint helper
+    /// never emitted `arkavo_npe`, so no test drove `Claims::to_json` — the
+    /// crate's largest function — through a real, signed agent-shaped token.
+    #[test]
+    fn accepts_agent_shaped_token_with_npe_and_no_act() {
+        let signer = new_key();
+        let kid = [0x55u8; 32];
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())]))
+            .expect("parse key set");
+
+        let npe = Value::Map(vec![
+            (Value::Text("type".into()), Value::Text("agent".into())),
+            (
+                Value::Text("delegation_id".into()),
+                Value::Text("did:key:zAgentUnderTest".into()),
+            ),
+            (Value::Text("depth".into()), Value::Integer(1.into())),
+            (
+                Value::Text("chain".into()),
+                Value::Array(vec![
+                    Value::Text("did:key:zRootPrincipal".into()),
+                    Value::Text("did:key:zAgentUnderTest".into()),
+                ]),
+            ),
+        ]);
+        let aud = Value::Array(vec![Value::Text("arkavo-kas".into())]);
+        let token = mint_claims(&signer, &kid, aud, NOW + 600, None, Some(npe), true);
+
+        let claims = verify(&token, &keys, &opts(Some("arkavo-kas"))).expect("verify agent CWT");
+
+        assert!(
+            claims.actors.is_empty(),
+            "act must be absent, not a bogus empty array: {:?}",
+            claims.actors
+        );
+        assert_eq!(
+            claims.npe,
+            Some(serde_json::json!({
+                "type": "agent",
+                "delegation_id": "did:key:zAgentUnderTest",
+                "depth": 1,
+                "chain": ["did:key:zRootPrincipal", "did:key:zAgentUnderTest"],
+            })),
+            "arkavo_npe must survive into the JSON claims unchanged"
+        );
+    }
+
+    /// authnz-contract.md: "Agent-token `aud` is ALWAYS a CBOR array ...
+    /// Other token types use a bare text string — a verifier must accept
+    /// both." This mints the non-agent, bare-text shape (the array shape is
+    /// already exercised by every other test in this module).
+    #[test]
+    fn accepts_bare_text_audience_for_non_agent_token() {
+        let signer = new_key();
+        let kid = [0x66u8; 32];
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())]))
+            .expect("parse key set");
+
+        let aud = Value::Text("arkavo-kas".into());
+        let token = mint_claims(&signer, &kid, aud, NOW + 600, None, None, true);
+
+        let claims = verify(&token, &keys, &opts(Some("arkavo-kas")))
+            .expect("verify token with bare-text aud");
+
+        assert_eq!(claims.aud, vec!["arkavo-kas".to_string()]);
+        assert!(claims.actors.is_empty());
+        assert!(claims.npe.is_none());
+    }
+
+    /// agent-cwt.spec.yaml invariant: "ES256 only; any other COSE algorithm is
+    /// refused before a key is even looked up." Nothing pinned that; a verifier
+    /// that honoured the token's own `alg` would let an attacker pick a weaker
+    /// one, or none at all.
+    #[test]
+    fn refuses_any_algorithm_other_than_es256() {
+        let signer = new_key();
+        let kid = [0x77u8; 32];
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())]))
+            .expect("parse key set");
+        let aud = Value::Array(vec![Value::Text("arkavo-kas".into())]);
+
+        let eddsa = encode_sign1(
+            &signer,
+            HeaderBuilder::new()
+                .algorithm(coset::iana::Algorithm::EdDSA)
+                .key_id(kid.to_vec())
+                .build(),
+            Header::default(),
+            claims_cbor(ISS, aud.clone(), NOW + 600, NOW - 60, None, None),
+            true,
+        );
+        assert!(matches!(
+            verify(&eddsa, &keys, &opts(Some("arkavo-kas"))),
+            Err(CwtError::UnsupportedAlgorithm(_))
+        ));
+
+        let no_alg = encode_sign1(
+            &signer,
+            HeaderBuilder::new().key_id(kid.to_vec()).build(),
+            Header::default(),
+            claims_cbor(ISS, aud, NOW + 600, NOW - 60, None, None),
+            true,
+        );
+        assert!(matches!(
+            verify(&no_alg, &keys, &opts(Some("arkavo-kas"))),
+            Err(CwtError::UnsupportedAlgorithm(_))
+        ));
+    }
+
+    /// A correctly signed token minted by some other issuer must not be
+    /// accepted just because its signature verifies under a key we publish.
+    #[test]
+    fn refuses_a_wrong_issuer() {
+        let signer = new_key();
+        let kid = [0x88u8; 32];
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())]))
+            .expect("parse key set");
+
+        let token = encode_sign1(
+            &signer,
+            es256_protected(&kid),
+            Header::default(),
+            claims_cbor(
+                "https://identity.attacker.example",
+                Value::Array(vec![Value::Text("arkavo-kas".into())]),
+                NOW + 600,
+                NOW - 60,
+                None,
+                None,
+            ),
+            true,
+        );
+
+        assert!(matches!(
+            verify(&token, &keys, &opts(Some("arkavo-kas"))),
+            Err(CwtError::IssuerMismatch { .. })
+        ));
+    }
+
+    /// A token whose `iat` is beyond the allowed skew has not been issued yet;
+    /// accepting it would let a clock-skewed or forged token extend its own
+    /// window past the 15-minute agent CWT lifetime.
+    #[test]
+    fn refuses_a_token_issued_in_the_future() {
+        let signer = new_key();
+        let kid = [0x99u8; 32];
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())]))
+            .expect("parse key set");
+
+        let token = encode_sign1(
+            &signer,
+            es256_protected(&kid),
+            Header::default(),
+            claims_cbor(
+                ISS,
+                Value::Array(vec![Value::Text("arkavo-kas".into())]),
+                NOW + 600,
+                NOW + 31,
+                None,
+                None,
+            ),
+            true,
+        );
+
+        assert!(matches!(
+            verify(&token, &keys, &opts(Some("arkavo-kas"))),
+            Err(CwtError::IssuedInFuture { .. })
+        ));
+    }
+
+    /// Flipping one byte of the signed payload must be caught. Without this the
+    /// suite could pass with the signature check reduced to a no-op: every other
+    /// rejection test fails on a header, a clock or a claim comparison.
+    #[test]
+    fn refuses_a_tampered_payload() {
+        let signer = new_key();
+        let kid = [0xAAu8; 32];
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())]))
+            .expect("parse key set");
+
+        let token = mint(&signer, &kid, &["arkavo-kas"], NOW + 600, true);
+        assert!(verify(&token, &keys, &opts(Some("arkavo-kas"))).is_ok());
+
+        let bytes = URL_SAFE_NO_PAD.decode(&token).expect("decode token");
+        let body = bytes.strip_prefix(&[0xD8u8, 0x3D][..]).expect("tag 61");
+        let mut sign1 = CoseSign1::from_slice(body).expect("parse COSE_Sign1");
+        sign1.payload.as_mut().expect("attached payload")[0] ^= 0x01;
+        let tampered = URL_SAFE_NO_PAD.encode(sign1.to_vec().expect("re-encode"));
+
+        assert!(matches!(
+            verify(&tampered, &keys, &opts(Some("arkavo-kas"))),
+            Err(CwtError::BadSignature)
+        ));
+    }
+
+    /// authnz-contract.md: "`kid`: in the **protected** header." An unprotected
+    /// `kid` is not covered by the signature, so it is not accepted even as a
+    /// lookup hint.
+    #[test]
+    fn refuses_a_kid_carried_only_in_the_unprotected_header() {
+        let signer = new_key();
+        let kid = [0xBBu8; 32];
+        let keys = KeySet::from_cbor(&key_set_cbor(&[(&kid, *signer.verifying_key())]))
+            .expect("parse key set");
+
+        let token = encode_sign1(
+            &signer,
+            HeaderBuilder::new()
+                .algorithm(coset::iana::Algorithm::ES256)
+                .build(),
+            HeaderBuilder::new().key_id(kid.to_vec()).build(),
+            claims_cbor(
+                ISS,
+                Value::Array(vec![Value::Text("arkavo-kas".into())]),
+                NOW + 600,
+                NOW - 60,
+                None,
+                None,
+            ),
+            true,
+        );
+
+        assert!(matches!(
+            verify(&token, &keys, &opts(Some("arkavo-kas"))),
+            Err(CwtError::MissingKid)
+        ));
+    }
+}

--- a/specs/arkavo-edge/agent-cwt.spec.yaml
+++ b/specs/arkavo-edge/agent-cwt.spec.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=../schema.json
+
+feature: Agent CWT verification
+module: arkavo_cwt
+version: 0.89.4
+
+invariants:
+  - The agent verifies its own credential rather than treating it as an opaque bearer string
+  - ES256 only; any other COSE algorithm is refused before a key is even looked up
+  - Signing keys come from the issuer's published COSE key set, matched on raw kid bytes
+  - An unknown kid never turns into a key-set fetch per verification
+
+scenarios:
+  - id: ACWT-001
+    name: Verify an ES256 agent CWT and read its Arkavo claims
+    criticality: critical
+    given:
+      - A COSE key set publishing the issuer's ES256 P-256 key under a raw 32-byte kid
+      - A CWT signed by that key, tag-61 prefixed around an untagged COSE_Sign1
+    when: verify() is called with the issuer, audience and current time
+    then:
+      - The COSE_Sign1 signature verifies under the published key
+      - iss, sub, aud, exp and iat are decoded from their integer claim keys
+      - arkavo_account_id, arkavo_roles and arkavo_entitlements are decoded from their text claim keys
+      - act yields the human principals the agent acts for
+      - The same token without the tag-61 prefix verifies identically
+    refs:
+      - crates/arkavo-cwt/src/verify.rs
+      - crates/arkavo-cwt/src/claims.rs
+      - crates/arkavo-cwt/src/keys.rs
+
+  - id: ACWT-002
+    name: Reject a wrong key, an expired token and a wrong audience
+    criticality: critical
+    given:
+      - A published key set and tokens minted against it
+    when: verify() is called on a token signed by another key, on an expired token, and with an audience the token does not carry
+    then:
+      - A signature made by a different key is refused as BadSignature
+      - A token whose exp precedes now beyond the allowed skew is refused as Expired
+      - An audience absent from the token's aud is refused as AudienceMismatch
+    refs:
+      - crates/arkavo-cwt/src/verify.rs
+
+  - id: ACWT-003
+    name: Cached key set refreshes on an unknown kid at most once per ttl
+    criticality: high
+    given:
+      - A CachedKeySet pointed at the issuer's /.well-known/cose-keys endpoint
+      - A key rotation, so the first response omits the kid the token names
+    when: verify() is called on a token whose kid is absent from the cached key set
+    then:
+      - An elapsed ttl triggers one re-fetch, which picks up the rotated key and verifies
+      - Within the ttl no re-fetch happens and the unknown kid is reported
+      - Repeated verification of an unknown kid does not repeat the fetch
+    refs:
+      - crates/arkavo-cwt/src/keys.rs

--- a/specs/arkavo-edge/index.yaml
+++ b/specs/arkavo-edge/index.yaml
@@ -978,10 +978,21 @@ components:
       - Token file written atomically at unix mode 0o600
       - Refresh-before-expiry with 60-second skew; dead refresh deletes the token file
 
+  - name: agent-cwt
+    file: agent-cwt.spec.yaml
+    module: arkavo_cwt
+    description: COSE_Sign1/ES256 verification of the agent CWT against the published COSE key set
+    criticality: critical
+    scenario_count: 3
+    invariants:
+      - ES256 only
+      - Keys matched on raw kid bytes from the published COSE key set
+      - Unknown kid refreshes the key set at most once per ttl
+
 stats:
-  total_specs: 83
-  total_scenarios: 805
-  critical_scenarios: 245
+  total_specs: 84
+  total_scenarios: 808
+  critical_scenarios: 247
   coverage_areas:
     - authentication
     - authorization


### PR DESCRIPTION
Extracts `crates/arkavo-cwt` from #665 unchanged, then adds `sign1::parse` (tag-61 optional, tagged or bare COSE_Sign1, EdDSA|ES256, 16 KiB cap) and a `VerifyingKey` enum (Ed25519 + P-256, COSE_Key round-trip, algorithm/key-type agreement enforced before any verifier runs). Bearer verification (`verify`, `KeySet`) now goes through both and stays ES256-only. `arkavo-permit` (#662 follow-up) and `arkavo-authorization` (#659) are expected to depend on this crate instead of carrying their own parsers.

Workspace gains `coset = "0.4"`, `ciborium = "0.2"`, `p256 = "0.13"`. Version 0.91.2. Stacked on #682 (base retargets to main when that merges).

Tracking: #655 (finding 1 of the 2026-09-01 review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WuaQ415QEhE1MNxQ7rF5nz
